### PR TITLE
cmake: Remove EXCLUDE_FROM_ALL directive from interface libraries

### DIFF
--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -32,7 +32,7 @@ target_link_libraries(obs-studio PRIVATE crypt32 OBS::blake2 OBS::w32-pthreads M
 target_compile_options(obs-studio PRIVATE PSAPI_VERSION=2)
 target_link_options(obs-studio PRIVATE /IGNORE:4098 /IGNORE:4099)
 
-add_library(obs-update-helpers INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-update-helpers INTERFACE)
 add_library(OBS::update-helpers ALIAS obs-update-helpers)
 
 target_sources(obs-update-helpers INTERFACE win-update/win-update-helpers.cpp win-update/win-update-helpers.hpp)

--- a/deps/file-updater/CMakeLists.txt
+++ b/deps/file-updater/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16...3.25)
 
 find_package(CURL REQUIRED)
 
-add_library(file-updater INTERFACE EXCLUDE_FROM_ALL)
+add_library(file-updater INTERFACE)
 add_library(OBS::file-updater ALIAS file-updater)
 
 target_sources(file-updater INTERFACE file-updater/file-updater.c file-updater/file-updater.h)

--- a/deps/json11/CMakeLists.txt
+++ b/deps/json11/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
-add_library(json11 INTERFACE EXCLUDE_FROM_ALL)
+add_library(json11 INTERFACE)
 add_library(OBS::json11 ALIAS json11)
 
 target_include_directories(json11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/deps/libff/CMakeLists.txt
+++ b/deps/libff/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
-add_library(libff-util INTERFACE EXCLUDE_FROM_ALL)
+add_library(libff-util INTERFACE)
 add_library(OBS::libff-util ALIAS libff-util)
 
 target_sources(libff-util INTERFACE libff/ff-util.c libff/ff-util.h)

--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16...3.25)
 
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avdevice avutil avformat)
 
-add_library(media-playback INTERFACE EXCLUDE_FROM_ALL)
+add_library(media-playback INTERFACE)
 add_library(OBS::media-playback ALIAS media-playback)
 
 target_sources(

--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT ENABLE_SCRIPTING)
   return()
 endif()
 
-add_library(obs-cstrcache INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-cstrcache INTERFACE)
 add_library(OBS::cstrcache ALIAS obs-cstrcache)
 
 target_sources(obs-cstrcache INTERFACE cstrcache.cpp cstrcache.h)

--- a/deps/opts-parser/CMakeLists.txt
+++ b/deps/opts-parser/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.16...3.25)
 
-add_library(opts-parser INTERFACE EXCLUDE_FROM_ALL)
+add_library(opts-parser INTERFACE)
 add_library(OBS::opts-parser ALIAS opts-parser)
 
 target_sources(opts-parser INTERFACE opts-parser.c opts-parser.h)

--- a/libobs/cmake/32bit-build.cmake
+++ b/libobs/cmake/32bit-build.cmake
@@ -1,15 +1,15 @@
 if(OS_WINDOWS)
-  add_library(obs-obfuscate INTERFACE EXCLUDE_FROM_ALL)
+  add_library(obs-obfuscate INTERFACE)
   add_library(OBS::obfuscate ALIAS obs-obfuscate)
   target_sources(obs-obfuscate INTERFACE util/windows/obfuscate.c util/windows/obfuscate.h)
   target_include_directories(obs-obfuscate INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-  add_library(obs-comutils INTERFACE EXCLUDE_FROM_ALL)
+  add_library(obs-comutils INTERFACE)
   add_library(OBS::COMutils ALIAS obs-comutils)
   target_sources(obs-comutils INTERFACE util/windows/ComPtr.hpp)
   target_include_directories(obs-comutils INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-  add_library(obs-winhandle INTERFACE EXCLUDE_FROM_ALL)
+  add_library(obs-winhandle INTERFACE)
   add_library(OBS::winhandle ALIAS obs-winhandle)
   target_sources(obs-winhandle INTERFACE util/windows/WinHandle.hpp)
   target_include_directories(obs-winhandle INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/libobs/cmake/os-windows.cmake
+++ b/libobs/cmake/os-windows.cmake
@@ -1,16 +1,16 @@
 configure_file(cmake/windows/obs-module.rc.in libobs.rc)
 
-add_library(obs-obfuscate INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-obfuscate INTERFACE)
 add_library(OBS::obfuscate ALIAS obs-obfuscate)
 target_sources(obs-obfuscate INTERFACE util/windows/obfuscate.c util/windows/obfuscate.h)
 target_include_directories(obs-obfuscate INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library(obs-comutils INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-comutils INTERFACE)
 add_library(OBS::COMutils ALIAS obs-comutils)
 target_sources(obs-comutils INTERFACE util/windows/ComPtr.hpp)
 target_include_directories(obs-comutils INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-add_library(obs-winhandle INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-winhandle INTERFACE)
 add_library(OBS::winhandle ALIAS obs-winhandle)
 target_sources(obs-winhandle INTERFACE util/windows/WinHandle.hpp)
 target_include_directories(obs-winhandle INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/plugins/mac-virtualcam/CMakeLists.txt
+++ b/plugins/mac-virtualcam/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 target_enable_feature(mac-virtualcam "macOS Virtual Camera support")
 
-add_library(obs-mach-protocol INTERFACE EXCLUDE_FROM_ALL)
+add_library(obs-mach-protocol INTERFACE)
 add_library(OBS::mach-protocol ALIAS obs-mach-protocol)
 
 target_sources(obs-mach-protocol INTERFACE src/common/MachProtocol.h src/common/data/placeholder.png)

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 if(OS_WINDOWS)
   find_package(AMF 1.4.29 REQUIRED)
 
-  add_library(nvenc-headers INTERFACE EXCLUDE_FROM_ALL)
+  add_library(nvenc-headers INTERFACE)
   add_library(OBS::nvenc-headers ALIAS nvenc-headers)
 
   target_sources(nvenc-headers INTERFACE external/nvEncodeAPI.h jim-nvenc-ver.h)

--- a/plugins/obs-outputs/cmake/ftl.cmake
+++ b/plugins/obs-outputs/cmake/ftl.cmake
@@ -1,7 +1,7 @@
 find_package(CURL REQUIRED)
 find_package(jansson REQUIRED)
 
-add_library(ftl-sdk INTERFACE EXCLUDE_FROM_ALL)
+add_library(ftl-sdk INTERFACE)
 add_library(OBS::ftl-sdk ALIAS ftl-sdk)
 
 target_compile_definitions(ftl-sdk INTERFACE FTL_STATIC_COMPILE FTL_FOUND)


### PR DESCRIPTION
### Description
Removes `EXCLUDE_FROM_ALL` for `INTERFACE` type libraries.

### Motivation and Context
Emits an error on older CMake versions, seems to be ignored by more recent ones. As interface-type libraries are not built by themselves anyway (they are vehicles for header files and compile options), the `EXCLUDE_FROM_ALL` directive is practically superfluous.

Fixes https://github.com/obsproject/obs-studio/issues/8595.

### How Has This Been Tested?
Needs to be tested on Linux with CMake 3.16.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
