### PR TITLE
UI: Fix unassigned audio source check in callback

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -119,7 +119,8 @@ void VolControl::VolumeMuted(bool muted)
 void VolControl::OBSMixersChanged(void *data, calldata_t *calldata)
 {
 	VolControl *volControl = static_cast<VolControl *>(data);
-	bool unassigned = calldata_int(calldata, "mixers") == 0;
+	bool unassigned = (calldata_int(calldata, "mixers") &
+			   ((1 << MAX_AUDIO_MIXES) - 1)) == 0;
 
 	QMetaObject::invokeMethod(volControl, "AssignmentChanged",
 				  Q_ARG(bool, unassigned));


### PR DESCRIPTION
### Description

Fix callback not masking the new mixer state to check unassigned status.

### Motivation and Context

Fix bugs.

### How Has This Been Tested?

Ran on macOS, tested it now works correctly.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
