### PR TITLE
deps/media-playback: Check if frame can be played before using it

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -356,14 +356,15 @@ void mp_media_next_audio(mp_media_t *m)
 	struct obs_source_audio audio = {0};
 	AVFrame *f = d->frame;
 	int channels;
+
+	if (!mp_media_can_play_frame(m, d))
+		return;
+
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 19, 100)
 	channels = f->channels;
 #else
 	channels = f->ch_layout.nb_channels;
 #endif
-
-	if (!mp_media_can_play_frame(m, d))
-		return;
 
 	d->frame_ready = false;
 	if (!m->a_cb)


### PR DESCRIPTION
### Description
Moves the `mp_media_can_play_frame` check earlier in the `mp_media_next_audio` function.

### Motivation and Context
It's possible that `frame_ready` is false when this function is called, which implies that the `mp_decode` `frame` field is not valid. However we dereference the `frame` (variable `f`) by counting the number of audio channels before calling `mp_media_can_play_frame` which checks the value of `frame_ready`.

One of several fixes for issues discovered in https://obsproject.com/forum/threads/obs-crashing-all-the-time-from-rtsp-sources.165637/

### How Has This Been Tested?
Untested, but should be correct.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
