### PR TITLE
rtmp-services: Allow service updates to be disabled on *nix

### DIFF
--- a/plugins/rtmp-services/rtmp-services-main.c
+++ b/plugins/rtmp-services/rtmp-services-main.c
@@ -83,7 +83,7 @@ bool obs_module_load(void)
 	proc_handler_add(ph, "void twitch_ingests_refresh(int seconds)",
 			 refresh_callback, NULL);
 
-#if !defined(_WIN32) || defined(ENABLE_SERVICE_UPDATES)
+#if defined(ENABLE_SERVICE_UPDATES)
 	char *local_dir = obs_module_file("");
 	char *cache_dir = obs_module_config_path("");
 	char update_url[128];


### PR DESCRIPTION
### Description
Effectively reverts 8b315186a724f3af59163196db79080ffd26dfcb, as the cmake referenced in the description has long since been completely rewritten and replaced.

### Motivation and Context
v5 service schema isn't up on the webhost yet, and the warning was bothering me. I don't even need services anyway, and I found that I could not disable them.

### How Has This Been Tested?
The plugin no longer attempts to download the services file from the internet when I disable the service updates cmake variable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
