### PR TITLE
cmake: Fix build without Sparkle

### DIFF
--- a/UI/cmake/feature-sparkle.cmake
+++ b/UI/cmake/feature-sparkle.cmake
@@ -14,5 +14,6 @@ if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
 
   target_enable_feature(obs-studio "Sparkle updater" ENABLE_SPARKLE_UPDATER)
 else()
+  set(SPARKLE_UPDATE_INTERVAL 0) # Set anything that's not an empty integer
   target_disable_feature(obs-studio "Sparkle updater")
 endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets `SPARKLE_UPDATE_INTERVAL` to 0 instead of not setting it if Sparkle is disabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Plist files don't like empty integers (`<integer></integer>`), and an empty integer gets generated in Info.plist if `SPARKLE_UPDATE_INTERVAL` isn't set. This is a regression of 50d1b5ccb.
This means that OBS doesn't compile without Sparkle anymore which makes me sad because I quite like being able to compile OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3
OBS now compiles on my Mac.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
