### PR TITLE
UI: Fix FLAC missing from builtin codecs list

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4980,8 +4980,8 @@ void OBSBasicSettings::AdvOutSplitFileChanged()
 }
 
 static const unordered_set<string> builtin_codecs = {
-	"h264", "hevc", "av1",       "prores",    "aac",
-	"opus", "alac", "pcm_s16le", "pcm_s24le", "pcm_f32le"};
+	"h264", "hevc", "av1",       "prores",    "aac",      "opus",
+	"alac", "flac", "pcm_s16le", "pcm_s24le", "pcm_f32le"};
 
 static const unordered_map<string, unordered_set<string>> codec_compat = {
 	// Technically our muxer supports HEVC and AV1 as well, but nothing else does


### PR DESCRIPTION
### Description

Fixes FLAC missing from the builtin codecs list, which resulted in it being erroneously shown as compatible for MOV.

### Motivation and Context

Fix bug.

### How Has This Been Tested?

Confirmed FLAC is now greyed-out for MOV.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
