### PR TITLE
CI: Prevent build artifact creation for macOS without pushed tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,14 +156,22 @@ jobs:
           fi
 
       - name: 'Create build artifact'
-        if: ${{ success() && fromJSON(needs.config.outputs.create_artifacts) }}
+        if: ${{ fromJSON(needs.config.outputs.create_artifacts) }}
         run: |
-          CI/macos/03_package_obs.sh --codesign --architecture "${{ matrix.arch }}"
-          ARTIFACT_NAME=$(basename $(/usr/bin/find build_${{ matrix.arch }} -type f -name "obs-studio-*.dmg" -depth 1 | head -1))
-          echo "FILE_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+          : ${PACKAGE:=}
+          case "${GITHUB_EVENT_NAME}" in
+              push) if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta).+)? ]]; then PACKAGE=1; fi ;;
+              pull_request) PACKAGE=1 ;;
+          esac
+
+          if [[ "${PACKAGE}" ]]; then
+            CI/macos/03_package_obs.sh --codesign --architecture "${{ matrix.arch }}"
+            ARTIFACT_NAME=$(basename $(/usr/bin/find build_${{ matrix.arch }} -type f -name "obs-studio-*.dmg" -depth 1 | head -1))
+            echo "FILE_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
+          fi
 
       - name: 'Upload build Artifact'
-        if: ${{ success() && fromJSON(needs.config.outputs.create_artifacts) }}
+        if: ${{ fromJSON(needs.config.outputs.create_artifacts) && env.FILE_NAME != '' }}
         uses: actions/upload-artifact@v3
         with:
           name: 'obs-studio-macos-${{ matrix.arch }}-${{ steps.setup.outputs.commitHash }}'


### PR DESCRIPTION
### Description
Fixes macOS CI runs on master pushes.

### Motivation and Context
Pushes to master will use faster Ninja builds on macOS, which cannot generate macOS app bundles anymore. Thus packaging will only work with PR pushes (and the "Seeking Testers" label set) or upon pushing a release tag to the master branch.

### How Has This Been Tested?
Tested with a push to master on my own fork.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
