### PR TITLE
UI,libobs: Fix possible use-after-free

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -114,8 +114,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		struct obs_frontend_source_list *sources) override
 	{
 		for (int i = 0; i < main->ui->transitions->count(); i++) {
-			obs_source_t *tr = main->ui->transitions->itemData(i)
-						   .value<OBSSource>();
+			OBSSource tr = main->ui->transitions->itemData(i)
+					       .value<OBSSource>();
 
 			if (!tr)
 				continue;

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -564,7 +564,7 @@ void OBSBasic::RenameTransition()
 {
 	QAction *action = reinterpret_cast<QAction *>(sender());
 	QVariant variant = action->property("transition");
-	obs_source_t *transition = variant.value<OBSSource>();
+	OBSSource transition = variant.value<OBSSource>();
 
 	string name;
 	QString placeHolderText = QT_UTF8(obs_source_get_name(transition));

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -733,7 +733,7 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 		switch (type) {
 		case ProjectorType::Scene:
 		case ProjectorType::Source: {
-			obs_source_t *source = projector->GetSource();
+			OBSSource source = projector->GetSource();
 			const char *name = obs_source_get_name(source);
 			obs_data_set_string(data, "name", name);
 			break;
@@ -5388,8 +5388,8 @@ void OBSBasic::on_actionAddScene_triggered()
 		auto undo_fn = [](const std::string &data) {
 			obs_source_t *t = obs_get_source_by_name(data.c_str());
 			if (t) {
-				obs_source_release(t);
 				obs_source_remove(t);
+				obs_source_release(t);
 			}
 		};
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5151,12 +5151,10 @@ void OBSBasic::on_actionMixerToolbarMenu_triggered()
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 					    QListWidgetItem *prev)
 {
-	obs_source_t *source = NULL;
+	OBSSource source;
 
 	if (current) {
-		obs_scene_t *scene;
-
-		scene = GetOBSRef<OBSScene>(current);
+		OBSScene scene = GetOBSRef<OBSScene>(current);
 		source = obs_scene_get_source(scene);
 
 		currentScene = scene;
@@ -8318,7 +8316,7 @@ static bool reset_tr(obs_scene_t *scene, obs_sceneitem_t *item, void *param)
 
 void OBSBasic::on_actionResetTransform_triggered()
 {
-	obs_scene_t *scene = GetCurrentScene();
+	OBSScene scene = GetCurrentScene();
 
 	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(scene, false);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2302,10 +2302,7 @@ static obs_source_t *CreateLabel(float pixelRatio)
 	const char *text_source_id = "text_ft2_source";
 #endif
 
-	OBSSource txtSource =
-		obs_source_create_private(text_source_id, NULL, settings);
-
-	return txtSource;
+	return obs_source_create_private(text_source_id, NULL, settings);
 }
 
 static void SetLabelText(int sourceIndex, int px)

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -354,6 +354,6 @@ void OBSBasicTransform::OnSceneChanged(QListWidgetItem *current,
 	if (!current)
 		return;
 
-	obs_scene_t *scene = GetOBSRef<OBSScene>(current);
+	OBSScene scene = GetOBSRef<OBSScene>(current);
 	this->SetScene(scene);
 }

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3301,10 +3301,10 @@ obs_sceneitem_t *obs_scene_insert_group(obs_scene_t *scene, const char *name,
 	obs_sceneitem_t *item =
 		obs_scene_add_internal(scene, sub_scene->source, last_item);
 
-	obs_scene_release(sub_scene);
-
-	if (!items || !count)
+	if (!items || !count) {
+		obs_scene_release(sub_scene);
 		return item;
+	}
 
 	/* ------------------------- */
 
@@ -3345,6 +3345,7 @@ obs_sceneitem_t *obs_scene_insert_group(obs_scene_t *scene, const char *name,
 
 	/* ------------------------- */
 
+	obs_scene_release(sub_scene);
 	return item;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

- Swap the order of `obs_source_release` and `obs_source_remove` in `OBSBasic::on_actionAddScene_triggered()`.
- Use `OBSSource` and `OBSScene` types instead of `obs_source_t` and `obs_scene_t`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm enabling GCC's `-Wuse-after-free` option to detect use-after-free of `bfree` and `obs_*_release` in [this branch](https://github.com/norihiro/obs-studio/commits/bfree-warning). Though this change is not finalized, I realized some codes are dangerous in multi-thread.
For example, creating a group and another thread removes the creating group by finding from an updated scene-item list. Such a non-sense operation won't happen in real but I think the code would be better to be revised.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36

1. Run OBS Studio
2. Activate the majority of the modified code (exceptions are `obs_frontend_get_transitions` and the failed branch in `obs_scene_insert_group`).
3. Check there is no memory leak.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
