### PR TITLE
win-capture: Fix compat info showing in hotkey mode

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -2258,7 +2258,8 @@ static bool window_changed_callback(obs_properties_t *ppts, obs_property_t *p,
 			obs_data_get_bool(settings, SETTING_ANY_FULLSCREEN);
 	} else {
 		const char *mode = obs_data_get_string(settings, SETTING_MODE);
-		capture_any = strcmp(mode, SETTING_MODE_ANY) == 0;
+		capture_any = strcmp(mode, SETTING_MODE_ANY) == 0 ||
+			      strcmp(mode, SETTING_MODE_HOTKEY) == 0;
 	}
 
 	if (capture_any)


### PR DESCRIPTION
### Description

Fixes compat info showing in hotkey mode.

### Motivation and Context

:(

### How Has This Been Tested?

Hasn't but I'm fairly confident it'll work.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
