### PR TITLE
cmake: Fix obs-frontend-apiConfig.cmake included from 3rd party plugin

### DIFF
--- a/UI/obs-frontend-api/cmake/obs-frontend-apiConfig.cmake.in
+++ b/UI/obs-frontend-api/cmake/obs-frontend-apiConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(OBS::libobs REQUIRED)
+find_dependency(libobs REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Use `find_dependency(libobs REQUIRED)` instead of `find_dependency(OBS::libobs REQUIRED)`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

3rd party plugin that has the line below will fail to run cmake.
```cmake
find_package(obs-frontend-api REQUIRED)
```

The error message is as below.
```plain
CMake Error at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:47 (find_package):
  By not providing "FindOBS::libobs.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "OBS::libobs", but CMake did not find one.

  Could not find a package configuration file provided by "OBS::libobs" with
  any of the following names:

    OBS::libobsConfig.cmake
    obs::libobs-config.cmake

  Add the installation prefix of "OBS::libobs" to CMAKE_PREFIX_PATH or set
  "OBS::libobs_DIR" to a directory containing one of the above files.  If
  "OBS::libobs" provides a separate development package or SDK, be sure it
  has been installed.
```

During configuration of the 3rd party plugin, cmake tries to find `OBS::libobsConfig.cmake` but there is no such file.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36

Tested with [obs-plugintemplate](https://github.com/obsproject/obs-plugintemplate) with a modification below.
```patch
diff --git a/CMakeLists.txt b/CMakeLists.txt
index 3b060d6..3e630c5 100644
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,11 +24,8 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.c)
 find_package(libobs REQUIRED)
 include(cmake/ObsPluginHelpers.cmake)
 
-# Uncomment these lines if you want to use the OBS Frontend API in your plugin
-#[[
 find_package(obs-frontend-api REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::obs-frontend-api)
-#]]
 
 # Uncomment those lines if you want to use Qt in your plugin
 #[[
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits are squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
