### PR TITLE
frontend-plugins: Fix auto scene switcher not saving settings on close

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
@@ -128,9 +128,10 @@ SceneSwitcher::SceneSwitcher(QWidget *parent)
 		SetStopped();
 
 	loading = false;
+	connect(this, &QDialog::finished, this, &SceneSwitcher::finished);
 }
 
-void SceneSwitcher::closeEvent(QCloseEvent *)
+void SceneSwitcher::finished()
 {
 	obs_frontend_save();
 }

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
@@ -21,8 +21,6 @@ public:
 
 	SceneSwitcher(QWidget *parent);
 
-	void closeEvent(QCloseEvent *event) override;
-
 	void SetStarted();
 	void SetStopped();
 
@@ -41,6 +39,7 @@ public slots:
 	void on_noMatchSwitchScene_currentTextChanged(const QString &text);
 	void on_checkInterval_valueChanged(int value);
 	void on_toggleStartButton_clicked();
+	void finished();
 };
 
 void GetWindowList(std::vector<std::string> &windows);


### PR DESCRIPTION
### Description
Fixes settings in the auto scene switcher window not being saved when the window is closed.

### Motivation and Context
The `done` event does not emit a `closeEvent`, but saving is only implemented in that event handler. Changing this to `close` correctly triggers the default QWidget event and thus settings are saved.

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
