### PR TITLE
mac-videotoolbox: Fix incorrect keyframe interval calculation

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -626,8 +626,9 @@ static bool create_encoder(struct vt_encoder *enc)
 			kVTCompressionPropertyKey_AllowFrameReordering,
 			kVTCompressionPropertyKey_ProfileLevel};
 
-		float key_frame_interval =
-			enc->keyint * ((float)enc->fps_num / enc->fps_den);
+		SInt32 key_frame_interval =
+			(SInt32)(enc->keyint *
+				 ((float)enc->fps_num / enc->fps_den));
 		float expected_framerate = (float)enc->fps_num / enc->fps_den;
 		CFNumberRef MaxKeyFrameInterval =
 			CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes an accidental float to integer conversion which makes the values set for `kVTCompressionPropertyKey_MaxKeyFrameInterval` hilariously wrong. We're creating a number of type `kCFNumberSInt32Type` so we should give that an int instead of a float.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It turns out that a keyframe every 1123024896 frames isn't super useful.
Hopefully fixes reports of encoders on Intel Macs not working properly and streaming services reporting incorrect keyframe intervals.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.3.1
Tested that when setting a 2 second keyframe interval and then retrieving the value via `VTSessionCopyProperty`, it's now `120` instead of `1123024896`.
Don't really have an Intel Mac anymore so can't test if it actually fixes the issue reported, but will ask people reporting the problem to test CI builds of this PR.

Edit: CI builds tested by someone on Discord having the problem, they say it does indeed fix it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
