### PR TITLE
Properly handle SIGINT on non-Windows platforms

### DIFF
--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -20,6 +20,9 @@
 #include <QApplication>
 #include <QTranslator>
 #include <QPointer>
+#ifndef _WIN32
+#include <QSocketNotifier>
+#endif
 #include <obs.hpp>
 #include <util/lexer.h>
 #include <util/profiler.h>
@@ -125,6 +128,11 @@ private:
 
 	bool notify(QObject *receiver, QEvent *e) override;
 
+#ifndef _WIN32
+	static int sigintFd[2];
+	QSocketNotifier *snInt = nullptr;
+#endif
+
 public:
 	OBSApp(int &argc, char **argv, profiler_name_store_t *store);
 	~OBSApp();
@@ -208,9 +216,13 @@ public:
 	}
 
 	inline void PopUITranslation() { translatorHooks.pop_front(); }
+#ifndef _WIN32
+	static void SigIntSignalHandler(int);
+#endif
 
 public slots:
 	void Exec(VoidFunc func);
+	void ProcessSigInt();
 
 signals:
 	void StyleChanged();


### PR DESCRIPTION
### Description
Running Qt code in a signal handler is not safe. Per the Qt docs, we instead create a pair of sockets and a `QSocketNotifier` so that the signal handler can notify the main thread which can process the exit request without risk.

https://man7.org/linux/man-pages/man7/signal-safety.7.html
https://doc.qt.io/archives/qt-6.3/unix-signals.html

### Motivation and Context
Make sure OBS handles Ctrl+C safely when run in a terminal.

### How Has This Been Tested?
Tested on Debian 11, other *nix variants likely need testing too assuming this even builds on non-Linux...

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
