### PR TITLE
libobs: Add sanity checks to some obs_output_t functions

### DIFF
--- a/libobs/obs-output-delay.c
+++ b/libobs/obs-output-delay.c
@@ -28,6 +28,22 @@ static inline bool delay_capturing(const struct obs_output *output)
 	return os_atomic_load_bool(&output->delay_capturing);
 }
 
+static inline bool flag_encoded(const struct obs_output *output)
+{
+	return (output->info.flags & OBS_OUTPUT_ENCODED) != 0;
+}
+
+static inline bool log_flag_encoded(const struct obs_output *output,
+				    const char *func_name, bool inverse_log)
+{
+	const char *prefix = inverse_log ? "n encoded" : " raw";
+	bool ret = flag_encoded(output);
+	if ((!inverse_log && !ret) || (inverse_log && ret))
+		blog(LOG_WARNING, "Output '%s': Tried to use %s on a%s output",
+		     output->context.name, func_name, prefix);
+	return ret;
+}
+
 static inline void push_packet(struct obs_output *output,
 			       struct encoder_packet *packet, uint64_t t)
 {
@@ -186,14 +202,8 @@ void obs_output_set_delay(obs_output_t *output, uint32_t delay_sec,
 {
 	if (!obs_output_valid(output, "obs_output_set_delay"))
 		return;
-
-	if ((output->info.flags & OBS_OUTPUT_ENCODED) == 0) {
-		blog(LOG_WARNING,
-		     "Output '%s': Tried to set a delay "
-		     "value on a non-encoded output",
-		     output->context.name);
+	if (!log_flag_encoded(output, __FUNCTION__, false))
 		return;
-	}
 
 	output->delay_sec = delay_sec;
 	output->delay_flags = flags;


### PR DESCRIPTION
### Description
Adds sanity checks for cases where we shouldn't let certain set functions be performed, when the output doesn't support the associated features. This also does a mild amount of code cleanup, adding inline functions for checking the flags mentioned below.

### Motivation and Context
Since OBS outputs can have any combination of flags for encoded, video, audio, and service, there are a number of cases where it would be a good idea to validate that we're not allowing output changes that risk undefined behavior given the supported flags.

### How Has This Been Tested?
Ubuntu 20.04
- Streaming
- Recording
- Virtual cam

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
