### PR TITLE
mac-videotoolbox: Fix compile issue if HEVC is disabled

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -148,6 +148,8 @@ static CFStringRef obs_to_vt_profile(CMVideoCodecType codec_type,
 		}
 #endif // macOS 12.3
 		return kVTProfileLevel_HEVC_Main_AutoLevel;
+#else
+		(void)format;
 #endif // ENABLE_HEVC
 	} else {
 		return kVTProfileLevel_H264_Baseline_AutoLevel;


### PR DESCRIPTION
### Description
Fix possible unused variable if obs-studio is built with `ENABLE_HEVC` disabled.

### Motivation and Context
The format is only checked for 10-bit capable formats, which in this case applies to HEVC only. When HEVC is disabled, then `format` is not checked and becomes an unused variable otherwise.

### How Has This Been Tested?
Compiled on macOS 13.3 with Xcode 14.3.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
