### PR TITLE
mac-syphon: Update syphon, use obs-deps framework, remove submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "plugins/win-dshow/libdshowcapture"]
 	path = plugins/win-dshow/libdshowcapture
 	url = https://github.com/obsproject/libdshowcapture.git
-[submodule "plugins/mac-syphon/syphon-framework"]
-	path = plugins/mac-syphon/syphon-framework
-	url = https://github.com/palana/Syphon-Framework.git
 [submodule "plugins/enc-amf"]
 	path = plugins/enc-amf
 	url = https://github.com/obsproject/obs-amd-encoder.git

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -65,6 +65,13 @@ function(set_target_properties_obs target)
           PROPERTY XCODE_EMBED_FRAMEWORKS ${SPARKLE})
       endif()
 
+      if(TARGET mac-syphon)
+        set_property(
+          TARGET ${target}
+          APPEND
+          PROPERTY XCODE_EMBED_FRAMEWORKS ${SYPHON})
+      endif()
+
       get_property(obs_executables GLOBAL PROPERTY _OBS_EXECUTABLES)
       add_dependencies(${target} ${obs_executables})
       foreach(executable IN LISTS obs_executables)

--- a/plugins/mac-syphon/CMakeLists.txt
+++ b/plugins/mac-syphon/CMakeLists.txt
@@ -11,76 +11,19 @@ else()
   target_enable_feature(mac-syphon "Syphon sharing support")
 endif()
 
-find_library(COCOA Cocoa)
-find_library(IOSURF IOSurface)
-find_library(SCRIPTINGBRIDGE ScriptingBridge)
-mark_as_advanced(COCOA IOSURF SCRIPTINGBRIDGE)
-
-add_library(syphon-framework STATIC EXCLUDE_FROM_ALL )
-add_library(Syphon::Framework ALIAS syphon-framework)
-
-target_sources(
-  syphon-framework
-  PRIVATE syphon-framework/Syphon_Prefix.pch
-          syphon-framework/Syphon.h
-          syphon-framework/SyphonBuildMacros.h
-          syphon-framework/SyphonCFMessageReceiver.m
-          syphon-framework/SyphonCFMessageReceiver.h
-          syphon-framework/SyphonCFMessageSender.h
-          syphon-framework/SyphonCFMessageSender.m
-          syphon-framework/SyphonClient.m
-          syphon-framework/SyphonClient.h
-          syphon-framework/SyphonClientConnectionManager.m
-          syphon-framework/SyphonClientConnectionManager.h
-          syphon-framework/SyphonDispatch.c
-          syphon-framework/SyphonDispatch.h
-          syphon-framework/SyphonIOSurfaceImage.m
-          syphon-framework/SyphonIOSurfaceImage.h
-          syphon-framework/SyphonImage.m
-          syphon-framework/SyphonImage.h
-          syphon-framework/SyphonMachMessageReceiver.m
-          syphon-framework/SyphonMachMessageReceiver.h
-          syphon-framework/SyphonMachMessageSender.m
-          syphon-framework/SyphonMachMessageSender.h
-          syphon-framework/SyphonMessageQueue.m
-          syphon-framework/SyphonMessageQueue.h
-          syphon-framework/SyphonMessageReceiver.m
-          syphon-framework/SyphonMessageReceiver.h
-          syphon-framework/SyphonMessageSender.m
-          syphon-framework/SyphonMessageSender.h
-          syphon-framework/SyphonMessaging.m
-          syphon-framework/SyphonMessaging.h
-          syphon-framework/SyphonOpenGLFunctions.c
-          syphon-framework/SyphonOpenGLFunctions.h
-          syphon-framework/SyphonPrivate.m
-          syphon-framework/SyphonPrivate.h
-          syphon-framework/SyphonServer.m
-          syphon-framework/SyphonServer.h
-          syphon-framework/SyphonServerConnectionManager.m
-          syphon-framework/SyphonServerConnectionManager.h
-          syphon-framework/SyphonServerDirectory.m
-          syphon-framework/SyphonServerDirectory.h)
-
-target_compile_options(
-  syphon-framework
-  PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/syphon-framework/Syphon_Prefix.pch" -Wno-error=deprecated-declarations
-  PUBLIC -Wno-error=newline-eof -Wno-error=deprecated-implementations)
-
-target_compile_definitions(syphon-framework PUBLIC "SYPHON_UNIQUE_CLASS_NAME_PREFIX=OBS_")
-
-target_link_libraries(syphon-framework PUBLIC OpenGL::GL ${COCOA} ${IOSURF})
-
-set_target_properties(syphon-framework PROPERTIES FOLDER "plugins/mac-syphon" PREFIX "")
+find_library(SYPHON Syphon)
+mark_as_advanced(SYPHON)
 
 add_library(mac-syphon MODULE)
 add_library(OBS::syphon ALIAS mac-syphon)
 
