### PR TITLE
obs-ffmpeg: Fix compilation when ENABLE_HEVC is not set

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -287,6 +287,8 @@ static bool vaapi_update(void *data, obs_data_t *settings, bool hevc)
 
 		hevc_vaapi_video_info(enc, &info);
 	} else
+#else
+	UNUSED_PARAMETER(hevc);
 #endif
 	{
 		h264_vaapi_video_info(enc, &info);
@@ -564,6 +566,8 @@ static bool vaapi_encode_internal(void *data, struct encoder_frame *frame,
 					&enc->header_size, &enc->sei,
 					&enc->sei_size);
 			} else
+#else
+			UNUSED_PARAMETER(hevc);
 #endif
 			{
 				obs_extract_avc_headers(
@@ -649,6 +653,8 @@ static void vaapi_defaults_internal(obs_data_t *settings, bool hevc)
 					 FF_PROFILE_HEVC_MAIN);
 
 	} else
+#else
+	UNUSED_PARAMETER(hevc);
 #endif
 	{
 		obs_data_set_default_int(settings, "profile",


### PR DESCRIPTION
When ENABLE_HEVC is not set the 'bool hevc' function parameter is not being used in this function causing a warning and aborting compilation.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes compilation with a specific feature set.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Not sure why it actually happened I had `ENABLE_HEVC=OFF`, but with that option compilation would error out due to unused variables.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled with `ENABLE_HEVC=OFF` and `ENABLE_HEVC=ON`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
