### PR TITLE
CI: Update ccache cache entries to enable restoration from master branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,10 +106,19 @@ jobs:
 
       - name: 'Check for GitHub Labels'
         id: github-check
-        if: github.event_name == 'pull_request'
         run: |
-          if test -n "$(curl -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')"; then
-            echo "generator=Xcode" >> $GITHUB_OUTPUT
+          if [[ "${GITHUB_EVENT_NAME}" == 'pull_request' ]]; then
+            if test -n "$(curl -H "Authorization: Bearer ${{ github.token }}" -s "${{ github.event.pull_request.url }}" | jq -e '.labels[] | select(.name == "Seeking Testers")')"; then
+              echo "generator=Xcode" >> $GITHUB_OUTPUT
+            else
+              echo "generator=Ninja" >> $GITHUB_OUTPUT
+            fi
+          elif [[ "${GITHUB_EVENT_NAME}" == 'push' ]]; then
+            if [[ ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta).+)? ]]; then
+              echo "generator=Xcode" >> $GITHUB_OUTPUT
+            else
+              echo "generator=Ninja" >> $GITHUB_OUTPUT
+            fi
           else
             echo "generator=Ninja" >> $GITHUB_OUTPUT
           fi
@@ -119,7 +128,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-${{ github.ref_name }}-${{ steps.github-check.outputs.generator }}-ccache-${{ matrix.arch }}-${{ needs.config.outputs.cache_date }}
+          key: ${{ runner.os }}-ccache-${{ steps.github-check.outputs.generator }}-${{ matrix.arch }}-${{ github.event_name }}-${{ github.head_ref }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ steps.github-check.outputs.generator }}-${{ matrix.arch }}-push-
 
       - name: 'Setup build environment'
         id: setup
@@ -215,7 +226,9 @@ jobs:
           CACHE_NAME: 'ccache-cache'
         with:
           path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-pr-${{ env.CACHE_NAME }}-${{ matrix.ubuntu }}-${{ needs.config.outputs.cache_date }}
+          key: ${{ runner.os }}-ccache-${{ matrix.ubuntu }}-${{ github.event_name }}-${{ github.head_ref }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.ubuntu }}-push-
 
       - name: 'Restore Chromium Embedded Framework from cache'
         id: cef-cache


### PR DESCRIPTION
### Description
Update cache keys used for saving and restoring `ccache` cache data.

### Motivation and Context
Current caching steps do not use a coarse restore key to enable cache restoration from a possible master cache. This is a forward-port of a future CI workflow update that uses the same cache key logic.

Also fixes missing generator token for cache keys generated by master branch.

### How Has This Been Tested?
Tested on `obs-studio` fork with upgraded workflows.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
