### PR TITLE
UI: Rework recording format handling

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2130,7 +2130,22 @@ string GetFormatString(const char *format, const char *prefix,
 	return f;
 }
 
-string GetOutputFilename(const char *path, const char *ext, bool noSpace,
+string GetFormatExt(const char *container)
+{
+	string ext = container;
+	if (ext == "fragmented_mp4")
+		ext = "mp4";
+	else if (ext == "fragmented_mov")
+		ext = "mov";
+	else if (ext == "hls")
+		ext = "m3u8";
+	else if (ext == "mpegts")
+		ext = "ts";
+
+	return ext;
+}
+
+string GetOutputFilename(const char *path, const char *container, bool noSpace,
 			 bool overwrite, const char *format)
 {
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
@@ -2157,7 +2172,8 @@ string GetOutputFilename(const char *path, const char *ext, bool noSpace,
 	if (lastChar != '/' && lastChar != '\\')
 		strPath += "/";
 
-	strPath += GenerateSpecifiedFilename(ext, noSpace, format);
+	string ext = GetFormatExt(container);
+	strPath += GenerateSpecifiedFilename(ext.c_str(), noSpace, format);
 	ensure_directory_exists(strPath);
 	if (!overwrite)
 		FindBestFilename(strPath, noSpace);

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -45,8 +45,9 @@ std::string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 				      const char *format);
 std::string GetFormatString(const char *format, const char *prefix,
 			    const char *suffix);
-std::string GetOutputFilename(const char *path, const char *ext, bool noSpace,
-			      bool overwrite, const char *format);
+std::string GetFormatExt(const char *container);
+std::string GetOutputFilename(const char *path, const char *container,
+			      bool noSpace, bool overwrite, const char *format);
 QObject *CreateShortcutFilter();
 
 struct BaseLexer {

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1297,14 +1297,10 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 	int tracks =
 		config_get_int(main->Config(), "SimpleOutput", "RecTracks");
 
-	bool is_fragmented = strcmp(format, "fmp4") == 0 ||
-			     strcmp(format, "fmov") == 0;
+	bool is_fragmented = strncmp(format, "fragmented", 10) == 0;
 
 	string f;
 	string strPath;
-
-	if (is_fragmented)
-		++format;
 
 	OBSDataAutoRelease settings = obs_data_create();
 	if (updateReplayBuffer) {
@@ -1324,8 +1320,7 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 		strPath = GetRecordingFilename(path,
 					       ffmpegOutput ? "avi" : format,
 					       noSpace, overwriteIfExists,
-					       f.c_str(), ffmpegOutput,
-					       is_fragmented);
+					       f.c_str(), ffmpegOutput);
 		obs_data_set_string(settings, ffmpegOutput ? "url" : "path",
 				    strPath.c_str());
 		if (ffmpegOutput)
@@ -1782,9 +1777,7 @@ inline void AdvancedOutput::SetupRecording()
 	const char *recFormat =
 		config_get_string(main->Config(), "AdvOut", "RecFormat2");
 
-	bool is_fragmented = strcmp(recFormat, "fmp4") == 0 ||
-			     strcmp(recFormat, "fmov") == 0;
-
+	bool is_fragmented = strncmp(recFormat, "fragmented", 10) == 0;
 	bool flv = strcmp(recFormat, "flv") == 0;
 
 	if (flv)
@@ -1843,14 +1836,14 @@ inline void AdvancedOutput::SetupRecording()
 
 	// Use fragmented MOV/MP4 if user has not already specified custom movflags
 	if (is_fragmented && (!mux || strstr(mux, "movflags") == NULL)) {
-		string mux_fmp4 =
+		string mux_frag =
 			"movflags=frag_keyframe+empty_moov+delay_moov";
 		if (mux) {
-			mux_fmp4 += " ";
-			mux_fmp4 += mux;
+			mux_frag += " ";
+			mux_frag += mux;
 		}
 		obs_data_set_string(settings, "muxer_settings",
-				    mux_fmp4.c_str());
+				    mux_frag.c_str());
 	} else {
 		if (is_fragmented)
 			blog(LOG_WARNING,
@@ -2176,7 +2169,6 @@ bool AdvancedOutput::StartRecording()
 	const char *recFormat;
 	const char *filenameFormat;
 	bool noSpace = false;
-	bool fragmented = false;
 	bool overwriteIfExists = false;
 	bool splitFile;
 	const char *splitFileType;
@@ -2214,16 +2206,10 @@ bool AdvancedOutput::StartRecording()
 		splitFile = config_get_bool(main->Config(), "AdvOut",
 					    "RecSplitFile");
 
-		// Strip leading "f" in case fragmented format was selected
-		if (strcmp(recFormat, "fmp4") == 0 ||
-		    strcmp(recFormat, "fmov") == 0) {
-			++recFormat;
-			fragmented = true;
-		}
-
-		string strPath = GetRecordingFilename(
-			path, recFormat, noSpace, overwriteIfExists,
-			filenameFormat, ffmpegRecording, fragmented);
+		string strPath = GetRecordingFilename(path, recFormat, noSpace,
+						      overwriteIfExists,
+						      filenameFormat,
+						      ffmpegRecording);
 
 		OBSDataAutoRelease settings = obs_data_create();
 		obs_data_set_string(settings, ffmpegRecording ? "url" : "path",
@@ -2322,11 +2308,6 @@ bool AdvancedOutput::StartReplayBuffer()
 		rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 		rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 
-		/* Skip leading f for fragmented formats. */
-		if (strcmp(recFormat, "fmp4") == 0 ||
-		    strcmp(recFormat, "fmov") == 0)
-			++recFormat;
-
 		string f = GetFormatString(filenameFormat, rbPrefix, rbSuffix);
 		string strPath = GetOutputFilename(
 			path, recFormat, noSpace, overwriteIfExists, f.c_str());
@@ -2400,21 +2381,22 @@ bool AdvancedOutput::ReplayBufferActive() const
 
 /* ------------------------------------------------------------------------ */
 
-void BasicOutputHandler::SetupAutoRemux(const char *&ext, bool is_fragmented)
+void BasicOutputHandler::SetupAutoRemux(const char *&container)
 {
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
-	if (autoRemux && !is_fragmented && strcmp(ext, "mp4") == 0)
-		ext = "mkv";
+	if (autoRemux && strcmp(container, "mp4") == 0)
+		container = "mkv";
 }
 
 std::string BasicOutputHandler::GetRecordingFilename(
-	const char *path, const char *ext, bool noSpace, bool overwrite,
-	const char *format, bool ffmpeg, bool is_fragmented)
+	const char *path, const char *container, bool noSpace, bool overwrite,
+	const char *format, bool ffmpeg)
 {
 	if (!ffmpeg)
-		SetupAutoRemux(ext, is_fragmented);
+		SetupAutoRemux(container);
 
-	string dst = GetOutputFilename(path, ext, noSpace, overwrite, format);
+	string dst =
+		GetOutputFilename(path, container, noSpace, overwrite, format);
 	lastRecordingPath = dst;
 	return dst;
 }

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -72,11 +72,11 @@ struct BasicOutputHandler {
 	}
 
 protected:
-	void SetupAutoRemux(const char *&ext, bool is_fragmented);
-	std::string GetRecordingFilename(const char *path, const char *ext,
-					 bool noSpace, bool overwrite,
-					 const char *format, bool ffmpeg,
-					 bool is_fragmented);
+	void SetupAutoRemux(const char *&container);
+	std::string GetRecordingFilename(const char *path,
+					 const char *container, bool noSpace,
+					 bool overwrite, const char *format,
+					 bool ffmpeg);
 };
 
 BasicOutputHandler *CreateSimpleOutputHandler(OBSBasic *main);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5748,8 +5748,8 @@ static void DisableIncompatibleSimpleContainer(QComboBox *cbox,
 {
 	/* Similar to above, but works in reverse to disable incompatible formats
 	 * based on the encoder selection. */
-	QString aCodec = aEncoder;
-	QString vCodec = obs_get_encoder_codec(
+	const char *aCodec = QT_TO_UTF8(aEncoder);
+	const char *vCodec = obs_get_encoder_codec(
 		get_simple_output_encoder(QT_TO_UTF8(vEncoder)));
 
 	bool currentCompatible = true;
@@ -5760,8 +5760,8 @@ static void DisableIncompatibleSimpleContainer(QComboBox *cbox,
 			dynamic_cast<QStandardItemModel *>(cbox->model());
 		QStandardItem *item = model->item(idx);
 
-		if (ContainerSupportsCodec(QT_TO_UTF8(format),
-					   QT_TO_UTF8(vCodec))) {
+		if (ContainerSupportsCodec(format.toStdString(), vCodec) &&
+		    ContainerSupportsCodec(format.toStdString(), aCodec)) {
 			item->setFlags(Qt::ItemIsSelectable |
 				       Qt::ItemIsEnabled);
 		} else {


### PR DESCRIPTION
### Description

Reworks how recording formats are handled to avoid some of the string manipulation required to properly work with fragmented formats by only translating from the internal name to the extension when the filename is generated.

This should make it less error prone and easier to extend with new formats should that ever be desireable.

**Note:** Superseedes and closes #8629 

### Motivation and Context

The old stuff kinda sucked.

### How Has This Been Tested?

Recorded fragmented video, verified config migration works.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
