### PR TITLE
obs-ffmpeg/obs-outputs: Fix AV1/HEVC padding with enhanced RTMP and NVENC

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -734,6 +734,10 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings,
 
 	h264_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_DISABLED;
 
+	/* Enable CBR padding */
+	if (config->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR)
+		h264_config->enableFillerDataInsertion = 1;
+
 	vui_params->videoSignalTypePresentFlag = 1;
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
 	vui_params->colourDescriptionPresentFlag = 1;
@@ -818,6 +822,10 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 	hevc_config->sliceModeData = 1;
 
 	hevc_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_DISABLED;
+
+	/* Enable CBR padding */
+	if (config->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR)
+		hevc_config->enableFillerDataInsertion = 1;
 
 	vui_params->videoSignalTypePresentFlag = 1;
 	vui_params->videoFullRangeFlag = (voi->range == VIDEO_RANGE_FULL);
@@ -909,6 +917,10 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 	av1_config->useBFramesAsRef = NV_ENC_BFRAME_REF_MODE_DISABLED;
 
 	av1_config->colorRange = (voi->range == VIDEO_RANGE_FULL);
+
+	/* Enable CBR padding */
+	if (config->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR)
+		av1_config->enableBitstreamPadding = 1;
 
 	switch (voi->colorspace) {
 	case VIDEO_CS_601:

--- a/plugins/obs-outputs/rtmp-av1.c
+++ b/plugins/obs-outputs/rtmp-av1.c
@@ -566,7 +566,6 @@ static void serialize_av1_data(struct serializer *s, const uint8_t *data,
 		case AV1_OBU_TEMPORAL_DELIMITER:
 		case AV1_OBU_REDUNDANT_FRAME_HEADER:
 		case AV1_OBU_TILE_LIST:
-		case AV1_OBU_PADDING:
 			if (state == START_FOUND)
 				state = END_FOUND;
 			break;


### PR DESCRIPTION
### Description

Enable filler data insertion for native NVENC encoders.

### Motivation and Context

CBR should be constant.

### How Has This Been Tested?

Recorded HEVC CBR, now actually fills the requested bitrate envelope.

Not tested with AV1 as I do not have hardware for that.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
