### PR TITLE
UI: Relax mc_trans_video_imagescaler.dll DLL block

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -124,8 +124,9 @@ static blocked_module_t blocked_modules[] = {
 	// Wacom / Other tablet driver, locks up UI
 	{L"\\wintab32.dll", 0, 0, TS_IGNORE},
 
-	// Adobe Dynamic Link (Adobe CC), crashes in its own thread
-	{L"\\mc_trans_video_imagescaler.dll", 0, 0, TS_IGNORE},
+	// MainConcept Image Scaler, crashes in its own thread. Block versions
+	// older than the one Elgato uses (2016-02-15).
+	{L"\\mc_trans_video_imagescaler.dll", 0, 1455495131, TS_LESS_THAN},
 
 	// Weird Polish banking "security" software, breaks UI
 	{L"\\wslbscr64.dll", 0, 0, TS_IGNORE},


### PR DESCRIPTION
### Description
This is actually a MainConcept redistributable and not related to Adobe. Unfortunately Elgato Game Capture HD software relies on this dependency when presenting the DirectShow device to OBS, so we unintentionally blocked it from loading.

Instead of outright blocking, we now block only versions older than the one shipped by Elgato, which has hopefully been patched to fix the random crashes.

### Motivation and Context
Blocking legit capture devices isn't great.

### How Has This Been Tested?
Hasn't as I don't have the necessary hardware.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
