### PR TITLE
graphics-hook: Handle VK_KHR_imageless_framebuffer

### DIFF
--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -13,7 +13,7 @@
 
 #define HOOK_VER_MAJOR 1
 #define HOOK_VER_MINOR 8
-#define HOOK_VER_PATCH 0
+#define HOOK_VER_PATCH 1
 
 #ifndef STRINGIFY
 #define STRINGIFY(s) #s

--- a/plugins/win-capture/graphics-hook/vulkan-capture.h
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.h
@@ -42,6 +42,13 @@ struct vk_device_funcs {
 	DEF_FUNC(DestroyFence);
 	DEF_FUNC(WaitForFences);
 	DEF_FUNC(ResetFences);
+	DEF_FUNC(CreateImageView);
+	DEF_FUNC(DestroyImageView);
+	DEF_FUNC(CreateFramebuffer);
+	DEF_FUNC(DestroyFramebuffer);
+	DEF_FUNC(CmdBeginRenderPass);
+	DEF_FUNC(CmdBeginRenderPass2KHR);
+	DEF_FUNC(CmdBeginRenderPass2);
 };
 
 #undef DEF_FUNC


### PR DESCRIPTION
### Description
Applications that use this Vulkan extension would have image usage mismatches because we add VK_IMAGE_USAGE_TRANSFER_SRC_BIT to VkSwapchainCreateInfoKHR::imageUsage, so make the same modification to VkFramebufferAttachmentImageInfo::usage.

### Motivation and Context
Vulkan hook stability.

### How Has This Been Tested?
- [x] Unmodified cube sample still works (doesn't use VK_KHR_imageless_framebuffer)
- [x] Cube sample modified to use VK_KHR_imageless_framebuffer and BeginRenderPass2KHR extension throws validation errors without PR changes and no validation errors with PR changes
- [x] Cube sample modified to use VK_KHR_imageless_framebuffer, API 1.2, and BeginRenderPass2 throws validation errors without PR changes and no validation errors with PR changes
- [x] Debugger inspection to check attachment count is clamped to mask size (32) when greater
- [x] Debugger inspection to check color attachment count is clamped to 8 when greater
- [x] Debugger inspection to check several permutations of color attachments generate the correct number of framebuffer variants with the correct masks when creating a framebuffer, and are cleaned up properly when destroyed
- [x] Debugger inspection to check swap view nodes are removed and freed from the tracking collection when image views are destroyed
- [x] Debugger inspection to check several permutations of swap image views are processed correctly when using BeginRenderPass
- [x] Doom 2016 still captures fine
- [x] cube and Doom 2016 both work even if vk_data::valid is forced off in code so OBS does not capture either

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.