### PR TITLE
UI: Properly update filter properties after resetting

### DIFF
--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -141,9 +141,11 @@ private:
 	void GetScrollPos(int &h, int &v);
 	void SetScrollPos(int h, int v);
 
+private slots:
+	void RefreshProperties();
+
 public slots:
 	void ReloadProperties();
-	void RefreshProperties();
 	void SignalChanged();
 
 signals:

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -1219,7 +1219,7 @@ void OBSBasicFilters::ResetFilters()
 	if (!view->DeferUpdate())
 		obs_source_update(filter, nullptr);
 
-	view->RefreshProperties();
+	view->ReloadProperties();
 }
 
 void OBSBasicFilters::CopyFilter()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Calling `RefreshProperties` on a properties view only rebuilds the widgets from the currently held `obs_properties_t` object. This is useful for when a modified_callback changes visibility of items.
It does not re-fetch the `obs_properties_t` from the object again. Such re-fetching is however required when the `obs_properties_t` itself wasn't updated, for example after a simple `obs_source_update` call (which is what the defaults button does). `OBSPropertiesView::ReloadProperties` is the function that does this before itself calling `RefreshProperties` and as such is the correct function to call.
This brings the filters window correctly in line with the source properties window.

In fact, I don't believe there is a reason for anything except the properties view itself to ever simply call `RefreshProperties` instead of `ReloadProperties` since the properties view holds the `obs_properties_t` object and as such would have to initiate anything that will change said object. For that reason, I also made `RefreshProperties` a private function which should prevent issues like this from arising again.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #7906

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2.1
Tested with the scroll filter that the view now gets updated properly after clicking "Defaults" (see #7906 for the original problem).


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
