### PR TITLE
UI: Remove unused variables to fix errors in the CMake 3.0 rework

### DIFF
--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -141,7 +141,6 @@ static void PopulateBitrateLists()
 	call_once(once, []() {
 		struct obs_audio_info aoi;
 		obs_get_audio_info(&aoi);
-		uint32_t output_channels = get_audio_channels(aoi.speakers);
 
 		/* NOTE: ffmpeg_aac and ffmpeg_opus have the same properties
 		 * their bitrates will also be used as a fallback */
@@ -275,7 +274,6 @@ static void PopulateSimpleOpusBitrateMap()
 	call_once(once, []() {
 		struct obs_audio_info aoi;
 		obs_get_audio_info(&aoi);
-		uint32_t output_channels = get_audio_channels(aoi.speakers);
 
 		for (auto &bitrate : fallbackBitrates)
 			simpleOpusBitrateMap[bitrate] = "ffmpeg_opus";

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1060,9 +1060,6 @@ bool SimpleOutput::SetupStreaming(obs_service_t *service)
 			obs_output_get_signal_handler(streamOutput), "stop",
 			OBSStopStreaming, this);
 
-		bool isEncoded = obs_output_get_flags(streamOutput) &
-				 OBS_OUTPUT_ENCODED;
-
 		outputType = type;
 	}
 
@@ -1975,9 +1972,6 @@ inline void AdvancedOutput::SetupVodTrack(obs_service_t *service)
 
 bool AdvancedOutput::SetupStreaming(obs_service_t *service)
 {
-	int streamTrack =
-		config_get_int(main->Config(), "AdvOut", "TrackIndex");
-
 	if (!useStreamEncoder ||
 	    (!ffmpegOutput && !obs_output_active(fileOutput))) {
 		UpdateStreamSettings();
@@ -2028,9 +2022,6 @@ bool AdvancedOutput::SetupStreaming(obs_service_t *service)
 		stopStreaming.Connect(
 			obs_output_get_signal_handler(streamOutput), "stop",
 			OBSStopStreaming, this);
-
-		bool isEncoded = obs_output_get_flags(streamOutput) &
-				 OBS_OUTPUT_ENCODED;
 
 		outputType = type;
 	}


### PR DESCRIPTION
### Description
Removes unused variables in recently updated source code.

### Motivation and Context
CMake 3.0 rework has stricter warning settings than master branch and will break on unused variables left in code.

### How Has This Been Tested?
Successfully compiled with CMake 3.0 rework active.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
