### PR TITLE
UI: Fix missing translations

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -102,7 +102,6 @@ LockVolume="Lock Volume"
 LogViewer="Log Viewer"
 ShowOnStartup="Show on startup"
 OpenFile="Open file"
-AddValue="Add %1"
 AddSource="Add Source"
 RemoveScene="Remove Selected Scene"
 RemoveSource="Remove Selected Source(s)"
@@ -206,7 +205,6 @@ Basic.AutoConfig.StreamPage.Service.Custom="Custom..."
 Basic.AutoConfig.StreamPage.Server="Server"
 Basic.AutoConfig.StreamPage.StreamKey="Stream Key"
 Basic.AutoConfig.StreamPage.StreamKey.ToolTip="RIST: enter the encryption passphrase.\nRTMP: enter the key provided by the service.\nSRT: enter the streamid if the service uses one."
-Basic.AutoConfig.StreamPage.StreamKey.LinkToSite="(Link)"
 Basic.AutoConfig.StreamPage.EncoderKey="Encoder Key"
 Basic.AutoConfig.StreamPage.ConnectedAccount="Connected account"
 Basic.AutoConfig.StreamPage.PerformBandwidthTest="Estimate bitrate with bandwidth test (may take a few minutes)"
@@ -264,8 +262,6 @@ Updater.Text="There is a new update available:"
 Updater.UpdateNow="Update Now"
 Updater.RemindMeLater="Remind me Later"
 Updater.Skip="Skip Version"
-Updater.Running.Title="Program currently active"
-Updater.Running.Text="Outputs are currently active, please shut down any active outputs before attempting to update"
 Updater.NoUpdatesAvailable.Title="No updates available"
 Updater.NoUpdatesAvailable.Text="No updates are currently available"
 Updater.BranchNotFound.Title="Update Channel Removed"
@@ -275,8 +271,6 @@ Updater.RepairButUpdatesAvailable.Text="Checking file integrity is only possible
 Updater.RepairConfirm.Title="Confirm Integrity Check"
 Updater.RepairConfirm.Text="Starting the integrity check will scan your OBS installation for corruption and redownload broken/modified files. This may take a moment.\n\nDo you wish to proceed?"
 Updater.FailedToLaunch="Failed to launch updater"
-Updater.GameCaptureActive.Title="Game capture active"
-Updater.GameCaptureActive.Text="Game capture hook library is currently in use. Please close any games/programs being captured (or restart Windows) and try again."
 
 # quick transitions
 QuickTransitions.SwapScenes="Swap Preview/Program Scenes After Transitioning"
@@ -461,6 +455,8 @@ Remux.FileExists="The following target files already exist. Do you want to repla
 Remux.ExitUnfinishedTitle="Remuxing in progress"
 Remux.ExitUnfinished="Remuxing is not finished, stopping now may render the target file unusable.\nAre you sure you want to stop remuxing?"
 Remux.HelpText="Drop files in this window to remux, or select an empty \"OBS Recording\" cell to browse for a file."
+Remux.NoFilesAddedTitle="No remuxing file added"
+Remux.NoFilesAdded="No file is added to remux. Drop a folder containing one or more video files."
 
 # missing file dialog
 MissingFiles="Missing Files"
@@ -498,10 +494,6 @@ MacPermissions.Item.Microphone.Details="OBS requires this permission if you want
 MacPermissions.Item.Accessibility="Accessibility"
 MacPermissions.Item.Accessibility.Details="For keyboard shortcuts (hotkeys) to work while other apps are focused, please enable this permission."
 MacPermissions.Continue="Continue"
-
-# update dialog
-UpdateAvailable="New Update Available"
-UpdateAvailable.Text="Version %1.%2.%3 is now available. <a href='%4'>Click here to download</a>"
 
 # Source leak error message
 SourceLeak.Title="Source Cleanup Error"
@@ -797,7 +789,6 @@ Basic.MainMenu.View="&View"
 Basic.MainMenu.View.Toolbars="&Toolbars"
 Basic.MainMenu.View.ListboxToolbars="Scene/Source List Buttons"
 Basic.MainMenu.View.ContextBar="Source Toolbar"
-Basic.MainMenu.View.SceneTransitions="S&cene Transitions"
 Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"
 Basic.MainMenu.View.Fullscreen.Interface="Fullscreen Interface"
@@ -819,7 +810,6 @@ Basic.MainMenu.Profile.Export="Export Profile"
 Basic.MainMenu.SceneCollection.Import="Import Scene Collection"
 Basic.MainMenu.SceneCollection.Export="Export Scene Collection"
 Basic.MainMenu.Profile.Exists="The profile already exists"
-Basic.MainMenu.SceneCollection.Exists="The scene collection already exists"
 
 # basic mode help menu
 Basic.MainMenu.Tools="&Tools"
@@ -914,7 +904,6 @@ Basic.Settings.General.ChannelDescription.beta="Potentially unstable pre-release
 
 # basic mode 'stream' settings
 Basic.Settings.Stream="Stream"
-Basic.Settings.Stream.StreamType="Stream Type"
 Basic.Settings.Stream.Custom.UseAuthentication="Use authentication"
 Basic.Settings.Stream.Custom.Username="Username"
 Basic.Settings.Stream.Custom.Password="Password"
@@ -955,7 +944,6 @@ Basic.Settings.Output.Format.TT.fmp4="Fragmented MP4 writes the recording in chu
 Basic.Settings.Output.Encoder.Video="Video Encoder"
 Basic.Settings.Output.Encoder.Audio="Audio Encoder"
 Basic.Settings.Output.SelectDirectory="Select Recording Directory"
