### PR TITLE
mac-capture: Make display selection based on UUID instead of CGDirectDisplayID

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -311,15 +311,13 @@ void DisplayCaptureToolbar::Init()
 	const char *device_str =
 		get_os_text(mod, "Monitor", "DisplayCapture.Display", "Screen");
 	ui->deviceLabel->setText(device_str);
-#ifndef _WIN32
-	is_int = true;
-#endif
 
 #ifdef _WIN32
 	prop_name = "monitor_id";
 #elif __APPLE__
-	prop_name = "display";
+	prop_name = "display_uuid";
 #else
+	is_int = true;
 	prop_name = "screen";
 #endif
 


### PR DESCRIPTION
### Description
Changes current code for "Display Capture" and "Screen Capture" to store a display's `UUID` instead of its `CGDirectDisplayID` as the latter will be reset upon system restarts.

### Motivation and Context
Display IDs are only (somewhat) guaranteed to stay stable within a given macOS boot session and will be reset/changed upon a reboot. While reboots/shutdowns on macOS are uncommon (a Mac should usually only be restarted upon an OS update), this can lead to user frustration.

Storing the display UUID (and deriving the _current_ Display ID from it) allows us to retain a more stable value in the settings.

The sources themselves use the Display ID at runtime (which makes interacting with macOS system APIs easier and more straight-forward) but when it comes to OBS' settings the code will convert to and from UUIDs.

Existing setups will be gracefully upgraded:

* The new setting is called `display_uuid`
* If a setting called `display` is available,
    * its value will be read
    * its value will be converted to the corresponding UUID
    * the UUID will be stored under the new setting name
    * the old setting name is then deleted
* Source initialisation then continues with the UUID value

Fixes https://github.com/obsproject/obs-studio/issues/4991

### How Has This Been Tested?
Tested on macOS 13 with a physical display and another AirPlay-based display.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
