### PR TITLE
linux-pipewire: Use premultiplied alpha

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1090,6 +1090,18 @@ void obs_pipewire_video_render(obs_pipewire *obs_pw, gs_effect_t *effect)
 	rotated = push_rotation(obs_pw);
 
 	flip = get_buffer_flip(obs_pw);
+
+	/* There is a SPA_VIDEO_FLAG_PREMULTIPLIED_ALPHA flag, but it does not
+	 * seem to be fully implemented nor ever set. Just assume premultiplied
+	 * always, which seems to be the default convention.
+	 *
+	 * See https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3126
+	 *
+	 * The cursor bitmap alpha mode is also not specified, and the
+	 * convention there also seems to be premultiplied. */
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_ONE, GS_BLEND_INVSRCALPHA);
+
 	if (has_effective_crop(obs_pw)) {
 		gs_draw_sprite_subregion(obs_pw->texture, flip, obs_pw->crop.x,
 					 obs_pw->crop.y, obs_pw->crop.width,
@@ -1115,6 +1127,8 @@ void obs_pipewire_video_render(obs_pipewire *obs_pw, gs_effect_t *effect)
 
 		gs_matrix_pop();
 	}
+
+	gs_blend_state_pop();
 }
 
 void obs_pipewire_set_cursor_visible(obs_pipewire *obs_pw, bool cursor_visible)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Pipewire desktop portal capture assumes premultiplied alpha, so make sure to use the right blend equation to make translucent pixels work properly.

This is still broken for emissive pixels (alpha < color) since OBS seems to unpremultiply at some point during blending, but it works properly for translucent pixels (emissive pixel support requires an end-to-end premultiplied pipeline).

There is actually partial support in PipeWire for specifying whether the video format is premultiplied or not, but it seems to be incomplete and nobody uses it. I opened an issue [here](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3126). In the future if this is properly implemented as a property, OBS could support both formats.

### Motivation and Context

Makes transparent window capture with PipeWire/Wayland work properly. Without this change, translucent pixels are too dark.

### How Has This Been Tested?

Tested on an Apple M2 running Asahi Linux and KDE Plasma Wayland.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
