### PR TITLE
cmake: Set C standard to C17

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -5,6 +5,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+# TODO/FIXME: Investigate disabling C extensions on Linux/POSIX
+if(OS_MACOS OR NOT OS_POSIX)
+  set(CMAKE_C_EXTENSIONS OFF)
+endif()
+
 # Set compile options for MSVC
 if(OS_WINDOWS AND MSVC)
   if(NOT EXISTS "${CMAKE_BINARY_DIR}/ALL_BUILD.vcxproj.user")
@@ -66,8 +73,7 @@ if(OS_WINDOWS AND MSVC)
     /utf-8
     /permissive-
     /Zc:__cplusplus
-    /Zc:preprocessor
-    /std:c17)
+    /Zc:preprocessor)
 
   add_link_options(
     "LINKER:/Brepro" "LINKER:/OPT:REF" "LINKER:/WX" "$<$<NOT:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>>:LINKER\:/SAFESEH\:NO>"

--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -14,6 +14,20 @@ include(ccache)
 include(compiler_common)
 include(simd)
 
+# Set C17 / C++17 standards as required and disable extensions
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+# Set symbols to be hidden by default for C and C++
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
+
 # Add default C and C++ compiler options if Xcode generator is not used
 if(NOT XCODE)
   list(
@@ -30,14 +44,6 @@ if(NOT XCODE)
     -Wformat
     -fno-strict-aliasing
     -Wno-error=shorten-64-to-32)
-
-  # Set symbols to be hidden by default for C and C++
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-  set(CMAKE_C_VISIBILITY_PRESET hidden)
-  set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
   # Enable stripping of dead symbols when not building for Debug configuration
   set(_release_configs RelWithDebInfo Release MinSizeRel)

--- a/cmake/macos/xcode.cmake
+++ b/cmake/macos/xcode.cmake
@@ -85,10 +85,8 @@ set(CMAKE_XCODE_ATTRIBUTE_LINKER_DISPLAYS_MANGLED_NAMES[variant=Debug] YES)
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC NO)
 # Disable strict aliasing
 set(CMAKE_XCODE_ATTRIBUTE_GCC_STRICT_ALIASING NO)
-# cmake-format: off
-# Re-enable once the bad goto statements are fixed
-# set(CMAKE_XCODE_ATTRIBUTE_GCC_C_LANGUAGE_STANDARD c99)
-# cmake-format: on
+# Set C language default to C17
+set(CMAKE_XCODE_ATTRIBUTE_GCC_C_LANGUAGE_STANDARD c17)
 # Set C++ language default to c++17
 set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD c++17)
 # Enable support for module imports in ObjC

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -487,6 +487,9 @@ static bool code_to_str(int code, struct dstr *str)
 
 void obs_key_to_str(obs_key_t key, struct dstr *str)
 {
+	const UniCharCount max_length = 16;
+	UniChar buffer[max_length];
+
 	if (localized_key_to_str(key, str))
 		return;
 
@@ -519,9 +522,7 @@ void obs_key_to_str(obs_key_t key, struct dstr *str)
 		goto err;
 	}
 
-	const UniCharCount max_length = 16;
 	UInt32 dead_key_state = 0;
-	UniChar buffer[max_length];
 	UniCharCount len = 0;
 
 	OSStatus err =


### PR DESCRIPTION
### Description

Set default compiler options C standard to C17. For MSVC this was previously manually set via the compiler flags but we can probably use this on all platforms (I can't quite remember why it was necessary for MSVC).

### Motivation and Context

Might fix issue reported here: https://github.com/obsproject/obs-studio/pull/8377#issuecomment-1499495578

### How Has This Been Tested?

Compiled on macOS with Xcode 14.3, this PR will be the test for Windows/Linux.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
