### PR TITLE
UI: Disable incompatible codecs in settings

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -971,6 +971,7 @@ Basic.Settings.Output.Simple.RecordingQuality.Lossless="Lossless Quality, Tremen
 Basic.Settings.Output.Simple.Warn.VideoBitrate="Warning: The streaming video bitrate will be set to %1, which is the upper limit for the current streaming service."
 Basic.Settings.Output.Simple.Warn.AudioBitrate="Warning: The streaming audio bitrate will be set to %1, which is the upper limit for the current streaming service."
 Basic.Settings.Output.Simple.Warn.CannotPause="Warning: Recordings cannot be paused if the recording quality is set to \"Same as stream\"."
+Basic.Settings.Output.Simple.Warn.IncompatibleContainer="Warning: The currently selected recording format is incompatible with the selected stream encoder(s)."
 Basic.Settings.Output.Simple.Warn.Encoder="Warning: Recording with a software encoder at a different quality than the stream will require extra CPU usage if you stream and record at the same time."
 Basic.Settings.Output.Simple.Warn.Lossless="Warning: Lossless quality generates tremendously large file sizes! Lossless quality can use upward of 7 gigabytes of disk space per minute at high resolutions and framerates. Lossless is not recommended for long recordings unless you have a very large amount of disk space available."
 Basic.Settings.Output.Simple.Warn.Lossless.Msg="Are you sure you want to use lossless quality?"
@@ -1323,6 +1324,12 @@ SceneItemHide="Hide '%1'"
 OutputWarnings.NoTracksSelected="You must select at least one track"
 OutputWarnings.MP4Recording="Warning: Recordings saved to MP4/MOV will be unrecoverable if the file cannot be finalized (e.g. as a result of BSODs, power losses, etc.). If you want to record multiple audio tracks consider using MKV and remux the recording to MP4/MOV after it is finished (File → Remux Recordings)"
 OutputWarnings.CannotPause="Warning: Recordings cannot be paused if the recording encoder is set to \"(Use stream encoder)\""
+OutputWarnings.CodecIncompatible="The audio or video encoder selection was reset due to incompatibility. Please select a compatible encoder from the list."
+
+# codec compatibility
+CodecCompat.Incompatible="(Incompatible with %1)"
+CodecCompat.CodecPlaceholder="Select Encoder..."
+CodecCompat.ContainerPlaceholder="Select Format..."
 
 # deleting final scene
 FinalScene.Title="Delete Scene"

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1322,7 +1322,6 @@ SceneItemHide="Hide '%1'"
 # Output warnings
 OutputWarnings.NoTracksSelected="You must select at least one track"
 OutputWarnings.MP4Recording="Warning: Recordings saved to MP4/MOV will be unrecoverable if the file cannot be finalized (e.g. as a result of BSODs, power losses, etc.). If you want to record multiple audio tracks consider using MKV and remux the recording to MP4/MOV after it is finished (File → Remux Recordings)"
-OutputWarnings.ProResRecording="Apple ProRes is not supported by the %1 container format - supported container formats are mov (preferred) and mkv."
 OutputWarnings.CannotPause="Warning: Recordings cannot be paused if the recording encoder is set to \"(Use stream encoder)\""
 
 # deleting final scene

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4919,47 +4919,17 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 			errorMsg = QTStr("OutputWarnings.NoTracksSelected");
 	}
 
