### PR TITLE
libobs: Update cocoa functionality for modern macOS

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -43,43 +43,28 @@ const char *get_module_extension(void)
 
 void add_default_module_paths(void)
 {
-	struct dstr plugin_path;
+	NSURL *pluginURL = [[NSBundle mainBundle] builtInPlugInsURL];
+	NSString *pluginModulePath = [[pluginURL path]
+		stringByAppendingString:@"/%module%.plugin/Contents/MacOS/"];
+	NSString *pluginDataPath = [[pluginURL path]
+		stringByAppendingString:@"/%module%.plugin/Contents/Resources/"];
 
-	dstr_init_move_array(&plugin_path, os_get_executable_path_ptr(""));
-	dstr_cat(&plugin_path, "../PlugIns");
-	char *abs_plugin_path = os_get_abs_path_ptr(plugin_path.array);
-
-	if (abs_plugin_path != NULL) {
-		dstr_move_array(&plugin_path, abs_plugin_path);
-		struct dstr plugin_data;
-		dstr_init_copy_dstr(&plugin_data, &plugin_path);
-		dstr_cat(&plugin_path, "/%module%.plugin/Contents/MacOS/");
-		dstr_cat(&plugin_data, "/%module%.plugin/Contents/Resources/");
-
-		obs_add_module_path(plugin_path.array, plugin_data.array);
-
-		dstr_free(&plugin_data);
-	}
-
-	dstr_free(&plugin_path);
+	obs_add_module_path(pluginModulePath.UTF8String,
+			    pluginDataPath.UTF8String);
 }
 
 char *find_libobs_data_file(const char *file)
 {
-	struct dstr path;
-
 	NSBundle *frameworkBundle =
 		[NSBundle bundleWithIdentifier:@"com.obsproject.libobs"];
-	NSURL *bundleURL = [frameworkBundle bundleURL];
-	NSURL *libobsDataURL =
-		[bundleURL URLByAppendingPathComponent:@"Resources/"];
-	const char *libobsDataPath = [[libobsDataURL path]
-		cStringUsingEncoding:NSUTF8StringEncoding];
-	dstr_init_copy(&path, libobsDataPath);
-	dstr_cat(&path, "/");
+	NSString *libobsDataPath = [[[frameworkBundle bundleURL] path]
+		stringByAppendingFormat:@"/%@/%s", @"Resources", file];
+	size_t path_length = strlen(libobsDataPath.UTF8String);
 
-	dstr_cat(&path, file);
-	return path.array;
+	char *path = bmalloc(path_length + 1);
+	snprintf(path, (path_length + 1), "%s", libobsDataPath.UTF8String);
+
+	return path;
 }
 
 static void log_processor_name(void)

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -408,20 +408,12 @@ uint64_t os_get_sys_total_size(void)
 	return total_memory;
 }
 
-#ifndef MACH_TASK_BASIC_INFO
-typedef task_basic_info_data_t mach_task_basic_info_data_t;
-#endif
-
 static inline bool
 os_get_proc_memory_usage_internal(mach_task_basic_info_data_t *taskinfo)
 {
-#ifdef MACH_TASK_BASIC_INFO
 	const task_flavor_t flavor = MACH_TASK_BASIC_INFO;
 	mach_msg_type_number_t out_count = MACH_TASK_BASIC_INFO_COUNT;
-#else
-	const task_flavor_t flavor = TASK_BASIC_INFO;
-	mach_msg_type_number_t out_count = TASK_BASIC_INFO_COUNT;
-#endif
+
 	if (task_info(mach_task_self(), flavor, (task_info_t)taskinfo,
 		      &out_count) != KERN_SUCCESS)
 		return false;


### PR DESCRIPTION
### Description
Updates Cocoa-specific functions to use Objective C functions instead of C functions to reduce code complexity and ease maintenance.

Also removes support for the older, deprecated, `MACH_TASK_BASIC_INFO` struct.

### Motivation and Context
Cocoa has safe, Unicode-capable, and extensive string handling support - using that functionality brings our code closer to native platform functionality and also easier to maintain (as Apple takes care of maintaining `NSString` and other Cocoa types).

### How Has This Been Tested?
Ran OBS with changes and used step-debugging to check the steps taken by code.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
