### PR TITLE
UI: Fix building macOS/Sparkle without Browser

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 include(cmake/feature-twitch.cmake)
 include(cmake/feature-restream.cmake)
 include(cmake/feature-youtube.cmake)
+include(cmake/feature-sparkle.cmake)
 include(cmake/feature-whatsnew.cmake)
 
 add_subdirectory(frontend-plugins)

--- a/UI/cmake/feature-macos-update.cmake
+++ b/UI/cmake/feature-macos-update.cmake
@@ -1,0 +1,10 @@
+include_guard(DIRECTORY)
+
+if(NOT TARGET OBS::blake2)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/deps/blake2" "${CMAKE_BINARY_DIR}/deps/blake2")
+endif()
+
+target_sources(obs-studio PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mac.mm update/shared-update.cpp
+                                  update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
+
+target_link_libraries(obs-studio PRIVATE "$<LINK_LIBRARY:FRAMEWORK,Security.framework>" OBS::blake2)

--- a/UI/cmake/feature-sparkle.cmake
+++ b/UI/cmake/feature-sparkle.cmake
@@ -13,6 +13,8 @@ if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
   endif()
 
   target_enable_feature(obs-studio "Sparkle updater" ENABLE_SPARKLE_UPDATER)
+
+  include(cmake/feature-macos-update.cmake)
 else()
   set(SPARKLE_UPDATE_INTERVAL 0) # Set anything that's not an empty integer
   target_disable_feature(obs-studio "Sparkle updater")

--- a/UI/cmake/feature-whatsnew.cmake
+++ b/UI/cmake/feature-whatsnew.cmake
@@ -1,21 +1,8 @@
 option(ENABLE_WHATSNEW "Enable WhatsNew dialog" ON)
 
-if(NOT TARGET OBS::blake2)
-  add_subdirectory("${CMAKE_SOURCE_DIR}/deps/blake2" "${CMAKE_BINARY_DIR}/deps/blake2")
-endif()
-
 if(ENABLE_WHATSNEW AND TARGET OBS::browser-panels)
   if(OS_MACOS)
-
-    find_library(SECURITY Security)
-    mark_as_advanced(SECURITY)
-
-    target_sources(obs-studio PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mac.mm update/shared-update.cpp
-                                      update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
-
-    target_link_libraries(obs-studio PRIVATE ${SECURITY} OBS::blake2)
-
-    include(cmake/feature-sparkle.cmake)
+    include(cmake/feature-macos-update.cmake)
   elseif(OS_LINUX)
     find_package(MbedTLS REQUIRED)
     target_link_libraries(obs-studio PRIVATE MbedTLS::MbedTLS OBS::blake2)


### PR DESCRIPTION
### Description

Fixes building on macOS without browser being enabled.  
Also allows building Sparkle support without the browser.

### Motivation and Context

Fixes good.

### How Has This Been Tested?

Compiled on my Mac without browser and with Sparkle.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
