### PR TITLE
libobs: Check for extension validity in os_generate_formatted_filename

### DIFF
--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -796,8 +796,11 @@ char *os_generate_formatted_filename(const char *extension, bool space,
 	if (!space)
 		dstr_replace(&sf, " ", "_");
 
-	dstr_cat_ch(&sf, '.');
-	dstr_cat(&sf, extension);
+	if (extension && *extension) {
+		dstr_cat_ch(&sf, '.');
+		dstr_cat(&sf, extension);
+	}
+
 	dstr_free(&c);
 
 	if (sf.len > 255)


### PR DESCRIPTION
### Description
In some cases (ffmpeg_mux), the extension and format values are a direct passthrough from arbitrary data. Instead of always postfixing a `.` at the end of a generated path if the extension is invalid, don't postfix the `.` at all.

Before: `my_formatted_string.`
After: `my_formatted_string`

### Motivation and Context
I want to make ffmpeg_mux write data to a named pipe which does not have a file extension.

### How Has This Been Tested?
```c
const char *testformat = "test format pp";
const char *extension = NULL;
//const char *extension = "";
//const char *extension = "mp4";

char *filename = os_generate_formatted_filename(extension, false, testformat);
blog(LOG_INFO, "filename: \"%s\"", filename);
bfree(filename);
```

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
