### PR TITLE
.github: Add workflow to clean caches

### DIFF
--- a/.github/workflows/clean-caches.yml
+++ b/.github/workflows/clean-caches.yml
@@ -1,0 +1,76 @@
+name: Cache Cleanup
+
+on:
+  schedule:
+  - cron: 0 0 * * *
+  workflow_dispatch:
+
+jobs:
+  purge:
+    name: Cache Cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Python & Modules
+        run: |
+          sudo apt install -y python3.11
+          python3.11 -m pip install requests
+
+      - name: Clean Caches
+        shell: python3.11 {0}
+        run: |
+          import re
+          from datetime import datetime
+          import requests
+          
+          s = requests.session()
+          s.headers['Authorization'] = 'Bearer ${{ secrets.GITHUB_TOKEN }}'
+          
+          r = s.get('https://api.github.com/repos/${{ github.repository }}/actions/caches', params=dict(per_page=100))
+          r.raise_for_status()
+          caches = r.json()['actions_caches']
+          
+          print(f'There are {len(caches)} total caches.')
+          
+          # find latest flatpak cache
+          flatpak_last_ts = None
+          flatpak_key = None
+          for cache in caches:
+              if not cache['ref'] == 'refs/heads/master' or not cache['key'].startswith('flatpak-builder'):
+                  continue
+              ts = datetime.fromisoformat(cache['created_at'])
+              if not flatpak_last_ts or ts > flatpak_last_ts:
+                  flatpak_key = cache['key']
+                  flatpak_last_ts = ts
+          
+          if flatpak_key:
+              print(f'Latest flatpak cache: {flatpak_key}')
+          
+          now = datetime.utcnow()
+          to_be_removed = []
+          for cache in caches:
+              # add merge queue caches
+              if 'gh-readonly-queue' in cache['ref']:
+                  to_be_removed.append(cache)
+                  continue
+              
+              if flatpak_key and cache['key'].startswith('flatpak-builder'):
+                  # add non-master flatpak caches that match latest key
+                  if cache['key'] == flatpak_key and not cache['ref'] == 'refs/heads/master':
+                      to_be_removed.append(cache)
+                      continue
+                  # add master flatpak caches that do not match the latest key    
+                  elif cache['key'] != flatpak_key and cache['ref'] == 'refs/heads/master':
+                      to_be_removed.append(cache)
+                      continue
+              
+              # add dated caches predating today
+              if (cache_date := re.search('[0-9]{4}\-[0-9]{2}\-[0-9]{2}', cache['key'])) is not None:
+                  parsed_date = datetime.strptime(cache_date.group(), '%Y-%m-%d')
+                  if (now - parsed_date).days > 0:
+                      to_be_removed.append(cache)
+          
+          print(f'Removing {len(to_be_removed)} caches...')
+          for cache in to_be_removed:
+              print(f'Deleting cache "{cache["key"]}" with ID {cache["id"]}...', end=' ')
+              r = s.delete(f'https://api.github.com/repos/${{ github.repository }}/actions/caches/{cache["id"]}')
+              print(f'[{r.status_code}]')


### PR DESCRIPTION
### Description

Adds a scheduled or manually runnable workflow that removes outdated caches.

- Removes PR with a date before the current one
- Removes duplicate Flatpak caches not on the master branch
- Removes outdated Flatpak caches on the master branch

Note that it requires Python 3.11+ since `datetime.fromisoformat()` was fixed in that version to properly understand nanosecond precision timestamps and the `Z` suffix as a UTC timezone alias.

### Motivation and Context

Cache usage high.

### How Has This Been Tested?

Test run on my fork: https://github.com/derrod/obs-studio/actions/runs/4682838775/jobs/8297197955

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
