### PR TITLE
UI: Add HAGS warning on startup

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -119,6 +119,10 @@ SceneFilters="Open Scene Filters"
 PluginsFailedToLoad.Title="Plugin Load Error"
 PluginsFailedToLoad.Text="The following OBS plugins failed to load:\n\n%1\nPlease update or remove these plugins."
 
+# warning if HAGS is enabled
+HAGSEnabled.Title="HAGS Enabled"
+HAGSEnabled.Text="OBS has detected that Hardware-Accelerated GPU Scheduling (HAGS) is enabled on your system.<br><br>HAGS may cause performance issues and failures with OBS or hardware encoders. It is recommend to disable it while using OBS.<br><br><a href='https://obsproject.com/kb/hags#how-to-disable-hags'>Learn more</a>"
+
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
 AlreadyRunning.Text="OBS is already running! Unless you meant to do this, please shut down any existing instances of OBS before trying to run a new instance. If you have OBS set to minimize to the system tray, please check to see if it's still running there."

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -656,6 +656,10 @@ private:
 
 	void UpdatePreviewOverflowSettings();
 
+#ifdef _WIN32
+	void ShowHAGSWarning();
+#endif
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -26,6 +26,7 @@
 #include <d3d9.h>
 #include "d3d11-subsystem.hpp"
 #include <shellscalingapi.h>
+#include <d3dkmthk.h>
 
 struct UnsupportedHWError : HRError {
 	inline UnsupportedHWError(const char *str, HRESULT hr)
@@ -524,6 +525,43 @@ static bool set_priority(ID3D11Device *device)
 
 #endif
 
+static bool adapter_hags_enabled(DXGI_ADAPTER_DESC *desc)
+{
+	D3DKMT_OPENADAPTERFROMLUID d3dkmt_openluid{};
+	bool hags_enabled = false;
+	NTSTATUS res;
+
+	d3dkmt_openluid.AdapterLuid = desc->AdapterLuid;
+
+	res = D3DKMTOpenAdapterFromLuid(&d3dkmt_openluid);
+	if (FAILED(res)) {
+		blog(LOG_DEBUG, "Failed opening D3DKMT adapter: %x", res);
+		return hags_enabled;
+	}
+
+	D3DKMT_WDDM_2_7_CAPS caps = {};
+	D3DKMT_QUERYADAPTERINFO args = {};
+	args.hAdapter = d3dkmt_openluid.hAdapter;
+	args.Type = KMTQAITYPE_WDDM_2_7_CAPS;
+	args.pPrivateDriverData = &caps;
+	args.PrivateDriverDataSize = sizeof(caps);
+	res = D3DKMTQueryAdapterInfo(&args);
+
+	/* On Windows 10 pre-2004 this will fail, but HAGS isn't supported
+	 * there anyway. */
+	if (SUCCEEDED(res))
+		hags_enabled = caps.HwSchEnabled;
+
+	D3DKMT_CLOSEADAPTER d3dkmt_close = {d3dkmt_openluid.hAdapter};
+	res = D3DKMTCloseAdapter(&d3dkmt_close);
+	if (FAILED(res)) {
+		blog(LOG_DEBUG, "Failed closing D3DKMT adapter %x: %x",
+		     d3dkmt_openluid.hAdapter, res);
+	}
+
+	return hags_enabled;
+}
+
 static bool CheckFormat(ID3D11Device *device, DXGI_FORMAT format)
 {
 	constexpr UINT required = D3D11_FORMAT_SUPPORT_TEXTURE2D |
@@ -580,6 +618,13 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 			       "failed (not admin?)");
 	}
 #endif
+
+	/* check HAGS status for used adapter */
+	hagsEnabled = adapter_hags_enabled(&desc);
+	if (hagsEnabled) {
+		blog(LOG_WARNING,
+		     "Hardware-accelerated GPU Scheduling (HAGS) is enabled!");
+	}
 
 	/* ---------------------------------------- */
 	/* check for nv12 texture output support    */
