### PR TITLE
obs-outputs: Fix AV1 header parser adding ref count to data

### DIFF
--- a/plugins/obs-outputs/rtmp-av1.c
+++ b/plugins/obs-outputs/rtmp-av1.c
@@ -523,10 +523,8 @@ size_t obs_parse_av1_header(uint8_t **header, const uint8_t *data, size_t size)
 
 	struct array_output_data output;
 	struct serializer s;
-	long ref = 1;
 
 	array_output_serializer_init(&s, &output);
-	serialize(&s, &ref, sizeof(ref));
 
 	s_write(&s, av1header, sizeof(av1header));
 	if (seq_size)
@@ -534,8 +532,8 @@ size_t obs_parse_av1_header(uint8_t **header, const uint8_t *data, size_t size)
 	if (meta_size)
 		s_write(&s, meta, meta_size);
 
-	*header = output.bytes.array + sizeof(ref);
-	return output.bytes.num - sizeof(ref);
+	*header = output.bytes.array;
+	return output.bytes.num;
 }
 
 static void serialize_av1_data(struct serializer *s, const uint8_t *data,


### PR DESCRIPTION
### Description

The header packets are only used within the rtmp-output and do not need or use the ref counter as the data is manually free'd directly.

The presence of this ref counter causes a crash on *nix platforms due to our memory alignment hack attempting to free memory but reading the wrong offset due to the ref counter being there rather than the alignment offset.

### Motivation and Context

Fix crash.

### How Has This Been Tested?

Streamed with libaom-av1 on macOS.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
