### PR TITLE
UI: Only defer property updates for input and transition sources

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -88,18 +88,32 @@ Q_DECLARE_METATYPE(media_frames_per_second);
 
 void OBSPropertiesView::ReloadProperties()
 {
+	deferUpdate = false;
 	if (weakObj || rawObj) {
 		OBSObject strongObj = GetObject();
 		void *obj = strongObj ? strongObj.Get() : rawObj;
-		if (obj)
+		if (obj) {
 			properties.reset(reloadCallback(obj));
+
+			if (obs_obj_get_type(obj) == OBS_OBJ_TYPE_SOURCE) {
+				enum obs_source_type type = obs_source_get_type(
+					(obs_source_t *)obj);
+				if (type == OBS_SOURCE_TYPE_INPUT ||
+				    type == OBS_SOURCE_TYPE_TRANSITION) {
+					uint32_t flags =
+						obs_properties_get_flags(
+							properties.get());
+					deferUpdate =
+						(flags &
+						 OBS_PROPERTIES_DEFER_UPDATE) !=
+						0;
+				}
+			}
+		}
 	} else {
 		properties.reset(reloadCallback((void *)type.c_str()));
 		obs_properties_apply_settings(properties.get(), settings);
 	}
-
-	uint32_t flags = obs_properties_get_flags(properties.get());
-	deferUpdate = (flags & OBS_PROPERTIES_DEFER_UPDATE) != 0;
 
 	RefreshProperties();
 }

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -51,7 +51,9 @@ General Functions
                  - OBS_PROPERTIES_DEFER_UPDATE - A hint that tells the
                    front-end to defers updating the settings until the
                    user has finished editing all properties rather than
-                   immediately updating any settings
+                   immediately updating any settings. Currently only
+                   works for properties of input and transition sources,
+                   this flag is a no-op for other properties at this time.
 
 ---------------------
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Deferring properties was only ever made for input sources. As other property dialogs do not have an "Ok" button that would cause an update to happen, if the deferred flag was set the callback would never be called.
Also clarifies the docs to reflect this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #5139

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that whereas before, setting the flag on scripts and filters would prevent the update signal from being called basically ever, it now is a no-op and the signal is called in all cases.
Tested that with normal sources, the flag still defers saving until pressing Ok/Apply.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
