### PR TITLE
cmake: Enforce -Wmaybe-uninitialized to never turn into an error

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -100,6 +100,13 @@ else()
   endif()
 
   option(CALM_DEPRECATION "Keep deprecated-declarations as warnings" OFF)
+  #[[
+    Note about -Wmaybe-uninitialized on GCC, this warning seems to be subject of various regressions and false positives. This
+    warning is set to not turn into an error.
+
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562 for 12.1.0
+    - https://github.com/obsproject/obs-studio/issues/8850 for 13.1.1
+  ]]
   add_compile_options(
     -Werror
     -Wextra
@@ -117,19 +124,13 @@ else()
     "$<$<CONFIG:DEBUG>:-DDEBUG=1;-D_DEBUG=1>"
     "$<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wnull-conversion;-fcolor-diagnostics;-Wno-error=shorten-64-to-32>"
     "$<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wnull-conversion;-fcolor-diagnostics;-Wno-error=shorten-64-to-32>"
-    "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wconversion-null>"
+    "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-Wconversion-null;-Wno-error=maybe-uninitialized>"
+    "$<$<COMPILE_LANG_AND_ID:C,GNU>:-Wno-error=maybe-uninitialized>"
     "$<$<BOOL:${CALM_DEPRECATION}>:-Wno-error=deprecated-declarations>")
 
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # GCC on aarch64 emits type-limits warnings that do not appear on x86_64
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-      add_compile_options(-Wno-error=type-limits)
-    endif()
-
-    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105562
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "12.1.0")
-      add_compile_options(-Wno-error=maybe-uninitialized)
-    endif()
+  # GCC on aarch64 emits type-limits warnings that do not appear on x86_64
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    add_compile_options(-Wno-error=type-limits)
   endif()
 
   if(OBS_CODESIGN_LINKER)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Supersedes #8852
Fixes #8850

`-Wmaybe-uninitialized` has proven to be too unstable (GCC regressions, false positive) to be turn into an error.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

GCC does not seem to keep this warning stable enough through versions, which is not a complaint it is just incompatible with `-Werror` purpose.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Build with GCC 13 in Release mode and no errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
