### PR TITLE
Revert "UI: Remove bitness strings"

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1754,6 +1754,11 @@ string OBSApp::GetVersionString(bool platform) const
 	if (platform) {
 		ver << " (";
 #ifdef _WIN32
+		if (sizeof(void *) == 8)
+			ver << "64-bit, ";
+		else
+			ver << "32-bit, ";
+
 		ver << "windows)";
 #elif __APPLE__
 		ver << "mac)";

--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -15,7 +15,13 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 
 	ui->setupUi(this);
 
+	QString bitness;
 	QString ver;
+
+	if (sizeof(void *) == 4)
+		bitness = " (32 bit)";
+	else if (sizeof(void *) == 8)
+		bitness = " (64 bit)";
 
 #ifdef HAVE_OBSCONFIG_H
 	ver += OBS_VERSION;
@@ -24,7 +30,7 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 	       LIBOBS_API_PATCH_VER;
 #endif
 
-	ui->version->setText(ver);
+	ui->version->setText(ver + bitness);
 
 	ui->contribute->setText(QTStr("About.Contribute"));
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This reverts commit 64d4ae0106ff9c61978bdb7b55dc35679edb5a13.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
@WizardCM 's comment on #8267 indicated that it would be preferable to remove the display of extra build information from the application window's title bar (platform and bitness) but that we should keep it in the log and the About dialog. Removing this string caused the log analyzer to throw false positives for the "32-bit OBS on 64-bit OS" warning (see https://github.com/obsproject/loganalyzer/issues/122 and https://github.com/obsproject/loganalyzer/pull/124). Per discussion with @Fenrirthviti , I've reverted the changes in #8267 accounting for the new `platform` bool in #8371. The string will still be absent from the application window's title bar. We can reconsider removing the strings from the log and About dialog for a later release and also ensure that any future changes are well-tested with the log analyzer.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested the build locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
