### PR TITLE
Support PCM in MP4 with newer libavformat

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7399,16 +7399,17 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 	const char *format = config_get_string(
 		config, isSimpleMode ? "SimpleOutput" : "AdvOut", "RecFormat2");
 
-	/* AV1+PCM cannot be remuxed into any supported format (until FFmpeg 6.1) */
-	if (strcmp(vCodecName, "av1") == 0 &&
-	    strncmp(aCodecName, "pcm", 3) == 0)
+	bool audio_is_pcm = strncmp(aCodecName, "pcm", 3) == 0;
+	/* FFmpeg <= 6.0 cannot remux AV1+PCM into any supported format. */
+	if (audio_is_pcm && !ff_supports_pcm_in_mp4() &&
+	    strcmp(vCodecName, "av1") == 0)
 		return;
 
 	/* Retain original container for fMP4/fMOV */
 	if (strncmp(format, "fragmented", 10) == 0) {
 		output += "remuxed." + suffix;
 	} else if (strcmp(vCodecName, "prores") == 0 ||
-		   strncmp(aCodecName, "pcm", 3) == 0) {
+		   (audio_is_pcm && !ff_supports_pcm_in_mp4())) {
 		output += "mov";
 	} else {
 		output += "mp4";

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4989,15 +4989,18 @@ static const unordered_map<string, unordered_set<string>> codec_compat = {
 	{"mpegts", {"h264", "hevc", "aac", "opus"}},
 	{"hls",
 	 {"h264", "hevc", "aac"}}, // Also using MPEG-TS, but no Opus support
+	{"mp4",
+	 {"h264", "hevc", "av1", "aac", "opus", "alac", "flac", "pcm_s16le",
+	  "pcm_s24le", "pcm_f32le"}},
+	{"fragmented_mp4",
+	 {"h264", "hevc", "av1", "aac", "opus", "alac", "flac", "pcm_s16le",
+	  "pcm_s24le", "pcm_f32le"}},
 	{"mov",
 	 {"h264", "hevc", "prores", "aac", "alac", "pcm_s16le", "pcm_s24le",
 	  "pcm_f32le"}},
-	{"mp4", {"h264", "hevc", "av1", "aac", "opus", "alac", "flac"}},
 	{"fragmented_mov",
 	 {"h264", "hevc", "prores", "aac", "alac", "pcm_s16le", "pcm_s24le",
 	  "pcm_f32le"}},
-	{"fragmented_mp4",
-	 {"h264", "hevc", "av1", "aac", "opus", "alac", "flac"}},
 	// MKV supports everything
 	{"mkv", {}},
 };
@@ -5012,6 +5015,12 @@ static bool ContainerSupportsCodec(const string &container, const string &codec)
 	// Assume everything is supported
 	if (codecs.empty())
 		return true;
+
+	// PCM in MP4 is only supported in FFmpeg > 6.0
+	if ((container == "mp4" || container == "fragmented_mp4") &&
+	    !ff_supports_pcm_in_mp4() && codec.find("pcm_") != string::npos)
+		return false;
+
 	return codecs.count(codec) > 0;
 }
 

--- a/deps/libff/libff/ff-util.c
+++ b/deps/libff/libff/ff-util.c
@@ -473,3 +473,12 @@ bool ff_format_codec_compatible(const char *codec, const char *format)
 	return avformat_query_codec(output_format, codec_desc->id, FF_COMPLIANCE_NORMAL) == 1;
 #endif
 }
+
+bool ff_supports_pcm_in_mp4()
+{
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 5, 100)
+	return false;
+#else
+	return true;
+#endif
+}

--- a/deps/libff/libff/ff-util.h
+++ b/deps/libff/libff/ff-util.h
@@ -64,6 +64,7 @@ ff_format_desc_next(const struct ff_format_desc *format_desc);
 
 // Utility to check compatibility
 bool ff_format_codec_compatible(const char *codec, const char *format);
+bool ff_supports_pcm_in_mp4();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

FFmpeg added support for PCM in MP4 in https://github.com/FFmpeg/FFmpeg/commit/d4ee177a36c59b19de474d3713304c7828263cb0 and bumped the minor version of libavformat in https://github.com/FFmpeg/FFmpeg/commit/dc2da568cfd281740102032582ca25bbf4449100 so we can now support this via some simple ifdefing.

### Motivation and Context

Support AV1+PCM in containers other than MKV.

### How Has This Been Tested?

Has not been tested yet.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
