### PR TITLE
 UI: Delete selection dialogs when parent is deleted

### DIFF
--- a/UI/context-bar-controls.hpp
+++ b/UI/context-bar-controls.hpp
@@ -3,6 +3,9 @@
 #include <memory>
 #include <obs.hpp>
 #include <QWidget>
+#include <QFileDialog>
+#include <QColorDialog>
+#include <QFontDialog>
 
 class Ui_BrowserSourceToolbar;
 class Ui_DeviceSelectToolbar;
@@ -136,6 +139,7 @@ class ImageSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
 	std::unique_ptr<Ui_ImageSourceToolbar> ui;
+	QScopedPointer<QFileDialog> fileDialog;
 
 public:
 	ImageSourceToolbar(QWidget *parent, OBSSource source);
@@ -149,6 +153,7 @@ class ColorSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
 	std::unique_ptr<Ui_ColorSourceToolbar> ui;
+	QScopedPointer<QColorDialog> colorDialog;
 	QColor color;
 
 	void UpdateColor();
@@ -165,6 +170,8 @@ class TextSourceToolbar : public SourceToolbar {
 	Q_OBJECT
 
 	std::unique_ptr<Ui_TextSourceToolbar> ui;
+	QScopedPointer<QFontDialog> fontDialog;
+	QScopedPointer<QColorDialog> colorDialog;
 	QFont font;
 	QColor color;
 


### PR DESCRIPTION
### Description
In the source context bar, when an user opens a selection dialog
(font, color or file), and they switch scenes (causing the source
toolbar to be deleted), OBS would crash, as the dialog is no longer
valid. This is fixed by deleting the dialog when the toolbar is
deleted.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/7824

### How Has This Been Tested?
Made sure the selection dialogs were deleted when switching scenes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
