### PR TITLE
obs-frontend-api: Deprecate set and save service functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,4 +15,4 @@
 	url = https://github.com/Mixer/ftl-sdk.git
 [submodule "plugins/obs-websocket"]
 	path = plugins/obs-websocket
-	url = https://github.com/obsproject/obs-websocket.git
+	url = https://github.com/tytan652/obs-websocket.git

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -199,9 +199,10 @@ EXPORT obs_output_t *obs_frontend_get_replay_buffer_output(void);
 EXPORT config_t *obs_frontend_get_profile_config(void);
 EXPORT config_t *obs_frontend_get_global_config(void);
 
-EXPORT void obs_frontend_set_streaming_service(obs_service_t *service);
+OBS_DEPRECATED EXPORT void
+obs_frontend_set_streaming_service(obs_service_t *service);
 EXPORT obs_service_t *obs_frontend_get_streaming_service(void);
-EXPORT void obs_frontend_save_streaming_service(void);
+OBS_DEPRECATED EXPORT void obs_frontend_save_streaming_service(void);
 
 EXPORT bool obs_frontend_preview_program_mode_active(void);
 EXPORT void obs_frontend_set_preview_program_mode(bool enable);

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -661,6 +661,8 @@ Functions
 
    :param service: The streaming service to set
 
+.. deprecated:: 29.1
+
 ---------------------------------------
 
 .. function:: obs_service_t *obs_frontend_get_streaming_service(void)
@@ -673,6 +675,8 @@ Functions
 .. function:: void obs_frontend_save_streaming_service(void)
 
    Saves the current streaming service data.
+
+.. deprecated:: 29.1
 
 ---------------------------------------
 

--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -54,7 +54,7 @@
 #ifdef _MSC_VER
 #define PRAGMA_WARN_PUSH __pragma(warning(push))
 #define PRAGMA_WARN_POP __pragma(warning(pop))
-#define PRAGMA_WARN_DEPRECATION
+#define PRAGMA_WARN_DEPRECATION __pragma(warning(disable : 4996))
 #define PRAGMA_WARN_STRINGOP_OVERFLOW
 #elif defined(__clang__)
 #define PRAGMA_WARN_PUSH _Pragma("clang diagnostic push")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Depends on:
 - https://github.com/obsproject/obs-websocket/pull/1114

RFC 39 is plan to overhaul services in OBS Studio, unfortunately those functions need to be deprecated and then dropped while landing RFC 39 to avoid issues.

`obs_frontend_save_streaming_service`, plugin should not be able to override what is saved by the settings window.

Since output selection is planned to be moved in settings, `obs_frontend_set_streaming_service` allows to set a service that might mismatch the used output (and even encoders depending on the protocol and services).

At the present time, I can't promise replacement for those functions in RFC 39.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Make a clean deprecation plan for those functions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Deprecation

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
