### PR TITLE
libobs: Fix ccache misses due to unstable obsconfig header

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -370,6 +370,7 @@ if(OS_WINDOWS)
   target_compile_definitions(obs PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
                                          PSAPI_VERSION=2)
 
+  set_source_files_properties(update/win-update.cpp PROPERTIES COMPILE_DEFINITIONS OBS_COMMIT="${OBS_COMMIT}")
   if(MSVC)
     target_link_options(obs PRIVATE "LINKER:/IGNORE:4098" "LINKER:/IGNORE:4099")
     target_link_libraries(obs PRIVATE OBS::w32-pthreads)

--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -37,6 +37,7 @@ add_library(OBS::update-helpers ALIAS obs-update-helpers)
 
 target_sources(obs-update-helpers INTERFACE win-update/win-update-helpers.cpp win-update/win-update-helpers.hpp)
 target_include_directories(obs-update-helpers INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/win-update")
+set_source_files_properties(update/win-update.cpp PROPERTIES COMPILE_DEFINITIONS OBS_COMMIT="${OBS_COMMIT}")
 
 add_subdirectory(win-update/updater)
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1743,7 +1743,7 @@ string OBSApp::GetVersionString(bool platform) const
 	stringstream ver;
 
 #ifdef HAVE_OBSCONFIG_H
-	ver << OBS_VERSION;
+	ver << obs_get_version_string();
 #else
 	ver << LIBOBS_API_MAJOR_VER << "." << LIBOBS_API_MINOR_VER << "."
 	    << LIBOBS_API_PATCH_VER;

--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -24,7 +24,7 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 		bitness = " (64 bit)";
 
 #ifdef HAVE_OBSCONFIG_H
-	ver += OBS_VERSION;
+	ver += obs_get_version_string();
 #else
 	ver += LIBOBS_API_MAJOR_VER + "." + LIBOBS_API_MINOR_VER + "." +
 	       LIBOBS_API_PATCH_VER;

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.16...3.25)
 
 legacy_check()
 
+# cmake-format: off
+add_library(libobs-version STATIC EXCLUDE_FROM_ALL)
+add_library(OBS::libobs-version ALIAS libobs-version)
+# cmake-format: on
+configure_file(obsversion.c.in obsversion.c @ONLY)
+target_sources(libobs-version PRIVATE obsversion.c obsversion.h)
+set_property(TARGET libobs-version PROPERTY FOLDER core)
+
 add_library(libobs SHARED)
 add_library(OBS::libobs ALIAS libobs)
 
