### PR TITLE
Update win-dshow.cpp

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -860,9 +860,9 @@ static long long GetOBSFPS();
 static inline bool IsDelayedDevice(const VideoConfig &config)
 {
 	return config.format > VideoFormat::MJPEG ||
-	       (wstrstri(config.name.c_str(), L"elgato") != NULL &&
-		wstrstri(config.name.c_str(), L"facecam") == NULL) ||
-	       wstrstri(config.name.c_str(), L"stream engine") != NULL;
+	       wstrstri(config.name.c_str(), L"elgato game capture hd") !=
+		       nullptr ||
+	       wstrstri(config.name.c_str(), L"stream engine") != nullptr;
 }
 
 static inline bool IsDecoupled(const VideoConfig &config)


### PR DESCRIPTION
### Description
Currently buffering is enabled by default for Elgato capture devices due to an ancient patch.  

This PR disables buffering for Elgato devices by default except for "Elgato Game Capture HD" and devices that are producing encoded video.

### Motivation and Context
The old patch was only necessary only for the old capture devices "Game Capture HD" and "Game Capture HD60" that were accessed through a virtual capture device named "Elgato Game Capture HD".  These old devices delivered audio much later than video. Therefore buffering needed to be enabled to force OBS to respect timestamps.

All newer devices perform better and with lower latency when buffering is disabled.

### How Has This Been Tested?
I connected the old devices and "Game Capture HD" and "Game Capture HD60" and made sure buffering is still on by default.
I connected newer Elgato capture devices and made sure buffering is off and audio/video still in sync.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.