### PR TITLE
UI: Auto-Remux fragmented containers to regular counterparts

### DIFF
--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -72,10 +72,11 @@ struct BasicOutputHandler {
 	}
 
 protected:
-	void SetupAutoRemux(const char *&ext);
+	void SetupAutoRemux(const char *&ext, bool is_fragmented);
 	std::string GetRecordingFilename(const char *path, const char *ext,
 					 bool noSpace, bool overwrite,
-					 const char *format, bool ffmpeg);
+					 const char *format, bool ffmpeg,
+					 bool is_fragmented);
 };
 
 BasicOutputHandler *CreateSimpleOutputHandler(OBSBasic *main);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7401,8 +7401,13 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 	const obs_encoder_t *videoEncoder =
 		obs_output_get_video_encoder(outputHandler->fileOutput);
 	const char *codecName = obs_encoder_get_codec(videoEncoder);
+	string format = config_get_string(
+		config, isSimpleMode ? "SimpleOutput" : "AdvOut", "RecFormat2");
 
-	if (strcmp(codecName, "prores") == 0) {
+	/* Retain original container for fMP4/fMOV */
+	if (format == "fmp4" || format == "fmov") {
+		output += "remuxed." + suffix;
+	} else if (strcmp(codecName, "prores") == 0) {
 		output += "mov";
 	} else {
 		output += "mp4";


### PR DESCRIPTION
### Description

Changes autoremux so it retains the same container type when using fmp4 or fmov. In order to separate the files it adds `remuxed` to the suffix.

Also fixes automremux recording as MKV when fMP4 is selected.

### Motivation and Context

AutoRemux kinda doesn't work correctly right now when fmp4/fmov are used.

### How Has This Been Tested?

Recorded in fmp4, autoremux remuxed to regular MP4 without recording to MKV.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
