### PR TITLE
cmake: Add properties and log viewer UI files to sources list

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -103,6 +103,7 @@ target_sources(
           forms/OBSBasic.ui
           forms/OBSBasicFilters.ui
           forms/OBSBasicInteraction.ui
+          forms/OBSBasicProperties.ui
           forms/OBSBasicSettings.ui
           forms/OBSBasicSourceSelect.ui
           forms/OBSBasicTransform.ui
@@ -110,6 +111,7 @@ target_sources(
           forms/OBSExtraBrowsers.ui
           forms/OBSImporter.ui
           forms/OBSLogReply.ui
+          forms/OBSLogViewer.ui
           forms/OBSMissingFiles.ui
           forms/OBSRemux.ui
           forms/OBSUpdate.ui

--- a/UI/cmake/ui-qt.cmake
+++ b/UI/cmake/ui-qt.cmake
@@ -27,6 +27,7 @@ set(_qt_sources
     forms/OBSBasic.ui
     forms/OBSBasicFilters.ui
     forms/OBSBasicInteraction.ui
+    forms/OBSBasicProperties.ui
     forms/OBSBasicSettings.ui
     forms/OBSBasicSourceSelect.ui
     forms/OBSBasicTransform.ui
@@ -34,6 +35,7 @@ set(_qt_sources
     forms/OBSExtraBrowsers.ui
     forms/OBSImporter.ui
     forms/OBSLogReply.ui
+    forms/OBSLogViewer.ui
     forms/OBSMissingFiles.ui
     forms/OBSRemux.ui
     forms/OBSUpdate.ui


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds `OBSBasicProperties.ui` and `OBSLogViewer.ui` to the cmake sources list.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Used Xcode to search for code that should be in the properties dialog for an unrelated PR, and wondered why I didn't get any results. This also made me check the other files which revealed that log viewer was also missing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3.1
Files now show up in the "UI Files" category.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- DX Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
