### PR TITLE
Adjust AV1 tiles at 4K+

### DIFF
--- a/plugins/obs-ffmpeg/jim-nvenc.c
+++ b/plugins/obs-ffmpeg/jim-nvenc.c
@@ -922,6 +922,17 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 	if (config->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR)
 		av1_config->enableBitstreamPadding = 1;
 
+#define FOUR_K_CX 3840
+#define FOUR_K_CY 2160
+#define PIXELCOUNT_4K (FOUR_K_CX * FOUR_K_CY)
+
+	/* If 4K+, set tiles to 2x2 uniform tiles. */
+	if ((voi->width * voi->height) >= PIXELCOUNT_4K) {
+		av1_config->enableCustomTileConfig = 0;
+		av1_config->numTileColumns = 2;
+		av1_config->numTileRows = 2;
+	}
+
 	switch (voi->colorspace) {
 	case VIDEO_CS_601:
 		av1_config->colorPrimaries = 6;

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -2018,6 +2018,15 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
 	const char *preset = obs_data_get_string(settings, "preset");
 
+	constexpr uint32_t four_k_cx = 3840;
+	constexpr uint32_t four_k_cy = 2160;
+	constexpr uint32_t pixelcount_4k = four_k_cx * four_k_cy;
+
+	/* If 4K+, set tiles per frame to 2. */
+	if ((enc->cx * enc->cy) >= pixelcount_4k) {
+		set_av1_property(enc, TILES_PER_FRAME, 2);
+	}
+
 	set_av1_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
 	set_av1_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
 	set_av1_property(enc, ALIGNMENT_MODE,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use 2x2 tiles in NVENC AV1 for 4K+. When resolution is 4K or higher, use 2x2 uniform tiles for NVENC AV1.

Use 2 tiles per frame in AMF AV1 for 4K+. When resolution is 4K or higher, use 2 tiles per frame in AMF AV1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Single-tile 4K videos are more difficult to decode. Using 1x2 or 2x2 tiles for 4K should make decoding easier.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with NVENC AV1 at 4K and verified that the output was 2x2 (2 columns, 2 rows) tiles. I have not tested this with AMF AV1, but I expect this to produce 1x2 (1 column, 2 rows) tiles at 4K.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
