### PR TITLE
UI: Disallow exiting settings with no audio tracks selected

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1332,6 +1332,8 @@ SceneItemHide="Hide '%1'"
 
 # Output warnings
 OutputWarnings.NoTracksSelected="You must select at least one track"
+OutputWarnings.NoTracksSelectedOnExit.Title="Output Settings Error"
+OutputWarnings.NoTracksSelectedOnExit.Text="All outputs must have at least one audio track selected."
 OutputWarnings.MP4Recording="Warning: Recordings saved to MP4/MOV will be unrecoverable if the file cannot be finalized (e.g. as a result of BSODs, power losses, etc.). If you want to record multiple audio tracks consider using MKV and remux the recording to MP4/MOV after it is finished (File → Remux Recordings)"
 OutputWarnings.CannotPause="Warning: Recordings cannot be paused if the recording encoder is set to \"(Use stream encoder)\""
 OutputWarnings.CodecIncompatible="The audio or video encoder selection was reset due to incompatibility. Please select a compatible encoder from the list."

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1792,6 +1792,10 @@ inline void AdvancedOutput::SetupRecording()
 	unsigned int cy = 0;
 	int idx = 0;
 
+	/* Hack to allow recordings without any audio tracks selected. It is no
+	 * longer possible to select such a configuration in settings, but legacy
+	 * configurations might still have this configured and we don't want to
+	 * just break them. */
 	if (tracks == 0)
 		tracks = config_get_int(main->Config(), "AdvOut", "TrackIndex");
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -3886,14 +3886,8 @@ void OBSBasicSettings::SaveOutputSettings()
 	SaveSpinBox(ui->advOutSplitFileTime, "AdvOut", "RecSplitFileTime");
 	SaveSpinBox(ui->advOutSplitFileSize, "AdvOut", "RecSplitFileSize");
 
-	config_set_int(
-		main->Config(), "AdvOut", "RecTracks",
-		(ui->advOutRecTrack1->isChecked() ? (1 << 0) : 0) |
-			(ui->advOutRecTrack2->isChecked() ? (1 << 1) : 0) |
-			(ui->advOutRecTrack3->isChecked() ? (1 << 2) : 0) |
-			(ui->advOutRecTrack4->isChecked() ? (1 << 3) : 0) |
-			(ui->advOutRecTrack5->isChecked() ? (1 << 4) : 0) |
-			(ui->advOutRecTrack6->isChecked() ? (1 << 5) : 0));
+	config_set_int(main->Config(), "AdvOut", "RecTracks",
+		       AdvOutGetSelectedAudioTracks());
 
 	config_set_int(main->Config(), "AdvOut", "FLVTrack", CurrentFLVTrack());
 
@@ -4237,6 +4231,10 @@ bool OBSBasicSettings::QueryAllowedToClose()
 		    ui->advOutRecAEncoder->currentIndex() == -1 ||
 		    ui->advOutAEncoder->currentIndex() == -1)
 			invalidEncoder = true;
+
+		QString format = ui->advOutRecFormat->currentData().toString();
+		if (AdvOutGetSelectedAudioTracks() == 0 && format != "flv")
+			invalidTracks = true;
 	}
 
 	if (invalidEncoder) {
@@ -6174,6 +6172,17 @@ int OBSBasicSettings::SimpleOutGetSelectedAudioTracks()
 		     (ui->simpleOutRecTrack4->isChecked() ? (1 << 3) : 0) |
 		     (ui->simpleOutRecTrack5->isChecked() ? (1 << 4) : 0) |
 		     (ui->simpleOutRecTrack6->isChecked() ? (1 << 5) : 0);
+	return tracks;
+}
+
+int OBSBasicSettings::AdvOutGetSelectedAudioTracks()
+{
+	int tracks = (ui->advOutRecTrack1->isChecked() ? (1 << 0) : 0) |
+		     (ui->advOutRecTrack2->isChecked() ? (1 << 1) : 0) |
+		     (ui->advOutRecTrack3->isChecked() ? (1 << 2) : 0) |
+		     (ui->advOutRecTrack4->isChecked() ? (1 << 3) : 0) |
+		     (ui->advOutRecTrack5->isChecked() ? (1 << 4) : 0) |
+		     (ui->advOutRecTrack6->isChecked() ? (1 << 5) : 0);
 	return tracks;
 }
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -375,6 +375,7 @@ private:
 	QIcon GetAdvancedIcon() const;
 
 	int CurrentFLVTrack();
+	int SimpleOutGetSelectedAudioTracks();
 
 	OBSService GetStream1Service();
 

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -376,6 +376,7 @@ private:
 
 	int CurrentFLVTrack();
 	int SimpleOutGetSelectedAudioTracks();
+	int AdvOutGetSelectedAudioTracks();
 
 	OBSService GetStream1Service();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Disallows the user from exiting the audio settings without having selected an audio track.

<img width="300" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/b859d87d-f685-48bf-9118-45e145cb7ad7">

Split into two commits so that the first commit (for simple mode) can be cherry-picked to the 29.1 branch, while the second commit can wait until the next version.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #8887

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3.1
Unselected all audio tracks in both simple and advanced mode, and saw the popup appear, preventing me from exiting settings. Selected an audio track and exited successfully.
Selected FLV (and "Same as Stream" quality in simple mode) with none of the checkboxes checked beforehand and exited the settings successfully (since the checkboxes don't have an effect with FLV or with Same as stream quality in simple mode).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
