### PR TITLE
CI: Fix Steam workflow not finding win asset

### DIFF
--- a/.github/workflows/steam.yml
+++ b/.github/workflows/steam.yml
@@ -80,7 +80,7 @@ jobs:
             fi
 
             ASSETS="$(curl -s "${ASSETS_URL}")"
-            WIN_ASSET_URL="$(jq -r '.[] | select(.name|test(".*x64.zip")) .browser_download_url' <<< ${ASSETS})"
+            WIN_ASSET_URL="$(jq -r '.[] | select(.name|test(".*.zip")) .browser_download_url' <<< ${ASSETS})"
             MAC_ASSET_URL="$(jq -r '.[] | select(.name|test(".*x86_64.*.dmg")) .browser_download_url' <<< ${ASSETS})"
             MAC_ARM_ASSET_URL="$(jq -r '.[] | select(.name|test(".*arm64.*.dmg")) .browser_download_url' <<< ${ASSETS})"
             TYPE='release'


### PR DESCRIPTION

### Description

Fixes Steam workflow being unable to find Windows asset since "x64" is no longer part of the ZIP name.

### Motivation and Context

Want automatic upload to succeed once we release beta2.

### How Has This Been Tested?

Has not been tested.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