-target_sources(mac-syphon PRIVATE syphon.m plugin-main.c)
+target_sources(mac-syphon PRIVATE syphon.m plugin-main.c SyphonOBSClient.h SyphonOBSClient.m)
 
-target_compile_options(mac-syphon PRIVATE -include "${CMAKE_CURRENT_SOURCE_DIR}/syphon-framework/Syphon_Prefix.pch"
-                                          -fobjc-arc)
-
-target_link_libraries(mac-syphon PRIVATE OBS::libobs Syphon::Framework ${SCRIPTINGBRIDGE})
+target_compile_options(mac-syphon PRIVATE -fobjc-arc)
+target_link_libraries(
+  mac-syphon
+  PRIVATE OBS::libobs "$<LINK_LIBRARY:FRAMEWORK,AppKit.framework>" "$<LINK_LIBRARY:FRAMEWORK,IOSurface.framework>"
+          "$<LINK_LIBRARY:FRAMEWORK,ScriptingBridge.framework>" "$<LINK_LIBRARY:FRAMEWORK,${SYPHON}>")
 
 set_target_properties_obs(
   mac-syphon

--- a/plugins/mac-syphon/SyphonOBSClient.h
+++ b/plugins/mac-syphon/SyphonOBSClient.h
@@ -1,0 +1,11 @@
+#import <Syphon/Syphon.h>
+#import <Syphon/SyphonSubclassing.h>
+#import <IOSurface/IOSurface.h>
+
+@interface SyphonOBSClient : SyphonClientBase
+- (id)initWithServerDescription:(NSDictionary<NSString *, id> *)description
+                        options:(NSDictionary<NSString *, id> *)options
+                newFrameHandler:(void (^)(SyphonOBSClient *))handler;
+
+- (IOSurfaceRef)newFrameImage;
+@end

--- a/plugins/mac-syphon/SyphonOBSClient.m
+++ b/plugins/mac-syphon/SyphonOBSClient.m
@@ -1,0 +1,17 @@
+#import "SyphonOBSClient.h"
+
+@implementation SyphonOBSClient
+
+- (id)initWithServerDescription:(NSDictionary<NSString *, id> *)description
+                        options:(NSDictionary<NSString *, id> *)options
+                newFrameHandler:(void (^)(SyphonOBSClient *))handler
+{
+    self = [super initWithServerDescription:description options:options newFrameHandler:handler];
+    return self;
+}
+
+- (IOSurfaceRef)newFrameImage
+{
+    return [self newSurface];
+}
+@end


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Updates the syphon to use the Syphon.framework from obs-deps instead of the submodule, and removes the submodule.

#### Draft TODO-list:
- [x] Merge https://github.com/obsproject/obs-deps/pull/176
- [x] Update obs-deps in obs-studio

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The submodule was not updated in 9 years and additionally had custom patches. We want to get away from having submodule dependencies, and also from having custom patches for dependencies.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3
Tested with a custom obs-deps that includes `Syphon.framework` framework.
Ran their [sample server](https://github.com/Syphon/Simple) and had it correctly get picked up, announce creation and retirement; and received the correct frames.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
