### PR TITLE
UI: Fix inconsistencies in FindProtocol 

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -533,11 +533,14 @@ void OBSBasicSettings::ServiceChanged()
 
 QString OBSBasicSettings::FindProtocol()
 {
-	if (IsCustomService() && !ui->customServer->text().isEmpty()) {
+	if (IsCustomService()) {
+		if (ui->customServer->text().isEmpty())
+			return QString("RTMP");
 
 		QString server = ui->customServer->text();
 
-		if (server.startsWith("rtmps://"))
+		if (obs_is_output_protocol_registered("RTMPS") &&
+		    server.startsWith("rtmps://"))
 			return QString("RTMPS");
 
 		if (server.startsWith("ftl://"))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix inconsistencies that might lead to issue or even a crash.

Note: The else branch should not have been taken in custom server scenarios.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix a crash reported on discord: https://discord.com/channels/348973006581923840/374636084883095554/1087384798894501939

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Switch from a FTL service to custom (with empty server URL) and the encoder warning shown up. Without the fix it doesn't show.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
