### PR TITLE
CI: Download Qt5 conditionally on Linux

### DIFF
--- a/CI/linux/01_install_dependencies.sh
+++ b/CI/linux/01_install_dependencies.sh
@@ -37,7 +37,10 @@ install_qt5-deps() {
     status "Install Qt5 dependencies"
     trap "caught_error 'install_qt5-deps'" ERR
 
-    sudo apt-get install --no-install-recommends -y $@
+    _QT6_AVAILABLE="$(sudo apt-cache madison qt6-base-dev)"
+    if [ -z "${_QT6_AVAILABLE}" ]; then
+        sudo apt-get install --no-install-recommends -y $@
+    fi
 }
 
 install_qt6-deps() {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Qt6 libraries are installed if the package is available on the system.
Uses the inverted condition to install Qt5 libraries to avoid unnecessarily install both libraries.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Installing Qt5 library is unnecessary but it took ~17 seconds to download and install the packages.

This will also reduce ~100 MB usage of storage.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Checked CI ran without errors.

Compared the log file of with and without this commit.
The difference is only that `WrapVulkanHeaders` is not found while loading Qt6-Widgets, which should not affect the results.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
