### PR TITLE
linux-pipewire: Clear cursor texture on empty bitmap

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -719,6 +719,10 @@ read_metadata:
 			bitmap = SPA_MEMBER(cursor, cursor->bitmap_offset,
 					    struct spa_meta_bitmap);
 
+		if (bitmap)
+			g_clear_pointer(&obs_pw->cursor.texture,
+					gs_texture_destroy);
+
 		if (bitmap && bitmap->size.width > 0 &&
 		    bitmap->size.height > 0 &&
 		    lookup_format_info_from_spa_format(
@@ -732,8 +736,7 @@ read_metadata:
 			obs_pw->cursor.width = bitmap->size.width;
 			obs_pw->cursor.height = bitmap->size.height;
 
-			g_clear_pointer(&obs_pw->cursor.texture,
-					gs_texture_destroy);
+			assert(obs_pw->cursor.texture == NULL);
 			obs_pw->cursor.texture = gs_texture_create(
 				obs_pw->cursor.width, obs_pw->cursor.height,
 				gs_format, 1, &bitmap_data, GS_DYNAMIC);


### PR DESCRIPTION
If we receive an empty cursor bitmap - one without valid size - we should hide the cursor. Do so by clearing the texture.

This fixes visible cursors when recording various games with Wayland compositors.

Closes https://github.com/obsproject/obs-studio/issues/4895

### How Has This Been Tested?
Locally tested, asking other people to test as well.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
