### PR TITLE
linux-pipewire: Only consider chunks with size set

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -578,13 +578,14 @@ static void on_process_cb(void *user_data)
 		blog(LOG_ERROR, "[pipewire] buffer is corrupt");
 		pw_stream_queue_buffer(obs_pw->stream, b);
 		return;
-	} else if (!header) {
-		has_buffer = buffer->datas[0].chunk->size != 0;
 	}
 
 	obs_enter_graphics();
 
+	// Workaround for kwin behaviour pre 5.27.5
 	// Workaround for mutter behaviour pre GNOME 43
+	// Only check this if !SPA_META_Header, once supported platforms update.
+	has_buffer = buffer->datas[0].chunk->size != 0;
 	if (!has_buffer)
 		goto read_metadata;
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Compositors did not agree on how to communicate invalid buffers until recently, so e0a4d8628d287217cebc3d05d2077e1f0709b450 resulted in regressions on KDE. This restores our old behavior which is too conservative but mostly works on old and new compositors (which contain similar workarounds to pass in invalid but non-zero sizes for dma-bufs).

Once all old compositors are out of use we can remove this workaround and then compositors can remove their random size workaround.

fixes #8630

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We should carry a workaround while we support ubuntu who wont backport such compositor fixes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I havent as I dont have an ubuntu install to test this on right now.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
