### PR TITLE
CI: Bump Flatpak actions to v6.1

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -80,7 +80,7 @@ jobs:
           echo "cache_hit=$CACHE_HIT" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
         with:
           bundle: obs-studio-${{ steps.setup.outputs.git_hash }}.flatpak
           manifest-path: CI/flatpak/com.obsproject.Studio.json
@@ -107,7 +107,7 @@ jobs:
           ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
 
       - name: Publish to Flathub Beta
-        uses: flatpak/flatpak-github-actions/flat-manager@v6
+        uses: flatpak/flatpak-github-actions/flat-manager@v6.1
         if: matrix.branch == 'beta'
         with:
           flat-manager-url: https://hub.flathub.org/
@@ -115,7 +115,7 @@ jobs:
           token: ${{ secrets.FLATHUB_BETA_TOKEN }}
 
       - name: Publish to Flathub
-        uses: flatpak/flatpak-github-actions/flat-manager@v6
+        uses: flatpak/flatpak-github-actions/flat-manager@v6.1
         if: matrix.branch == 'stable'
         with:
           flat-manager-url: https://hub.flathub.org/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -376,7 +376,7 @@ jobs:
           echo "cache_hit=$CACHE_HIT" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest
-        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
         with:
           build-bundle: ${{ fromJSON(needs.config.outputs.create_artifacts) }}
           bundle: obs-studio-flatpak-${{ steps.setup.outputs.git_hash }}.flatpak


### PR DESCRIPTION
### Description

Use Flatpak GitHub action v6.1.

### Motivation and Context

Sadly, v6 had an issue where it pushed the build to the `master` branch regardless of the branch specified in the action config. This was fixed in v6.1, so let's use that, and publish further releases on the right branch.

### How Has This Been Tested?

 - Publish another OBS beta release
 - See that it pushed to the `beta` branch on Flathub Beta (stable releases are unaffected)

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
