### PR TITLE
UI: Do not show unassigned icon for monitored sources

### DIFF
--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -301,14 +301,14 @@ private:
 				   const float peak[MAX_AUDIO_CHANNELS],
 				   const float inputPeak[MAX_AUDIO_CHANNELS]);
 	static void OBSVolumeMuted(void *data, calldata_t *calldata);
-	static void OBSMixersChanged(void *data, calldata_t *alldata);
+	static void OBSMixersOrMonitoringChanged(void *data, calldata_t *);
 
 	void EmitConfigClicked();
 
 private slots:
 	void VolumeChanged();
 	void VolumeMuted(bool muted);
-	void AssignmentChanged(bool unassigned);
+	void MixersOrMonitoringChanged();
 
 	void SetMuted(bool checked);
 	void SliderChanged(int vol);


### PR DESCRIPTION
### Description

Disables unassigned indicator/warning for sources set to "Monitor only (mute output)".

### Motivation and Context

Sources that are monitored are intentionally not mixed into any tracks, so they should not be shown as unassigned.

Reported on Discord: https://discord.com/channels/348973006581923840/768389015484760106/1103309430633803817

### How Has This Been Tested?

Toggled tracks and monitoring state for a source.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- 
### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
