### PR TITLE
libobs: Fix transition lookup by uuid

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2123,7 +2123,14 @@ obs_source_t *obs_get_transition_by_name(const char *name)
 
 obs_source_t *obs_get_transition_by_uuid(const char *uuid)
 {
-	return obs_get_source_by_uuid(uuid);
+	obs_source_t *source = obs_get_source_by_uuid(uuid);
+
+	if (source && source->info.type == OBS_SOURCE_TYPE_TRANSITION)
+		return source;
+	else if (source)
+		obs_source_release(source);
+
+	return NULL;
 }
 
 obs_output_t *obs_get_output_by_name(const char *name)


### PR DESCRIPTION
### Description
The obs_get_transition_by_uuid function would return a valid source even if it wasn't a transition.

### Motivation and Context
Fixes bug I've found

### How Has This Been Tested?
Got transitions by uuid

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
