### PR TITLE
win-capture: Add frame timestamp and a new frame signal

### DIFF
--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -11,6 +11,8 @@
 #define EVENT_CAPTURE_RESTART L"CaptureHook_Restart"
 #define EVENT_CAPTURE_STOP L"CaptureHook_Stop"
 
+#define EVENT_NEW_FRAME L"CaptureHook_Frame"
+
 #define EVENT_HOOK_READY L"CaptureHook_HookReady"
 #define EVENT_HOOK_EXIT L"CaptureHook_Exit"
 

--- a/plugins/win-capture/graphics-hook-info.h
+++ b/plugins/win-capture/graphics-hook-info.h
@@ -72,10 +72,12 @@ struct shmem_data {
 	volatile int last_tex;
 	uint32_t tex1_offset;
 	uint32_t tex2_offset;
+	uint64_t timestamp;
 };
 
 struct shtex_data {
 	uint32_t tex_handle;
+	uint64_t timestamp;
 };
 
 enum capture_type {

--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -12,8 +12,8 @@
  * THIS IS YOUR ONLY WARNING. */
 
 #define HOOK_VER_MAJOR 1
-#define HOOK_VER_MINOR 8
-#define HOOK_VER_PATCH 1
+#define HOOK_VER_MINOR 9
+#define HOOK_VER_PATCH 0
 
 #ifndef STRINGIFY
 #define STRINGIFY(s) #s

--- a/plugins/win-capture/graphics-hook/d3d8-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d8-capture.cpp
@@ -245,6 +245,7 @@ static void d3d8_capture(IDirect3DDevice8 *device,
 	}
 	if (capture_ready()) {
 		d3d8_shmem_capture(device, backbuffer);
+		shmem_update_timestamp();
 		signal_frame_ready();
 	}
 }

--- a/plugins/win-capture/graphics-hook/d3d8-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d8-capture.cpp
@@ -245,6 +245,7 @@ static void d3d8_capture(IDirect3DDevice8 *device,
 	}
 	if (capture_ready()) {
 		d3d8_shmem_capture(device, backbuffer);
+		signal_frame_ready();
 	}
 }
 

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -585,10 +585,13 @@ static void d3d9_capture(IDirect3DDevice9 *device,
 			return;
 		}
 
-		if (data.using_shtex)
+		if (data.using_shtex) {
 			d3d9_shtex_capture(backbuffer);
-		else
+			shtex_update_timestamp();
+		} else {
 			d3d9_shmem_capture(backbuffer);
+			shmem_update_timestamp();
+		}
 
 		signal_frame_ready();
 	}

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -589,6 +589,8 @@ static void d3d9_capture(IDirect3DDevice9 *device,
 			d3d9_shtex_capture(backbuffer);
 		else
 			d3d9_shmem_capture(backbuffer);
+
+		signal_frame_ready();
 	}
 }
 

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -226,6 +226,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 
 		if (backbuffer) {
 			data.capture(swap, backbuffer);
+			signal_frame_ready();
 			backbuffer->Release();
 		}
 	}
@@ -250,6 +251,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 
 			if (backbuffer) {
 				data.capture(swap, backbuffer);
+				signal_frame_ready();
 				backbuffer->Release();
 			}
 		}
@@ -291,6 +293,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 
 		if (backbuffer) {
 			data.capture(swap, backbuffer);
+			signal_frame_ready();
 			backbuffer->Release();
 		}
 	}
@@ -308,6 +311,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 
 			if (backbuffer) {
 				data.capture(swap, backbuffer);
+				signal_frame_ready();
 				backbuffer->Release();
 			}
 		}

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -226,6 +226,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 
 		if (backbuffer) {
 			data.capture(swap, backbuffer);
+			shtex_update_timestamp();
 			signal_frame_ready();
 			backbuffer->Release();
 		}
