### PR TITLE
mac-capture: Fix possible division by zero error.

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -297,6 +297,13 @@ static inline void screen_stream_audio_update(struct screen_capture *sc,
 		CMAudioFormatDescriptionGetStreamBasicDescription(
 			format_description);
 
+	if (audio_description->mChannelsPerFrame < 1) {
+		MACCAP_ERR(
+			"screen_stream_audio_update: Received sample buffer has less than 1 channel per frame (mChannelsPerFrame set to '%d')\n",
+			audio_description->mChannelsPerFrame);
+		return;
+	}
+
 	char *_Nullable bytes = NULL;
 	CMBlockBufferRef data_buffer =
 		CMSampleBufferGetDataBuffer(sample_buffer);


### PR DESCRIPTION
### Description
Catch possible division-by-zero issue in audio handling code.

### Motivation and Context
The possibility of `mChannelsPerFrame` being 0 is not properly covered by current code, which will result in a division-by-zero error.

Issue was discovered by Xcode's "Analyze" run.

### How Has This Been Tested?
Tested and re-analyzed on macOS 13 with Xcode 14.3.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
