### PR TITLE
UI: Make hotkey edit layout margins symmetrical

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -333,7 +333,7 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 			 [&, CurrentIndex] { RemoveEdit(CurrentIndex()); });
 
 	QHBoxLayout *subLayout = new QHBoxLayout;
-	subLayout->setContentsMargins(0, 4, 0, 0);
+	subLayout->setContentsMargins(0, 2, 0, 2);
 	subLayout->addWidget(edit);
 	subLayout->addWidget(revert);
 	subLayout->addWidget(clear);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the margins of the horizontal layout of the hotkey edit widget to have 2 pixels on the top and bottom each, rather than 4 on the top and 0 on the bottom.

Before/After (with horizontal helper lines added):
<p>
<img width="400" alt="Bildschirmfoto 2023-04-14 um 18 29 26" src="https://user-images.githubusercontent.com/59806498/232164772-eefbb4d0-a490-45ed-a2f0-e7ff59655768.png">
<img width="400" alt="Bildschirmfoto 2023-04-14 um 18 27 54" src="https://user-images.githubusercontent.com/59806498/232164779-2f09ac92-105e-427d-a51f-d2425561c49b.png">
</p>

Closes https://github.com/obsproject/obs-studio/issues/8468

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw https://github.com/obsproject/obs-studio/issues/8468 and couldn't unsee since. Thus, I had to fix it.
Also, smaller issue count == better.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3.1
See the screenshots above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
