### PR TITLE
UI: Fix incorrect use of QT_TO_UTF8 in SpeakerLayoutChanged

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4671,17 +4671,20 @@ void OBSBasicSettings::SpeakerLayoutChanged(int idx)
 		 */
 		PopulateSimpleBitrates(ui->simpleOutputABitrate, isOpus);
 
-		const char *encoder_id = QT_TO_UTF8(
-			ui->advOutAEncoder->currentData().toString());
-		QString rec_encoder_id =
-			ui->advOutRecAEncoder->currentData().toString();
+		string stream_encoder_id = ui->advOutAEncoder->currentData()
+						   .toString()
+						   .toStdString();
+		string record_encoder_id = ui->advOutRecAEncoder->currentData()
+						   .toString()
+						   .toStdString();
 		PopulateAdvancedBitrates(
 			{ui->advOutTrack1Bitrate, ui->advOutTrack2Bitrate,
 			 ui->advOutTrack3Bitrate, ui->advOutTrack4Bitrate,
 			 ui->advOutTrack5Bitrate, ui->advOutTrack6Bitrate},
-			encoder_id,
-			rec_encoder_id == "none" ? encoder_id
-						 : QT_TO_UTF8(rec_encoder_id));
+			stream_encoder_id.c_str(),
+			record_encoder_id == "none"
+				? stream_encoder_id.c_str()
+				: record_encoder_id.c_str());
 	} else {
 		/*
 		 * Reset audio bitrate for simple and adv mode, update list of


### PR DESCRIPTION
### Description
Fix an invalid pointer caused by holding on to freed memory.

### Motivation and Context
After #8661 I wanted to see if there were other places affected by this anti-pattern.

### How Has This Been Tested?
Compiled and ran OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
