### PR TITLE
libobs: Fix luma sampling for packed 4:2:2 sources

### DIFF
--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -153,12 +153,12 @@ VertTexTexPos VSPacked422Left_Reverse(uint id : VERTEXID)
 	float x = idHigh * 4. - 1.;
 	float y = idLow * 4. - 1.;
 
-	float u = idHigh * 2. + width_x2_i;
+	float u = idHigh * 2.;
 	float v = idLow * 2.;
 	v = obs_glsl_compile ? v : (1. - v);
 
 	VertTexTexPos vert_out;
-	vert_out.uvuv = float4(width_d2 * u, height * v, u, v);
+	vert_out.uvuv = float4(width_d2 * u, height * v, u + width_x2_i, v);
 	vert_out.pos = float4(x, y, 0., 1.);
 	return vert_out;
 }


### PR DESCRIPTION
### Description
We are currently loading luma samples unnecessarily close to texel boundaries, and that's causing the wrong texels to be sampled depending on the GPU that's doing the rounding. We can adjust the math to use much safer coordinates.

Fixes #7742

### Motivation and Context
Distorted sources are bad.

### How Has This Been Tested?
- Intel Mac looks good now
- RenderDoc shader debugger shows texel coordinates are what they were intended to be

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.