### PR TITLE
UI: Fix replay buffer with fragmented formats

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2334,6 +2334,11 @@ bool AdvancedOutput::StartReplayBuffer()
 		rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 		rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 
+		/* Skip leading f for fragmented formats. */
+		if (strcmp(recFormat, "fmp4") == 0 ||
+		    strcmp(recFormat, "fmov") == 0)
+			++recFormat;
+
 		string f = GetFormatString(filenameFormat, rbPrefix, rbSuffix);
 		string strPath = GetOutputFilename(
 			path, recFormat, noSpace, overwriteIfExists, f.c_str());


### PR DESCRIPTION
### Description

Fixes replay buffer not starting when fragmented format is selected.

The whole format handling needs a rethink, using the internal ID as a file extension is a bit of a headache in multiple places, but this will fix it for now.

### Motivation and Context

Do I really have to explain this?

### How Has This Been Tested?

Has not.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
