### PR TITLE
cmake: Set C11 for CMake < 3.21

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -5,8 +5,15 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_C_STANDARD 17)
-set(CMAKE_C_STANDARD_REQUIRED ON)
+# CMake < 3.21 only goes up to 11, but it's mostly identical to 17 anyway.
+if(${CMAKE_VERSION} VERSION_LESS "3.21.0")
+  set(CMAKE_C_STANDARD 11)
+  set(CMAKE_C_STANDARD_REQUIRED ON)
+else()
+  set(CMAKE_C_STANDARD 17)
+  set(CMAKE_C_STANDARD_REQUIRED ON)
+endif()
+
 # TODO/FIXME: Investigate disabling C extensions on Linux/POSIX
 if(OS_MACOS OR NOT OS_POSIX)
   set(CMAKE_C_EXTENSIONS OFF)


### PR DESCRIPTION
### Description

Sets C standard version to C11 for CMake versions that do not support higher values.

### Motivation and Context

Fix building with older CMake versions (CMake 3.16 is still the default on Ubuntu 20.04).

### How Has This Been Tested?

Has not.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
