### PR TITLE
obs-outputs: Fix compilation without ENABLE_HEVC

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -359,7 +359,8 @@ void flv_packet_frames(struct encoder_packet *packet, enum video_id_t codec,
 		      (codec == CODEC_HEVC) ? PACKETTYPE_FRAMESX
 					    : PACKETTYPE_FRAMES);
 #else
-	flv_packet_ex(packet, dts_offset, output, size, PACKETTYPE_FRAMES);
+	flv_packet_ex(packet, codec, dts_offset, output, size,
+		      PACKETTYPE_FRAMES);
 #endif
 }
 


### PR DESCRIPTION
### Description

Fixes compiling without `ENABLE_HEVC`.

### Motivation and Context

Somebody broke it.

### How Has This Been Tested?

Compiled without it.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
