### PR TITLE
UI: Fix simple mode container check

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5749,20 +5749,21 @@ static void DisableIncompatibleSimpleContainer(QComboBox *cbox,
 {
 	/* Similar to above, but works in reverse to disable incompatible formats
 	 * based on the encoder selection. */
-	const char *aCodec = QT_TO_UTF8(aEncoder);
-	const char *vCodec = obs_get_encoder_codec(
+	string vCodec = obs_get_encoder_codec(
 		get_simple_output_encoder(QT_TO_UTF8(vEncoder)));
+	string aCodec = aEncoder.toStdString();
 
 	bool currentCompatible = true;
 	for (int idx = 0; idx < cbox->count(); idx++) {
 		QString format = cbox->itemData(idx).toString();
+		string formatStr = format.toStdString();
 
 		QStandardItemModel *model =
 			dynamic_cast<QStandardItemModel *>(cbox->model());
 		QStandardItem *item = model->item(idx);
 
-		if (ContainerSupportsCodec(format.toStdString(), vCodec) &&
-		    ContainerSupportsCodec(format.toStdString(), aCodec)) {
+		if (ContainerSupportsCodec(formatStr, vCodec) &&
+		    ContainerSupportsCodec(formatStr, aCodec)) {
 			item->setFlags(Qt::ItemIsSelectable |
 				       Qt::ItemIsEnabled);
 		} else {


### PR DESCRIPTION
### Description

Fixes the compatibility check again, this time because of a silly mistake I should've caught because I made it before. `QT_TO_UTF8(x)` (which just expands to `x.toUtf8().constData()`) returns a pointer to memory that gets freed immediately at the end of the statement. This is valid in function calls but will cause issues in cases like this one.

Fun fact: This is a use-after-free and `rustc` would yell at you for this, but C++ compilers just go "nah seems goot mate".

### Motivation and Context

Fix bugs.

### How Has This Been Tested?

Opened settings a few times and validated things work now.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
