### PR TITLE
libobs: Add missing VIDEO_FORMAT_V210 handling in switch statements

### DIFF
--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -371,6 +371,7 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 	case VIDEO_FORMAT_BGRX:
 	case VIDEO_FORMAT_BGR3:
 	case VIDEO_FORMAT_AYUV:
+	case VIDEO_FORMAT_V210:
 		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
 		break;
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -779,6 +779,7 @@ static void set_gpu_converted_data(struct video_frame *output,
 	case VIDEO_FORMAT_YUVA:
 	case VIDEO_FORMAT_YA2L:
 	case VIDEO_FORMAT_AYUV:
+	case VIDEO_FORMAT_V210:
 		/* unimplemented */
 		;
 	}


### PR DESCRIPTION
### Description
Adds explicit handling of recently introduced `VIDEO_FORMAT_V210` enum value to all switch statements in `libobs`. 

### Motivation and Context
Format was added to enum but not handled in all switch statement handling the enum, which breaks warnings-as-errors about non-exhaustive switch statements.

### How Has This Been Tested?
Compiled successfully with stricter warnings enabled.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
