### PR TITLE
UI: Don't std::move main in SetUndoProperties

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -56,8 +56,8 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 	if (!currentSceneSource)
 		return;
 	std::string scene_name = obs_source_get_name(currentSceneSource);
-	auto undo_redo = [scene_name,
-			  main = std::move(main)](const std::string &data) {
+	auto undo_redo = [scene_name = std::move(scene_name),
+			  main](const std::string &data) {
 		OBSDataAutoRelease settings =
 			obs_data_create_from_json(data.c_str());
 		OBSSourceAutoRelease source = obs_get_source_by_name(


### PR DESCRIPTION
### Description
`main` is used later in the function after being `std::move`ed which is technically undefined behavior even though it's only a basic type (pointer) that `std::move` has no effect on. `scene_name` however is safe to move so let's do that instead.

Detected by PVS Studio.

### Motivation and Context
Solve a warning and weird behavior.

### How Has This Been Tested?
Ran in debugger. I would appreciate comments by someone with more C++ experience about this behavior.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
