### PR TITLE
cmake: Fix build system for macOS universal builds

### DIFF
--- a/buildspec.json
+++ b/buildspec.json
@@ -62,6 +62,11 @@
             "deploymentTarget": "11.0",
             "buildTarget": "11.0"
         },
+        "macos-universal": {
+            "qtVersion": 6,
+            "deploymentTarget": "11.0",
+            "buildTarget": "11.0"
+        },
         "windows-x64": {
             "qtVersion": 6
         },

--- a/cmake/macos/buildspec.cmake
+++ b/cmake/macos/buildspec.cmake
@@ -14,7 +14,7 @@ macro(_check_deps_version version)
     if(EXISTS "${path}/share/obs-deps/VERSION")
       if(dependency STREQUAL qt6 AND NOT EXISTS "${path}/lib/cmake/Qt6/Qt6Config.cmake")
         set(found FALSE)
-        break()
+        continue()
       endif()
 
       file(READ "${path}/share/obs-deps/VERSION" _check_version)

--- a/cmake/macos/buildspec.cmake
+++ b/cmake/macos/buildspec.cmake
@@ -70,6 +70,10 @@ function(_check_dependencies)
   set(cef_destination "cef_binary_VERSION_macos_ARCH")
 
   foreach(dependency IN ITEMS prebuilt qt6 cef)
+    if(dependency STREQUAL cef AND arch STREQUAL universal)
+      continue()
+    endif()
+
     # cmake-format: off
     string(JSON data GET ${dependency_data} ${dependency})
     string(JSON version GET ${data} version)

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -6,6 +6,7 @@ if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
 
   if(NOT ENABLE_PLUGINS)
     set_property(GLOBAL APPEND PROPERTY OBS_FEATURES_DISABLED "Plugin Support")
+    return()
   endif()
 
   set_property(GLOBAL APPEND PROPERTY OBS_FEATURES_ENABLED "Plugin Support")


### PR DESCRIPTION
### Description
Fixes the following issues that arose when trying to compile `libobs` for plugin development:

* Add platform configuration for universal architecture (require for JSON parsing)
* Fix `OBS_VERSION_OVERRIDE` handling
* Fix detection of available prebuilt dependencies (dependencies will be set up for building plugins already and should be shared by the build tree for `libobs`
* Skip setup of Chromium Embedded Framework for universal builds (we do not provide a Universal binary variant of CEF)
* Skip plugin targets when `ENABLE_PLUGINS` is not enabled

### Motivation and Context
These fixes are required for an incoming update to `obs-plugintemplate` to work correctly with the updated CMake build system.

### How Has This Been Tested?
Tested with obs-plugintemplate on macOS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
