### PR TITLE
libobs, plugins: Deprecate obs_output_t functions with flag parameters

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -882,44 +882,35 @@ Functions used by outputs
 
 ---------------------
 
-.. function:: bool obs_output_can_begin_data_capture(const obs_output_t *output, uint32_t flags)
+.. function:: bool obs_output_can_begin_data_capture2(const obs_output_t *output)
 
    Determines whether video/audio capture (encoded or raw) is able to
-   start.  Call this before initializing any output data to ensure that
+   start.  Call this before initializing any output state to ensure that
    the output can start.
 
-   :param flags: Set to 0 to initialize both audio/video, otherwise a
-                 bitwise OR combination of OBS_OUTPUT_VIDEO and/or
-                 OBS_OUTPUT_AUDIO
    :return:      *true* if data capture can begin
 
 ---------------------
 
-.. function:: bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)
+.. function:: bool obs_output_initialize_encoders2(obs_output_t *output)
 
    Initializes any encoders/services associated with the output.  This
    must be called for encoded outputs before calling
-   :c:func:`obs_output_begin_data_capture()`.
+   :c:func:`obs_output_begin_data_capture2()`.
 
-   :param flags: Set to 0 to initialize both audio/video, otherwise a
-                 bitwise OR combination of OBS_OUTPUT_VIDEO and/or
-                 OBS_OUTPUT_AUDIO
    :return:      *true* if successful, *false* otherwise
 
 ---------------------
 
-.. function:: bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
+.. function:: bool obs_output_begin_data_capture2(obs_output_t *output)
 
    Begins data capture from raw media or encoders.  This is typically
    when the output actually activates (starts) internally.  Video/audio
    data will start being sent to the callbacks of the output.
 
-   :param flags: Set to 0 to initialize both audio/video, otherwise a
-                 bitwise OR combination of OBS_OUTPUT_VIDEO and/or
-                 OBS_OUTPUT_AUDIO
    :return:      *true* if successful, *false* otherwise.  Typically the
                  return value does not need to be checked if
-                 :c:func:`obs_output_can_begin_data_capture()` was
+                 :c:func:`obs_output_can_begin_data_capture2()` was
                  called
 
 ---------------------

--- a/libobs/obs-output-delay.c
+++ b/libobs/obs-output-delay.c
@@ -157,10 +157,10 @@ bool obs_output_delay_start(obs_output_t *output)
 	};
 
 	if (!delay_active(output)) {
-		bool can_begin = obs_output_can_begin_data_capture(output, 0);
+		bool can_begin = obs_output_can_begin_data_capture2(output);
 		if (!can_begin)
 			return false;
-		if (!obs_output_initialize_encoders(output, 0))
+		if (!obs_output_initialize_encoders2(output))
 			return false;
 	}
 
@@ -175,7 +175,7 @@ bool obs_output_delay_start(obs_output_t *output)
 		return true;
 	}
 
-	if (!obs_output_begin_data_capture(output, 0)) {
+	if (!obs_output_begin_data_capture2(output)) {
 		obs_output_cleanup_delay(output);
 		return false;
 	}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2250,26 +2250,24 @@ obs_output_set_audio_conversion(obs_output_t *output,
 				const struct audio_convert_info *conversion);
 
 /** Returns whether data capture can begin with the specified flags */
-EXPORT bool obs_output_can_begin_data_capture(const obs_output_t *output,
-					      uint32_t flags);
+EXPORT bool obs_output_can_begin_data_capture2(const obs_output_t *output);
+OBS_DEPRECATED EXPORT bool
+obs_output_can_begin_data_capture(const obs_output_t *output, uint32_t flags);
 
 /** Initializes encoders (if any) */
-EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
-					   uint32_t flags);
+EXPORT bool obs_output_initialize_encoders2(obs_output_t *output);
+OBS_DEPRECATED EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
+							  uint32_t flags);
 
 /**
  * Begins data capture from media/encoders.
  *
  * @param  output  Output context
- * @param  flags   Set this to 0 to use default output flags set in the
- *                 obs_output_info structure, otherwise set to a either
- *                 OBS_OUTPUT_VIDEO or OBS_OUTPUT_AUDIO to specify whether to
- *                 connect audio or video.  This is useful for things like
- *                 ffmpeg which may or may not always want to use both audio
- *                 and video.
  * @return         true if successful, false otherwise.
  */
