### PR TITLE
UI: Use UUIDs for QDataStream

### DIFF
--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -192,17 +192,16 @@ QDataStream &operator>>(QDataStream &in,
 
 QDataStream &operator<<(QDataStream &out, const OBSScene &scene)
 {
-	return out << QString(obs_source_get_name(obs_scene_get_source(scene)));
+	return out << QString(obs_source_get_uuid(obs_scene_get_source(scene)));
 }
 
 QDataStream &operator>>(QDataStream &in, OBSScene &scene)
 {
-	QString sceneName;
+	QString uuid;
 
-	in >> sceneName;
+	in >> uuid;
 
-	OBSSourceAutoRelease source =
-		obs_get_source_by_name(QT_TO_UTF8(sceneName));
+	OBSSourceAutoRelease source = obs_get_source_by_uuid(QT_TO_UTF8(uuid));
 	scene = obs_scene_from_source(source);
 
 	return in;


### PR DESCRIPTION
### Description
UUIDs are more robust than names as they can't be changed.

### Motivation and Context
More robust code.

### How Has This Been Tested?
Dragged / dropped scenes in scene tree.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
