### PR TITLE
obs-outputs: Fix enhanced RTMP frame type not being set

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -339,7 +339,8 @@ void flv_packet_ex(struct encoder_packet *packet, enum video_id_t codec_id,
 	s_wb24(&s, 0); // always 0
 
 	// packet ext header
-	s_w8(&s, FRAME_HEADER_EX | type | (packet->keyframe ? FT_KEY : 0));
+	s_w8(&s,
+	     FRAME_HEADER_EX | type | (packet->keyframe ? FT_KEY : FT_INTER));
 	s_w4cc(&s, codec_id);
 
 #ifdef ENABLE_HEVC


### PR DESCRIPTION
### Description

Per the spec, non-metadata packets still use the frame type. In OBS's use case this should either be 1 (key frame) or 2 (inter frame), but never 0 (reserved/undefined). The enum for inter frames existed but was not used here due to an oversight.

### Motivation and Context

Send spec-conforming stream.

### How Has This Been Tested?

Tested HEVC streaming to YouTube, still worked as expected.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