@@ -251,6 +252,7 @@ static HRESULT STDMETHODCALLTYPE hook_present(IDXGISwapChain *swap,
 
 			if (backbuffer) {
 				data.capture(swap, backbuffer);
+				shtex_update_timestamp();
 				signal_frame_ready();
 				backbuffer->Release();
 			}
@@ -293,6 +295,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 
 		if (backbuffer) {
 			data.capture(swap, backbuffer);
+			shtex_update_timestamp();
 			signal_frame_ready();
 			backbuffer->Release();
 		}
@@ -311,6 +314,7 @@ hook_present1(IDXGISwapChain1 *swap, UINT sync_interval, UINT flags,
 
 			if (backbuffer) {
 				data.capture(swap, backbuffer);
+				shtex_update_timestamp();
 				signal_frame_ready();
 				backbuffer->Release();
 			}

--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -628,6 +628,7 @@ static void gl_shtex_capture(void)
 
 	jimglDXUnlockObjectsNV(data.gl_device, 1, &data.gl_dxobj);
 
+	shtex_update_timestamp();
 	signal_frame_ready();
 
 	IDXGISwapChain_Present(data.dxgi_swap, 0, 0);
@@ -650,7 +651,7 @@ static void gl_shmem_capture_copy(int i)
 		if (buffer) {
 			data.texture_mapped[i] = true;
 			shmem_copy_data(i, buffer);
-
+			shmem_update_timestamp();
 			signal_frame_ready();
 		}
 	}

--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -628,6 +628,8 @@ static void gl_shtex_capture(void)
 
 	jimglDXUnlockObjectsNV(data.gl_device, 1, &data.gl_dxobj);
 
+	signal_frame_ready();
+
 	IDXGISwapChain_Present(data.dxgi_swap, 0, 0);
 }
 
@@ -648,6 +650,8 @@ static void gl_shmem_capture_copy(int i)
 		if (buffer) {
 			data.texture_mapped[i] = true;
 			shmem_copy_data(i, buffer);
+
+			signal_frame_ready();
 		}
 	}
 }

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -47,7 +47,7 @@ wchar_t keepalive_name[64] = {0};
 HWND dummy_window = NULL;
 
 static unsigned int shmem_id_counter = 0;
-static void *shmem_info = NULL;
+void *shmem_info = NULL;
 static HANDLE shmem_file_handle = 0;
 
 static struct thread_data thread_data = {0};
@@ -576,6 +576,7 @@ bool capture_init_shtex(struct shtex_data **data, HWND window, uint32_t cx,
 
 	*data = shmem_info;
 	(*data)->tex_handle = (uint32_t)handle;
+	(*data)->timestamp = 0;
 
 	global_hook_info->hook_ver_major = HOOK_VER_MAJOR;
 	global_hook_info->hook_ver_minor = HOOK_VER_MINOR;
@@ -644,6 +645,8 @@ static DWORD CALLBACK copy_thread(LPVOID unused)
 				unlock_shmem_tex(lock_id);
 				((struct shmem_data *)shmem_info)->last_tex =
 					lock_id;
+
+				shmem_update_timestamp();
 
 				shmem_id = lock_id == 0 ? 1 : 0;
 			}
