### PR TITLE
updater: Add workaround for broken CLI arguments

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1433,6 +1433,12 @@ static bool Update(wchar_t *cmdLine)
 				} else if (wcscmp(argv[i], L"--portable") ==
 					   0) {
 					bIsPortable = true;
+				} else if (wcsncmp(argv[i],
+						   L"--portable--branch=",
+						   19) == 0) {
+					/* Versions pre-29.1 beta 2 produce broken parameters :( */
+					bIsPortable = true;
+					branch = argv[i] + 19;
 				}
 			}
 			LocalFree((HLOCAL)argv);


### PR DESCRIPTION
### Description

Adds a workaround so the updater works correctly with portable builds pre-#8566

### Motivation and Context

I'm an idiot.

### How Has This Been Tested?

Ran locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