-	QString recEncoder = ui->advOutRecEncoder->currentText();
+	if (recFormat == "mp4" || recFormat == "mov") {
+		if (!warningMsg.isEmpty())
+			warningMsg += "\n\n";
 
-	if (recEncoder.contains("ProRes")) {
-		if (recFormat == "mkv") {
-			ui->autoRemux->setText(
-				QTStr("Basic.Settings.Advanced.AutoRemux")
-					.arg("mov"));
-		} else if (recFormat == "mov") {
-			if (!warningMsg.isEmpty())
-				warningMsg += "\n\n";
-			warningMsg += QTStr("OutputWarnings.MP4Recording");
-
-			ui->autoRemux->setText(
-				QTStr("Basic.Settings.Advanced.AutoRemux")
-					.arg("mov") +
-				" " +
-				QTStr("Basic.Settings.Advanced.AutoRemux.MP4"));
-		} else {
-			if (!errorMsg.isEmpty()) {
-				errorMsg += "\n\n";
-			}
-
-			errorMsg += QTStr("OutputWarnings.ProResRecording")
-					    .arg(recFormat);
-		}
+		warningMsg += QTStr("OutputWarnings.MP4Recording");
+		ui->autoRemux->setText(
+			QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4") +
+			" " + QTStr("Basic.Settings.Advanced.AutoRemux.MP4"));
 	} else {
-		if (recFormat == "mp4" || recFormat == "mov") {
-			if (!warningMsg.isEmpty())
-				warningMsg += "\n\n";
-
-			warningMsg += QTStr("OutputWarnings.MP4Recording");
-			ui->autoRemux->setText(
-				QTStr("Basic.Settings.Advanced.AutoRemux")
-					.arg("mp4") +
-				" " +
-				QTStr("Basic.Settings.Advanced.AutoRemux.MP4"));
-		} else {
-			ui->autoRemux->setText(
-				QTStr("Basic.Settings.Advanced.AutoRemux")
-					.arg("mp4"));
-		}
+		ui->autoRemux->setText(
+			QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4"));
 	}
 
 	delete advOutRecWarning;

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -446,6 +446,7 @@ private slots:
 
 	void AdvOutSplitFileChanged();
 	void AdvOutRecCheckWarnings();
+	void AdvOutRecCheckCodecs();
 
 	void SimpleRecordingQualityChanged();
 	void SimpleRecordingEncoderChanged();

--- a/deps/libff/libff/ff-util.c
+++ b/deps/libff/libff/ff-util.c
@@ -447,3 +447,29 @@ void ff_format_desc_free(const struct ff_format_desc *format_desc)
 		desc = next;
 	}
 }
+
+
+bool ff_format_codec_compatible(const char *codec, const char *format)
+{
+	if (!codec || !format)
+		return false;
+
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
+	AVOutputFormat *output_format;
+#else
+	const AVOutputFormat *output_format;
+#endif
+	output_format = av_guess_format(format, NULL, NULL);
+	if (!output_format)
+		return false;
+	
+	const AVCodecDescriptor *codec_desc = avcodec_descriptor_get_by_name(codec);
+	if (!codec_desc)
+		return false;
+	
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 0, 100)
+	return avformat_query_codec(output_format, codec_desc->id, FF_COMPLIANCE_EXPERIMENTAL) == 1;
+#else
+	return avformat_query_codec(output_format, codec_desc->id, FF_COMPLIANCE_NORMAL) == 1;
+#endif
+}

--- a/deps/libff/libff/ff-util.h
+++ b/deps/libff/libff/ff-util.h
@@ -62,6 +62,9 @@ ff_format_desc_get_default_name(const struct ff_format_desc *format_desc,
 const struct ff_format_desc *
 ff_format_desc_next(const struct ff_format_desc *format_desc);
 
+// Utility to check compatibility
+bool ff_format_codec_compatible(const char *codec, const char *format);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description

Disable codecs that are incompatible based on the container drop down state. If an incompatible codec is selected when changing container, the encoder selection is reset to an invalid state and a warning is shown.

**Screenshot:**
![2023-03-24_11-30-51_cCsexx](https://user-images.githubusercontent.com/3123295/227497857-79affbf6-080c-479c-aabb-05dfe5b59612.png)

### Motivation and Context

Wanted to avoid having to add more warnings for Opus and #8289

### How Has This Been Tested?

Selected different contaiers, ensured codecs got disabled as necessary. Also tested with #8289 and made sure that works correctly.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
