### PR TITLE
image-source: Retry image load if not loaded

### DIFF
--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -208,7 +208,8 @@ static void image_source_tick(void *data, float seconds)
 			time_t t = get_modified_timestamp(context->file);
 			context->update_time_elapsed = 0.0f;
 
-			if (context->file_timestamp != t) {
+			if (context->file_timestamp != t ||
+			    !context->if4.image3.image2.image.loaded) {
 				image_source_load(context);
 			}
 		}

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -209,7 +209,8 @@ static void image_source_tick(void *data, float seconds)
 			context->update_time_elapsed = 0.0f;
 
 			if (context->file_timestamp != t ||
-			    !context->if4.image3.image2.image.loaded) {
+			    (!context->if4.image3.image2.image.loaded &&
+			     t != -1)) {
 				image_source_load(context);
 			}
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Allows an image source to attempt another load, at the regular polling interval, even if the timestamp is unchanged. This handles situations where a previous load attempt may have failed, such as the file being locked by another process.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

If an image source attempts to load an image and it fails, the image source will never reattempt to load the image until the file timestamp changes. 

I came across this issue when using an external program to update images for my stream. I noticed that occasionally an image update would coincide with the image not showing in OBS. I dug into the logs and noticed the following entries:

```
19:48:23.144: Failed to open file 'C:/Users/.../rightSongMetadata.png': Permission denied
19:48:23.145: WIC: Failed to create IWICBitmapDecoder from file: C:/Users/.../rightSongMetadata.png
19:48:23.145: gs_image_file_init_internal: Failed to load file 'C:/Users/.../rightSongMetadata.png'
19:48:23.145: [image_source: 'Right Song'] failed to load texture 'C:/Users/.../rightSongMetadata.png'
```

Upon further investigation, I saw this problem described in [this issue comment](https://github.com/obsproject/obs-studio/issues/3011#issuecomment-1437666466). While I could not recreate the text source problem described in the original issue, I was able to consistently reproduce the problem with an image source.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I tested on Windows 11 using the following PowerShell script:

```
param([bool] $lock)

$source = Join-Path $PSScriptRoot "example1.jpg"
$target = Join-Path $PSScriptRoot "example.jpg"

Remove-Item $target -Force
Start-Sleep -Milliseconds 1500
Copy-Item $source $target -Force
if ($lock)
{
	Write-Host "Locking $target"
	$fileStream = New-Object IO.FileStream($target, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
	Start-Sleep -Milliseconds 1500
	$fileStream.Close()
	Write-Host "Lock released"
}
```

If I ran the script with `-lock $true`, I was able to consistently reproduce the issue. The `lock` parameter was included in the script so I could easily reset the test.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
