### PR TITLE
mac-avcapture: Fix questionable use of comma

### DIFF
--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -2396,7 +2396,7 @@ bool obs_module_load(void)
 	av_capture_info.output_flags = OBS_SOURCE_ASYNC_VIDEO |
 				       OBS_SOURCE_AUDIO |
 				       OBS_SOURCE_DO_NOT_DUPLICATE;
-	av_capture_info.get_defaults = av_capture_defaults_v2,
+	av_capture_info.get_defaults = av_capture_defaults_v2;
 
 	obs_register_source(&av_capture_info);
 	return true;


### PR DESCRIPTION
### Description
Fixes a possible typo in mac-avcapture - it's a single line assignment and should obviously be terminated by a semicolon.

### Motivation and Context
Fixes a "questionable use of comma" compile error when using clang with default Xcode settings.

### How Has This Been Tested?
Tested on macOS 13 with Xcode 14.3 and default compile settings.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
