### PR TITLE
UI: Fix crash on macOS when closing OAUTH browser panel

### DIFF
--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -71,12 +71,7 @@ OAuthLogin::OAuthLogin(QWidget *parent, const std::string &url, bool token)
 #endif
 }
 
-OAuthLogin::~OAuthLogin()
-{
-#ifdef BROWSER_AVAILABLE
-	delete cefWidget;
-#endif
-}
+OAuthLogin::~OAuthLogin() {}
 
 int OAuthLogin::exec()
 {
@@ -86,6 +81,22 @@ int OAuthLogin::exec()
 	}
 #endif
 	return QDialog::Rejected;
+}
+
+void OAuthLogin::reject()
+{
+#ifdef BROWSER_AVAILABLE
+	delete cefWidget;
+#endif
+	QDialog::reject();
+}
+
+void OAuthLogin::accept()
+{
+#ifdef BROWSER_AVAILABLE
+	delete cefWidget;
+#endif
+	QDialog::accept();
 }
 
 void OAuthLogin::urlChanged(const QString &url)

--- a/UI/auth-oauth.hpp
+++ b/UI/auth-oauth.hpp
@@ -24,6 +24,8 @@ public:
 	inline bool LoadFail() const { return fail; }
 
 	virtual int exec() override;
+	virtual void reject() override;
+	virtual void accept() override;
 
 public slots:
 	void urlChanged(const QString &url);


### PR DESCRIPTION
### Description
Fixes possible crash when a panel's browser source is destroyed after its associated `NSView` has been removed by Cocoa.

### Motivation and Context
Deleting the cefWidget in the panel's destructor can result in a crash on macOS because the underlying NSView might have been destroyed in memory between Qt closing the QDialog and the destructor call.

Moving the browser destruction into the accept and reject calls ensures that CEF can clean up its state _before_ Qt tears down the view hierarchy.

Fixes #8836.

### How Has This Been Tested?
Tested on macOS by several team members.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
