### PR TITLE
UI: Disallow closing settings without selected codec or format

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1335,6 +1335,10 @@ OutputWarnings.CodecIncompatible="The audio or video encoder selection was reset
 CodecCompat.Incompatible="(Incompatible with %1)"
 CodecCompat.CodecPlaceholder="Select Encoder..."
 CodecCompat.ContainerPlaceholder="Select Format..."
+CodecCompat.CodecMissingOnExit.Title="No Encoder Selected"
+CodecCompat.CodecMissingOnExit.Text="At least one video or audio encoder is not set. Please make sure to select encoders for both recording and streaming."
+CodecCompat.ContainerMissingOnExit.Title="No Format Selected"
+CodecCompat.ContainerMissingOnExit.Text="No recording format has been selected. Please select a recording format that is compatible with the selected stream encoder."
 
 # deleting final scene
 FinalScene.Title="Delete Scene"

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4196,6 +4196,9 @@ bool OBSBasicSettings::QueryChanges()
 	if (button == QMessageBox::Cancel) {
 		return false;
 	} else if (button == QMessageBox::Yes) {
+		if (!QueryAllowedToClose())
+			return false;
+
 		SaveSettings();
 	} else {
 		if (savedTheme != App()->GetTheme())
@@ -4206,6 +4209,44 @@ bool OBSBasicSettings::QueryChanges()
 	}
 
 	ClearChanged();
+	return true;
+}
+
+bool OBSBasicSettings::QueryAllowedToClose()
+{
+	bool simple = (ui->outputMode->currentIndex() == 0);
+
+	bool invalidEncoder = false;
+	bool invalidFormat = false;
+	if (simple) {
+		if (ui->simpleOutRecEncoder->currentIndex() == -1 ||
+		    ui->simpleOutStrEncoder->currentIndex() == -1 ||
+		    ui->simpleOutRecAEncoder->currentIndex() == -1 ||
+		    ui->simpleOutStrAEncoder->currentIndex() == -1)
+			invalidEncoder = true;
+
+		if (ui->simpleOutRecFormat->currentIndex() == -1)
+			invalidFormat = true;
+	} else {
+		if (ui->advOutRecEncoder->currentIndex() == -1 ||
+		    ui->advOutEncoder->currentIndex() == -1 ||
+		    ui->advOutRecAEncoder->currentIndex() == -1 ||
+		    ui->advOutAEncoder->currentIndex() == -1)
+			invalidEncoder = true;
+	}
+
+	if (invalidEncoder) {
+		OBSMessageBox::warning(
+			this, QTStr("CodecCompat.CodecMissingOnExit.Title"),
+			QTStr("CodecCompat.CodecMissingOnExit.Text"));
+		return false;
+	} else if (invalidFormat) {
+		OBSMessageBox::warning(
+			this, QTStr("CodecCompat.ContainerMissingOnExit.Title"),
+			QTStr("CodecCompat.ContainerMissingOnExit.Text"));
+		return false;
+	}
+
 	return true;
 }
 
@@ -4258,6 +4299,9 @@ void OBSBasicSettings::on_buttonBox_clicked(QAbstractButton *button)
 
 	if (val == QDialogButtonBox::ApplyRole ||
 	    val == QDialogButtonBox::AcceptRole) {
+		if (!QueryAllowedToClose())
+			return;
+
 		SaveSettings();
 		ClearChanged();
 	}

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -224,6 +224,7 @@ private:
 	void HookWidget(QWidget *widget, const char *signal, const char *slot);
 
 	bool QueryChanges();
+	bool QueryAllowedToClose();
 
 	void ResetEncoders(bool streamOnly = false);
 	void LoadColorRanges();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a message preventing the user from saving the settings if they have a config where an encoder or container is set to "Select Encoder/Format".
<img width="431" alt="image" src="https://user-images.githubusercontent.com/59806498/228106390-1bdc095d-323a-4c6d-bfd5-448869ad7cd5.png">
I'm not 100% sold on the strings used here, feedback on those (especially by native english speakers) would be appreciated.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, this UX workflow is possible:

https://user-images.githubusercontent.com/59806498/228105567-c4560301-3853-4918-8314-43adbe9330de.mov

The user can easily miss that the field they just set changed to "Select Encoder...", and then go on with their lives, saving the settings, starting a recording and get the generic error (or alternatively get the incompatible encoder that was selected before to start recording, usually resulting in another opaque error message).

This doesn't fix the fact that the warning at the bottom can be missed easily after selecting the incompatible encoder, but makes sure that the user won't end up with an invalid configuration and the generic "Failed to start recording" message.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.2.1
Tried to exit settings with several combinations of incompatible codecs in both advanced and simple mode.
Not all of the scenarios that are caught here can actually be reached currently, such as the incompatible container in advanced mode, but since that might change in the future I still added the checks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