@@ -770,6 +773,7 @@ bool capture_init_shmem(struct shmem_data **data, HWND window, uint32_t cx,
 	(*data)->last_tex = -1;
 	(*data)->tex1_offset = (uint32_t)align_pos;
 	(*data)->tex2_offset = (*data)->tex1_offset + aligned_tex;
+	(*data)->timestamp = 0;
 
 	global_hook_info->hook_ver_major = HOOK_VER_MAJOR;
 	global_hook_info->hook_ver_minor = HOOK_VER_MINOR;

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -29,6 +29,7 @@ struct thread_data {
 
 ipc_pipe_client_t pipe = {0};
 HANDLE signal_restart = NULL;
+HANDLE signal_frame = NULL;
 HANDLE signal_stop = NULL;
 HANDLE signal_ready = NULL;
 HANDLE signal_exit = NULL;
@@ -98,6 +99,11 @@ static inline bool init_signals(void)
 
 	signal_restart = init_event(EVENT_CAPTURE_RESTART, pid);
 	if (!signal_restart) {
+		return false;
+	}
+
+	signal_frame = init_event(EVENT_NEW_FRAME, pid);
+	if (!signal_frame) {
 		return false;
 	}
 
@@ -276,6 +282,7 @@ static void free_hook(void)
 	close_handle(&signal_ready);
 	close_handle(&signal_stop);
 	close_handle(&signal_restart);
+	close_handle(&signal_frame);
 	close_handle(&dup_hook_mutex);
 	ipc_pipe_client_free(&pipe);
 }

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -110,6 +110,7 @@ extern char system_path[MAX_PATH];
 extern char process_name[MAX_PATH];
 extern wchar_t keepalive_name[64];
 extern HWND dummy_window;
+extern void *shmem_info;
 extern volatile bool active;
 
 static inline const char *get_process_name(void)
@@ -163,6 +164,27 @@ static inline bool capture_alive(void)
 static inline bool capture_active(void)
 {
 	return active;
+}
+
+static inline void update_timestamp(uint64_t *ts)
+{
+	InterlockedExchange64((LONG64 *)ts, os_gettime_ns());
+}
+
+static inline void shtex_update_timestamp()
+{
+	if (!shmem_info)
+		return;
+
+	update_timestamp(&((struct shtex_data *)shmem_info)->timestamp);
+}
+
+static inline void shmem_update_timestamp()
+{
+	if (!shmem_info)
+		return;
+
+	update_timestamp(&((struct shmem_data *)shmem_info)->timestamp);
 }
 
 static inline void signal_frame_ready()

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -103,6 +103,7 @@ extern ipc_pipe_client_t pipe;
 extern HANDLE signal_restart;
 extern HANDLE signal_stop;
 extern HANDLE signal_ready;
+extern HANDLE signal_frame;
 extern HANDLE signal_exit;
 extern HANDLE tex_mutexes[2];
 extern char system_path[MAX_PATH];
@@ -162,6 +163,14 @@ static inline bool capture_alive(void)
 static inline bool capture_active(void)
 {
 	return active;
+}
+
+static inline void signal_frame_ready()
+{
+	if (!SetEvent(signal_frame)) {
+		hlog("signal_frame_ready: Failed to signal new frame: %d",
+		     GetLastError());
+	}
 }
 
 static inline bool frame_ready(uint64_t interval)

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1251,6 +1251,7 @@ static void vk_shtex_capture(struct vk_data *data,
 
 	if (res == VK_SUCCESS) {
 		frame_data->cmd_buffer_busy = true;
+		shtex_update_timestamp();
 		signal_frame_ready();
 	}
 }

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1249,8 +1249,10 @@ static void vk_shtex_capture(struct vk_data *data,
 	debug_res("QueueSubmit", res);
 #endif
 
-	if (res == VK_SUCCESS)
+	if (res == VK_SUCCESS) {
 		frame_data->cmd_buffer_busy = true;
+		signal_frame_ready();
+	}
 }
 
 static inline bool valid_rect(struct vk_swap_data *swap)


### PR DESCRIPTION
### Description

Two new features in win-capture:
- frame timestamps, that enable synchronizing with other events like user input or audio
- `CaptureHook_Frame` signal to let the capture receiver be notified that a new frame was captured

### Motivation and Context
Both features are necessary for precise video/audio synchronization.
With the frame signal it should be possible to lower latency by 1/2 of a frame on average by picking the new frame up ASAP.

### How Has This Been Tested?
Tested on Windows 11 22H2. OBS can still capture games using win-capture.
I wrote a small test program, that ensures the timestamps and signals are set correctly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

@jp9000 tagging you as requested in graphics-hook-ver.h. The minor version bump is due to the new features. I am assuming adding a new field to the shared texture is not a breaking change as long as the receivers know to either read size or to limit the size to 1.8 structure's size.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
