### PR TITLE
libobs: Remove dependency on Visual Studio 2019+

### DIFF
--- a/libobs/util/util_uint64.h
+++ b/libobs/util/util_uint64.h
@@ -22,7 +22,7 @@
 
 static inline uint64_t util_mul_div64(uint64_t num, uint64_t mul, uint64_t div)
 {
-#if defined(_MSC_VER) && defined(_M_X64)
+#if defined(_MSC_VER) && defined(_M_X64) && (_MSC_VER >= 1920)
 	unsigned __int64 high;
 	const unsigned __int64 low = _umul128(num, mul, &high);
 	unsigned __int64 rem;


### PR DESCRIPTION
In util_uint64.h the intrinsic function _udiv128 is used. The implementation of _udiv128 is only available in Visual Studio 2019+.
This quick fix removes the dependency on VS 2019 without cutting any functionality.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
In the file libobs/util/util_uint64.h the compiler-intrinsic function _udiv128 is used when compiling with MSVC.
The implementation of _udiv128 is only available in VisualStudio 2019 and above.
With the check _MSC_VER >= 1920 said function is only called when compiling with MSVC 2019 and above.
As documented [here](https://learn.microsoft.com/en-us/cpp/intrinsics/udiv128?view=msvc-170), _udiv128 is available starting in Visual Studio 2019.

### Motivation and Context
When trying to compile a custom project with VisualStudio 2017 while including the obs headers,
the compilation fails because of the missing implementation of _udiv128.
This Pull Request is not intended to allow the whole obs-studio to be compiled with MSVC 2017. It only allows linking against obs with its headers.

### How Has This Been Tested?
I tested the change by compiling and running obs-studio with MSVC 2022 on Windows 10.
Also compiling another project with MSVC 2017, 2019 or 2022 that includes obs headers works just fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
