### PR TITLE
UI: Explicitly make Ok button in properties dialog default

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -63,6 +63,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
 	ui->setupUi(this);
+	ui->buttonBox->button(QDialogButtonBox::Ok)->setDefault(true);
 
 	if (cx > 400 && cy > 400)
 		resize(cx, cy);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Explicitly sets the Ok button in the source properties dialog to be the default button of the button box.

Interestingly, the [Qt docs](https://doc.qt.io/qt-6/qdialogbuttonbox.html#details) state that
> If you want a specific button to be default you need to call [QPushButton::setDefault](https://doc.qt.io/qt-6/qpushbutton.html#default-prop)() on it yourself.

but also that 
> if there is no default button set [...] the first push button with the accept role is made the default button when the QDialogButtonBox is shown

which would indicate that Ok should already be the default (since RestoreDefaults shouldn't have the accept role), so either we're running into a Qt bug or this fix isn't actually the fix. However I'm not running into the reported problem myself, so I need someone (ideally the reporter of the bug) to confirm this.

#### Draft TODO-list:
- [ ] Have someone actually test this change on an effected operating system.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Hopefully fixes #8749

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
On my Mac: Tested with a small change to this PR that using `QDialogButtonBox::RestoreDefaults` would make the "Defaults" button the default when clicking enter. However currently the "OK" button already is the default on my machine so this PR itself doesn't make any difference.

Needs testing from effected people.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
