### PR TITLE
updater: Fix building in Debug

### DIFF
--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_definitions(updater PRIVATE NOMINMAX "PSAPI_VERSION=2")
 if(MSVC)
   target_compile_options(updater PRIVATE $<IF:$<CONFIG:DEBUG>,/MTd,/MT>)
   target_compile_options(updater PRIVATE "/utf-8")
+  target_link_options(updater PRIVATE "LINKER:/IGNORE:4098")
 endif()
 
 target_link_libraries(updater PRIVATE OBS::blake2 zstd::libzstd_static comctl32


### PR DESCRIPTION
### Description

Fixes linker error when trying to build OBS in debug with the updater enabled

### Motivation and Context

*Somebody* forgot to add this again after already causing the same issue once this week.

### How Has This Been Tested?

Built in debug.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
