### PR TITLE
libobs,obs-filters: Align HDR to SDR disparity

### DIFF
--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -42,14 +42,12 @@ float3 rec2020_to_rec709(float3 v)
 	return float3(r, g, b);
 }
 
-float reinhard_channel(float x)
-{
-	return x / (x + 1.);
-}
-
 float3 reinhard(float3 rgb)
 {
-	return float3(reinhard_channel(rgb.r), reinhard_channel(rgb.g), reinhard_channel(rgb.b));
+	rgb /= rgb + float3(1., 1., 1.);
+	rgb = pow(rgb, float3(1. / 2.4, 1. / 2.4, 1. / 2.4));
+	rgb = srgb_nonlinear_to_linear(rgb);
+	return rgb;
 }
 
 float linear_to_st2084_channel(float x)

--- a/plugins/obs-filters/data/color.effect
+++ b/plugins/obs-filters/data/color.effect
@@ -8,6 +8,16 @@ float3 srgb_linear_to_nonlinear(float3 v)
 	return float3(srgb_linear_to_nonlinear_channel(v.r), srgb_linear_to_nonlinear_channel(v.g), srgb_linear_to_nonlinear_channel(v.b));
 }
 
+float srgb_nonlinear_to_linear_channel(float u)
+{
+	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+}
+
+float3 srgb_nonlinear_to_linear(float3 v)
+{
+	return float3(srgb_nonlinear_to_linear_channel(v.r), srgb_nonlinear_to_linear_channel(v.g), srgb_nonlinear_to_linear_channel(v.b));
+}
+
 float3 rec709_to_rec2020(float3 v)
 {
 	float r = dot(v, float3(0.62740389593469903, 0.32928303837788370, 0.043313065687417225));
@@ -24,14 +34,12 @@ float3 rec2020_to_rec709(float3 v)
 	return float3(r, g, b);
 }
 
-float reinhard_channel(float x)
-{
-	return x / (x + 1.);
-}
-
 float3 reinhard(float3 rgb)
 {
-	return float3(reinhard_channel(rgb.r), reinhard_channel(rgb.g), reinhard_channel(rgb.b));
+	rgb /= rgb + float3(1., 1., 1.);
+	rgb = pow(rgb, float3(1. / 2.4, 1. / 2.4, 1. / 2.4));
+	rgb = srgb_nonlinear_to_linear(rgb);
+	return rgb;
 }
 
 float linear_to_st2084_channel(float x)


### PR DESCRIPTION
### Description
Adjust colors from BT.1886 to sRGB.

### Motivation and Context
Want colors to be bad because of Reinhard, and not because we used the wrong transfer function.

### How Has This Been Tested?
- Compared screenshots and tonemapped image is now brighter than before.
- Verified HDR tonemap shader behavior matches common shader.
- Checked D3D11 and OpenGL backends on Windows.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.