### PR TITLE
Avoid calling libobs functions with null pointers in projectors

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -19,8 +19,10 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	: OBSQTDisplay(widget, Qt::Window), weakSource(OBSGetWeakRef(source_))
 {
 	OBSSource source = GetSource();
-	destroyedSignal.Connect(obs_source_get_signal_handler(source),
-				"destroy", OBSSourceDestroyed, this);
+	if (source) {
+		destroyedSignal.Connect(obs_source_get_signal_handler(source),
+					"destroy", OBSSourceDestroyed, this);
+	}
 
 	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					"ProjectorAlwaysOnTop");
@@ -50,7 +52,10 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 	else
 		SetMonitor(monitor);
 
-	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
+	if (source)
+		UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
+	else
+		UpdateProjectorTitle(QString());
 
 	QAction *action = new QAction(this);
 	action->setShortcut(Qt::Key_Escape);


### PR DESCRIPTION
### Description
Skips calling `obs_source_get_signal_handler` and `obs_source_get_name` if not using a source / scene projector (i.e. multiview).

### Motivation and Context
Calling libobs functions with a null pointer is bad behavior.

### How Has This Been Tested?
Ran OBS, opened projectors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
