### PR TITLE
deps/obs-scripting: Set file/chunk name when loading lua scripts

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -129,7 +129,8 @@ static bool load_lua_script(struct obs_lua_script *data)
 		goto fail;
 	}
 
-	if (luaL_loadbuffer(script, file_data, strlen(file_data), NULL) != 0) {
+	if (luaL_loadbuffer(script, file_data, strlen(file_data),
+			    data->base.path.array) != 0) {
 		script_warn(&data->base, "Error loading file: %s",
 			    lua_tostring(script, -1));
 		bfree(file_data);


### PR DESCRIPTION
### Description

Sets the script's path as the name when loading the lua script from a buffer.

### Motivation and Context

Someone complained on Discord that their script can no longer get its own filename, and I don't see a compelling reason not to set it.

### How Has This Been Tested?

Short snippet:
```lua
function filename() 
    local str = debug.getinfo(2).source:sub(2) 
    return str:match("^.*/(.*).lua$") or str 
end

print(filename())
```

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
