### PR TITLE
UI: Fix updater parameters missing a space

### DIFF
--- a/UI/update/win-update.cpp
+++ b/UI/update/win-update.cpp
@@ -367,8 +367,11 @@ try {
 	string parameters = "";
 	if (App()->IsPortableMode())
 		parameters += "--portable";
-	if (branch != WIN_DEFAULT_BRANCH)
+	if (branch != WIN_DEFAULT_BRANCH) {
+		if (!parameters.empty())
+			parameters += " ";
 		parameters += "--branch=" + branch;
+	}
 
 	BPtr<wchar_t> lpParameters;
 	size = os_utf8_to_wcs_ptr(parameters.c_str(), 0, &lpParameters);


### PR DESCRIPTION
### Description

Fixes portable mode installs + beta branches not updating correctly due to the updater not getting the correct arguments.

### Motivation and Context

This is wrong.

### How Has This Been Tested?

Has not.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
