### PR TITLE
CI: Switch service checker to macOS

### DIFF
--- a/.github/workflows/services-json.yml
+++ b/.github/workflows/services-json.yml
@@ -45,7 +45,7 @@ jobs:
 
   service_check:
     name: Service Check
-    runs-on: ubuntu-20.04
+    runs-on: macos-latest
     needs: schema
     if: ${{ github.repository_owner == 'obsproject' && github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
 
@@ -66,12 +66,11 @@ jobs:
 
       - name: Install & Configure Python
         run: |
-          sudo apt install python3.9
-          python3.9 -m pip install requests
+          python3 -m pip install requests
 
       - name: Check Services
         id: check
-        run: python3.9 -u CI/check-services.py
+        run: python3 -u CI/check-services.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}


### PR DESCRIPTION
### Description

Switches the service checker to macOS, which runs on different networks and seems to have fewer connection issues that aren't actually the service's fault.

### Motivation and Context

Finally get #8549 over with by removing the false-positive.

### How Has This Been Tested?

Ran on my fork, confirmed the wpstream server can now be connected to normally.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
