### PR TITLE
UI: Exit if clearing scene data fails

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -502,6 +502,10 @@ MacPermissions.Continue="Continue"
 UpdateAvailable="New Update Available"
 UpdateAvailable.Text="Version %1.%2.%3 is now available. <a href='%4'>Click here to download</a>"
 
+# Source leak error message
+SourceLeak.Title="Source Cleanup Error"
+SourceLeak.Text="There was a problem while changing scene collections and some sources could not be unloaded. This issue is typically caused by plugins that are not releasing resources properly. Please ensure that any plugins you are using are up to date.\n\nOBS Studio will now exit to prevent any potential data corruption."
+
 # audio device names
 Basic.DesktopDevice1="Desktop Audio"
 Basic.DesktopDevice2="Desktop Audio 2"

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -245,6 +245,8 @@ private:
 	OBSWeakSourceAutoRelease copySourceTransition;
 
 	bool closing = false;
+	bool clearingFailed = false;
+
 	QScopedPointer<QThread> devicePropertiesThread;
 	QScopedPointer<QThread> whatsNewInitThread;
 	QScopedPointer<QThread> updateCheckThread;


### PR DESCRIPTION
### Description

Faulty plugins or other bugs resulting in references to source outliving the intended lifetime can result in data corruption or loss as in #8843. Instead of corrupting data just crash as something has gone horribly wrong.

### Motivation and Context

Crashing > Data corruption.

### How Has This Been Tested?

Manually incremented ref counter of some sources. Couldn't reproduce #8843 directly.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
