### PR TITLE
obs-outputs: Do not set DTS offset for Seq start/end packets

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -361,10 +361,9 @@ void flv_packet_ex(struct encoder_packet *packet, enum video_id_t codec_id,
 }
 
 void flv_packet_start(struct encoder_packet *packet, enum video_id_t codec,
-		      int32_t dts_offset, uint8_t **output, size_t *size)
+		      uint8_t **output, size_t *size)
 {
-	flv_packet_ex(packet, codec, dts_offset, output, size,
-		      PACKETTYPE_SEQ_START);
+	flv_packet_ex(packet, codec, 0, output, size, PACKETTYPE_SEQ_START);
 }
 
 void flv_packet_frames(struct encoder_packet *packet, enum video_id_t codec,
@@ -381,10 +380,9 @@ void flv_packet_frames(struct encoder_packet *packet, enum video_id_t codec,
 }
 
 void flv_packet_end(struct encoder_packet *packet, enum video_id_t codec,
-		    int32_t dts_offset, uint8_t **output, size_t *size)
+		    uint8_t **output, size_t *size)
 {
-	flv_packet_ex(packet, codec, dts_offset, output, size,
-		      PACKETTYPE_SEQ_END);
+	flv_packet_ex(packet, codec, 0, output, size, PACKETTYPE_SEQ_END);
 }
 
 void flv_packet_metadata(enum video_id_t codec_id, uint8_t **output,

--- a/plugins/obs-outputs/flv-mux.h
+++ b/plugins/obs-outputs/flv-mux.h
@@ -61,13 +61,13 @@ extern void flv_additional_packet_mux(struct encoder_packet *packet,
 				      size_t index);
 // Y2023 spec
 extern void flv_packet_start(struct encoder_packet *packet,
-			     enum video_id_t codec, int32_t dts_offset,
-			     uint8_t **output, size_t *size);
+			     enum video_id_t codec, uint8_t **output,
+			     size_t *size);
 extern void flv_packet_frames(struct encoder_packet *packet,
 			      enum video_id_t codec, int32_t dts_offset,
 			      uint8_t **output, size_t *size);
 extern void flv_packet_end(struct encoder_packet *packet, enum video_id_t codec,
-			   int32_t dts_offset, uint8_t **output, size_t *size);
+			   uint8_t **output, size_t *size);
 extern void flv_packet_metadata(enum video_id_t codec, uint8_t **output,
 				size_t *size, int bits_per_raw_sample,
 				uint8_t color_primaries, int color_trc,

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -490,11 +490,9 @@ static int send_packet_ex(struct rtmp_stream *stream,
 		return -1;
 
 	if (is_header) {
-		flv_packet_start(packet, stream->video_codec,
-				 stream->start_dts_offset, &data, &size);
+		flv_packet_start(packet, stream->video_codec, &data, &size);
 	} else if (is_footer) {
-		flv_packet_end(packet, stream->video_codec,
-			       stream->start_dts_offset, &data, &size);
+		flv_packet_end(packet, stream->video_codec, &data, &size);
 	} else {
 		flv_packet_frames(packet, stream->video_codec,
 				  stream->start_dts_offset, &data, &size);


### PR DESCRIPTION
### Description

Prevent underflow of RTMP timestamp delta by not setting the DTS offset for packets without a valid DTS (SEQ start/end) to prevent librtmp from trying to calculate the delta in the first place.

### Motivation and Context

Fixes an issue reported on Discord.

### How Has This Been Tested?

Verified in Wireshark capture that OBS now sends a zero timestamp rather than invalid delta.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
