### PR TITLE
UI: Fix simple mode replay buffer maximum not being set

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5588,6 +5588,7 @@ void OBSBasicSettings::SimpleReplayBufferChanged()
 		}
 	} else {
 		ui->simpleRBEstimate->setText(QTStr(ESTIMATE_UNKNOWN_STR));
+		ui->simpleRBMegsMax->setMaximum(memMaxMB);
 	}
 
 	ui->simpleRBEstimate->style()->polish(ui->simpleRBEstimate);


### PR DESCRIPTION
### Description

Fixes maximum of memory limit spinbox not being set in simple mode replay buffer.

### Motivation and Context

Fixes #8704 

### How Has This Been Tested?

Verified spinbox now goes beyond 8192.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