@@ -226,6 +234,7 @@ target_link_libraries(
   libobs
   PRIVATE OBS::caption
           OBS::uthash
+          OBS::libobs-version
           FFmpeg::avcodec
           FFmpeg::avformat
           FFmpeg::avutil

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -4,6 +4,15 @@ endif()
 
 project(libobs)
 
+# cmake-format: off
+add_library(libobs-version STATIC EXCLUDE_FROM_ALL)
+add_library(OBS::libobs-version ALIAS libobs-version)
+# cmake-format: on
+configure_file(obsversion.c.in obsversion.c @ONLY)
+target_sources(libobs-version PRIVATE obsversion.c obsversion.h)
+target_include_directories(libobs-version PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+set_property(TARGET libobs-version PROPERTY FOLDER core)
+
 find_package(Threads REQUIRED)
 find_package(
   FFmpeg REQUIRED
@@ -249,6 +258,7 @@ target_link_libraries(
           Jansson::Jansson
           OBS::caption
           OBS::uthash
+          OBS::libobs-version
           ZLIB::ZLIB
   PUBLIC Threads::Threads)
 
@@ -304,7 +314,8 @@ if(OS_WINDOWS)
             audio-monitoring/win32/wasapi-monitoring-available.c)
 
   target_compile_definitions(libobs PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
-
+  set_source_files_properties(obs-win-crash-handler.c PROPERTIES COMPILE_DEFINITIONS
+                                                                 OBS_VERSION="${OBS_VERSION_CANONICAL}")
   target_link_libraries(libobs PRIVATE dxgi Avrt Dwmapi winmm Rpcrt4)
 
   if(MSVC)

--- a/libobs/cmake/os-windows.cmake
+++ b/libobs/cmake/os-windows.cmake
@@ -40,6 +40,8 @@ target_sources(
           util/windows/window-helpers.h)
 
 target_compile_options(libobs PRIVATE $<$<COMPILE_LANGUAGE:C,CXX>:/EHc->)
+set_source_files_properties(obs-win-crash-handler.c PROPERTIES COMPILE_DEFINITIONS
+                                                               OBS_VERSION="${OBS_VERSION_CANONICAL}")
 
 target_link_libraries(
   libobs

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -38,6 +38,7 @@
 
 #include "obs.h"
 
+#include <obsversion.h>
 #include <caption/caption.h>
 
 /* Custom helpers for the UUID hash table */

--- a/libobs/obsconfig.h.in
+++ b/libobs/obsconfig.h.in
@@ -1,13 +1,9 @@
 #pragma once
 
-#define OBS_VERSION "@OBS_VERSION@"
-
-#cmakedefine OBS_VERSION_CANONICAL "@OBS_VERSION_CANONICAL@"
 #cmakedefine OBS_DATA_PATH "@OBS_DATA_PATH@"
 #cmakedefine OBS_PLUGIN_PATH "@OBS_PLUGIN_PATH@"
 #cmakedefine OBS_PLUGIN_DESTINATION "@OBS_PLUGIN_DESTINATION@"
 
-#cmakedefine OBS_COMMIT "@OBS_COMMIT@"
 #cmakedefine GIO_FOUND
 #cmakedefine PULSEAUDIO_FOUND
 #cmakedefine XCB_XINPUT_FOUND

--- a/libobs/obsversion.c.in
+++ b/libobs/obsversion.c.in
@@ -1,0 +1,5 @@
+#include <obsversion.h>
+
+const char *OBS_VERSION = "@OBS_VERSION@";
+const char *OBS_VERSION_CANONICAL = "@OBS_VERSION_CANONICAL@";
+const char *OBS_COMMIT = "@OBS_COMMIT@";

--- a/libobs/obsversion.h
+++ b/libobs/obsversion.h
@@ -1,0 +1,5 @@
+#pragma once
+
+extern const char *OBS_VERSION;
+extern const char *OBS_VERSION_CANONICAL;
+extern const char *OBS_COMMIT;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -136,7 +136,7 @@ bool ffmpeg_hls_mux_start(void *data)
 	dstr_copy(&stream->muxer_settings,
 		  "method=PUT http_persistent=1 ignore_io_errors=1 ");
 	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
-		  OBS_VERSION);
+		  obs_get_version_string());
 
 	vencoder = obs_output_get_video_encoder(stream->output);
 	settings = obs_encoder_get_settings(vencoder);

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -167,7 +167,7 @@ static void build_flv_meta_data(obs_output_t *context, uint8_t **output,
 	dstr_printf(&encoder_name, "%s (libobs version ", MODULE_NAME);
 
 #ifdef HAVE_OBSCONFIG_H
-	dstr_cat(&encoder_name, OBS_VERSION);
+	dstr_cat(&encoder_name, obs_get_version_string());
 #else
 	dstr_catf(&encoder_name, "%d.%d.%d", LIBOBS_API_MAJOR_VER,
 		  LIBOBS_API_MINOR_VER, LIBOBS_API_PATCH_VER);

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -1074,7 +1074,7 @@ static int init_connect(struct ftl_stream *stream)
 	stream->params.audio_codec = FTL_AUDIO_OPUS;
 	stream->params.ingest_hostname = stream->path.array;
 	stream->params.vendor_name = "OBS Studio";
-	stream->params.vendor_version = OBS_VERSION;
+	stream->params.vendor_version = obs_get_version_string();
 	stream->params.peak_kbps = stream->peak_kbps < 0 ? 0
 							 : stream->peak_kbps;
 

--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -51,7 +51,8 @@ if(MSVC)
   target_link_options(win-capture PRIVATE "LINKER:/IGNORE:4098")
 endif()
 
-target_compile_definitions(win-capture PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
+target_compile_definitions(win-capture PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
+                                               OBS_VERSION="${OBS_VERSION_CANONICAL}")
 
 set_property(GLOBAL APPEND PROPERTY OBS_MODULE_LIST "win-capture")
 


### PR DESCRIPTION
### Description
Moves version and commit hash information out of `obsconfig.h` and into a slim static library to improve ccache hit rate for local compilations and CI runs, as well as reduce amount of necessary recompilations on new commits or reconfigured CMake runs.

### Motivation and Context
Currently CMake generates the `obsconfig.h` header file each time the project is configured (either manually or automatically because a file in the dependency graph has changed).

In its current state this leads to several architectural issues:

* `obsconfig.h` is included by `obs.h` (which is in turn included by `obs-module.h`), so almost every module or piece of OBS is affected by a change of this file and leads to recompilations even though the underlying files haven't changed
* `obsconfig.h` includes version strings but also git commit hashes, which can change quite regularly - this also forces a recompilation of a majority of code in the codebase as almost everything includes this file (see above)
* `ccache` can be configured to ignore modification and creation timestamps of included files and only go by content
   * In this case a CMake reconfiguration will not lead to cache misses, but a new git hash will

This is such a common issue that Craig Scott suggested a more elegant alternative in his book "Professional CMake":

Instead of providing compiler definitions or a header file generated by CMake, a slim static library is used, which fixes several issues at once:

* Proper `const char` arrays are used in place of preprocessor strings (you see what the compiler sees)
* Only the static library is affected by a reconfiguration or a different git commit hash
* Consumers only need to link the static library to get the updated information - compilation units stay unaffected

As the link step need to happen anyway, it cuts down the amount of recompilations down to a single file.

#### How this affects Ccache

This change positively impacts our Ccache performance in multiple ways:

* By default Ccache uses two modes: "direct" and "preprocessor"
    * At first it will attempt to find a cache hit using the "direct" mode, which uses a combined hash of source code, compiler type, working directory, as well as hashes of all included files to generate a "manifest" for any given source code file
    * If this manifest lookup fails, Ccache will attempt to look up a preprocessor result and use that one as a fallback
    * If the preprocessor lookup fails as well, Ccache invokes the compiler and stores the output
* Every time the project is configured by CMake (or compiled based on a new git commit hash), the direct mode will fail, as the hash of `obsconfig.h` will have changed
* The preprocessor fallback will yield _some_ cache hits because not every file including `obsconfig.h` seems to contain its contents in the preprocessed output.

As part of our modernisation of the macOS codebase we have enabled the use of ObjC modules, which is supported by recent versions of Ccache. Module support requires enabling "direct" and "depend" mode, which affects the above in a meaningful way:

* Enabling "depend" mode disables "preprocessor" mode, and as such even this fallback cannot be used anymore, leading to a much higher cache miss rate.

This is the core reason for the 70%+ cache miss rate of our CI builds and all of which is fixed by this PR.

*Note:* Even though Ccache supports MSVC since version 4.6, this is limited to builds with embedded debug information (`/Z7`). We need product databases (`PDB` files) to be generated however, so we still have to compile Windows unaccelerated. Windows is also most severely affected by configuration/header changes, which are mitigated to some degree by adding the changing compiler definitions to affected source code files only.

### How Has This Been Tested?
* Successful compilation and runs on macOS 13, Windows 11, Ubuntu 22.04, and FreeBSD 13
* Tested Ccache hit rates with and without this fix, using new empty commits to force content changes of `obsconfig.h`, as well as simple CMake reconfigurations to force inode cache misses.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
