### PR TITLE
cmake: Fix buildspec version parsing for dependencies

### DIFF
--- a/cmake/macos/buildspec.cmake
+++ b/cmake/macos/buildspec.cmake
@@ -19,6 +19,8 @@ macro(_check_deps_version version)
 
       file(READ "${path}/share/obs-deps/VERSION" _check_version)
       string(REPLACE "\n" "" _check_version "${_check_version}")
+      string(REPLACE "-" "." _check_version "${_check_version}")
+      string(REPLACE "-" "." version "${version}")
 
       if(_check_version VERSION_EQUAL version)
         set(found TRUE)


### PR DESCRIPTION
### Description
Fix version comparison in build spec parser to ensure outdated `obs-deps` are automatically detected and new variants downloaded automatically.

### Motivation and Context
VERSION comparison requires semver-compliant version strings, but obs-deps versions are based on dates, which are not compliant. Fix version strings to semver variants before comparison.

### How Has This Been Tested?
Tested with new updated deps available for beta-4.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
