### PR TITLE
updater: Support delta patch bundles & Refactor

### DIFF
--- a/UI/win-update/updater/hash.cpp
+++ b/UI/win-update/updater/hash.cpp
@@ -21,33 +21,33 @@
 
 using namespace std;
 
-void HashToString(const uint8_t *in, wchar_t *out)
+void HashToString(const B2Hash &in, string &out)
 {
-	const wchar_t alphabet[] = L"0123456789abcdef";
+	const char alphabet[] = "0123456789abcdef";
+	out.resize(kBlake2StrLength);
 
-	for (int i = 0; i != BLAKE2_HASH_LENGTH; ++i) {
-		out[2 * i] = alphabet[in[i] / 16];
-		out[2 * i + 1] = alphabet[in[i] % 16];
+	for (int i = 0; i != kBlake2HashLength; ++i) {
+		out[2 * i] = alphabet[(uint8_t)in[i] / 16];
+		out[2 * i + 1] = alphabet[(uint8_t)in[i] % 16];
 	}
-
-	out[BLAKE2_HASH_LENGTH * 2] = 0;
 }
 
-void StringToHash(const wchar_t *in, BYTE *out)
+void StringToHash(const string &in, B2Hash &out)
 {
 	unsigned int temp;
+	const char *str = in.c_str();
 
-	for (int i = 0; i < BLAKE2_HASH_LENGTH; i++) {
-		swscanf_s(in + i * 2, L"%02x", &temp);
-		out[i] = (BYTE)temp;
+	for (int i = 0; i < kBlake2HashLength; i++) {
+		sscanf_s(str + i * 2, "%02x", &temp);
+		out[i] = (std::byte)temp;
 	}
 }
 
-bool CalculateFileHash(const wchar_t *path, BYTE *hash)
+bool CalculateFileHash(const wchar_t *path, B2Hash &hash)
 {
 	static __declspec(thread) vector<BYTE> hashBuffer;
 	blake2b_state blake2;
-	if (blake2b_init(&blake2, BLAKE2_HASH_LENGTH) != 0)
+	if (blake2b_init(&blake2, kBlake2HashLength) != 0)
 		return false;
 
 	hashBuffer.resize(1048576);
@@ -70,7 +70,7 @@ bool CalculateFileHash(const wchar_t *path, BYTE *hash)
 			return false;
 	}
 
-	if (blake2b_final(&blake2, hash, BLAKE2_HASH_LENGTH) != 0)
+	if (blake2b_final(&blake2, &hash[0], hash.size()) != 0)
 		return false;
 
 	return true;

--- a/UI/win-update/updater/http.cpp
+++ b/UI/win-update/updater/http.cpp
@@ -352,3 +352,131 @@ bool HTTPGetFile(HINTERNET hConnect, const wchar_t *url,
 
 	return true;
 }
+
+bool HTTPGetBuffer(HINTERNET hConnect, const wchar_t *url,
+		   const wchar_t *extraHeaders, vector<std::byte> &out,
+		   int *responseCode)
+{
+	HttpHandle hRequest;
+
+	const wchar_t *acceptTypes[] = {L"*/*", nullptr};
+
+	URL_COMPONENTS urlComponents = {};
+	bool secure = false;
+
+	wchar_t hostName[256];
+	wchar_t path[1024];
+
+	/* -------------------------------------- *
+	 * get URL components                     */
+
+	urlComponents.dwStructSize = sizeof(urlComponents);
+
+	urlComponents.lpszHostName = hostName;
+	urlComponents.dwHostNameLength = _countof(hostName);
+
+	urlComponents.lpszUrlPath = path;
+	urlComponents.dwUrlPathLength = _countof(path);
+
+	WinHttpCrackUrl(url, 0, 0, &urlComponents);
+
+	if (urlComponents.nPort == 443)
+		secure = true;
+
+	/* -------------------------------------- *
+	 * request data                           */
+
+	hRequest = WinHttpOpenRequest(hConnect, L"GET", path, nullptr,
+				      WINHTTP_NO_REFERER, acceptTypes,
+				      secure ? WINHTTP_FLAG_SECURE |
+						       WINHTTP_FLAG_REFRESH
+					     : WINHTTP_FLAG_REFRESH);
+	if (!hRequest) {
+		*responseCode = -3;
+		return false;
+	}
+
+	bool bResults = !!WinHttpSendRequest(hRequest, extraHeaders,
+					     extraHeaders ? -1 : 0,
+					     WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+
+	/* -------------------------------------- *
+	 * end request                            */
+
+	if (bResults) {
+		bResults = !!WinHttpReceiveResponse(hRequest, nullptr);
+	} else {
+		*responseCode = GetLastError();
+		return false;
+	}
+
+	/* -------------------------------------- *
+	 * get headers                            */
+
+	wchar_t statusCode[8];
+	DWORD statusCodeLen;
+
+	statusCodeLen = sizeof(statusCode);
+	if (!WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE,
+				 WINHTTP_HEADER_NAME_BY_INDEX, &statusCode,
+				 &statusCodeLen, WINHTTP_NO_HEADER_INDEX)) {
+		*responseCode = -4;
+		return false;
+	} else {
+		statusCode[_countof(statusCode) - 1] = 0;
+	}
+
+	/* -------------------------------------- *
+	 * read data                              */
+
+	*responseCode = wcstoul(statusCode, nullptr, 10);
+
+	/* are we supposed to return true here? */
+	if (!bResults || *responseCode != 200)
+		return true;
+
+	BYTE buffer[READ_BUF_SIZE];
+	DWORD dwSize, outSize;
+	int lastPosition = 0;
+
+	do {
+		/* Check for available data. */
+		dwSize = 0;
+		if (!WinHttpQueryDataAvailable(hRequest, &dwSize)) {
+			*responseCode = -8;
+			return false;
+		}
+
+		dwSize = std::min(dwSize, (DWORD)sizeof(buffer));
+
+		if (!WinHttpReadData(hRequest, (void *)buffer, dwSize,
+				     &outSize)) {
+			*responseCode = -9;
+			return false;
+		} else {
+			if (!outSize)
+				break;
+
+			out.insert(out.end(), (std::byte *)buffer,
+				   (std::byte *)buffer + outSize);
+
+			completedFileSize += outSize;
+			int position = (int)(((float)completedFileSize /
+					      (float)totalFileSize) *
+					     100.0f);
+			if (position > lastPosition) {
+				lastPosition = position;
+				SendDlgItemMessage(hwndMain, IDC_PROGRESS,
+						   PBM_SETPOS, position, 0);
+			}
+		}
+
+		if (WaitForSingleObject(cancelRequested, 0) == WAIT_OBJECT_0) {
+			*responseCode = -14;
+			return false;
+		}
+
+	} while (dwSize > 0);
+
+	return true;
+}

--- a/UI/win-update/updater/patch.cpp
+++ b/UI/win-update/updater/patch.cpp
@@ -51,136 +51,12 @@ int64_t offtin(const uint8_t *buf)
 
 /* ------------------------------------------------------------------------ */
 
-int ApplyPatch(ZSTD_DCtx *zstdCtx, const wchar_t *patchFile,
-	       const wchar_t *targetFile)
-try {
-	uint8_t header[24];
-	int64_t newsize;
-	bool success;
+constexpr const char *kDeltaMagic = "BOUF//ZSTD//DICT";
+constexpr int kMagicSize = 16;
+constexpr int kHeaderSize = kMagicSize + 8; // magic + int64_t delta size
 
-	WinHandle hPatch;
-	WinHandle hTarget;
-
-	/* --------------------------------- *
-	 * open patch and file to patch      */
-
-	hPatch = CreateFile(patchFile, GENERIC_READ, 0, nullptr, OPEN_EXISTING,
-			    0, nullptr);
-	if (!hPatch.Valid())
-		throw int(GetLastError());
-
-	hTarget = CreateFile(targetFile, GENERIC_READ, 0, nullptr,
-			     OPEN_EXISTING, 0, nullptr);
-	if (!hTarget.Valid())
-		throw int(GetLastError());
-
-	/* --------------------------------- *
-	 * read patch header                 */
-
-	DWORD read;
-	DWORD patchFileSize;
-
-	patchFileSize = GetFileSize(hPatch, nullptr);
-	if (patchFileSize == INVALID_FILE_SIZE)
-		throw int(GetLastError());
-
-	success = !!ReadFile(hPatch, header, sizeof(header), &read, nullptr);
-	if (success && read == sizeof(header)) {
-		if (memcmp(header, "BOUF//ZSTD//DICT", 16))
-			throw int(-4);
-	} else {
-		throw int(GetLastError());
-	}
-
-	/* --------------------------------- *
-	 * allocate new file size data       */
-
-	newsize = offtin(header + 16);
-	if (newsize < 0 || newsize >= 0x7ffffffff)
-		throw int(-5);
-
-	vector<uint8_t> newData;
-	try {
-		newData.resize((size_t)newsize);
-	} catch (...) {
-		throw int(-1);
-	}
-
-	/* --------------------------------- *
-	 * read remainder of patch file     */
-
-	vector<uint8_t> patchData;
-	try {
-		patchData.resize(patchFileSize - sizeof(header));
-	} catch (...) {
-		throw int(-1);
-	}
-
-	if (!ReadFile(hPatch, &patchData[0], patchFileSize - sizeof(header),
-		      &read, nullptr))
-		throw int(GetLastError());
-
-	if (read != (patchFileSize - sizeof(header)))
-		throw int(-1);
-
-	/* --------------------------------- *
-	 * read old file                     */
-
-	DWORD targetFileSize;
-
-	targetFileSize = GetFileSize(hTarget, nullptr);
-	if (targetFileSize == INVALID_FILE_SIZE)
-		throw int(GetLastError());
-
-	vector<uint8_t> oldData;
-	try {
-		oldData.resize(targetFileSize);
-	} catch (...) {
-		throw int(-1);
-	}
-
-	if (!ReadFile(hTarget, &oldData[0], targetFileSize, &read, nullptr))
-		throw int(GetLastError());
-	if (read != targetFileSize)
-		throw int(-1);
-
-	/* --------------------------------- *
-	 * patch to new file data            */
-
-	size_t result = ZSTD_decompress_usingDict(
-		zstdCtx, &newData[0], newData.size(), patchData.data(),
-		patchData.size(), oldData.data(), oldData.size());
-
-	if (result != newsize || ZSTD_isError(result))
-		throw int(-9);
-
-	/* --------------------------------- *
-	 * write new file                    */
-
-	hTarget = nullptr;
-	hTarget = CreateFile(targetFile, GENERIC_WRITE, 0, nullptr,
-			     CREATE_ALWAYS, 0, nullptr);
-	if (!hTarget.Valid())
-		throw int(GetLastError());
-
-	DWORD written;
-
-	success = !!WriteFile(hTarget, newData.data(), (DWORD)newsize, &written,
-			      nullptr);
-	if (!success || written != newsize)
-		throw int(GetLastError());
-
-	return 0;
-
-} catch (int code) {
-	return code;
-}
-
-#define HEADER_SIZE 24
-
-int ApplyBundlePatch(ZSTD_DCtx *zstdCtx, const char *bundle_data,
-		     const size_t patch_offset, const size_t patch_size,
-		     const wchar_t *targetFile)
+int ApplyPatch(ZSTD_DCtx *zstdCtx, std::byte *buffer, const size_t patch_offset,
+	       const size_t patch_size, const wchar_t *targetFile)
 try {
 	int64_t newsize;
 	bool success;
@@ -198,18 +74,18 @@ try {
 	/* --------------------------------- *
 	 * read patch header                 */
 
-	const char *patch_data = bundle_data + patch_offset;
-	if (memcmp(patch_data, "BOUF//ZSTD//DICT", 16))
+	std::byte *patch_data = buffer + patch_offset;
+	if (memcmp(patch_data, kDeltaMagic, kMagicSize))
 		throw int(-4);
 
 	/* --------------------------------- *
 	 * allocate new file size data       */
 
-	newsize = offtin((const uint8_t *)patch_data + 16);
+	newsize = offtin((const uint8_t *)patch_data + kMagicSize);
 	if (newsize < 0 || newsize >= 0x7ffffffff)
 		throw int(-5);
 
-	vector<uint8_t> newData;
+	vector<std::byte> newData;
 	try {
 		newData.resize((size_t)newsize);
 	} catch (...) {
@@ -220,30 +96,30 @@ try {
 	 * read old file                     */
 
 	DWORD read;
-	DWORD targetFileSize;
+	DWORD oldFileSize;
 
-	targetFileSize = GetFileSize(hTarget, nullptr);
-	if (targetFileSize == INVALID_FILE_SIZE)
+	oldFileSize = GetFileSize(hTarget, nullptr);
+	if (oldFileSize == INVALID_FILE_SIZE)
 		throw int(GetLastError());
 
-	vector<uint8_t> oldData;
+	vector<std::byte> oldData;
 	try {
-		oldData.resize(targetFileSize);
+		oldData.resize(oldFileSize);
 	} catch (...) {
 		throw int(-1);
 	}
 
-	if (!ReadFile(hTarget, &oldData[0], targetFileSize, &read, nullptr))
+	if (!ReadFile(hTarget, &oldData[0], oldFileSize, &read, nullptr))
 		throw int(GetLastError());
-	if (read != targetFileSize)
+	if (read != oldFileSize)
 		throw int(-1);
 
 	/* --------------------------------- *
 	 * patch to new file data            */
 
 	size_t result = ZSTD_decompress_usingDict(
-		zstdCtx, &newData[0], newData.size(), patch_data + HEADER_SIZE,
-		patch_size - HEADER_SIZE, oldData.data(), oldData.size());
+		zstdCtx, &newData[0], newData.size(), patch_data + kHeaderSize,
+		patch_size - kHeaderSize, oldData.data(), oldData.size());
 
 	if (result != newsize || ZSTD_isError(result))
 		throw int(-9);
@@ -266,77 +142,6 @@ try {
 
 	return 0;
 
-} catch (int code) {
-	return code;
-}
-
-int DecompressFile(ZSTD_DCtx *ctx, const wchar_t *tempFile, size_t newSize)
-try {
-	WinHandle hTemp;
-
-	hTemp = CreateFile(tempFile, GENERIC_READ, 0, nullptr, OPEN_EXISTING, 0,
-			   nullptr);
-	if (!hTemp.Valid())
-		throw int(GetLastError());
-
-	/* --------------------------------- *
-	 * read compressed data              */
-
-	DWORD read;
-	DWORD compressedFileSize;
-
-	compressedFileSize = GetFileSize(hTemp, nullptr);
-	if (compressedFileSize == INVALID_FILE_SIZE)
-		throw int(GetLastError());
-
-	vector<uint8_t> oldData;
-	try {
-		oldData.resize(compressedFileSize);
-	} catch (...) {
-		throw int(-1);
-	}
-
-	if (!ReadFile(hTemp, &oldData[0], compressedFileSize, &read, nullptr))
-		throw int(GetLastError());
-	if (read != compressedFileSize)
-		throw int(-1);
-
-	/* --------------------------------- *
-	 * decompress data                   */
-
-	vector<uint8_t> newData;
-	try {
-		newData.resize((size_t)newSize);
-	} catch (...) {
-		throw int(-1);
-	}
-
-	size_t result = ZSTD_decompressDCtx(ctx, &newData[0], newData.size(),
-					    oldData.data(), oldData.size());
-
-	if (result != newSize)
-		throw int(-9);
-	if (ZSTD_isError(result))
-		throw int(-10);
-
-	/* --------------------------------- *
-	 * overwrite temp file with new data */
-
-	hTemp = nullptr;
-	hTemp = CreateFile(tempFile, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS,
-			   0, nullptr);
-	if (!hTemp.Valid())
-		throw int(GetLastError());
-
-	bool success;
-	DWORD written;
-
-	success = !!WriteFile(hTemp, newData.data(), (DWORD)newSize, &written,
-			      nullptr);
-	if (!success || written != newSize)
-		throw int(GetLastError());
-
-	return 0;
 } catch (int code) {
 	return code;
 }

--- a/UI/win-update/updater/updater.hpp
+++ b/UI/win-update/updater/updater.hpp
@@ -88,7 +88,11 @@ void StringToHash(const wchar_t *in, BYTE *out);
 
 bool CalculateFileHash(const wchar_t *path, BYTE *hash);
 
+int64_t offtin(const uint8_t *buf);
 int ApplyPatch(ZSTD_DCtx *ctx, LPCTSTR patchFile, LPCTSTR targetFile);
+int ApplyBundlePatch(ZSTD_DCtx *ctx, const char *bundle_data,
+		     size_t patch_offset, size_t patch_size,
+		     LPCTSTR targetFile);
 int DecompressFile(ZSTD_DCtx *ctx, LPCTSTR tempFile, size_t newSize);
 
 extern HWND hwndMain;

--- a/UI/win-update/updater/updater.hpp
+++ b/UI/win-update/updater/updater.hpp
@@ -36,12 +36,15 @@
 #include <blake2.h>
 #include <zstd.h>
 
+#include <array>
 #include <string>
+#include <vector>
 
 #include "helpers.hpp"
 
-#define BLAKE2_HASH_LENGTH 20
-#define BLAKE2_HASH_STR_LENGTH ((BLAKE2_HASH_LENGTH * 2) + 1)
+constexpr uint8_t kBlake2HashLength = 20;
+constexpr uint8_t kBlake2StrLength = kBlake2HashLength * 2;
+using B2Hash = std::array<std::byte, kBlake2HashLength>;
 
 #if defined _M_IX86
 #pragma comment(linker, "/manifestdependency:\"type='win32' "       \
@@ -79,21 +82,21 @@
 bool HTTPGetFile(HINTERNET hConnect, const wchar_t *url,
 		 const wchar_t *outputPath, const wchar_t *extraHeaders,
 		 int *responseCode);
+bool HTTPGetBuffer(HINTERNET hConnect, const wchar_t *url,
+		   const wchar_t *extraHeaders, std::vector<std::byte> &out,
+		   int *responseCode);
 bool HTTPPostData(const wchar_t *url, const BYTE *data, int dataLen,
 		  const wchar_t *extraHeaders, int *responseCode,
 		  std::string &response);
 
-void HashToString(const BYTE *in, wchar_t *out);
-void StringToHash(const wchar_t *in, BYTE *out);
+void HashToString(const B2Hash &in, std::string &out);
+void StringToHash(const std::string &in, B2Hash &out);
 
-bool CalculateFileHash(const wchar_t *path, BYTE *hash);
+bool CalculateFileHash(const wchar_t *path, B2Hash &hash);
 
 int64_t offtin(const uint8_t *buf);
-int ApplyPatch(ZSTD_DCtx *ctx, LPCTSTR patchFile, LPCTSTR targetFile);
-int ApplyBundlePatch(ZSTD_DCtx *ctx, const char *bundle_data,
-		     size_t patch_offset, size_t patch_size,
-		     LPCTSTR targetFile);
-int DecompressFile(ZSTD_DCtx *ctx, LPCTSTR tempFile, size_t newSize);
+int ApplyPatch(ZSTD_DCtx *zstdCtx, std::byte *buffer, const size_t patch_offset,
+	       const size_t patch_size, const wchar_t *targetFile);
 
 extern HWND hwndMain;
 extern HCRYPTPROV hProvider;


### PR DESCRIPTION
### Description

Adds support for delta patch bundles to the OBS updater. These bundle all the delta patches required for patching between two versions into a single file, improving update speeds by reducing total I/O and downloading one larger file instead of potentially hundreds of small ones (very slow, especially HTTP/1.1).

Additionally, a second commit refactors a number of a things to be cleaner/easier to read, this includes:

- New `B2Hash` typedef for blake 2 hashes (`std::array<std::byte, 20>`)
  + Also added `std::hash` specialisation to allow using it in maps or sets
- Stop using temporary files for downloads (uses RAM instead)
  + VC redistributables installation still uses a temp file if necessary, so the folder in `%TEMP%` will still be created/removed
- Moved some defines to global `constexpr` variables
- Moved some hardcoded values to global variables
- Removed a lot of utf8<->wide conversions that were unnecessary now that temporary files aren't used anymore
- Changed some for loops to use iterators instead of indices


### Motivation and Context

- Significant speedup when downloading lots of small delta patches
- Cleanup and simplification of existing code

### How Has This Been Tested?

Tested with https://github.com/obsproject/bouf/pull/30 on my test deployment.

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
