### PR TITLE
deps/media-playback: Initialize mutex earlier for cached media

### DIFF
--- a/deps/media-playback/media-playback/cache.c
+++ b/deps/media-playback/media-playback/cache.c
@@ -560,6 +560,9 @@ bool mp_cache_init(mp_cache_t *c, const struct mp_media_info *info)
 	info2.full_decode = true;
 
 	mp_media_t *m = &c->m;
+
+	pthread_mutex_init_value(&c->mutex);
+
 	if (!mp_media_init(m, &info2)) {
 		mp_cache_free(c);
 		return false;
@@ -569,7 +572,6 @@ bool mp_cache_init(mp_cache_t *c, const struct mp_media_info *info)
 		return false;
 	}
 
-	pthread_mutex_init_value(&c->mutex);
 	c->opaque = info->opaque;
 	c->v_cb = info->v_cb;
 	c->a_cb = info->a_cb;


### PR DESCRIPTION
### Description
Moves mutex initialization before any function calls.

### Motivation and Context
`mp_cache_stop` / `mp_cache_free` both try to use the mutex so we need to make sure it's initialized before calling functions that may fail or OBS will crash. Reported on Discord: https://discord.com/channels/348973006581923840/1090367203385278514/1101725241434177536

### How Has This Been Tested?
Tested with a removed cached stinger, OBS no longer crashes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
