### PR TITLE
libobs: Fix mouse button push to talk for linux

### DIFF
--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -22,7 +22,7 @@
 #include "obs-nix-x11.h"
 
 #include <xcb/xcb.h>
-#if defined(XINPUT_FOUND)
+#if defined(XCB_XINPUT_FOUND)
 #include <xcb/xinput.h>
 #endif
 #include <X11/Xlib.h>
@@ -94,7 +94,7 @@ struct obs_hotkeys_platform {
 	int num_keysyms;
 	int syms_per_code;
 
-#if defined(XINPUT_FOUND)
+#if defined(XCB_XINPUT_FOUND)
 	bool pressed[XINPUT_MOUSE_LEN];
 	bool update[XINPUT_MOUSE_LEN];
 	bool button_pressed[XINPUT_MOUSE_LEN];
@@ -829,7 +829,7 @@ static inline xcb_window_t root_window(obs_hotkeys_platform_t *context,
 	return 0;
 }
 
-#if defined(XINPUT_FOUND)
+#if defined(XCB_XINPUT_FOUND)
 static inline void registerMouseEvents(struct obs_core_hotkeys *hotkeys)
 {
 	obs_hotkeys_platform_t *context = hotkeys->platform_context;
@@ -860,7 +860,7 @@ static bool obs_nix_x11_hotkeys_platform_init(struct obs_core_hotkeys *hotkeys)
 	hotkeys->platform_context = bzalloc(sizeof(obs_hotkeys_platform_t));
 	hotkeys->platform_context->display = display;
 
-#if defined(XINPUT_FOUND)
+#if defined(XCB_XINPUT_FOUND)
 	registerMouseEvents(hotkeys);
 #endif
 	fill_base_keysyms(hotkeys);
@@ -889,7 +889,7 @@ static bool mouse_button_pressed(xcb_connection_t *connection,
 {
 	bool ret = false;
 
-#if defined(XINPUT_FOUND)
+#if defined(XCB_XINPUT_FOUND)
 	memset(context->pressed, 0, XINPUT_MOUSE_LEN);
 	memset(context->update, 0, XINPUT_MOUSE_LEN);
 


### PR DESCRIPTION
Fixes issue with mouse buttons 4 and 5 not working for push to talk when using linux

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If I understand correctly, according to FindXCB.cmake, the definition for xinput should be XCB_XINPUT_FOUND which was causing the obs-nix-x11.c to not utilize xinput. This caused the function mouse_button_pressed to fallback onto code that does not include support for mouse buttons greater than 3. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes issue  #8517

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
info: Using EGL/X11
info: CPU Name: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
info: CPU Speed: 3099.713MHz
info: Physical Cores: 4, Logical Cores: 8
info: Physical Memory: 15883MB Total, 8226MB Free
info: Kernel Version: Linux 6.2.10-arch1-1
info: Distribution: "Arch Linux" Unknown
info: Desktop Environment: KDE
info: Session Type: tty
info: Window System: X11.0, Vendor: The X.Org Foundation, Version: 1.21.1
info: Qt Version: 6.4.3 (runtime), 6.4.3 (compiled)
info: Portable mode: false
info: OBS 29.1.0-beta4 (linux)

1.) Enable push to talk
2.) Set push to talk key to mouse button 4 or 5
3.) See that the microphone input was active when mouse button 4 or 5 is pressed

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