-EXPORT bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags);
+EXPORT bool obs_output_begin_data_capture2(obs_output_t *output);
+OBS_DEPRECATED EXPORT bool obs_output_begin_data_capture(obs_output_t *output,
+							 uint32_t flags);
 
 /** Ends data capture from media/encoders */
 EXPORT void obs_output_end_data_capture(obs_output_t *output);

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -1229,7 +1229,7 @@ static bool aja_output_start(void *data)
 
 	obs_output_set_audio_conversion(ajaOutput->GetOBSOutput(), &conversion);
 
-	if (!obs_output_begin_data_capture(ajaOutput->GetOBSOutput(), 0)) {
+	if (!obs_output_begin_data_capture2(ajaOutput->GetOBSOutput())) {
 		blog(LOG_ERROR,
 		     "aja_output_start: Begin OBS data capture failed!");
 		return false;

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -110,7 +110,7 @@ static bool decklink_output_start(void *data)
 
 	obs_output_set_audio_conversion(decklink->GetOutput(), &conversion);
 
-	if (!obs_output_begin_data_capture(decklink->GetOutput(), 0))
+	if (!obs_output_begin_data_capture2(decklink->GetOutput()))
 		return false;
 
 	return true;

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -173,7 +173,7 @@ static bool try_connect(void *data, const char *device)
 	}
 
 	blog(LOG_INFO, "Virtual camera started");
-	obs_output_begin_data_capture(vcam->output, 0);
+	obs_output_begin_data_capture2(vcam->output);
 
 	return true;
 

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -523,7 +523,7 @@ static bool virtualcam_output_start(void *data)
 		[vcam->machServer run];
 	}
 
-	if (!obs_output_begin_data_capture(vcam->output, 0)) {
+	if (!obs_output_begin_data_capture2(vcam->output)) {
 		return false;
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -118,9 +118,9 @@ bool ffmpeg_hls_mux_start(void *data)
 	obs_data_t *settings;
 	int keyint_sec;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
+	if (!obs_output_can_begin_data_capture2(stream->output))
 		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
+	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
 
 	service = obs_output_get_service(stream->output);
@@ -170,7 +170,7 @@ bool ffmpeg_hls_mux_start(void *data)
 	stream->dropped_frames = 0;
 	stream->min_priority = 0;
 
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	dstr_copy(&stream->printable_path, path_str);
 	info("Writing to path '%s'...", stream->printable_path.array);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1025,9 +1025,9 @@ static bool set_config(struct ffmpeg_output *stream)
 		}
 		av_dump_format(ff_data->output, 0, NULL, 1);
 	}
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
+	if (!obs_output_can_begin_data_capture2(stream->output))
 		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
+	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
 
 	ret = pthread_create(&stream->write_thread, NULL, write_thread, stream);
@@ -1042,7 +1042,7 @@ static bool set_config(struct ffmpeg_output *stream)
 	os_atomic_set_bool(&stream->active, true);
 	stream->write_thread_active = true;
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	return true;
 fail:

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -411,9 +411,9 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 
 	update_encoder_settings(stream, path);
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
+	if (!obs_output_can_begin_data_capture2(stream->output))
 		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
+	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
 
 	if (stream->is_network) {
@@ -468,7 +468,7 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	info("Writing file '%s'...", stream->path.array);
 	return true;
@@ -1039,9 +1039,9 @@ static bool replay_buffer_start(void *data)
 {
 	struct ffmpeg_muxer *stream = data;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
+	if (!obs_output_can_begin_data_capture2(stream->output))
 		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
+	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
 
 	obs_data_t *s = obs_output_get_settings(stream->output);
@@ -1052,7 +1052,7 @@ static bool replay_buffer_start(void *data)
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	return true;
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1209,7 +1209,7 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	output->active = true;
 
-	if (!obs_output_can_begin_data_capture(output->output, 0))
+	if (!obs_output_can_begin_data_capture2(output->output))
 		return false;
 
 	ret = pthread_create(&output->write_thread, NULL, write_thread, output);
@@ -1223,7 +1223,7 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	obs_output_set_video_conversion(output->output, NULL);
 	obs_output_set_audio_conversion(output->output, &aci);
-	obs_output_begin_data_capture(output->output, 0);
+	obs_output_begin_data_capture2(output->output);
 	output->write_thread_active = true;
 	return true;
 }

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -154,9 +154,9 @@ static bool flv_output_start(void *data)
 	obs_data_t *settings;
 	const char *path;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
+	if (!obs_output_can_begin_data_capture2(stream->output))
 		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
+	if (!obs_output_initialize_encoders2(stream->output))
 		return false;
 
 	stream->got_first_video = false;
@@ -177,7 +177,7 @@ static bool flv_output_start(void *data)
 
 	/* write headers and start capture */
 	os_atomic_set_bool(&stream->active, true);
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	info("Writing FLV file '%s'...", stream->path.array);
 	return true;

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -593,7 +593,7 @@ static int init_send(struct ftl_stream *stream)
 
 	os_atomic_set_bool(&stream->active, true);
 
-	obs_output_begin_data_capture(stream->output, 0);
+	obs_output_begin_data_capture2(stream->output);
 
 	return OBS_OUTPUT_SUCCESS;
 }
