### PR TITLE
Destroy frontend API on shutdown

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -13,7 +13,7 @@ void obs_frontend_set_callbacks_internal(obs_frontend_callbacks *callbacks)
 static inline bool callbacks_valid_(const char *func_name)
 {
 	if (!c) {
-		blog(LOG_WARNING, "Tried to call %s with no callbacks!",
+		blog(LOG_ERROR, "Tried to call %s with no callbacks!",
 		     func_name);
 		return false;
 	}

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -641,6 +641,9 @@ void SourceTreeModel::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 		stm->SceneChanged();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
+		stm->Clear();
+		obs_frontend_remove_event_callback(OBSFrontendEvent, stm);
+		break;
 	case OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP:
 		stm->Clear();
 		break;
@@ -858,11 +861,6 @@ SourceTreeModel::SourceTreeModel(SourceTree *st_)
 	: QAbstractListModel(st_), st(st_)
 {
 	obs_frontend_add_event_callback(OBSFrontendEvent, this);
-}
-
-SourceTreeModel::~SourceTreeModel()
-{
-	obs_frontend_remove_event_callback(OBSFrontendEvent, this);
 }
 
 int SourceTreeModel::rowCount(const QModelIndex &parent) const

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -136,7 +136,6 @@ class SourceTreeModel : public QAbstractListModel {
 
 public:
 	explicit SourceTreeModel(SourceTree *st);
-	~SourceTreeModel();
 
 	virtual int rowCount(const QModelIndex &parent) const override;
 	virtual QVariant data(const QModelIndex &index,

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4896,6 +4896,10 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	if (api)
 		api->on_event(OBS_FRONTEND_EVENT_EXIT);
 
+	// Destroys the frontend API so plugins can't continue calling it
+	obs_frontend_set_callbacks_internal(nullptr);
+	api = nullptr;
+
 	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
 }
 

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -29,6 +29,9 @@ void OBSBasicStats::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
 		stats->ResetRecTimeLeft();
 		break;
+	case OBS_FRONTEND_EVENT_EXIT:
+		obs_frontend_remove_event_callback(OBSFrontendEvent, stats);
+		break;
 	default:
 		break;
 	}
@@ -234,8 +237,6 @@ void OBSBasicStats::closeEvent(QCloseEvent *event)
 
 OBSBasicStats::~OBSBasicStats()
 {
-	obs_frontend_remove_event_callback(OBSFrontendEvent, this);
-
 	delete shortcutFilter;
 	os_cpu_usage_info_destroy(cpu_info);
 }

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -129,7 +129,10 @@ Structures/Enumerations
 
    - **OBS_FRONTEND_EVENT_EXIT**
 
-     Triggered when the program is about to exit.
+     Triggered when the program is about to exit. This is the last chance
+     to call any frontend API functions for any saving / cleanup / etc.
+     After returning from this event callback, it is not permitted to make
+     any further frontend API calls.
 
    - **OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING**
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Destroys the frontend API after the `OBS_FRONTEND_EVENT_EXIT` event has finished and fixes some internal use of the frontend API that violates this.

### Motivation and Context
Many plugins (and even some parts of OBS itself) continue to call the frontend API after the `OBS_FRONTEND_EVENT_EXIT` event . This is very dangerous as OBS is in the process of shutting down so there are no guarantees that the functions they want to call will be valid or the data returned won't be in the middle of destruction, resulting in crashes.

Fixes #8370.

### How Has This Been Tested?
Ran OBS with default set of plugins, no errors logged or broken behavior noticed. Some 3rd party plugins may be relying on this previously dangerous behavior though so this needs testing well.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
