### PR TITLE
obs-ffmpeg: Add FFmpeg Options for VA-API

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -29,6 +29,7 @@
 #ifdef ENABLE_HEVC
 #include <obs-hevc.h>
 #endif
+#include <opts-parser.h>
 
 #include <unistd.h>
 
@@ -354,6 +355,14 @@ static bool vaapi_update(void *data, obs_data_t *settings, bool hevc)
 
 	enc->height = enc->context->height;
 
+	const char *ffmpeg_opts = obs_data_get_string(settings, "ffmpeg_opts");
+	struct obs_options opts = obs_parse_options(ffmpeg_opts);
+	for (size_t i = 0; i < opts.count; i++) {
+		struct obs_option *opt = &opts.options[i];
+		av_opt_set(enc->context->priv_data, opt->name, opt->value, 0);
+	}
+	obs_free_options(opts);
+
 	info("settings:\n"
 	     "\tdevice:       %s\n"
 	     "\trate_control: %s\n"
@@ -365,10 +374,11 @@ static bool vaapi_update(void *data, obs_data_t *settings, bool hevc)
 	     "\tkeyint:       %d\n"
 	     "\twidth:        %d\n"
 	     "\theight:       %d\n"
-	     "\tb-frames:     %d\n",
+	     "\tb-frames:     %d\n"
+	     "\tffmpeg opts:  %s\n",
 	     device, rate_control, profile, level, qp, bitrate, maxrate,
 	     enc->context->gop_size, enc->context->width, enc->context->height,
-	     enc->context->max_b_frames);
+	     enc->context->max_b_frames, ffmpeg_opts);
 
 	return vaapi_init_codec(enc, device);
 }
@@ -938,6 +948,10 @@ static obs_properties_t *vaapi_properties_internal(bool hevc)
 				   obs_module_text("KeyframeIntervalSec"), 0,
 				   20, 1);
 	obs_property_int_set_suffix(p, " s");
+
+	obs_properties_add_text(props, "ffmpeg_opts",
+				obs_module_text("FFmpegOpts"),
+				OBS_TEXT_DEFAULT);
 
 	return props;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add FFmpeg Options for VA-API.
![2023-04-30_12:53:46](https://user-images.githubusercontent.com/522831/235349160-38603d1c-52e4-4eaf-99d0-c8339680f546.png)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Add option to set custom FFmpeg options for VA-API encoder, which is already available for other FFmpeg encoders.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Checked the options were applied correctly. ArchLinux.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
