### PR TITLE
libobs: Adds obs.hpp to exported header files

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -283,6 +283,7 @@ set(public_headers
     obs-source.h
     obs-ui.h
     obs.h
+    obs.hpp
     util/base.h
     util/bmem.h
     util/c99defs.h


### PR DESCRIPTION
### Description
Adds `obs.hpp` to list of public headers for `libobs`.

### Motivation and Context
Required for C++-based plugins to correctly compile and link against `libobs`. 

### How Has This Been Tested?
Tested with plugintemplate if include of `obs.hpp` was correctly resolved.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
