### PR TITLE
Remove Some Windows 7 leftovers

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -500,12 +500,10 @@ bool OBSApp::InitGlobalConfigDefaults()
 				"MultiviewDrawAreas", true);
 
 #ifdef _WIN32
-	uint32_t winver = GetWindowsVersion();
-
 	config_set_default_bool(globalConfig, "Audio", "DisableAudioDucking",
 				true);
 	config_set_default_bool(globalConfig, "General", "BrowserHWAccel",
-				winver > 0x601);
+				true);
 #endif
 
 #ifdef __APPLE__

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -609,24 +609,6 @@ static void *send_thread(void *data)
 	os_set_thread_name("rtmp-stream: send_thread");
 
 #if defined(_WIN32)
-	// Despite MSDN claiming otherwise, send buffer auto tuning on
-	// Windows 7 doesn't seem to work very well.
-	if (get_win_ver_int() == 0x601) {
-		DWORD cur_sendbuf_size;
-		DWORD desired_sendbuf_size = 524288;
-		socklen_t int_size = sizeof(int);
-
-		if (!getsockopt(stream->rtmp.m_sb.sb_socket, SOL_SOCKET,
-				SO_SNDBUF, (char *)&cur_sendbuf_size,
-				&int_size) &&
-		    cur_sendbuf_size < desired_sendbuf_size) {
-
-			setsockopt(stream->rtmp.m_sb.sb_socket, SOL_SOCKET,
-				   SO_SNDBUF, (char *)&desired_sendbuf_size,
-				   sizeof(desired_sendbuf_size));
-		}
-	}
-
 	log_sndbuf_size(stream);
 #endif
 


### PR DESCRIPTION
### Description

Removes two checks for Windows 7 I stumbled over during other work.

### Motivation and Context

Windows 7.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
