### PR TITLE
rtmp-services: Replace preprocessor defines with actual constant values

### DIFF
--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -35,7 +35,7 @@ target_sources(
           rtmp-services-main.c
           rtmp-format-ver.h)
 
-target_compile_definitions(rtmp-services PRIVATE RTMP_SERVICES_URL="${RTMP_SERVICES_URL}"
+target_compile_definitions(rtmp-services PRIVATE SERVICES_URL="${RTMP_SERVICES_URL}"
                                                  $<$<BOOL:${ENABLE_SERVICE_UPDATES}>:ENABLE_SERVICE_UPDATES>)
 
 target_link_libraries(rtmp-services PRIVATE OBS::libobs OBS::file-updater jansson::jansson)

--- a/plugins/rtmp-services/cmake/legacy.cmake
+++ b/plugins/rtmp-services/cmake/legacy.cmake
@@ -28,7 +28,7 @@ target_sources(
           rtmp-services-main.c
           rtmp-format-ver.h)
 
-target_compile_definitions(rtmp-services PRIVATE RTMP_SERVICES_URL="${RTMP_SERVICES_URL}"
+target_compile_definitions(rtmp-services PRIVATE SERVICES_URL="${RTMP_SERVICES_URL}"
                                                  $<$<BOOL:${ENABLE_SERVICE_UPDATES}>:ENABLE_SERVICE_UPDATES>)
 
 target_include_directories(rtmp-services PRIVATE ${CMAKE_BINARY_DIR}/config)

--- a/plugins/rtmp-services/rtmp-format-ver.h
+++ b/plugins/rtmp-services/rtmp-format-ver.h
@@ -1,3 +1,3 @@
 #pragma once
 
-#define RTMP_SERVICES_FORMAT_VERSION 4
+static const int RTMP_SERVICES_FORMAT_VERSION = 4;

--- a/plugins/rtmp-services/rtmp-services-main.c
+++ b/plugins/rtmp-services/rtmp-services-main.c
@@ -17,8 +17,8 @@ MODULE_EXPORT const char *obs_module_description(void)
 	return "OBS core RTMP services";
 }
 
-#define RTMP_SERVICES_LOG_STR "[rtmp-services plugin] "
-#define RTMP_SERVICES_VER_STR "rtmp-services plugin (libobs " OBS_VERSION ")"
+static const char *RTMP_SERVICES_LOG_STR = "[rtmp-services plugin] ";
+static const char *RTMP_SERVICES_URL = (const char *)SERVICES_URL;
 
 extern struct obs_service_info rtmp_common_service;
 extern struct obs_service_info rtmp_custom_service;


### PR DESCRIPTION
### Description
Replaces preprocessor defines with actual constant values.

### Motivation and Context
Quoting from [Google Objective-C Style Guide](https://google.github.io/styleguide/objcguide.html):

> Avoid macros, especially where const variables, enums, XCode snippets, or C functions may be used instead.
> Macros make the code you see different from the code the compiler sees. Modern C renders traditional uses of macros for constants and utility functions unnecessary. Macros should only be used when there is no other solution available.

The use of macros and defines was a valid crutch in past decades when languages didn't have first-class support for the desired constructs. This has not been the case for a long time, and as such this old practise needs to be laid to rest.

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
