### PR TITLE
UI: Add unassigned indicator and warning to mixer

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -559,6 +559,8 @@ VolControl.SliderUnmuted="Volume slider for '%1':"
 VolControl.SliderMuted="Volume slider for '%1': (currently muted)"
 VolControl.Mute="Mute '%1'"
 VolControl.Properties="Properties for '%1'"
+VolControl.UnassignedWarning.Title="Unassigned Audio Source"
+VolControl.UnassignedWarning.Text="\"%1\" is not assigned to any audio tracks and it will not be audible in streams or recordings.\n\nTo assign an audio source to a track, open the Advanced Audio Properties via the right-click menu or the cog button in the mixer dock toolbar."
 
 # add scene dialog
 Basic.Main.AddSceneDlg.Title="Add Scene"

--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -986,6 +986,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Dark/settings/audio.svg);
 }

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -667,6 +667,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Dark/settings/audio.svg);
 }

--- a/UI/data/themes/Dark/unassigned.svg
+++ b/UI/data/themes/Dark/unassigned.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="100%" height="100%" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
+    <g>
+        <path d="M7,1.008C6.703,1.004 6.422,1.133 6.23,1.359L3,5L2,5C0.906,5 0,5.844 0,7L0,9C0,10.09 0.91,11 2,11L3,11L6.23,14.641C6.441,14.895 6.723,15.004 7,15L7,1.008Z" style="fill:rgb(230,179,28);fill-rule:nonzero;"/>
+    </g>
+    <g transform="matrix(1.30638,0,0,1.30638,-2.74526,7.10116)">
+        <g id="Layer1">
+            <g transform="matrix(12,0,0,12,9.58198,4.86608)">
+                <path d="M0.203,-0.237L0.084,-0.237L0.059,-0.714L0.228,-0.714L0.203,-0.237ZM0.057,-0.07C0.057,-0.097 0.064,-0.118 0.079,-0.132C0.094,-0.146 0.115,-0.153 0.143,-0.153C0.17,-0.153 0.191,-0.146 0.206,-0.131C0.221,-0.117 0.228,-0.097 0.228,-0.07C0.228,-0.044 0.221,-0.024 0.206,-0.009C0.191,0.006 0.17,0.013 0.143,0.013C0.116,0.013 0.095,0.006 0.08,-0.009C0.065,-0.023 0.057,-0.043 0.057,-0.07Z" style="fill:rgb(230,179,28);fill-rule:nonzero;"/>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -974,6 +974,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Dark/settings/audio.svg);
 }

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -974,6 +974,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Light/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Light/settings/audio.svg);
 }

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -978,6 +978,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Dark/settings/audio.svg);
 }

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -70,6 +70,10 @@ MuteCheckBox::indicator:checked {
     image: url(:/res/images/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(:/settings/images/settings/audio.svg);
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -978,6 +978,10 @@ MuteCheckBox::indicator:checked {
     image: url(./Dark/mute.svg);
 }
 
+MuteCheckBox::indicator:indeterminate {
+    image: url(./Dark/unassigned.svg);
+}
+
 MuteCheckBox::indicator:unchecked {
     image: url(./Dark/settings/audio.svg);
 }

--- a/UI/mute-checkbox.hpp
+++ b/UI/mute-checkbox.hpp
@@ -4,4 +4,21 @@
 
 class MuteCheckBox : public QCheckBox {
 	Q_OBJECT
+
+public:
+	MuteCheckBox(QWidget *parent = nullptr) : QCheckBox(parent)
+	{
+		setTristate(true);
+	}
+
+protected:
+	/* While we need it to be tristate internally, we don't want a user being
+	 * able to manually get into the partial state. */
+	void nextCheckState() override
+	{
+		if (checkState() != Qt::Checked)
+			setCheckState(Qt::Checked);
+		else
+			setCheckState(Qt::Unchecked);
+	}
 };

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -301,12 +301,14 @@ private:
 				   const float peak[MAX_AUDIO_CHANNELS],
 				   const float inputPeak[MAX_AUDIO_CHANNELS]);
 	static void OBSVolumeMuted(void *data, calldata_t *calldata);
+	static void OBSMixersChanged(void *data, calldata_t *alldata);
 
 	void EmitConfigClicked();
 
 private slots:
 	void VolumeChanged();
 	void VolumeMuted(bool muted);
+	void AssignmentChanged(bool unassigned);
 
 	void SetMuted(bool checked);
 	void SliderChanged(int vol);


### PR DESCRIPTION
### Description

Adds a new icon to the volume meter indicating that a source is unmuted, but inaudible due to not being assigned to any tracks:
![2023-03-24_15-00-06_Qd4YJB](https://user-images.githubusercontent.com/3123295/227541675-10a1777e-b595-4db0-81b2-8838886b8a2d.png)

When attempting to unmute a source in this state, the following message is shown:
![2023-03-24_15-00-08_st9Zlg](https://user-images.githubusercontent.com/3123295/227541660-a6728171-129f-4eb2-812e-b6ea5fd91a1b.png)

### Motivation and Context

Had no audio in a 4+ hour D&D session recording because the track assignment got lost (possibly fixed by #8495), probably a good idea to warn users about such cases.

### How Has This Been Tested?

Unassigned a soure, tried to start output.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
