### PR TITLE
UI: Only adjust size of properties on first draw

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -108,12 +108,15 @@ void OBSPropertiesView::ReloadProperties()
 
 void OBSPropertiesView::RefreshProperties()
 {
+	bool firstDraw = false;
 	int h, v;
 	GetScrollPos(h, v);
 
 	children.clear();
 	if (widget)
 		widget->deleteLater();
+	else
+		firstDraw = true;
 
 	widget = new QWidget();
 	widget->setObjectName("PropertiesContainer");
@@ -138,7 +141,8 @@ void OBSPropertiesView::RefreshProperties()
 	setWidget(widget);
 	SetScrollPos(h, v);
 	setSizePolicy(mainPolicy);
-	adjustSize();
+	if (firstDraw)
+		adjustSize();
 
 	lastFocused.clear();
 	if (lastWidget) {


### PR DESCRIPTION
### Description

Makes sure size is only adjusted the first time `RefreshProeprties()` runs.

Fixes #8553

### Motivation and Context

Calling this is only required the first time properties widgets are created as Qt doesn't display them correctly otherwise. On subsequent updates it's no longer required and will result in the scroll position being reset.

### How Has This Been Tested?

Built, tested.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
