### PR TITLE
Add NVENC AV1 FFmpeg encoder

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -19,6 +19,7 @@
 #ifdef ENABLE_HEVC
 #include <obs-hevc.h>
 #endif
+#include <obs-av1.h>
 
 #include "obs-ffmpeg-video-encoders.h"
 
@@ -290,7 +291,9 @@ static void on_first_packet(void *data, AVPacket *pkt, struct darray *da)
 	} else
 #endif
 		if (enc->av1) {
-		// TODO: add obs_extract_av1_headers
+		obs_extract_av1_headers(pkt->data, pkt->size,
+					(uint8_t **)&da->array, &da->num,
+					&enc->header.array, &enc->header.num);
 	} else {
 		obs_extract_avc_headers(pkt->data, pkt->size,
 					(uint8_t **)&da->array, &da->num,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Adds NVENC AV1 support to obs-ffmpeg

![image](https://user-images.githubusercontent.com/12885163/233808210-018f1fdd-5480-468b-8585-7989c9485098.png)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Linux users can use NVENC only for H264 and HEVC currently. However current gen GPUs do support encoding AV1, which should be exposed as an option in OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested recording in mp4 and mkv so far on a Linux system with Nvidia RTX40xx GPU.

### TODO

- Testing (general functionality / performance / different bitrate & quality settings...)
- The detection of AV1 support is not optimal - only ffmpeg is checked if it offers the av1_nvenc encoder but afaik this does not guarantee that the GPU really supports it

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
