### PR TITLE
UI: Guard ResetInvalidSelection check behind Qt < 6.5.1

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5031,7 +5031,8 @@ void OBSBasicSettings::AdvOutRecCheckCodecs()
 	AdvOutRecCheckWarnings();
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && QT_VERSION < QT_VERSION_CHECK(6, 5, 1)
+// Workaround for QTBUG-56064 on macOS
 static void ResetInvalidSelection(QComboBox *cbox)
 {
 	int idx = cbox->currentIndex();
@@ -5094,7 +5095,7 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 			QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4"));
 	}
 
-#ifdef __APPLE__
+#if defined(__APPLE__) && QT_VERSION < QT_VERSION_CHECK(6, 5, 1)
 	// Workaround for QTBUG-56064 on macOS
 	ResetInvalidSelection(ui->advOutRecEncoder);
 	ResetInvalidSelection(ui->advOutRecAEncoder);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Guards the `ResetInvalidSelection` workaround behind Qt < 6.5.1, as the bug will be fixed on 6.5.1 and newer (currently in the merge queue to the 6.5 branch, already merged on the dev branch).
There's an argument to be made for the code to be scrapped entirely as we're back porting the fix to obs-deps (see obsproject/obs-deps#175), that would however mean that people not running obs-deps-qt would have the bug again. Admittedly that's not many people, but the code doesn't do any harm by itself either.

### Draft todo list:
- [x] Wait for the change to actually be cherry-picked successfully: https://codereview.qt-project.org/c/qt/qtbase/+/470262

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This workaround exists because of [QTBUG-56064](https://bugreports.qt.io/browse/QTBUG-56064).
I fixed the bug upstream, so the workaround can be removed on the fixed version (so that in the future we don't forget to remove it once we drop support for Qt < 6.5.1).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by decreasing the version check number and observing that the workaround is gone (and that, when built with current Qt, the bug is back, which is expected as the check is only for future Qt where the bug is fixed).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