@@ -3082,6 +3127,11 @@ extern "C" EXPORT bool device_nv12_available(gs_device_t *device)
 extern "C" EXPORT bool device_p010_available(gs_device_t *device)
 {
 	return device->p010Supported;
+}
+
+extern "C" EXPORT bool device_hags_enabled(gs_device_t *device)
+{
+	return device->hagsEnabled;
 }
 
 extern "C" EXPORT bool device_is_monitor_hdr(gs_device_t *device, void *monitor)

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1004,6 +1004,7 @@ struct gs_device {
 	uint32_t adpIdx = 0;
 	bool nv12Supported = false;
 	bool p010Supported = false;
+	bool hagsEnabled = false;
 
 	gs_texture_2d *curRenderTarget = nullptr;
 	gs_zstencil_buffer *curZStencilBuffer = nullptr;

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -236,6 +236,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(device_stagesurface_create_p010);
 	GRAPHICS_IMPORT_OPTIONAL(device_register_loss_callbacks);
 	GRAPHICS_IMPORT_OPTIONAL(device_unregister_loss_callbacks);
+	GRAPHICS_IMPORT_OPTIONAL(device_hags_enabled);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	GRAPHICS_IMPORT(device_texture_create_from_dmabuf);
 	GRAPHICS_IMPORT(device_query_dmabuf_capabilities);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -351,6 +351,8 @@ struct gs_exports {
 		gs_device_t *device, const struct gs_device_loss *callbacks);
 	void (*device_unregister_loss_callbacks)(gs_device_t *device,
 						 void *data);
+
+	bool (*device_hags_enabled)(gs_device_t *device);
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	struct gs_texture *(*device_texture_create_from_dmabuf)(
 		gs_device_t *device, unsigned int width, unsigned int height,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -3317,4 +3317,15 @@ void gs_unregister_loss_callbacks(void *data)
 			graphics->device, data);
 }
 
+bool gs_hags_enabled(void)
+{
+	if (!gs_valid("gs_hags_enabled"))
+		return false;
+
+	if (!thread_graphics->exports.device_hags_enabled)
+		return false;
+
+	return thread_graphics->exports.device_hags_enabled(
+		thread_graphics->device);
+}
 #endif

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -969,6 +969,7 @@ EXPORT gs_stagesurf_t *gs_stagesurface_create_p010(uint32_t width,
 
 EXPORT void gs_register_loss_callbacks(const struct gs_device_loss *callbacks);
 EXPORT void gs_unregister_loss_callbacks(void *data);
+EXPORT bool gs_hags_enabled(void);
 
 #elif defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -180,8 +180,6 @@ static void log_admin_status(void)
 	L"SOFTWARE\\Policies\\Microsoft\\Windows\\GameDVR"
 #define WIN10_GAME_DVR_REG_KEY L"System\\GameConfigStore"
 #define WIN10_GAME_MODE_REG_KEY L"Software\\Microsoft\\GameBar"
-#define WIN10_HAGS_REG_KEY \
-	L"SYSTEM\\CurrentControlSet\\Control\\GraphicsDrivers"
 
 static void log_gaming_features(void)
 {
@@ -193,7 +191,6 @@ static void log_gaming_features(void)
 	struct reg_dword game_dvr_enabled;
 	struct reg_dword game_dvr_bg_recording;
 	struct reg_dword game_mode_enabled;
-	struct reg_dword hags_enabled;
 
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_BAR_REG_KEY,
 		      L"AppCaptureEnabled", &game_bar_enabled);
@@ -205,8 +202,6 @@ static void log_gaming_features(void)
 		      L"HistoricalCaptureEnabled", &game_dvr_bg_recording);
 	get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
 		      L"AutoGameModeEnabled", &game_mode_enabled);
-	get_reg_dword(HKEY_LOCAL_MACHINE, WIN10_HAGS_REG_KEY, L"HwSchMode",
-		      &hags_enabled);
 
 	if (game_mode_enabled.status != ERROR_SUCCESS) {
 		get_reg_dword(HKEY_CURRENT_USER, WIN10_GAME_MODE_REG_KEY,
@@ -240,15 +235,6 @@ static void log_gaming_features(void)
 	} else if (win_build >= 19042) {
 		// On by default in newer Windows 10 builds (no registry key set)
 		blog(LOG_INFO, "\tGame Mode: Probably On (no reg key set)");
-	}
-
-	if (hags_enabled.status == ERROR_SUCCESS) {
-		blog(LOG_INFO, "\tHardware GPU Scheduler: %s",
-		     (hags_enabled.return_value == 2) ? "On" : "Off");
-	} else if (win_build >= 22000) {
-		// On by default in Windows 11 (no registry key set)
-		blog(LOG_INFO,
-		     "\tHardware GPU Scheduler: Probably On (no reg key set)");
 	}
 }
 


### PR DESCRIPTION
### Description

Adds the following warning on startup:
![2023-05-07_03-30-24_gJcbin](https://user-images.githubusercontent.com/3123295/236653249-5ca06171-03d0-4aed-9bbf-264b6cd90e3e.png)

Uses the same detection method as #8752, but only checks the device OBS loads up on.

### Motivation and Context

HAGS causes a number of issues with OBS, so we should tell users.

### How Has This Been Tested?

Only validated that off detection works correctly, not tested on a system with HAGS enabled.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
