### PR TITLE
deps: Fix lower CMake version boundary for file-updater

### DIFF
--- a/deps/file-updater/CMakeLists.txt
+++ b/deps/file-updater/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.16...3.25)
 
 find_package(CURL REQUIRED)
 


### PR DESCRIPTION
### Description
Changes lower version boundary for the file-updater interface library to 3.16, fixing build issues on Linux distributions that cannot update to more recent CMake versions.

### Motivation and Context
Version 3.16 required for Linux compatibility.

### How Has This Been Tested?
Needs to be tested by Linux contributors.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
