### PR TITLE
cmake: Fix version detection for FFmpeg find module

### DIFF
--- a/cmake/finders/FindFFmpeg.cmake
+++ b/cmake/finders/FindFFmpeg.cmake
@@ -277,8 +277,8 @@ endif()
 
 if(EXISTS "${FFmpeg_avutil_INCLUDE_DIR}/libavutil/ffversion.h")
   file(STRINGS "${FFmpeg_avutil_INCLUDE_DIR}/libavutil/ffversion.h" _version_string
-       REGEX "^.*FFMPEG_VERSION[ \t]+\"n[0-9\\.]+\"[ \t]*$")
-  string(REGEX REPLACE ".*FFMPEG_VERSION[ \t]+\"n([0-9\\.]+)\".*" "\\1" FFmpeg_VERSION "${_version_string}")
+       REGEX "^.*FFMPEG_VERSION[ \t]+\"n[0-9a-z\\.-]+\"[ \t]*$")
+  string(REGEX REPLACE ".*FFMPEG_VERSION[ \t]+\"n([0-9]+\\.[0-9]).+\".*" "\\1" FFmpeg_VERSION "${_version_string}")
 endif()
 
 list(REMOVE_DUPLICATES FFmpeg_INCLUDE_DIRS)


### PR DESCRIPTION
### Description
Fixes broken version detection in updated FFmpeg find module.

### Motivation and Context
This is a non-critical fix as we do not use a version parameter in our `find_package` calls to find FFmpeg.

Once we do, project generation will break as FFmpeg uses non-semantic versioning in their headers.

This PR updated the find module to work with FFmpeg's versioning to properly set `FFmpeg_VERSION´ so a call like `find_package(FFmpeg 6)` will succeed.

### How Has This Been Tested?
Tested on Windows and macOS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