@@ -649,10 +649,10 @@ static bool ftl_stream_start(void *data)
 	obs_data_set_int(video_settings, "bf", 0);
 	obs_data_release(video_settings);
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0)) {
+	if (!obs_output_can_begin_data_capture2(stream->output)) {
 		return false;
 	}
-	if (!obs_output_initialize_encoders(stream->output, 0)) {
+	if (!obs_output_initialize_encoders2(stream->output)) {
 		return false;
 	}
 

--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -51,15 +51,15 @@ static bool null_output_start(void *data)
 {
 	struct null_output *context = data;
 
-	if (!obs_output_can_begin_data_capture(context->output, 0))
+	if (!obs_output_can_begin_data_capture2(context->output))
 		return false;
-	if (!obs_output_initialize_encoders(context->output, 0))
+	if (!obs_output_initialize_encoders2(context->output))
 		return false;
 
 	if (context->stop_thread_active)
 		pthread_join(context->stop_thread, NULL);
 
-	obs_output_begin_data_capture(context->output, 0);
+	obs_output_begin_data_capture2(context->output);
 	return true;
 }
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1137,7 +1137,7 @@ static int init_send(struct rtmp_stream *stream)
 	}
 
 	if (!silently_reconnecting(stream))
-		obs_output_begin_data_capture(stream->output, 0);
+		obs_output_begin_data_capture2(stream->output);
 
 	return OBS_OUTPUT_SUCCESS;
 }
@@ -1456,9 +1456,9 @@ static bool rtmp_stream_start(void *data)
 	struct rtmp_stream *stream = data;
 
 	if (!silently_reconnecting(stream)) {
-		if (!obs_output_can_begin_data_capture(stream->output, 0))
+		if (!obs_output_can_begin_data_capture2(stream->output))
 			return false;
-		if (!obs_output_initialize_encoders(stream->output, 0))
+		if (!obs_output_initialize_encoders2(stream->output))
 			return false;
 	}
 

--- a/plugins/win-dshow/virtualcam.c
+++ b/plugins/win-dshow/virtualcam.c
@@ -68,7 +68,7 @@ static bool virtualcam_start(void *data)
 	os_atomic_set_bool(&vcam->active, true);
 	os_atomic_set_bool(&vcam->stopping, false);
 	blog(LOG_INFO, "Virtual output started");
-	obs_output_begin_data_capture(vcam->output, 0);
+	obs_output_begin_data_capture2(vcam->output);
 	return true;
 }
 


### PR DESCRIPTION
### Description
Depends #8873

This deprecates the following functions, replacing them with new versions:
- `obs_output_can_begin_data_capture()` - now `*capture2()`
- `obs_output_initialize_encoders()` - now `*encoders2()`
- `obs_output_begin_data_capture()` - now `*capture2()`

An implementation to allow audio/video to be optional is best done using the flag technique described below, with audio/video enablement specified by whether media (raw, `video_t/audio_t`) or encoder (`obs_encoder_t`) objects are specified.

Since every implementation I could find always specifies `flags` as 0, I was able to safely conclude that immediately removing the parameters' functionality is safe to do.

### Motivation and Context
The flags parameter was reportedly initially designed to support audio-only or video-only operation of an output which had the `OBS_OUTPUT_AV` flag, however, full support for that was never implemented, and there are likely fundamental issues with finishing the implementation, mainly that most outputs are programmed assuming that there will always be at least one audio and one video track. This requires new flags specifying support for optional audio/video, among other things.

To protect libobs from weird, unpredictable/undefined behavior, deprecating these parameters seems appropriate.

### How Has This Been Tested?
Ubuntu 20.04
- Streaming
- Recording
- Virtualcam

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Breaking change (fix or feature that would cause existing functionality to change)
- Documentation (a change to documentation pages)

(breaking change is subjective here. ABI has not directly changed but it signifies a time when ABI will eventually be broken by its removal)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