-Basic.Settings.Output.SelectFile="Select Recording File"
 Basic.Settings.Output.DynamicBitrate="Dynamically change bitrate to manage congestion"
 Basic.Settings.Output.DynamicBitrate.Beta="Dynamically change bitrate to manage congestion (Beta)"
 Basic.Settings.Output.DynamicBitrate.TT="Instead of dropping frames to reduce congestion, dynamically changes bitrate on the fly.\n\nNote that this can increase delay to viewers if there is significant sudden congestion.\nWhen the bitrate drops, it can take up to a few minutes to restore.\n\nCurrently only supported for RTMP."
@@ -1205,7 +1193,6 @@ Basic.Settings.Advanced.General.ProcessPriority.Idle="Idle"
 Basic.Settings.Advanced.FormatWarning="Warning: Color formats other than NV12/P010 are primarily intended for recording, and are not recommended when streaming. Streaming may incur increased CPU usage due to color format conversion."
 Basic.Settings.Advanced.FormatWarningPreciseSdr="Warning: High-precision formats are more commonly used with HDR color spaces."
 Basic.Settings.Advanced.FormatWarning2100="Warning: Rec. 2100 should use a format with more precision."
-Basic.Settings.Advanced.Audio.BufferingTime="Audio Buffering Time"
 Basic.Settings.Advanced.Video.ColorFormat="Color Format"
 Basic.Settings.Advanced.Video.ColorFormat.NV12="NV12 (8-bit, 4:2:0, 2 planes)"
 Basic.Settings.Advanced.Video.ColorFormat.I420="I420 (8-bit, 4:2:0, 3 planes)"
@@ -1409,7 +1396,6 @@ LoadProfileNeedsRestart="Profile contains settings that require restarting OBS:\
 # Context Bar
 ContextBar.NoSelectedSource="No source selected"
 ContextBar.ResetTransform="Reset Transform"
-ContextBar.FitToCanvas="Fit to Canvas"
 
 # Context Bar Media Controls
 ContextBar.MediaControls.PlayMedia="Play Media"
@@ -1418,7 +1404,6 @@ ContextBar.MediaControls.StopMedia="Stop Media"
 ContextBar.MediaControls.RestartMedia="Restart Media"
 ContextBar.MediaControls.PlaylistNext="Next in Playlist"
 ContextBar.MediaControls.PlaylistPrevious="Previous in Playlist"
-ContextBar.MediaControls.MediaProperties="Media Properties"
 ContextBar.MediaControls.BlindSeek="Media Seek Widget"
 
 # YouTube Actions and Auth

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -329,7 +329,7 @@ bool BasicOutputHandler::StartVirtualCam()
 		}
 
 		QMessageBox::critical(main,
-				      QTStr("Output.StartVirtualCameraFailed"),
+				      QTStr("Output.StartVirtualCamFailed"),
 				      errorReason);
 
 		DestroyVirtualCamView();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR fixes a typo in a translation key, adds two missing translations, and also removes obsolete translations in the translation files.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Some texts were not translated but showing the translation-keys.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

The newly added translation was tested by dropping an empty folder into the remux dialog.
![Screenshot_2023-05-19_11-46-51](https://github.com/obsproject/obs-studio/assets/780600/878926c6-0502-4833-ac0f-263bfc8c8201)


Concatinated all cpp files under `UI` (and preprocess some of the files).
then, used `sed` and `grep` below to list translation keys from the source code.
```
t=$(mktemp)
cat > $t
function str_arg
{
	f="$1"
	sed 's/\(\<'"$f"'([^()]*)\)/\1\n/g' < $t |
	grep "\\<$f\\>" | sed \
		-e 's/.*\<'"$f"'("\([^"]*\)")/\1\n/g' \
		-e 's/.*\<'"$f"'("\([^"]*\)" "\([^"]*\)").*/\1\2/g' \
		-e 's/.*\<'"$f"'([a-z]\+ ? "\([^"]*\)" : "\([^"]*\)").*/\1\n\2/g' |
}
{ str_arg QTStr; str_arg Str } | LC_ALL=C sort -u
```
Also processed UI files and en-US.ini.
Then, manually compare these files.

`Updater.Running.Title` and `Updater.Running.Text` were added by c1c84e9101 but later the source code vanished though the translations are left.

For other translation string removal, since sometimes translation keys are split in the source code, I checked these commands to ensure there is no such translations in the source code (and UI files) 
```
git grep 'AddValue' ':!*.ini'
git grep '\<LinkToSite' ':!*.ini'
git grep '\<Exists' ':!*.ini'
git grep 'SceneTransitions'  ':!*.ini' # Just saw Basic.SceneTransitions but not Basic.MainMenu.View.SceneTransitions
git grep 'BufferingTime'  ':!*.ini'
git grep 'SelectFile'  ':!*.ini' # Just saw unrelated translations
git grep '\<StreamType'  ':!*.ini'
git grep 'MediaProperties'  ':!*.ini'
git grep 'FitToCanvas'  ':!*.ini'
git grep GameCaptureActive ':!*.ini'
git grep UpdateAvailable ':!*.ini'
```
Above method assumed there is no text split at the middle of the word such as `std::string a="ContextBar.Fi"; QTStr(a + "tToCanvas")`. I think this is a valid assumption.

I realized these keys can be removed but didn't touch as I cannot find quick way to fix / confirm them.
- StudioMode.ProgramSceneLabel (exists only in source code.)
- Basic.MainMenu.SceneCollection.Import (exists only in translation file.)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
