### PR TITLE
obs-ffmpeg: Disable b-frames in FFmpeg NVENC (for now)

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -185,6 +185,14 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 
 	set_psycho_aq(enc, psycho_aq);
 
+	/* B-Frames in FFmpeg NVENC result in pts/dts being wrong,
+	 * disable them for now. */
+	if (bf != 0) {
+		warn("B-Frames enabled, disabling as they are currently broken"
+		     " in FFmpeg NVENC.");
+		bf = 0;
+	}
+
 	enc->ffve.context->max_b_frames = bf;
 
 	const char *ffmpeg_opts = obs_data_get_string(settings, "ffmpeg_opts");


### PR DESCRIPTION
### Description

Disables b-frames when FFmpeg NVENC is used (e.g. as fallback or on Linux).

### Motivation and Context

B-frames result in wrong timestamps with FFmpeg NVENC, until we know how to fix that (and if that's even on our end) force them to be disabled as to not produce files with decoding issues.

### How Has This Been Tested?

Recorded file in I444 with b-frames set to 2, recording had no b-frames and log noted they were disabled.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
