### PR TITLE
libobs: Finalise source creation before firing signal

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -409,11 +409,11 @@ obs_source_create_internal(const char *id, const char *name, const char *uuid,
 	source->flags = source->default_flags;
 	source->enabled = true;
 
+	obs_source_init_finalize(source);
 	if (!private) {
 		obs_source_dosignal(source, "source_create", NULL);
 	}
 
-	obs_source_init_finalize(source);
 	return source;
 
 fail:


### PR DESCRIPTION
### Description

Fixes a possible crash when renaming a source during the source_create signal callback as it has not been added to the hash table yet.

### Motivation and Context

Fix crash reported on Discord.

### How Has This Been Tested?

Has not been tested.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
