### PR TITLE
Add old Vtuber Maker versions to DLL blocklist

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -157,6 +157,13 @@ static blocked_module_t blocked_modules[] = {
 
 	// VSeeFace capture filter < v1.13.38b3 without above fix implemented
 	{L"\\vseefacecamera64bit.dll", 0, 1666993098, TS_LESS_THAN},
+
+	// VTuber Maker capture filter < 2023-03-13 without above fix implemented
+	{L"\\live3dvirtualcam\\lib64_new2.dll", 0, 1678695956, TS_LESS_THAN},
+
+	// Obsolete unfixed versions of VTuber Maker capture filter
+	{L"\\live3dvirtualcam\\lib64_new.dll", 0, 0, TS_IGNORE},
+	{L"\\live3dvirtualcam\\lib64.dll", 0, 0, TS_IGNORE},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
### Description
Blocks old versions of the Vtuber Maker `lib64_new2.dll` which don't have the Unity Capture deadlock fix implemented.

### Motivation and Context
Freezing OBS is bad.

### How Has This Been Tested?
Simulated using the NVIDIA Broadcast filter as I don't wish to install Vtuber Maker. Seemed to work.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
