### PR TITLE
obs-frontend-api: Fix deadlock when setting current scene

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -99,14 +99,14 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override
 	{
 		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(
-				main, "TransitionToScene", WaitConnection(),
-				Q_ARG(OBSSource, OBSSource(scene)));
+			QMetaObject::invokeMethod(main, "TransitionToScene",
+						  Q_ARG(OBSSource,
+							OBSSource(scene)));
 		} else {
-			QMetaObject::invokeMethod(
-				main, "SetCurrentScene", WaitConnection(),
-				Q_ARG(OBSSource, OBSSource(scene)),
-				Q_ARG(bool, false));
+			QMetaObject::invokeMethod(main, "SetCurrentScene",
+						  Q_ARG(OBSSource,
+							OBSSource(scene)),
+						  Q_ARG(bool, false));
 		}
 	}
 


### PR DESCRIPTION
### Description
OBS would freeze if obs_frontend_set_current_scene was called from a script. This fixes it by allowing Qt to select the best connection type in invokeMethod

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/3385

### How Has This Been Tested?
Used script in above issue

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
