### PR TITLE
UI: Reset Virualcam when clearing scene data

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -348,6 +348,7 @@ void BasicOutputHandler::UpdateVirtualCamOutputSource()
 
 	switch (main->vcamConfig.type) {
 	case VCamOutputType::InternalOutput:
+		DestroyVirtualCameraScene();
 		switch (main->vcamConfig.internal) {
 		case VCamInternalType::Default:
 			source = obs_get_output_source(0);
@@ -360,10 +361,11 @@ void BasicOutputHandler::UpdateVirtualCamOutputSource()
 		}
 		break;
 	case VCamOutputType::SceneOutput:
+		DestroyVirtualCameraScene();
 		source = obs_get_source_by_name(main->vcamConfig.scene.c_str());
 		break;
 	case VCamOutputType::SourceOutput:
-		OBSSource s =
+		OBSSourceAutoRelease s =
 			obs_get_source_by_name(main->vcamConfig.source.c_str());
 
 		if (!vCamSourceScene)
@@ -380,7 +382,6 @@ void BasicOutputHandler::UpdateVirtualCamOutputSource()
 
 		if (!vCamSourceSceneItem) {
 			vCamSourceSceneItem = obs_scene_add(vCamSourceScene, s);
-			obs_source_release(s);
 
 			obs_sceneitem_set_bounds_type(vCamSourceSceneItem,
 						      OBS_BOUNDS_SCALE_INNER);
@@ -410,6 +411,11 @@ void BasicOutputHandler::DestroyVirtualCamView()
 	obs_view_destroy(virtualCamView);
 	virtualCamView = nullptr;
 
+	DestroyVirtualCameraScene();
+}
+
+void BasicOutputHandler::DestroyVirtualCameraScene()
+{
 	if (!vCamSourceScene)
 		return;
 

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -64,6 +64,7 @@ struct BasicOutputHandler {
 
 	virtual void UpdateVirtualCamOutputSource();
 	virtual void DestroyVirtualCamView();
+	virtual void DestroyVirtualCameraScene();
 
 	inline bool Active() const
 	{

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -426,7 +426,8 @@ void OBSBasic::SetTransition(OBSSource transition)
 	ui->transitionRemove->setEnabled(configurable);
 	ui->transitionProps->setEnabled(configurable);
 
-	if (vcamEnabled && vcamConfig.internal == VCamInternalType::Default)
+	if (vcamEnabled && vcamConfig.type == VCamOutputType::InternalOutput &&
+	    vcamConfig.internal == VCamInternalType::Default)
 		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1280,7 +1280,7 @@ retryScene:
 
 	disableSaving--;
 
-	if (vcamEnabled && vcamConfig.internal == VCamInternalType::Preview)
+	if (vcamEnabled)
 		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api) {
@@ -4856,6 +4856,14 @@ void OBSBasic::ClearSceneData()
 
 	for (int i = 0; i < MAX_CHANNELS; i++)
 		obs_set_output_source(i, nullptr);
+
+	/* Reset VCam to default to clear its private scene and any references
+	 * it holds. It will be reconfigured during loading. */
+	if (vcamEnabled) {
+		vcamConfig.type = VCamOutputType::InternalOutput;
+		vcamConfig.internal = VCamInternalType::Default;
+		outputHandler->UpdateVirtualCamOutputSource();
+	}
 
 	lastScene = nullptr;
 	swapScene = nullptr;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5282,7 +5282,8 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 
 	SetCurrentScene(source);
 
-	if (vcamEnabled && vcamConfig.internal == VCamInternalType::Preview)
+	if (vcamEnabled && vcamConfig.type == VCamOutputType::InternalOutput &&
+	    vcamConfig.internal == VCamInternalType::Preview)
 		outputHandler->UpdateVirtualCamOutputSource();
 
 	if (api)


### PR DESCRIPTION
### Description

This fixes one of the leaks surfaced by #8846.

Mainly the current virtual cam has the following issues:
- The sceneitem is not released/removed when switching scene collections, retaining a reference to the source
- The private scene is not released, which doesn't itself break anything, but it's just wasting resources
- If `UpdateVirtualCamOutputSource()` gets called but the target source has not changed it is leaked as the reference acquired is only released in the branch where the scene item does not exist yet
  + This would happen e.g. with `SetTransition()` as it would not check if the output type is set to internal (also fixed in this PR)
- Fixed vcam update only being called when set to preview on loading, previously this only worked with scene/source output because `SetTransition()` would erroneously call the vcam update even if `LoadData()` didn't.

### Motivation and Context

Fix users running into OBS exiting when switching scene collections.

### How Has This Been Tested?

Switched between scenes while vcam is active a whole lot.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
