### PR TITLE
win-capture: Remove the redundant "-" in the CSGO launch option and Steam url language code

### DIFF
--- a/plugins/win-capture/data/compatibility.json
+++ b/plugins/win-capture/data/compatibility.json
@@ -13,8 +13,8 @@
             "game_capture": true,
             "window_capture": false,
             "window_capture_wgc": false,
-            "message": "CS:GO may require the <code>--allow_third_party_software</code> launch option to use Game Capture.",
-            "url": "https://help.steampowered.com/en/faqs/view/09A0-4879-4353-EF95#whitelist"
+            "message": "CS:GO may require the <code>-allow_third_party_software</code> launch option to use Game Capture.",
+            "url": "https://help.steampowered.com/faqs/view/09A0-4879-4353-EF95#whitelist"
         },
         {
             "name": "Electron",

--- a/plugins/win-capture/data/locale/en-US.ini
+++ b/plugins/win-capture/data/locale/en-US.ini
@@ -47,7 +47,7 @@ Compatibility.GameCapture.WrongGPU="If the preview is blank, make sure %name% is
 Compatibility.WindowCapture.BitBlt="%name% may not be capturable using the selected Capture Method (BitBlt)."
 
 # Specific compatibility messages
-Compatibility.Application.CSGO="CS:GO may require the <code>--allow_third_party_software</code> launch option to use Game Capture."
+Compatibility.Application.CSGO="CS:GO may require the <code>-allow_third_party_software</code> launch option to use Game Capture."
 Compatibility.Application.ElectronGameCapture="Games built on Electron cannot be captured using Game Capture. Use Window Capture or Display Capture instead."
 Compatibility.Application.ElectronBitBlt="Electron-based applications may not be capturable using the selected Capture Method (BitBlt)."
 Compatibility.Application.Minecraft="If you're having issues capturing Minecraft: Java Edition, check our troubleshooting guide."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove the redundant "-" in the CSGO launch option.
Remove Steam url language code. Users will be redirected to their own language page.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
https://github.com/SteamDatabase/GameTracking-CSGO/blob/be343ab9d6a2cd4cfb1ff917eeaf0ffc22d9a6b3/csgo/bin/linux64/client_client_strings.txt#L3455
It is not the latest client version, but launch option has not changed.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
