### PR TITLE
obs-ffmpeg: Fix iteration over sample formats

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -289,10 +289,10 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 		/* Check if the requested format is actually available for the specified
 		 * encoder. This may not always be the case due to FFmpeg changes or a
 		 * fallback being used (for example, when libopus is unavailable). */
-		enum AVSampleFormat fmt = enc->codec->sample_fmts[0];
-		while (fmt != AV_SAMPLE_FMT_NONE) {
-			if (fmt == sample_format) {
-				enc->context->sample_fmt = fmt;
+		const enum AVSampleFormat *fmt = enc->codec->sample_fmts;
+		while (*fmt != AV_SAMPLE_FMT_NONE) {
+			if (*fmt == sample_format) {
+				enc->context->sample_fmt = *fmt;
 				break;
 			}
 			fmt++;


### PR DESCRIPTION
### Description

The iteration was running on the enum rather than the actual array specified in the codec, so it would keep searching through FFmpeg's memory until it found `-1`, fun!

Fixes #8660

### Motivation and Context

Fix bug.

### How Has This Been Tested?

Breakpointed to validate things now work correctly.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
