### PR TITLE
test: Cover all array_output_serializer functions

### DIFF
--- a/test/cmocka/test_serializer.c
+++ b/test/cmocka/test_serializer.c
@@ -20,6 +20,10 @@ static void serialize_test(void **state)
 	assert_int_equal(output.bytes.num, 3);
 	uint8_t expected[3] = {0x01, 0xff, 0xe1};
 	assert_memory_equal(output.bytes.array, expected, 3);
+
+	assert_true(serializer_get_pos(&s) == 3);
+
+	array_output_serializer_free(&output);
 }
 
 int main()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds `serializer_get_pos` and `array_output_serializer_free` in the unit-test code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm looking at a code coverage report and realized `array_output_serializer_free` is never called.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 36
Configured with `-DENABLE_UNIT_TESTS=ON` and built.
Checked `make test` passed

Also checked the unit-test can cover all lines in `libobs/util/array-serializer.c`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
