### PR TITLE
obs-ffmpeg: Refactor muxer file path code

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -99,6 +99,7 @@ MediaFileFilter.AllFiles="All Files"
 ReplayBuffer="Replay Buffer"
 ReplayBuffer.Save="Save Replay"
 
+FilenameGenerationFailed="Failed to generate a filename for the recording. Please ensure that your format and directory are set correctly."
 HelperProcessFailed="Unable to start the recording helper process. Check that OBS files have not been blocked or removed by any 3rd party antivirus / security software."
 UnableToWritePath="Unable to write to %1. Make sure you're using a recording path which your user account is allowed to write to and that there is sufficient disk space."
 WarnWindowsDefender="If Windows 10 Ransomware Protection is enabled it can also cause this error. Try turning off controlled folder access in Windows Security / Virus & threat protection settings."

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -113,7 +113,6 @@ bool ffmpeg_hls_mux_start(void *data)
 	obs_service_t *service;
 	const char *path_str;
 	const char *stream_key;
-	struct dstr path = {0};
 	obs_encoder_t *vencoder;
 	obs_data_t *settings;
 	int keyint_sec;
@@ -131,8 +130,8 @@ bool ffmpeg_hls_mux_start(void *data)
 	stream_key = obs_service_get_connect_info(
 		service, OBS_SERVICE_CONNECT_INFO_STREAM_KEY);
 	dstr_copy(&stream->stream_key, stream_key);
-	dstr_copy(&path, path_str);
-	dstr_replace(&path, "{stream_key}", stream_key);
+	dstr_copy(&stream->path, path_str);
+	dstr_replace(&stream->path, "{stream_key}", stream_key);
 	dstr_copy(&stream->muxer_settings,
 		  "method=PUT http_persistent=1 ignore_io_errors=1 ");
 	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
@@ -148,8 +147,7 @@ bool ffmpeg_hls_mux_start(void *data)
 
 	obs_data_release(settings);
 
-	start_pipe(stream, path.array);
-	dstr_free(&path);
+	start_pipe(stream);
 
 	if (!stream->pipe) {
 		obs_output_set_last_error(

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -68,7 +68,7 @@ struct ffmpeg_muxer {
 
 bool stopping(struct ffmpeg_muxer *stream);
 bool active(struct ffmpeg_muxer *stream);
-void start_pipe(struct ffmpeg_muxer *stream, const char *path);
+void start_pipe(struct ffmpeg_muxer *stream);
 bool write_packet(struct ffmpeg_muxer *stream, struct encoder_packet *packet);
 bool send_headers(struct ffmpeg_muxer *stream);
 int deactivate(struct ffmpeg_muxer *stream, int code);


### PR DESCRIPTION
### Description
Refactors parts of the mux outputs which deal with file paths. 

General idea:
- Allows the `path` settings field to be unset, provided the appropriate `directory`, `format`, and `extension` fields have been set
  - If `path` is not set, it will generate its own initial file name
- Moves general path storage to `stream->path`
- Gets rid of a lot of unnecessary passing around of path strings between functions
- Adds a `last_file` field to the `file_changed` output signal for future usage by the UI for auto-remux and other features when file splitting is enabled

### Motivation and Context
This allows us to optionally move path generation to the output, away from the UI. This has benefits, notable for code deduplication and also for synchronizing behavior. It is also required for other features like inserting the part number into a file name for file splitting.

### How Has This Been Tested?
Unfortunately, this does touch a lot of code paths with little immediate user-facing benefits. I've done the best I can do testing this and I am not seeing any changed behavior, crashes, or memory leaks- so that's good I guess.

- Tested normal recording
- Split file recording
- HLS streaming
- Replay buffer start/stop/save
- Other things like closing OBS while recording is running

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
