### PR TITLE
UI: Add Citrix ICAService to Windows DLL blocklist

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -152,6 +152,10 @@ static blocked_module_t blocked_modules[] = {
 	// Reference: https://github.com/obsproject/obs-studio/issues/8552
 	{L"\\bdcam64.dll", 0, 0, TS_IGNORE},
 
+	// "Citrix ICAService" that crashes during DShow enumeration
+	// Reference: https://obsproject.com/forum/threads/165863/
+	{L"\\ctxdsendpoints64.dll", 0, 0, TS_IGNORE},
+
 	// Generic named unity capture filter. Unfortunately only a forked version
 	// has a critical fix to prevent deadlocks during enumeration. We block
 	// all versions since if someone didn't change the DLL name they likely


### PR DESCRIPTION
### Description
Block another broken DLL.

### Motivation and Context
Crashing reported by user, https://obsproject.com/forum/threads/obs-is-crashing-v29-0-2-and-27-2-4.165863/

### How Has This Been Tested?
Hasn't, but similar changes to block other DShow DLLs all seem to work.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
