### PR TITLE
CI: Fix macOS packaging for notarisation and forward compatibility

### DIFF
--- a/CI/include/build_support_macos.sh
+++ b/CI/include/build_support_macos.sh
@@ -120,6 +120,7 @@ read_codesign_ident() {
         step "Set up code signing..."
         read -p "${COLOR_ORANGE}  + Apple developer identity: ${COLOR_RESET}" CODESIGN_IDENT
     fi
+    CODESIGN_IDENT_SHORT=$(echo "${CODESIGN_IDENT}" | /usr/bin/sed -En "s/.+\((.+)\)/\1/p")
 }
 
 ##############################################################################
@@ -149,7 +150,6 @@ read_codesign_pass() {
 
     step "Update notarization keychain..."
 
-    CODESIGN_IDENT_SHORT=$(echo "${CODESIGN_IDENT}" | /usr/bin/sed -En "s/.+\((.+)\)/\1/p")
     echo -n "${COLOR_ORANGE}"
     /usr/bin/xcrun notarytool store-credentials "OBS-Codesign-Password" --apple-id "${CODESIGN_IDENT_USER}" --team-id "${CODESIGN_IDENT_SHORT}" --password "${CODESIGN_IDENT_PASS}"
     echo -n "${COLOR_RESET}"

--- a/UI/cmake/macos/exportOptions-extension.plist.in
+++ b/UI/cmake/macos/exportOptions-extension.plist.in
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>provisioningProfiles</key>
+	<dict>
+		<key>com.obsproject.obs-studio</key>
+		<string>${OBS_PROVISIONING_PROFILE}</string>
+	</dict>
+	<key>signingCertificate</key>
+	<string>${OBS_CODESIGN_IDENTITY}</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+</dict>
+</plist>

--- a/UI/cmake/macos/exportOptions.plist.in
+++ b/UI/cmake/macos/exportOptions.plist.in
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>developer-id</string>
+	<key>signingCertificate</key>
+	<string>${OBS_CODESIGN_IDENTITY}</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+</dict>
+</plist>

--- a/cmake/macos/resources/package.applescript.in
+++ b/cmake/macos/resources/package.applescript.in
@@ -62,5 +62,9 @@ on run (volumeName)
             if (do shell script "[ -f " & dsStore & " ]; echo $?") = "0" then set ejectMe to true
         end repeat
         log "waited " & waitTime & " seconds for .DS_STORE to be created."
+
+        tell disk (volumeName as string)
+            close
+        end tell
     end tell
 end run


### PR DESCRIPTION
### Description
Fixes packaging on CI to use Xcode's archiving and extraction functionality, which also ensures that all binaries contained in an app bundle are code-signed and fulfil Apple's requirements for application distribution.

### Motivation and Context
Xcode's automatic packaging will not check an entire application bundle for missing code signatures. This job is handled by the archiving and extraction functionalities, which we haven't used before.

This PR changes the build and packaging script to use Xcode's own functionality, which also ensures that the resulting application bundle fulfils notarisation requirements.

Moving forward this will need to be extended to also use proper provisioning profiles (see the Camera Extension PR), which also needs to tap into Xcode's built-in functionality.

### How Has This Been Tested?
`xcodebuild` and `hdiutil` commands tested locally, script functionality can be tested by PR runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
