### PR TITLE
UI: Update Cocoa functionality for modern macOS

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -482,7 +482,7 @@ MissingFiles.NoMissing.Title="Missing Files Check"
 MissingFiles.NoMissing.Text="No files appear to be missing."
 
 # macOS permissions dialog
-MacPermissions.Title="Review App Permissions"
+MacPermissions.Title="Review App Permissions..."
 MacPermissions.Description="OBS Studio requires your permission to be able to provide certain features. It is recommended to enable these permissions, but they are not required to use the app. You can always enable them later."
 MacPermissions.Description.OpenDialog="You can re-open this dialog via the OBS Studio menu."
 MacPermissions.AccessGranted="Access Granted"


### PR DESCRIPTION
### Description
Updates Cocoa-specific functions to use Objective C functions instead of C functions to reduce code complexity and ease maintenance.

This is a companion PR to https://github.com/obsproject/obs-studio/pull/8624.

### Motivation and Context
With the CMake 3.0 merge, there is no support for building or running OBS outside of an app bundle on macOS, as such a valid value for `NSBundle mainBundle` can be assumed (and any other situation should not be handled/supported).

Using the `NSScreenSaverWindowLevel` constant to set the window level to stay on top is the "canonical" way to do this, as this also allows the OS to safely place its own windows on top of OBS.

Ellipses added to the permissions menu item - per Apple's Human Interface Guidelines:

> Append an ellipsis to a menu item’s label when people need to provide additional information before the action can complete. The ellipsis character (…) signals that another view will open in which people can input information or make choices.

This probably needs to be added to more menu items, as their labels are global L10N strings, this might require more extensive workarounds to make the menus more HIG compliant.

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
