### PR TITLE
libobs/util: simplify implementation of os_get_path_extension

### DIFF
--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -245,7 +245,7 @@ Other Path/File Functions
 
 .. function:: const char *os_get_path_extension(const char *path)
 
-   Returns the extension portion of a path string.
+   Returns the extension portion of a path string, including the dot (.).
 
 ---------------------
 

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -654,28 +654,17 @@ int os_mkdirs(const char *dir)
 
 const char *os_get_path_extension(const char *path)
 {
-	struct dstr temp;
-	size_t pos = 0;
-	char *period;
-	char *slash;
+	for (size_t pos = strlen(path); pos > 0; pos--) {
+		switch (path[pos - 1]) {
+		case '.':
+			return path + pos - 1;
+		case '/':
+		case '\\':
+			return NULL;
+		}
+	}
 
-	if (!path[0])
-		return NULL;
-
-	dstr_init_copy(&temp, path);
-	dstr_replace(&temp, "\\", "/");
-
-	slash = strrchr(temp.array, '/');
-	period = strrchr(temp.array, '.');
-	if (period)
-		pos = (size_t)(period - temp.array);
-
-	dstr_free(&temp);
-
-	if (!period || slash > period)
-		return NULL;
-
-	return path + pos;
+	return NULL;
 }
 
 static inline bool valid_string(const char *str)

--- a/test/cmocka/CMakeLists.txt
+++ b/test/cmocka/CMakeLists.txt
@@ -21,3 +21,10 @@ target_include_directories(test_bitstream PRIVATE ${CMOCKA_INCLUDE_DIR})
 target_link_libraries(test_bitstream PRIVATE OBS::libobs ${CMOCKA_LIBRARIES})
 
 add_test(test_bitstream ${CMAKE_CURRENT_BINARY_DIR}/test_bitstream)
+
+# OS path test
+add_executable(test_os_path test_os_path.c)
+target_include_directories(test_os_path PRIVATE ${CMOCKA_INCLUDE_DIR})
+target_link_libraries(test_os_path PRIVATE OBS::libobs ${CMOCKA_LIBRARIES})
+
+add_test(test_os_path ${CMAKE_CURRENT_BINARY_DIR}/test_os_path)

--- a/test/cmocka/test_os_path.c
+++ b/test/cmocka/test_os_path.c
@@ -1,0 +1,54 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <util/platform.h>
+
+struct testcase {
+	const char *path;
+	const char *ext;
+};
+
+static void run_testcases(struct testcase *testcases)
+{
+	for (size_t i = 0; testcases[i].path; i++) {
+		const char *path = testcases[i].path;
+
+		const char *ext = os_get_path_extension(path);
+
+		printf("path: '%s' ext: '%s'\n", path, ext);
+		if (testcases[i].ext)
+			assert_string_equal(ext, testcases[i].ext);
+		else
+			assert_ptr_equal(ext, testcases[i].ext);
+	}
+}
+
+static void os_get_path_extension_test(void **state)
+{
+	UNUSED_PARAMETER(state);
+
+	static struct testcase testcases[] = {
+		{"/home/user/a.txt", ".txt"},
+		{"C:\\Users\\user\\Documents\\video.mp4", ".mp4"},
+		{"./\\", NULL},
+		{".\\/", NULL},
+		{"/.\\", NULL},
+		{"/\\.", "."},
+		{"\\/.", "."},
+		{"\\./", NULL},
+		{"", NULL},
+		{NULL, NULL}};
+
+	run_testcases(testcases);
+}
+
+int main()
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(os_get_path_extension_test),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR includes these changes.
- libobs/util: Simplify implementation of `os_get_path_extension`
  In current implementation, it allocate memory, replace `\` with `/`, and calls two `strrchr`. This PR will just iterate two times without allocating the memory.
- docs: Clarify a dot is included in the extension
- test: Add a test for `os_get_path_extension`

Also considered other implementations below but the code in PR would be the best balance of readability and simplicity.

This code has just one interaction but I feel it is worse to read.
```c
const char *os_get_path_extension(const char *path)
{
	const char *ext = NULL;

	for (; *path; path++) {
		switch (*path) {
		case '.':
			ext = path;
			break;
		case '/':
		case '\\':
			ext = NULL;
		}
	}

	return ext;
}
```

This is similar to the original code in terms of using `strrchr`. This has 3 iteration and I feel the ease of reading is not so different from the PR.
```c
const char *os_get_path_extension(const char *path)
{
	if (!path[0])
		return NULL;

	char *slash = strrchr(path, '/');
	char *bslash = strrchr(path, '\\');
	char *period = strrchr(path, '.');

	if (!period || slash > period || bslash > period)
		return NULL;

	return period;
}
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm enabling GCC's `-Wuse-after-free` option to detect use-after-free of `bfree` and `obs_*_release` in [this branch](https://github.com/norihiro/obs-studio/commits/bfree-warning).

I want to avoid memory allocation in that function because it can be replaced by a simple implementation.

When rewriting the function, I noticed an ambiguity so that I also fixed documentation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Some test cases are added and checked the test has passed for both old and new code.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
