### PR TITLE
UI: Move saving of scene tree grid mode

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -1,6 +1,4 @@
-#include "obs.hpp"
 #include "scene-tree.hpp"
-#include "obs-app.hpp"
 
 #include <QSizePolicy>
 #include <QScrollBar>
@@ -18,7 +16,6 @@ SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 
 void SceneTree::SetGridMode(bool grid)
 {
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode", grid);
 	parent()->setProperty("gridMode", grid);
 	gridMode = grid;
 

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -7,6 +7,7 @@
 #include <QDropEvent>
 #include <QPushButton>
 #include <QTimer>
+#include <cmath>
 
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
@@ -81,7 +82,7 @@ void SceneTree::resizeEvent(QResizeEvent *event)
 		}
 
 		int wid = contentsRect().width() - scrollWid - 1;
-		int items = (int)ceil((float)wid / maxWidth);
+		int items = (int)std::ceil((float)wid / maxWidth);
 		int itemWidth = wid / items;
 
 		setGridSize(QSize(itemWidth, itemHeight));
@@ -133,10 +134,10 @@ void SceneTree::dropEvent(QDropEvent *event)
 		QPoint point = event->pos();
 #endif
 
-		int x = (float)point.x() / wid * ceil(wid / maxWidth);
+		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
 		int y = (point.y() + firstItemY) / itemHeight;
 
-		int r = x + y * ceil(wid / maxWidth);
+		int r = x + y * std::ceil(wid / maxWidth);
 
 		QListWidgetItem *item = takeItem(selectedIndexes()[0].row());
 		insertItem(r, item);
@@ -178,10 +179,10 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 		QPoint point = event->pos();
 #endif
 
-		int x = (float)point.x() / wid * ceil(wid / maxWidth);
+		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
 		int y = (point.y() + firstItemY) / itemHeight;
 
-		int r = x + y * ceil(wid / maxWidth);
+		int r = x + y * std::ceil(wid / maxWidth);
 		int orig = selectedIndexes()[0].row();
 
 		for (int i = 0; i < count(); i++) {
@@ -196,8 +197,8 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 				  (i > orig && i > r ? 1 : 0) -
 				  (i > orig && i == r ? 2 : 0);
 
-			int xPos = (i + off) % (int)ceil(wid / maxWidth);
-			int yPos = (i + off) / (int)ceil(wid / maxWidth);
+			int xPos = (i + off) % (int)std::ceil(wid / maxWidth);
+			int yPos = (i + off) / (int)std::ceil(wid / maxWidth);
 			QSize g = gridSize();
 
 			QPoint position(xPos * g.width(), yPos * g.height());
@@ -212,8 +213,8 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 
 			QModelIndex index = indexFromItem(wItem);
 
-			int xPos = i % (int)ceil(wid / maxWidth);
-			int yPos = i / (int)ceil(wid / maxWidth);
+			int xPos = i % (int)std::ceil(wid / maxWidth);
+			int yPos = i / (int)std::ceil(wid / maxWidth);
 			QSize g = gridSize();
 
 			QPoint position(xPos * g.width(), yPos * g.height());

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5493,6 +5493,9 @@ void OBSBasic::GridActionClicked()
 		ui->actionSceneGridMode->setChecked(true);
 	else
 		ui->actionSceneListMode->setChecked(true);
+
+	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode",
+			gridMode);
 }
 
 void OBSBasic::on_actionAddScene_triggered()


### PR DESCRIPTION
### Description
This now saves the grid mode in the grid mode toggle action in the OBSBasic class.

### Motivation and Context
Widgets should not save their own states, just in case they are used elsewhere.

### How Has This Been Tested?
Toggled grid mode

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
