### PR TITLE
decklink: Query for preroll frame count

### DIFF
--- a/plugins/decklink/CMakeLists.txt
+++ b/plugins/decklink/CMakeLists.txt
@@ -49,6 +49,7 @@ target_link_libraries(decklink PRIVATE OBS::libobs OBS::caption Decklink::SDK)
 
 if(OS_WINDOWS)
   configure_file(cmake/windows/obs-module.rc.in win-decklink.rc)
+  target_compile_definitions(decklink PRIVATE NOMINMAX)
   target_sources(decklink PRIVATE win/platform.cpp win-decklink.rc)
 
   include(idlfilehelper)

--- a/plugins/decklink/cmake/legacy.cmake
+++ b/plugins/decklink/cmake/legacy.cmake
@@ -58,6 +58,7 @@ if(OS_WINDOWS)
   set(MODULE_DESCRIPTION "OBS DeckLink Windows module")
   configure_file(${CMAKE_SOURCE_DIR}/cmake/bundle/windows/obs-module.rc.in win-decklink.rc)
 
+  target_compile_definitions(decklink PRIVATE NOMINMAX)
   target_sources(decklink PRIVATE win/platform.cpp win-decklink.rc)
 
   target_sources(decklink-sdk INTERFACE win/decklink-sdk/DeckLinkAPIVersion.h ${win-decklink-sdk_GENERATED_FILES})

--- a/plugins/decklink/decklink-device-instance.hpp
+++ b/plugins/decklink/decklink-device-instance.hpp
@@ -70,7 +70,7 @@ protected:
 	std::vector<uint8_t> frameData;
 	BMDTimeValue frameDuration;
 	BMDTimeScale frameTimescale;
-	size_t totalFramesScheduled;
+	BMDTimeScale totalFramesScheduled;
 	ComPtr<RenderDelegate<DeckLinkDeviceInstance>> renderDelegate;
 
 	void FinalizeStream();

--- a/plugins/decklink/decklink-device.cpp
+++ b/plugins/decklink/decklink-device.cpp
@@ -114,6 +114,11 @@ bool DeckLinkDevice::Init()
 	attributes->GetInt(BMDDeckLinkSubDeviceIndex, &subDeviceIndex);
 	attributes->GetInt(BMDDeckLinkNumberOfSubDevices, &numSubDevices);
 
+	if (FAILED(attributes->GetInt(BMDDeckLinkMinimumPrerollFrames,
+				      &minimumPrerollFrames))) {
+		minimumPrerollFrames = 3;
+	}
+
 	decklink_string_t decklinkModelName;
 	decklink_string_t decklinkDisplayName;
 
@@ -253,6 +258,11 @@ int64_t DeckLinkDevice::GetSubDeviceCount()
 int64_t DeckLinkDevice::GetSubDeviceIndex()
 {
 	return subDeviceIndex;
+}
+
+int64_t DeckLinkDevice::GetMinimumPrerollFrames()
+{
+	return minimumPrerollFrames;
 }
 
 const std::string &DeckLinkDevice::GetName(void) const

--- a/plugins/decklink/decklink-device.hpp
+++ b/plugins/decklink/decklink-device.hpp
@@ -21,6 +21,7 @@ class DeckLinkDevice {
 	decklink_bool_t supportsInternalKeyer = false;
 	int64_t subDeviceIndex = 0;
 	int64_t numSubDevices = 0;
+	int64_t minimumPrerollFrames = 3;
 	int64_t supportedVideoInputConnections = -1;
 	int64_t supportedVideoOutputConnections = -1;
 	int64_t supportedAudioInputConnections = -1;
@@ -49,6 +50,7 @@ public:
 	bool GetSupportsInternalKeyer(void) const;
 	int64_t GetSubDeviceCount();
 	int64_t GetSubDeviceIndex();
+	int64_t GetMinimumPrerollFrames();
 	int GetKeyerMode(void);
 	void SetKeyerMode(int newKeyerMode);
 	const std::string &GetName(void) const;

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -36,7 +36,9 @@ static void *decklink_output_create(obs_data_t *settings, obs_output_t *output)
 		to.width = mode->GetWidth();
 		to.height = mode->GetHeight();
 		to.range = VIDEO_RANGE_FULL;
-		to.colorspace = VIDEO_CS_709;
+		struct obs_video_info ovi;
+		to.colorspace = obs_get_video_info(&ovi) ? ovi.colorspace
+							 : VIDEO_CS_DEFAULT;
 
 		obs_output_set_video_conversion(output, &to);
 	}


### PR DESCRIPTION
### Description
Three is recommended though, so use at least that many.

Also add commit to stop swscale from kicking in because of color space mismatch add chewing up CPU without actually fixing the colors.

### Motivation and Context
Correctness.

### How Has This Been Tested?
1080p and 2160p tested.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.