### PR TITLE
UI: Do not disable events when disabling codecs

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5088,17 +5088,18 @@ void OBSBasicSettings::AdvOutRecCheckCodecs()
 	QString streamAudioEncoder =
 		ui->advOutAEncoder->currentData().toString();
 
-	/* Disable the signals to prevent AdvOutRecCheckWarnings to be called here. */
-	ui->advOutRecEncoder->blockSignals(true);
-	ui->advOutRecAEncoder->blockSignals(true);
+	int oldVEncoderIdx = ui->advOutRecEncoder->currentIndex();
+	int oldAEncoderIdx = ui->advOutRecAEncoder->currentIndex();
 	DisableIncompatibleCodecs(ui->advOutRecEncoder, recFormat,
 				  recFormatName, streamEncoder);
 	DisableIncompatibleCodecs(ui->advOutRecAEncoder, recFormat,
 				  recFormatName, streamAudioEncoder);
-	ui->advOutRecEncoder->blockSignals(false);
-	ui->advOutRecAEncoder->blockSignals(false);
 
-	AdvOutRecCheckWarnings();
+	/* Only invoke AdvOutRecCheckWarnings() if it wouldn't already have
+	 * been triggered by one of the encoder selections being reset. */
+	if (ui->advOutRecEncoder->currentIndex() == oldVEncoderIdx &&
+	    ui->advOutRecAEncoder->currentIndex() == oldAEncoderIdx)
+		AdvOutRecCheckWarnings();
 }
 
 #if defined(__APPLE__) && QT_VERSION < QT_VERSION_CHECK(6, 5, 1)


### PR DESCRIPTION
### Description

Previously Qt events were temporarily disabled while the codec disablement check ran to prevent `AdvOutRecCheckWarnings` being called several times in a row, however, this also resulted in `on_advOutRecEncoder_currentIndexChanged()` never being called (I didn't see this function previously as it does not use the `connect()` syntax but the `on_` syntax).

To avoid any more issues related to this simply accept that `AdvOutRecCheckWarnings()` may be called twice in quick succession, this should not have any negative effects aside from wasting CPU cycles. The call at the end of `AdvOutRecCheckCodecs()` will now only happen if neither encoder had been changed.

### Motivation and Context

Fix properties still showing after encoder has been invalidated.

### How Has This Been Tested?

Mucked about with settings for a bit.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
