### PR TITLE
UI: Use name instead of internal extension for incompatible codec check

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5013,11 +5013,11 @@ static bool ContainerSupportsCodec(const string &container, const string &codec)
 }
 
 static void DisableIncompatibleCodecs(QComboBox *cbox, const QString &format,
+				      const QString &formatName,
 				      const QString &streamEncoder)
 {
 	QString strEncLabel =
 		QTStr("Basic.Settings.Output.Adv.Recording.UseStreamEncoder");
-	QString formatUpper = format.toUpper();
 	QString recEncoder = cbox->currentData().toString();
 
 	/* Check if selected encoders and output format are compatible, disable incompatible items. */
@@ -5056,7 +5056,7 @@ static void DisableIncompatibleCodecs(QComboBox *cbox, const QString &format,
 			item->setFlags(Qt::NoItemFlags);
 			encDisplayName += " ";
 			encDisplayName += QTStr("CodecCompat.Incompatible")
-						  .arg(formatUpper);
+						  .arg(formatName);
 		}
 
 		item->setText(encDisplayName);
@@ -5070,6 +5070,7 @@ static void DisableIncompatibleCodecs(QComboBox *cbox, const QString &format,
 void OBSBasicSettings::AdvOutRecCheckCodecs()
 {
 	QString recFormat = ui->advOutRecFormat->currentData().toString();
+	QString recFormatName = ui->advOutRecFormat->currentText();
 
 	/* Set tooltip if available */
 	QString tooltip =
@@ -5088,9 +5089,9 @@ void OBSBasicSettings::AdvOutRecCheckCodecs()
 	ui->advOutRecEncoder->blockSignals(true);
 	ui->advOutRecAEncoder->blockSignals(true);
 	DisableIncompatibleCodecs(ui->advOutRecEncoder, recFormat,
-				  streamEncoder);
+				  recFormatName, streamEncoder);
 	DisableIncompatibleCodecs(ui->advOutRecAEncoder, recFormat,
-				  streamAudioEncoder);
+				  recFormatName, streamAudioEncoder);
 	ui->advOutRecEncoder->blockSignals(false);
 	ui->advOutRecAEncoder->blockSignals(false);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Uses the localized name instead of the internal extension to display that something is incompatible.

Before:
![image](https://user-images.githubusercontent.com/59806498/229808020-2b1d64c8-f387-4697-8848-2d22158367dc.png)

After:
![image](https://user-images.githubusercontent.com/59806498/229808043-939d50b4-7975-4c56-8857-505a5db118de.png)

I will say that I'm a tiny bit torn on the double brackets, but also didn't want to introduce another string for this.

(and yes, I realize my screenshots were from different comboboxes, but the result is the same for both)
 
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Current warning doesn't look great.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3
See screenshots above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
