### PR TITLE
UI: Fix crash when double-clicking projector

### DIFF
--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -229,6 +229,10 @@ void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)
 	if (!transitionOnDoubleClick)
 		return;
 
+	// Only MultiView projectors handle double click
+	if (this->type != ProjectorType::Multiview)
+		return;
+
 	OBSBasic *main = (OBSBasic *)obs_frontend_get_main_window();
 	if (!main->IsPreviewProgramMode())
 		return;


### PR DESCRIPTION
### Description
If "transition on double click" was enabled, OBS assumed all double clicks were going to multiview projectors, which isn't necessarily the case.

### Motivation and Context
Fix [reported crash on the forum](https://obsproject.com/forum/threads/repeatable-crash-on-w11.166526/).

### How Has This Been Tested?
Crash was reproduced and new behavior verified.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
