### PR TITLE
UI: Remux mp4/mov to mp4/mov with suffix

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -474,10 +474,18 @@ void RemuxQueueModel::checkInputPath(int row)
 		else
 			entry.state = RemuxEntryState::InvalidPath;
 
+		QString newExt = ".mp4";
+		QString suffix = fileInfo.suffix();
+
+		if (suffix.contains("mov", Qt::CaseInsensitive) ||
+		    suffix.contains("mp4", Qt::CaseInsensitive)) {
+			newExt = ".remuxed." + suffix;
+		}
+
 		if (entry.state == RemuxEntryState::Ready)
 			entry.targetPath = QDir::toNativeSeparators(
 				fileInfo.path() + QDir::separator() +
-				fileInfo.completeBaseName() + ".mp4");
+				fileInfo.completeBaseName() + newExt);
 	}
 
 	if (entry.state == RemuxEntryState::Ready && isProcessing)


### PR DESCRIPTION
### Description

When the input file is an `.mp4` or `.mov` file remux it to `.remuxed.mp4` or `.remuxed.mov`.

### Motivation and Context

MP4 -> MP4 and MOV -> MOV is now valid due to the addition of fragmented formats.

### How Has This Been Tested?

Remuxed some recordings.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
