### PR TITLE
UI: Switch RecFormat to RecFormat2

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -834,7 +834,7 @@ void SimpleOutput::UpdateRecordingAudioSettings()
 	int tracks =
 		config_get_int(main->Config(), "SimpleOutput", "RecTracks");
 	const char *recFormat =
-		config_get_string(main->Config(), "SimpleOutput", "RecFormat");
+		config_get_string(main->Config(), "SimpleOutput", "RecFormat2");
 	const char *quality =
 		config_get_string(main->Config(), "SimpleOutput", "RecQuality");
 	bool flv = strcmp(recFormat, "flv") == 0;
@@ -1024,7 +1024,7 @@ inline void SimpleOutput::SetupOutputs()
 	int tracks =
 		config_get_int(main->Config(), "SimpleOutput", "RecTracks");
 	const char *recFormat =
-		config_get_string(main->Config(), "SimpleOutput", "RecFormat");
+		config_get_string(main->Config(), "SimpleOutput", "RecFormat2");
 	bool flv = strcmp(recFormat, "flv") == 0;
 
 	if (usingRecordingPreset) {
@@ -1228,7 +1228,7 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 void SimpleOutput::UpdateRecording()
 {
 	const char *recFormat =
-		config_get_string(main->Config(), "SimpleOutput", "RecFormat");
+		config_get_string(main->Config(), "SimpleOutput", "RecFormat2");
 	bool flv = strcmp(recFormat, "flv") == 0;
 	int tracks =
 		config_get_int(main->Config(), "SimpleOutput", "RecTracks");
@@ -1308,8 +1308,6 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 		config_get_int(main->Config(), "SimpleOutput", "RecRBSize");
 	int tracks =
 		config_get_int(main->Config(), "SimpleOutput", "RecTracks");
-	const char *recFormat =
-		config_get_string(main->Config(), "SimpleOutput", "RecFormat");
 
 	bool is_fragmented = strcmp(format, "fmp4") == 0 ||
 			     strcmp(format, "fmov") == 0;


### PR DESCRIPTION
### Description
Commit f1223ca566473bc90cf3643711db742b3d976c9c
(UI: Set fragmented MP4/MOV as default for beta/rc) changed RecFormat to RecFormat2.
This conflicts with the use of RecFormat introduced in d18b38e784a1e8ffef4ded32eece7bf6b7ef0589
(UI: Enable multiple audio tracks in Simple Output recording). This fixes the issue.
An unused var is also removed.

### Motivation and Context
RecFormat no longer has a default. This causes a bug when one tries to load the setting.
This fixes it.

### How Has This Been Tested?
Tested that with a new profile recording works oob.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
