### PR TITLE
CI: Disable Steam nightly upload

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -18,8 +18,6 @@ on:
       mac_arm_url_override:
         description: 'Mac ARM build to use (.dmg only)'
         required: false
-  schedule:
-  - cron: 0 0 * * *
 
 env:
   WORKFLOW_ID: 583765


### PR DESCRIPTION
### Description

Removes scheduled run from Steam Upload workflow.

### Motivation and Context

Due to 82f7a47438f6e39f350748ce63cffd94081faa99 and dc39edb23c11be3eef50bb777a3731dafea3f7a6 macOS builds no longer produce artifacts, which causes the nightly steam workflow to fail, so just disable it until the larger rework of workflows introduces a proper "nightly" build.

### How Has This Been Tested?

Has not.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
