### PR TITLE
rtmp-services: Bump format version to v5

### DIFF
--- a/plugins/rtmp-services/data/schema/service-schema-v5.json
+++ b/plugins/rtmp-services/data/schema/service-schema-v5.json
@@ -4,7 +4,7 @@
     "properties": {
         "format_version": {
             "type": "integer",
-            "description": "Identifier for parsing this file.\n- v4 introduced 'ffmpeg_mpegts_muxer' to services/recommended/output\n - v3 introduced 'ffmpeg_hls_muxer' to services/recommended/output\n - v2 introduced 'alt_names' to services"
+            "description": "Identifier for parsing this file.\n- v5 introduced the notion of protocol and Enhanced RTMP \n- v4 introduced 'ffmpeg_mpegts_muxer' to services/recommended/output\n - v3 introduced 'ffmpeg_hls_muxer' to services/recommended/output\n - v2 introduced 'alt_names' to services"
         },
         "services": {
             "type": "array",

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1,6 +1,6 @@
 {
-    "$schema": "schema/service-schema-v4.json",
-    "format_version": 4,
+    "$schema": "schema/service-schema-v5.json",
+    "format_version": 5,
     "services": [
         {
             "name": "Twitch",

--- a/plugins/rtmp-services/rtmp-format-ver.h
+++ b/plugins/rtmp-services/rtmp-format-ver.h
@@ -1,3 +1,3 @@
 #pragma once
 
-static const int RTMP_SERVICES_FORMAT_VERSION = 4;
+static const int RTMP_SERVICES_FORMAT_VERSION = 5;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Prevent newer version of OBS to use old version of `services.json` that are not updated for RFC 45 and Enhanced RTMP

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Avoid breakage for Windows user that have a v4 `services.json` in their roaming directory that is not up to date because OBS was built with `ENABLE_SERVICE_UPDATES` off.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
