### PR TITLE
mac-virtualcam: Fix DAL plugin entrypoint not being exported

### DIFF
--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInMain.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInMain.mm
@@ -23,7 +23,7 @@
 
 //! PlugInMain is the entrypoint for the plugin
 extern "C" {
-void *PlugInMain(CFAllocatorRef, CFUUIDRef requestedTypeUUID)
+__exported void *PlugInMain(CFAllocatorRef, CFUUIDRef requestedTypeUUID)
 {
 	DLogFunc(@"version=%@", PLUGIN_VERSION);
 	if (!CFEqual(requestedTypeUUID, kCMIOHardwarePlugInTypeID)) {


### PR DESCRIPTION
### Description
Fixes macOS virtualcam missing `PlugInMain` entry point for CoreMediaIO.

### Motivation and Context
With the recent change to enforce C17 standard for compilers, default visibility was also enforced to be hidden. This also automatically hid the `PlugInMain` symbol required for DAL plugins. Adding the `__exported` decorator makes the symbol explicitly visible.

(It also seems as if the related Xcode setting is forced to be "off" by CMake's Xcode generator even though we enable it in our build. Only setting it via the generator-independent CMake flags seems to has the desired effect, which is why it didn't occur before that PR was merged).

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
