### PR TITLE
UI: Update Windows DLL blocklist

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -148,6 +148,10 @@ static blocked_module_t blocked_modules[] = {
 	// Korean banking "security" software, crashes randomly
 	{L"\\t_prevent64.dll", 0, 0, TS_IGNORE},
 
+	// Bandicam, doesn't unhook cleanly and freezes preview
+	// Reference: https://github.com/obsproject/obs-studio/issues/8552
+	{L"\\bdcam64.dll", 0, 0, TS_IGNORE},
+
 	// Generic named unity capture filter. Unfortunately only a forked version
 	// has a critical fix to prevent deadlocks during enumeration. We block
 	// all versions since if someone didn't change the DLL name they likely
@@ -164,6 +168,16 @@ static blocked_module_t blocked_modules[] = {
 	// Obsolete unfixed versions of VTuber Maker capture filter
 	{L"\\live3dvirtualcam\\lib64_new.dll", 0, 0, TS_IGNORE},
 	{L"\\live3dvirtualcam\\lib64.dll", 0, 0, TS_IGNORE},
+
+	// VirtualMotionCapture capture filter < 2022-12-18 without above fix
+	// Reference: https://github.com/obsproject/obs-studio/issues/8552
+	{L"\\vmc_camerafilter64bit.dll", 0, 1671349891, TS_LESS_THAN},
+
+	// HolisticMotionCapture capture filter, not yet patched. Blocking
+	// all previous versions in case an update is released.
+	// Reference: https://github.com/obsproject/obs-studio/issues/8552
+	{L"\\holisticmotioncapturefilter64bit.dll", 0, 1680044549,
+	 TS_LESS_THAN},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
### Description
Adds some additional DLLs to the blocklist based on reports in #8552:

- Bandicam: Freezes OBS preview when unhooking.
- VirtualMotionCapture: Old versions without Unity Capture fix.
- HolisticMotionCapture: All versions prior to today as there is no fixed version yet (also Unity Capture based).

### Motivation and Context
Freezing OBS is bad.

### How Has This Been Tested?
Untested, but strong evidence was presented in the issue showing the problems.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
