### PR TITLE
obs-outputs: Log encoder incompatibility with dynamic bitrate

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1359,6 +1359,8 @@ static bool init_connect(struct rtmp_stream *stream)
 	caps = obs_encoder_get_caps(venc);
 	if ((caps & OBS_ENCODER_CAP_DYN_BITRATE) == 0) {
 		stream->dbr_enabled = false;
+		info("Dynamic bitrate disabled. "
+		     "The encoder does not support on-the-fly bitrate reconfiguration.");
 	}
 
 	if (obs_output_get_delay(stream->output) != 0) {


### PR DESCRIPTION
### Description
This logs that dynamic bitrate is disabled when a codec which does not support bitrate reconfiguration is used, such as aom, svt-av1 ...

### Motivation and Context
User reported that dynamic bitrate did not work with aom + rtmp to YouTube.
See #8740 

### How Has This Been Tested?
Tested that it logs that dbr is disabled.

### Types of changes
 - Tweak (non-breaking change to improve existing functionality)
### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
