### PR TITLE
UI: Fix Simple Mode compat check

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5752,18 +5752,23 @@ static void DisableIncompatibleSimpleContainer(QComboBox *cbox,
 
 	bool currentCompatible = true;
 	for (int idx = 0; idx < cbox->count(); idx++) {
-		QString format = cbox->itemData(idx).toString();
+		QString qFormat = cbox->itemData(idx).toString();
+
+		string format = qFormat.toStdString();
+		/* Remove leading "f" for fragmented MP4/MOV */
+		if (format == "fmp4" || format == "fmov")
+			format = format.erase(0, 1);
 
 		QStandardItemModel *model =
 			dynamic_cast<QStandardItemModel *>(cbox->model());
 		QStandardItem *item = model->item(idx);
 
-		if (ContainerSupportsCodec(QT_TO_UTF8(format),
-					   QT_TO_UTF8(vCodec))) {
+		if (ContainerSupportsCodec(format, QT_TO_UTF8(vCodec)) &&
+		    ContainerSupportsCodec(format, QT_TO_UTF8(aCodec))) {
 			item->setFlags(Qt::ItemIsSelectable |
 				       Qt::ItemIsEnabled);
 		} else {
-			if (format == currentFormat)
+			if (qFormat == currentFormat)
 				currentCompatible = false;
 
 			item->setFlags(Qt::NoItemFlags);


### PR DESCRIPTION
### Description

When reworking the codec check in #8602 I broke the simple mode check because it was no longer checking the audio codec and marking fragmented formats as incompatible.

### Motivation and Context

I break, I fix.

### How Has This Been Tested?

Ran OBS in Simple Mode and confirmed containers are now selectable again.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- 
### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
