### PR TITLE
UI: Fix simple stream encoder changed signal-slot connection

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1012,7 +1012,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		SLOT(UseStreamKeyAdvClicked()));
 
 	connect(ui->simpleOutStrAEncoder, SIGNAL(currentIndexChanged(int)),
-		this, SLOT(SimpleStreamAudioEncoderChanged));
+		this, SLOT(SimpleStreamAudioEncoderChanged()));
 	connect(ui->advOutAEncoder, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(AdvAudioEncodersChanged()));
 	connect(ui->advOutRecAEncoder, SIGNAL(currentIndexChanged(int)), this,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a signal-slot connection that was missing brackets.
This kind of error is what the new connection style would have been caught at compile-time for but that doesn't work with QComboBox::currentIndexChanged in Qt 5.12 which we unfortunately still support.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Qt yelled at me when opening the settings dialog. This code clearly wasn't tested before.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2.1
Changed my local services.json to have Youtube support both AAC and OPUS.

Confirmed that without this change, the slot doesn't get called when changing audio encoders in simple mode and as such the selectable bitrates don't change.
With this change, the slot does get called when switching between AAC and OPUS and the selectable bitrates change as well.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
