### PR TITLE
libobs: Keep mixer data for placeholder sources

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4905,7 +4905,8 @@ void obs_source_set_audio_mixers(obs_source_t *source, uint32_t mixers)
 
 	if (!obs_source_valid(source, "obs_source_set_audio_mixers"))
 		return;
-	if ((source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
+	if (!source->owns_info_id &&
+	    (source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
 		return;
 
 	if (source->audio_mixers == mixers)
@@ -4926,7 +4927,8 @@ uint32_t obs_source_get_audio_mixers(const obs_source_t *source)
 {
 	if (!obs_source_valid(source, "obs_source_get_audio_mixers"))
 		return 0;
-	if ((source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
+	if (!source->owns_info_id &&
+	    (source->info.output_flags & OBS_SOURCE_AUDIO) == 0)
 		return 0;
 
 	return source->audio_mixers;


### PR DESCRIPTION
### Description

Placeholder sources are created when a plugin providing a source type is unavailable. Since they're not marked as having audio any audio track settings for them get lost. With this change we retain mixer information if the source owns its id to avoid that.

(This commit was pulled from #8455)

### Motivation and Context

Lost most audio on a 4+ hour D&D session, probably because I ran OBS without the `win-capture-audio` plugin once which lost all of the track assignments.

### How Has This Been Tested?

Loaded up OBS without `win-wasapi`, sources still had assignment after relaunching with it.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
