### PR TITLE
libobs: Remove newly introduced PRAGMA_WARN_STRINGOP_OVERFLOW macro

### DIFF
--- a/libobs/util/c99defs.h
+++ b/libobs/util/c99defs.h
@@ -55,25 +55,20 @@
 #define PRAGMA_WARN_PUSH __pragma(warning(push))
 #define PRAGMA_WARN_POP __pragma(warning(pop))
 #define PRAGMA_WARN_DEPRECATION
-#define PRAGMA_WARN_STRINGOP_OVERFLOW
 #elif defined(__clang__)
 #define PRAGMA_WARN_PUSH _Pragma("clang diagnostic push")
 #define PRAGMA_WARN_POP _Pragma("clang diagnostic pop")
 #define PRAGMA_WARN_DEPRECATION \
 	_Pragma("clang diagnostic warning \"-Wdeprecated-declarations\"")
-#define PRAGMA_WARN_STRINGOP_OVERFLOW
 #elif defined(__GNUC__)
 #define PRAGMA_WARN_PUSH _Pragma("GCC diagnostic push")
 #define PRAGMA_WARN_POP _Pragma("GCC diagnostic pop")
 #define PRAGMA_WARN_DEPRECATION \
 	_Pragma("GCC diagnostic warning \"-Wdeprecated-declarations\"")
-#define PRAGMA_WARN_STRINGOP_OVERFLOW \
-	_Pragma("GCC diagnostic warning \"-Wstringop-overflow\"")
 #else
 #define PRAGMA_WARN_PUSH
 #define PRAGMA_WARN_POP
 #define PRAGMA_WARN_DEPRECATION
-#define PRAGMA_WARN_STRINGOP_OVERFLOW
 #endif
 
 #include <stddef.h>


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Extract the function `darray_push_back_new`, which is receiving `struct darray *` type in the macro `da_push_back_new`.
A GCC's extension is utilized so that `#ifdef __GNUC__` is added.

Also removes the macro `PRAGMA_WARN_STRINGOP_OVERFLOW`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The macro `PRAGMA_WARN_STRINGOP_OVERFLOW` was introduced to suppress a warning `-Wstringop-overflow` caused by the macro `da_push_back_new` calling `darray_push_back_new`. This looks a false-positive warning.

Less suppression of warnings is better.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36
GCC: 12.2.1 20221121 (Red Hat 12.2.1-4)
This will also enables checking the type check of the returned pointer.

For C++, I compiled the code with a modification below and the compile passed.

```patch
diff --git a/UI/api-interface.cpp b/UI/api-interface.cpp
index 800788be7..cb3f72bf4 100644
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -120,8 +120,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			if (!tr)
 				continue;
 
-			if (obs_source_get_ref(tr) != nullptr)
-				da_push_back(sources->sources, &tr);
+			obs_source_t **pp = da_push_back_new(sources->sources);
+			*pp = obs_source_get_ref(tr);
 		}
 	}
 
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

Since the newly introduced macro returns with a pointer type instead of `void *` type, this is a breaking change.
Hopefully, it catches a bug in 3rd party plugins.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
