### PR TITLE
libobs-d3d11: Better HAGS detection

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -180,8 +180,6 @@ static void log_admin_status(void)
 	L"SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR"
 #define WIN10_GAME_DVR_REG_KEY L"System\\GameConfigStore"
 #define WIN10_GAME_MODE_REG_KEY L"Software\\Microsoft\\GameBar"
-#define WIN10_HAGS_REG_KEY \
-	L"SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers"
 
 static void log_gaming_features(void)
 {
@@ -193,7 +191,6 @@ static void log_gaming_features(void)
 	struct reg_dword game_dvr_enabled;
 	struct reg_dword game_dvr_bg_recording;
 	struct reg_dword game_mode_enabled;
-	struct reg_dword hags_enabled;
 
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_BAR_REG_KEY,
 		      L"AppCaptureEnabled", &game_bar_enabled);
@@ -205,8 +202,6 @@ static void log_gaming_features(void)
 		      L"HistoricalCaptureEnabled", &game_dvr_bg_recording);
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
 		      L"AutoGameModeEnabled", &game_mode_enabled);
-	get_reg_dword(HKEY_LOCAL_MACHINE, WIN10_HAGS_REG_KEY, L"HwSchMode",
-		      &hags_enabled);
 
 	if (game_mode_enabled.status != ERROR_SUCCESS) {
 		get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
@@ -240,15 +235,6 @@ static void log_gaming_features(void)
 	} else if (win_build >= 19042) {
 		// On by default in newer Windows 10 builds (no registry key set)
 		blog(LOG_INFO, "\tGame Mode: Probably On (no reg key set)");
-	}
-
-	if (hags_enabled.status == ERROR_SUCCESS) {
-		blog(LOG_INFO, "\tHardware GPU Scheduler: %s",
-		     (hags_enabled.return_value == 2) ? "On" : "Off");
-	} else if (win_build >= 22000) {
-		// On by default in Windows 11 (no registry key set)
-		blog(LOG_INFO,
-		     "\tHardware GPU Scheduler: Probably On (no reg key set)");
 	}
 }
 


### PR DESCRIPTION
### Description

Queries and logs HAGS status directly rather than relying on registry entries.

Largely derived from capabilities check in NVIDIA's Streamline Framework (MIT licensed): https://github.com/NVIDIAGameWorks/Streamline/blob/f33459c2342498b6123d702f8a9dd0ce1733ea02/source/plugins/sl.common/commonInterface.cpp#L123

### Motivation and Context

Registry is unrealiable. HAGS causes issues.

### How Has This Been Tested?

Ran on my machine, status was logged correctly:
```
	  HAGS Supported: true
	  HAGS Enabled:   false
```

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
