### PR TITLE
win-capture: Fix compatibility info showing in any mode

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2252,7 +2252,16 @@ static bool window_changed_callback(obs_properties_t *ppts, obs_property_t *p,
 	bool modified = ms_check_window_property_setting(
 		ppts, p, settings, SETTING_CAPTURE_WINDOW, 1);
 
-	if (obs_data_get_bool(settings, SETTING_ANY_FULLSCREEN))
+	bool capture_any;
+	if (using_older_non_mode_format(settings)) {
+		capture_any =
+			obs_data_get_bool(settings, SETTING_ANY_FULLSCREEN);
+	} else {
+		const char *mode = obs_data_get_string(settings, SETTING_MODE);
+		capture_any = strcmp(mode, SETTING_MODE_ANY) == 0;
+	}
+
+	if (capture_any)
 		return modified;
 
 	const char *window =


### PR DESCRIPTION
### Description

Fix the mode check for game capture compatibility information.

### Motivation and Context

If the user created a new source and never used the manual mode the first game capture compatibility entry would erroneously be shown.

### How Has This Been Tested?

Created new game capture source, no longer shows wrong info.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
