### PR TITLE
obs-ffmpeg: Don't use standard newlines in HTML error messages

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -250,7 +250,7 @@ static void on_init_error(void *data, int ret)
 
 	dstr_copy(&error_message, obs_module_text("NVENC.Error"));
 	dstr_replace(&error_message, "%1", av_err2str(ret));
-	dstr_cat(&error_message, "\r\n\r\n");
+	dstr_cat(&error_message, "<br><br>");
 
 	if (enc->gpu > 0) {
 		// if a non-zero GPU failed, almost always

--- a/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c
@@ -26,7 +26,7 @@ bool ffmpeg_video_encoder_init_codec(struct ffmpeg_video_encoder *enc)
 					     enc->enc_name);
 				dstr_replace(&error_message, "%2",
 					     av_err2str(ret));
-				dstr_cat(&error_message, "\r\n\r\n");
+				dstr_cat(&error_message, "<br><br>");
 
 				obs_encoder_set_last_error(enc->encoder,
 							   error_message.array);


### PR DESCRIPTION
### Description

* HTML error messages were added for the first time in #8474

Qt's default QString renderer will use HTML when recognised, but will prioritise the plaintext renderer if newlines are used via `\r\n`.

This updates the error string generator to use HTML line breaks instead.

Before:

![image](https://user-images.githubusercontent.com/941350/229326715-f2dadfc2-a428-4358-b382-a779b8930320.png)

After:

![image](https://user-images.githubusercontent.com/941350/229326719-af4f7590-ba93-42da-8776-7476148eab17.png)


### Motivation and Context

Links should be clickable, not rendered as raw HTML.

### How Has This Been Tested?

* Set NVENC rescale resolution to `1920x10801` to trigger an invalid code path
* Start Recording

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
