### PR TITLE
UI: Fix properties resizing (again)

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -108,15 +108,12 @@ void OBSPropertiesView::ReloadProperties()
 
 void OBSPropertiesView::RefreshProperties()
 {
-	bool firstDraw = false;
 	int h, v;
 	GetScrollPos(h, v);
 
 	children.clear();
 	if (widget)
 		widget->deleteLater();
-	else
-		firstDraw = true;
 
 	widget = new QWidget();
 	widget->setObjectName("PropertiesContainer");
@@ -141,8 +138,7 @@ void OBSPropertiesView::RefreshProperties()
 	setWidget(widget);
 	SetScrollPos(h, v);
 	setSizePolicy(mainPolicy);
-	if (firstDraw)
-		adjustSize();
+	adjustSize();
 
 	lastFocused.clear();
 	if (lastWidget) {

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -108,8 +108,8 @@ void OBSPropertiesView::ReloadProperties()
 
 void OBSPropertiesView::RefreshProperties()
 {
-	int h, v;
-	GetScrollPos(h, v);
+	int h, v, hend, vend;
+	GetScrollPos(h, v, hend, vend);
 
 	children.clear();
 	if (widget)
@@ -136,9 +136,9 @@ void OBSPropertiesView::RefreshProperties()
 
 	setWidgetResizable(true);
 	setWidget(widget);
-	SetScrollPos(h, v);
 	setSizePolicy(mainPolicy);
 	adjustSize();
+	SetScrollPos(h, v, hend, vend);
 
 	lastFocused.clear();
 	if (lastWidget) {
@@ -154,28 +154,36 @@ void OBSPropertiesView::RefreshProperties()
 	emit PropertiesRefreshed();
 }
 
-void OBSPropertiesView::SetScrollPos(int h, int v)
+void OBSPropertiesView::SetScrollPos(int h, int v, int old_hend, int old_vend)
 {
 	QScrollBar *scroll = horizontalScrollBar();
-	if (scroll)
-		scroll->setValue(h);
+	if (scroll) {
+		int hend = scroll->maximum() + scroll->pageStep();
+		scroll->setValue(h * hend / old_hend);
+	}
 
 	scroll = verticalScrollBar();
-	if (scroll)
-		scroll->setValue(v);
+	if (scroll) {
+		int vend = scroll->maximum() + scroll->pageStep();
+		scroll->setValue(v * vend / old_vend);
+	}
 }
 
-void OBSPropertiesView::GetScrollPos(int &h, int &v)
+void OBSPropertiesView::GetScrollPos(int &h, int &v, int &hend, int &vend)
 {
 	h = v = 0;
 
 	QScrollBar *scroll = horizontalScrollBar();
-	if (scroll)
+	if (scroll) {
 		h = scroll->value();
+		hend = scroll->maximum() + scroll->pageStep();
+	}
 
 	scroll = verticalScrollBar();
-	if (scroll)
+	if (scroll) {
 		v = scroll->value();
+		vend = scroll->maximum() + scroll->pageStep();
+	}
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, obs_object_t *obj,

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -137,8 +137,8 @@ private:
 
 	void resizeEvent(QResizeEvent *event) override;
 
-	void GetScrollPos(int &h, int &v);
-	void SetScrollPos(int h, int v);
+	void GetScrollPos(int &h, int &v, int &hend, int &vend);
+	void SetScrollPos(int h, int v, int old_hend, int old_vend);
 
 private slots:
 	void RefreshProperties();


### PR DESCRIPTION
### Description

Sets the size before restoring the scroll position, and also recalculates the scroll position based on the change in maximum value to the scroll bars.

Fixes #8659

### Motivation and Context

Fixes odd behaviour.

### How Has This Been Tested?

Not easy to test, the main sources with this cursed behaviour are on Windows. But seems to work with mac avcapture sources.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
