### PR TITLE
libobs: Fix VIDEO_FORMAT_V210 shader for GLSL

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -927,56 +927,56 @@ float4 PSP010_HLG_2020_709_Reverse(VertTexPos frag_in) : TARGET
 
 float3 compute_v210_reverse(float2 pos)
 {
-	uint x = (uint)pos.x;
-	uint packed_x = x % 6;
-	uint base_x = (x / 6) * 4;
+	uint x = uint(pos.x);
+	uint packed_x = x % 6u;
+	uint base_x = x / 6u * 4u;
 	float y, cb, cr;
-	if (packed_x == 0)
+	if (packed_x == 0u)
 	{
 		float3 word0_rgb = image.Load(int3(base_x, pos.y, 0)).rgb;
 		y = word0_rgb.y;
 		cb = word0_rgb.x;
 		cr = word0_rgb.z;
 	}
-	else if (packed_x == 1)
+	else if (packed_x == 1u)
 	{
 		float2 word0_rb = image.Load(int3(base_x, pos.y, 0)).rb;
-		float2 word1_rg = image.Load(int3(base_x + 1, pos.y, 0)).rg;
+		float2 word1_rg = image.Load(int3(base_x + 1u, pos.y, 0)).rg;
 		y = word1_rg.x;
 		cb = (word0_rb.x + word1_rg.y) * 0.5;
-		cr = (word0_rb.y + image.Load(int3(base_x + 2, pos.y, 0)).r) * 0.5;
+		cr = (word0_rb.y + image.Load(int3(base_x + 2u, pos.y, 0)).r) * 0.5;
 	}
-	else if (packed_x == 2)
+	else if (packed_x == 2u)
 	{
-		float2 word1_gb = image.Load(int3(base_x + 1, pos.y, 0)).gb;
+		float2 word1_gb = image.Load(int3(base_x + 1u, pos.y, 0)).gb;
 		y = word1_gb.y;
 		cb = word1_gb.x;
-		cr = image.Load(int3(base_x + 2, pos.y, 0)).r;
+		cr = image.Load(int3(base_x + 2u, pos.y, 0)).r;
 	}
-	else if (packed_x == 3)
+	else if (packed_x == 3u)
 	{
-		float2 word2_rb = image.Load(int3(base_x + 2, pos.y, 0)).rb;
-		y = image.Load(int3(base_x + 2, pos.y, 0)).g;
-		cb = (image.Load(int3(base_x + 1, pos.y, 0)).g + word2_rb.y) * 0.5;
-		cr = (word2_rb.x + image.Load(int3(base_x + 3, pos.y, 0)).g) * 0.5;
+		float2 word2_rb = image.Load(int3(base_x + 2u, pos.y, 0)).rb;
+		y = image.Load(int3(base_x + 2u, pos.y, 0)).g;
+		cb = (image.Load(int3(base_x + 1u, pos.y, 0)).g + word2_rb.y) * 0.5;
+		cr = (word2_rb.x + image.Load(int3(base_x + 3u, pos.y, 0)).g) * 0.5;
 	}
-	else if (packed_x == 4)
+	else if (packed_x == 4u)
 	{
-		float2 word3_rg = image.Load(int3(base_x + 3, pos.y, 0)).rg;
+		float2 word3_rg = image.Load(int3(base_x + 3u, pos.y, 0)).rg;
 		y = word3_rg.x;
-		cb = image.Load(int3(base_x + 2, pos.y, 0)).b;
+		cb = image.Load(int3(base_x + 2u, pos.y, 0)).b;
 		cr = word3_rg.y;
 	}
 	else
 	{
-		float2 word3_gb = image.Load(int3(base_x + 3, pos.y, 0)).gb;
+		float2 word3_gb = image.Load(int3(base_x + 3u, pos.y, 0)).gb;
 		y = word3_gb.y;
-		cb = image.Load(int3(base_x + 2, pos.y, 0)).b;
+		cb = image.Load(int3(base_x + 2u, pos.y, 0)).b;
 		cr = word3_gb.x;
-		uint base_x_4 = base_x + 4;
+		uint base_x_4 = base_x + 4u;
 		if ((pos.x + 1.) < width)
 		{
-			float2 word4_gb = image.Load(int3(base_x + 4, pos.y, 0)).rb;
+			float2 word4_gb = image.Load(int3(base_x + 4u, pos.y, 0)).rb;
 			cb = (cb + word4_gb.x) * 0.5;
 			cr = (cr + word4_gb.y) * 0.5;
 		}
@@ -990,14 +990,14 @@ float3 compute_v210_reverse(float2 pos)
 
 float4 PSV210_SRGB_Reverse(FragPos frag_in) : TARGET
 {
-	float3 rgb = compute_v210_reverse(frag_in.pos);
+	float3 rgb = compute_v210_reverse(frag_in.pos.xy);
 	rgb = srgb_nonlinear_to_linear(rgb);
 	return float4(rgb, 1.);
 }
 
 float4 PSV210_PQ_2020_709_Reverse(FragPos frag_in) : TARGET
 {
-	float3 pq = compute_v210_reverse(frag_in.pos);
+	float3 pq = compute_v210_reverse(frag_in.pos.xy);
 	float3 hdr2020 = st2084_to_linear_eetf(pq, hdr_lw, hdr_lmax) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
 	return float4(rgb, 1.);
@@ -1005,7 +1005,7 @@ float4 PSV210_PQ_2020_709_Reverse(FragPos frag_in) : TARGET
 
 float4 PSV210_HLG_2020_709_Reverse(FragPos frag_in) : TARGET
 {
-	float3 hlg = compute_v210_reverse(frag_in.pos);
+	float3 hlg = compute_v210_reverse(frag_in.pos.xy);
 	float3 hdr2020 = hlg_to_linear(hlg, hlg_exponent) * maximum_over_sdr_white_nits;
 	float3 rgb = rec2020_to_rec709(hdr2020);
 	return float4(rgb, 1.);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixed these errors reported by GLSL.

- Type cast `(uint)pos.x` is not accepted by GLSL. It should be `uint(pos.x)`.
- GLSL is strictly compare types so that an implicit arithmetic operation with `int` and `uint` are not allowed.
- It was passing `float4` type variable to `float2` argument.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

OBS says error below and failed to initialize video.
```plain
error: Error compiling shader:
0:49(16): error: syntax error, unexpected ')', expecting '('
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36
Hardware: AMD Radeon RX 6600 + Intel i7-7700.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  - Only tested on Linux. It should be tested with HLSL on Windows.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
