### PR TITLE
UI: Fix preview rendering order

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4447,6 +4447,9 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 
 	window->ui->preview->DrawSceneEditing();
 
+	if (window->drawSpacingHelpers)
+		window->ui->preview->DrawSpacingHelpers();
+
 	uint32_t targetCX = window->previewCX;
 	uint32_t targetCY = window->previewCY;
 
@@ -4459,9 +4462,6 @@ void OBSBasic::RenderMain(void *data, uint32_t cx, uint32_t cy)
 		RenderSafeAreas(window->topLine, targetCX, targetCY);
 		RenderSafeAreas(window->rightLine, targetCX, targetCY);
 	}
-
-	if (window->drawSpacingHelpers)
-		window->ui->preview->DrawSpacingHelpers();
 
 	/* --------------------------------------- */
 


### PR DESCRIPTION
### Description
The spacing helpers were being rendered above the preview safe areas.

Before:
![Screenshot from 2023-03-28 04-25-09](https://user-images.githubusercontent.com/19962531/228193776-3dca2dce-ed04-4eb7-beda-7e1a44363be5.png)

After:
![Screenshot from 2023-03-28 04-30-21](https://user-images.githubusercontent.com/19962531/228193850-3e31b96e-e9d0-414b-b443-5009b56529cf.png)

### Motivation and Context
Fixes bug I noticed.

### How Has This Been Tested?
Enabled preview safe areas to make sure everything was rendered in the correct order.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
