### PR TITLE
UI: Replace use of macros for macOS updater with character constants

### DIFF
--- a/UI/update/mac-update.cpp
+++ b/UI/update/mac-update.cpp
@@ -10,13 +10,9 @@
 
 /* ------------------------------------------------------------------------ */
 
-#ifndef MAC_BRANCHES_URL
-#define MAC_BRANCHES_URL "https://obsproject.com/update_studio/branches.json"
-#endif
-
-#ifndef MAC_DEFAULT_BRANCH
-#define MAC_DEFAULT_BRANCH "stable"
-#endif
+static const char *MAC_BRANCHES_URL =
+	"https://obsproject.com/update_studio/branches.json";
+static const char *MAC_DEFAULT_BRANCH = "stable";
 
 /* ------------------------------------------------------------------------ */
 

--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -232,7 +232,7 @@ bool FetchAndVerifyFile(const char *name, const char *file, const char *url,
 						    BLAKE2_HASH_LENGTH);
 
 		QString header = "If-None-Match: " + hash.toHex();
-		headers.push_back(move(header.toStdString()));
+		headers.push_back(std::move(header.toStdString()));
 	}
 
 	/* ----------------------------------- *
@@ -242,7 +242,7 @@ bool FetchAndVerifyFile(const char *name, const char *file, const char *url,
 
 	if (!guid.empty()) {
 		std::string header = "X-OBS2-GUID: " + guid;
-		headers.push_back(move(header));
+		headers.push_back(std::move(header));
 	}
 
 	/* ----------------------------------- *


### PR DESCRIPTION
### Description
Replaces preprocessor definitions with actual constant string values.

### Motivation and Context
Removes code smell and adapts modern coding practices - as per SonarSource (https://rules.sonarsource.com/cpp/RSPEC-5028):

> A macro is a textual replacement, which means that it’s not respecting the type system, it’s not respecting scoping rules…​ There is no reason not to use a constant instead.

Also updates two stray occurrences of unqualified calls to `std::move`.

### How Has This Been Tested?
Compiled on macOS 13 and checked values with debugger.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
