### PR TITLE
mac-syphon: Remove macOS 10.15-only code

### DIFF
--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -549,25 +549,14 @@ static void show_syphon_license_internal(void)
 
 	NSWorkspace *ws = [NSWorkspace sharedWorkspace];
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 110000
-	if (@available(macOS 11.0, *)) {
-		NSURL *url = [NSURL
-			URLWithString:
-				[@"file://"
-					stringByAppendingString:
-						[NSString
-							stringWithCString:path
-								 encoding:NSUTF8StringEncoding]]];
-		[ws openURL:url];
-	} else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-		[ws openFile:@(path)];
-#pragma clang diagnostic pop
-	}
-#else
-	[ws openFile:@(path)];
-#endif
+	NSURL *url = [NSURL
+		URLWithString:
+			[@"file://"
+				stringByAppendingString:
+					[NSString
+						stringWithCString:path
+							 encoding:NSUTF8StringEncoding]]];
+	[ws openURL:url];
 	bfree(path);
 }
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes macOS 10.15-only code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The minimum version of macOS for OBS is 11.0 now, so this can be removed

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13, compiled and run.
Clicked on the Show License button which still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
