### PR TITLE
rtmp-services:  Add Ant Media Server Service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 224,
+    "version": 225,
     "files": [
         {
             "name": "services.json",
-            "version": 224
+            "version": 225
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2812,6 +2812,23 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Ant Media - Ultra Low Latency Streaming",
+            "more_info_link": "https://antmedia.io/",
+            "stream_key_link": "https://antmedia.io/webrtc-samples/rtmp-publish-webrtc-play/",
+            "servers": [
+                {
+                    "name": "EU Central",
+                    "url": "rtmp://test.antmedia.io/WebRTCAppEE/"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "baseline",
+                "max video bitrate": 9000,
+                "max audio bitrate": 192
+            }
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updating the rtmp-services ingestion list to add Ant Media Server as a streaming service RTMP endpoints


### Motivation and Context
To Add Ant Media Server ultra low latency streaming software as a rtmp service on obs.


### How Has This Been Tested?
checked lint of the JSON on online lint checking platform
build from src and tried streaming from the added service.

### Types of changes
New feature (non-breaking change which adds functionality)
Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
