### PR TITLE
 obs-scripting: Allow passing python methods as callbacks

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -319,7 +319,7 @@ static PyObject *remove_save_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -343,7 +343,7 @@ static PyObject *add_save_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -389,7 +389,7 @@ static PyObject *remove_event_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -413,7 +413,7 @@ static PyObject *add_event_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);

--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -182,6 +182,7 @@ bool import_python(const char *python_path, python_version_t *python_version)
 	IMPORT_FUNC(PyCapsule_GetPointer);
 	IMPORT_FUNC(PyArg_ParseTuple);
 	IMPORT_FUNC(PyFunction_Type);
+	IMPORT_FUNC(PyMethod_Type);
 	IMPORT_FUNC(PyObject_SetAttr);
 	IMPORT_FUNC(_PyObject_New);
 	IMPORT_FUNC(PyCapsule_Import);

--- a/deps/obs-scripting/obs-scripting-python-import.h
+++ b/deps/obs-scripting/obs-scripting-python-import.h
@@ -129,6 +129,7 @@ PY_EXTERN void *(*Import_PyCapsule_GetPointer)(PyObject *capsule,
 					       const char *name);
 PY_EXTERN int (*Import_PyArg_ParseTuple)(PyObject *, const char *, ...);
 PY_EXTERN PyTypeObject(*Import_PyFunction_Type);
+PY_EXTERN PyTypeObject(*Import_PyMethod_Type);
 PY_EXTERN int (*Import_PyObject_SetAttr)(PyObject *, PyObject *, PyObject *);
 PY_EXTERN PyObject *(*Import__PyObject_New)(PyTypeObject *);
 PY_EXTERN void *(*Import_PyCapsule_Import)(const char *name, int no_block);
@@ -217,6 +218,7 @@ extern bool import_python(const char *python_path,
 #define PyCapsule_GetPointer Import_PyCapsule_GetPointer
 #define PyArg_ParseTuple Import_PyArg_ParseTuple
 #define PyFunction_Type (*Import_PyFunction_Type)
+#define PyMethod_Type (*Import_PyMethod_Type)
 #define PyObject_SetAttr Import_PyObject_SetAttr
 #define _PyObject_New Import__PyObject_New
 #define PyCapsule_Import Import_PyCapsule_Import

--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -507,7 +507,7 @@ static PyObject *obs_python_remove_tick_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -532,7 +532,7 @@ static PyObject *obs_python_add_tick_callback(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -590,7 +590,7 @@ static PyObject *obs_python_signal_handler_disconnect(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -635,7 +635,7 @@ static PyObject *obs_python_signal_handler_connect(PyObject *self,
 		return python_none();
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -695,7 +695,7 @@ static PyObject *obs_python_signal_handler_disconnect_global(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -737,7 +737,7 @@ static PyObject *obs_python_signal_handler_connect_global(PyObject *self,
 
 	if (!py_to_libobs(signal_handler_t, py_sh, &handler))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -828,7 +828,7 @@ static PyObject *hotkey_unregister(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "O", &py_cb))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb =
@@ -850,7 +850,7 @@ static PyObject *hotkey_register_frontend(PyObject *self, PyObject *args)
 
 	if (!parse_args(args, "ssO", &name, &desc, &py_cb))
 		return py_invalid_hotkey_id();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return py_invalid_hotkey_id();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -915,7 +915,7 @@ static PyObject *properties_add_button(PyObject *self, PyObject *args)
 		return python_none();
 	if (!py_to_libobs(obs_properties_t, py_props, &props))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);
@@ -979,7 +979,7 @@ static PyObject *property_set_modified_callback(PyObject *self, PyObject *args)
 		return python_none();
 	if (!py_to_libobs(obs_property_t, py_p, &p))
 		return python_none();
-	if (!py_cb || !PyFunction_Check(py_cb))
+	if (!py_cb || (!PyFunction_Check(py_cb) && !PyMethod_Check(py_cb)))
 		return python_none();
 
 	struct python_obs_callback *cb = add_python_obs_callback(script, py_cb);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When adding an object as callback, obs-scripting-python requires the
object to be of function type, which excludes bound method objects, 
although they are perfectly valid as callback objects.

This changes the type check in functions that add script callbacks so 
that bound methods pass it.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There's no technical impossibility for bound methods to be used as 
callbacks, not allowing them to be used as such only removes potential 
functionality from python scripts.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested, on Ubuntu 22.04, by using the script linked below, and 
verifying  that the bound methods it requests to set as callbacks are correctly 
added, triggered and removed.
[method_callback.zip](https://github.com/obsproject/obs-studio/files/11495058/method_callback.zip)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
