### PR TITLE
test: Fix unused-parameter warnings in test-input

### DIFF
--- a/test/test-input/sync-pair-vid.c
+++ b/test/test-input/sync-pair-vid.c
@@ -46,6 +46,7 @@ static inline void fill_texture(uint32_t *pixels, uint32_t pixel)
 
 static void *sync_pair_vid_create(obs_data_t *settings, obs_source_t *source)
 {
+	UNUSED_PARAMETER(settings);
 	struct sync_pair_vid *spv = bzalloc(sizeof(struct sync_pair_vid));
 	spv->source = source;
 
@@ -83,6 +84,7 @@ static inline bool whitelist_time(uint64_t ts, uint64_t interval,
 
 static void sync_pair_vid_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
 	struct sync_pair_vid *spv = data;
 
 	uint64_t ts = obs_get_video_frame_time();
@@ -116,6 +118,7 @@ static void sync_pair_vid_render(void *data, gs_effect_t *effect)
 
 static uint32_t sync_pair_vid_size(void *data)
 {
+	UNUSED_PARAMETER(data);
 	return 32;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add `UNUSED_PARAMETER` to resolve errors.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

A source `test-input` is not build in CI and the source is now causing compile errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Fedora 36

Build with cmake option `-DBUILD_TESTS=ON`.

Built the source and checked `Sync Test Pair (Audio)` and `(Sync Test Pair (Video)` work.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
