### PR TITLE
UI: Improve AV1 fallbacks while changing services

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1354,12 +1354,14 @@ bool OBSBasicSettings::ServiceAndACodecCompatible()
 /* we really need a way to find fallbacks in a less hardcoded way. maybe. */
 static QString get_adv_fallback(const QString &enc)
 {
-	if (enc == "jim_hevc_nvenc")
+	if (enc == "jim_hevc_nvenc" || enc == "jim_av1_nvenc")
 		return "jim_nvenc";
-	if (enc == "h265_texture_amf")
+	if (enc == "h265_texture_amf" || enc == "av1_texture_amf")
 		return "h264_texture_amf";
 	if (enc == "com.apple.videotoolbox.videoencoder.ave.hevc")
 		return "com.apple.videotoolbox.videoencoder.ave.avc";
+	if (enc == "obs_qsv11_av1")
+		return "obs_qsv11";
 	return "obs_x264";
 }
 
@@ -1381,14 +1383,14 @@ static QString get_adv_audio_fallback(const QString &enc)
 
 static QString get_simple_fallback(const QString &enc)
 {
-	if (enc == SIMPLE_ENCODER_NVENC_HEVC)
+	if (enc == SIMPLE_ENCODER_NVENC_HEVC || enc == SIMPLE_ENCODER_NVENC_AV1)
 		return SIMPLE_ENCODER_NVENC;
-	if (enc == SIMPLE_ENCODER_NVENC_AV1)
-		return SIMPLE_ENCODER_NVENC;
-	if (enc == SIMPLE_ENCODER_AMD_HEVC)
+	if (enc == SIMPLE_ENCODER_AMD_HEVC || enc == SIMPLE_ENCODER_AMD_AV1)
 		return SIMPLE_ENCODER_AMD;
 	if (enc == SIMPLE_ENCODER_APPLE_HEVC)
 		return SIMPLE_ENCODER_APPLE_H264;
+	if (enc == SIMPLE_ENCODER_QSV_AV1)
+		return SIMPLE_ENCODER_QSV;
 	return SIMPLE_ENCODER_X264;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This makes AV1 encoders fallback to their H264 counterpart rather than just falling back to x264 while changing services.

AV1 streaming was still not a thing, now it is. It just a avoids falling back directly to x264 in some service change scenarios.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Better fallback, until we improve settings by avoiding hardcode.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I don't have AV1 HW encoders, sorry.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
