### PR TITLE
UI: Process Qt events once after destroy queue finishes

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4887,6 +4887,11 @@ void OBSBasic::ClearSceneData()
 		QApplication::sendPostedEvents(nullptr);
 	} while (obs_wait_for_destroy_queue());
 
+	/* Pump Qt events one final time to give remaining signals time to be
+	 * processed (since this happens after the destroy thread finishes and
+	 * the audio/video threads have processed their tasks). */
+	QApplication::sendPostedEvents(nullptr);
+
 	unsetCursor();
 
 	/* If scene data wasn't actually cleared, e.g. faulty plugin holding a


### PR DESCRIPTION
### Description

Process Qt Events one final time before the leak check runs to give UI code (e.g. volume meter) time to release their held references.

Unfortunately I do not know if this is *the* fix or just happens to work around a race condition. From my testing with additional logging related to the creation and release of references it did seem like the RAII wrapper was always the last one to release the affected sources, and that the `DeactivateAudioSource` function was the last to use the `OBSSource` (the affected sources were always audio sources).

My best guess is that the scheduled (`invokeMethod(...)`) calls from the signal handler for removing the sources from the mixer were not always processed by the time the loop exits, resulting in a race condition where sometimes sources were not fully destroyed by the time the check runs.

### Motivation and Context

Seems to fix a race condition with cleanup that results in false-positives with the leak checker.

### How Has This Been Tested?

Switched scene collections hundreds of times before, and probably a good 50 after. It just no longer happens.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
