### PR TITLE
libobs: Improve util_mul_div64 outside MSVC

### DIFF
--- a/libobs/util/util_uint64.h
+++ b/libobs/util/util_uint64.h
@@ -22,7 +22,17 @@
 
 static inline uint64_t util_mul_div64(uint64_t num, uint64_t mul, uint64_t div)
 {
-#if defined(_MSC_VER) && defined(_M_X64) && (_MSC_VER >= 1920)
+#if !defined(_MSC_VER)
+#if defined(__x86_64__)
+	uint64_t rax, rdx;
+	__asm__("mulq %2" : "=a"(rax), "=d"(rdx) : "r"(num), "a"(mul));
+	__asm__("divq %1" : "=a"(rax) : "r"(div), "a"(rax), "d"(rdx));
+	return rax;
+#else
+	return (uint64_t)(((__uint128_t)num * (__uint128_t)mul) /
+			  (__uint128_t)div);
+#endif
+#elif defined(_M_X64) && (_MSC_VER >= 1920)
 	unsigned __int64 high;
 	const unsigned __int64 low = _umul128(num, mul, &high);
 	unsigned __int64 rem;


### PR DESCRIPTION
### Description
Use inline assembly for x86_64 speed/accuracy.

Sacrifice speed for accuracy on other processors.

Continue to use original implementation for ARM on Windows.

### Motivation and Context
Make Linux behave like Windows. Make Mac behave closer to Windows.

### How Has This Been Tested?
Checked Windows (x64), Mac (ARM64), and WSL2 Ubuntu (x86_64). Modified code temporarily to verify previous failure case works now.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.