### PR TITLE
Add carla-patchbay as OBS plugin

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -35,6 +35,7 @@ if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
 
   # Add plugins in alphabetical order to retain order in IDE projects
   add_subdirectory(aja)
+  add_subdirectory(carla)
   if(OS_WINDOWS OR OS_MACOS)
     add_subdirectory(coreaudio-encoder)
   endif()
@@ -191,3 +192,4 @@ add_subdirectory(obs-transitions)
 add_subdirectory(rtmp-services)
 add_subdirectory(text-freetype2)
 add_subdirectory(aja)
+add_subdirectory(carla)

--- a/plugins/carla/CMakeLists.txt
+++ b/plugins/carla/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.16...3.25)
+
+option(ENABLE_CARLA "Enable building OBS with carla plugin host" ON)
+
+if(NOT ENABLE_CARLA)
+  if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
+    target_disable(carla)
+  else()
+    message(STATUS "OBS:  DISABLED   carla")
+  endif()
+  return()
+endif()
+
+# Use pkg-config to find carla libraries
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(carla REQUIRED IMPORTED_TARGET carla-host-plugin)
+
+# Find Qt
+find_qt(COMPONENTS Core Widgets)
+
+add_library(carla-patchbay MODULE)
+add_library(OBS::carla-patchbay ALIAS carla-patchbay)
+
+target_compile_definitions(
+  carla-patchbay
+  PRIVATE CARLA_MODULE_ID="carla-patchbay" CARLA_MODULE_NAME="Carla Patchbay"
+          # FIXME remove macro in next Carla stable release
+          REAL_BUILD)
+
+target_link_libraries(carla-patchbay PRIVATE OBS::libobs Qt::Core Qt::Widgets PkgConfig::carla)
+
+target_sources(carla-patchbay PRIVATE carla.c carla-patchbay-wrapper.c common.c qtutils.cpp)
+
+if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
+  set_target_properties_obs(carla-patchbay PROPERTIES FOLDER plugins PREFIX "")
+else()
+  set_target_properties(carla-patchbay PROPERTIES FOLDER plugins PREFIX "")
+  setup_plugin_target(carla-patchbay)
+endif()

--- a/plugins/carla/carla-patchbay-wrapper.c
+++ b/plugins/carla/carla-patchbay-wrapper.c
@@ -1,0 +1,526 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "carla-wrapper.h"
+#include "common.h"
+#include "qtutils.h"
+
+#include <util/platform.h>
+
+#include "CarlaNativePlugin.h"
+
+// If this changes we need to adapt Carla side for matching port count
+_Static_assert(MAX_AV_PLANES == 8, "expected 8 IO");
+
+// ----------------------------------------------------------------------------
+// helper methods
+
+struct carla_main_thread_param_change {
+	const NativePluginDescriptor *descriptor;
+	NativePluginHandle handle;
+	uint32_t index;
+	float value;
+};
+
+static void carla_main_thread_param_change(void *data)
+{
+	struct carla_main_thread_param_change *priv = data;
+	priv->descriptor->ui_set_parameter_value(priv->handle, priv->index,
+						 priv->value);
+	bfree(data);
+}
+
+// ----------------------------------------------------------------------------
+// private data methods
+
+struct carla_param_data {
+	uint32_t hints;
+	float min, max;
+};
+
+struct carla_priv {
+	obs_source_t *source;
+	uint32_t bufferSize;
+	double sampleRate;
+	const NativePluginDescriptor *descriptor;
+	NativePluginHandle handle;
+	NativeHostDescriptor host;
+	NativeTimeInfo timeInfo;
+
+	// cached parameter info
+	uint32_t paramCount;
+	struct carla_param_data *paramDetails;
+
+	// update properties when timeout is reached, 0 means do nothing
+	uint64_t update_request;
+
+	// keep track of active state
+	volatile bool activated;
+};
+
+// ----------------------------------------------------------------------------
+// carla host methods
+
+static uint32_t host_get_buffer_size(NativeHostHandle handle)
+{
+	const struct carla_priv *priv = handle;
+	return priv->bufferSize;
+}
+
+static double host_get_sample_rate(NativeHostHandle handle)
+{
+	const struct carla_priv *priv = handle;
+	return priv->sampleRate;
+}
+
+static bool host_is_offline(NativeHostHandle handle)
+{
+	UNUSED_PARAMETER(handle);
+	return false;
+}
+
+static const NativeTimeInfo *host_get_time_info(NativeHostHandle handle)
+{
+	const struct carla_priv *priv = handle;
+	return &priv->timeInfo;
+}
+
+static bool host_write_midi_event(NativeHostHandle handle,
+				  const NativeMidiEvent *event)
+{
+	UNUSED_PARAMETER(handle);
+	UNUSED_PARAMETER(event);
+	return false;
+}
+
+static void host_ui_parameter_changed(NativeHostHandle handle, uint32_t index,
+				      float value)
+{
+	struct carla_priv *priv = handle;
+
+	if (index >= priv->paramCount)
+		return;
+
+	// skip parameters that we do not show
+	const uint32_t hints = priv->paramDetails[index].hints;
+	if ((hints & NATIVE_PARAMETER_IS_ENABLED) == 0)
+		return;
+	if (hints & NATIVE_PARAMETER_IS_OUTPUT)
+		return;
+
+	char pname[PARAM_NAME_SIZE] = PARAM_NAME_INIT;
+	param_index_to_name(index, pname);
+
+	obs_source_t *source = priv->source;
+	obs_data_t *settings = obs_source_get_settings(source);
+
+	/**/ if (hints & NATIVE_PARAMETER_IS_BOOLEAN)
+		obs_data_set_bool(settings, pname, value > 0.5f ? 1.f : 0.f);
+	else if (hints & NATIVE_PARAMETER_IS_INTEGER)
+		obs_data_set_int(settings, pname, (int)value);
+	else
+		obs_data_set_double(settings, pname, value);
+
+	obs_data_release(settings);
+
+	postpone_update_request(&priv->update_request);
+}
+
+static void host_ui_midi_program_changed(NativeHostHandle handle,
+					 uint8_t channel, uint32_t bank,
+					 uint32_t program)
+{
+	UNUSED_PARAMETER(handle);
+	UNUSED_PARAMETER(channel);
+	UNUSED_PARAMETER(bank);
+	UNUSED_PARAMETER(program);
+}
+
+static void host_ui_custom_data_changed(NativeHostHandle handle,
+					const char *key, const char *value)
+{
+	UNUSED_PARAMETER(handle);
+	UNUSED_PARAMETER(key);
+	UNUSED_PARAMETER(value);
+}
+
+static void host_ui_closed(NativeHostHandle handle)
+{
+	UNUSED_PARAMETER(handle);
+}
+
+static const char *host_ui_open_file(NativeHostHandle handle, bool isDir,
+				     const char *title, const char *filter)
+{
+	UNUSED_PARAMETER(handle);
+	return carla_qt_file_dialog(false, isDir, title, filter);
+}
+
+static const char *host_ui_save_file(NativeHostHandle handle, bool isDir,
+				     const char *title, const char *filter)
+{
+	UNUSED_PARAMETER(handle);
+	return carla_qt_file_dialog(true, isDir, title, filter);
+}
+
+static intptr_t host_dispatcher(NativeHostHandle handle,
+				NativeHostDispatcherOpcode opcode,
+				int32_t index, intptr_t value, void *ptr,
+				float opt)
+{
+	UNUSED_PARAMETER(index);
+	UNUSED_PARAMETER(value);
+	UNUSED_PARAMETER(ptr);
+	UNUSED_PARAMETER(opt);
+
+	struct carla_priv *priv = handle;
+
+	switch (opcode) {
+	case NATIVE_HOST_OPCODE_NULL:
+	case NATIVE_HOST_OPCODE_RELOAD_MIDI_PROGRAMS:
+	case NATIVE_HOST_OPCODE_UPDATE_MIDI_PROGRAM:
+		break;
+	case NATIVE_HOST_OPCODE_UPDATE_PARAMETER:
+	case NATIVE_HOST_OPCODE_RELOAD_PARAMETERS:
+	case NATIVE_HOST_OPCODE_RELOAD_ALL:
+		postpone_update_request(&priv->update_request);
+		break;
+	case NATIVE_HOST_OPCODE_GET_FILE_PATH:
+	case NATIVE_HOST_OPCODE_HOST_IDLE:
+	case NATIVE_HOST_OPCODE_INTERNAL_PLUGIN:
+	case NATIVE_HOST_OPCODE_PREVIEW_BUFFER_DATA:
+	case NATIVE_HOST_OPCODE_QUEUE_INLINE_DISPLAY:
+	case NATIVE_HOST_OPCODE_REQUEST_IDLE:
+	case NATIVE_HOST_OPCODE_UI_UNAVAILABLE:
+	case NATIVE_HOST_OPCODE_UI_RESIZE:
+	case NATIVE_HOST_OPCODE_UI_TOUCH_PARAMETER:
+		break;
+	}
+
+	return 0;
+}
+
+// ----------------------------------------------------------------------------
+// carla + obs integration methods
+
+struct carla_priv *carla_priv_create(obs_source_t *source,
+				     enum buffer_size_mode bufsize,
+				     uint32_t srate)
+{
+	/* FIXME switch to OBS patchbay variant (8 IO, no MIDI)
+	 * No releases so far include this function
+	const NativePluginDescriptor *descriptor =
+		carla_get_native_patchbay_obs_plugin();
+	*/
+	const NativePluginDescriptor *descriptor =
+		carla_get_native_patchbay_plugin();
+	if (descriptor == NULL)
+		return NULL;
+
+	struct carla_priv *priv = bzalloc(sizeof(struct carla_priv));
+	if (priv == NULL)
+		return NULL;
+
+	priv->source = source;
+	priv->bufferSize = bufsize_mode_to_frames(bufsize);
+	priv->sampleRate = srate;
+	priv->descriptor = descriptor;
+
+	assert(priv->bufferSize != 0);
+	if (priv->bufferSize == 0)
+		goto fail;
+
+	{
+		NativeHostDescriptor host = {
+			.handle = priv,
+			.resourceDir = get_carla_resource_path(),
+			.uiName = "Carla-OBS",
+			.uiParentId = 0,
+			.get_buffer_size = host_get_buffer_size,
+			.get_sample_rate = host_get_sample_rate,
+			.is_offline = host_is_offline,
+			.get_time_info = host_get_time_info,
+			.write_midi_event = host_write_midi_event,
+			.ui_parameter_changed = host_ui_parameter_changed,
+			.ui_midi_program_changed = host_ui_midi_program_changed,
+			.ui_custom_data_changed = host_ui_custom_data_changed,
+			.ui_closed = host_ui_closed,
+			.ui_open_file = host_ui_open_file,
+			.ui_save_file = host_ui_save_file,
+			.dispatcher = host_dispatcher};
+		priv->host = host;
+	}
+
+	{
+		NativeTimeInfo timeInfo = {
+			.usecs = os_gettime_ns() / 1000,
+		};
+		priv->timeInfo = timeInfo;
+	}
+
+	priv->handle = descriptor->instantiate(&priv->host);
+	if (priv->handle == NULL)
+		goto fail;
+
+	/* TODO enable this if we end up shipping directly with Carla
+	descriptor->dispatcher(priv->handle, NATIVE_PLUGIN_OPCODE_HOST_OPTION,
+			       ENGINE_OPTION_PATH_BINARIES, 0,
+			       (void *)get_carla_bin_path(), 0.f);
+
+	descriptor->dispatcher(priv->handle, NATIVE_PLUGIN_OPCODE_HOST_OPTION,
+			       ENGINE_OPTION_PATH_RESOURCES, 0,
+			       (void *)get_carla_resource_path(), 0.f);
+	*/
+
+	return priv;
+
+fail:
+	bfree(priv);
+	return NULL;
+}
+
+void carla_priv_destroy(struct carla_priv *priv)
+{
+	if (priv->activated)
+		carla_priv_deactivate(priv);
+
+	priv->descriptor->cleanup(priv->handle);
+	bfree(priv->paramDetails);
+	bfree(priv);
+}
+
+// ----------------------------------------------------------------------------
+
+void carla_priv_activate(struct carla_priv *priv)
+{
+	assert(!priv->activated);
+	priv->descriptor->activate(priv->handle);
+	priv->activated = true;
+}
+
+void carla_priv_deactivate(struct carla_priv *priv)
+{
+	assert(priv->activated);
+	priv->activated = false;
+	priv->descriptor->deactivate(priv->handle);
+}
+
+void carla_priv_process_audio(struct carla_priv *priv,
+			      float *buffers[MAX_AV_PLANES], uint32_t frames)
+{
+	priv->timeInfo.usecs = os_gettime_ns() / 1000;
+	priv->descriptor->process(priv->handle, buffers, buffers, frames, NULL,
+				  0);
+}
+
+void carla_priv_idle(struct carla_priv *priv)
+{
+	priv->descriptor->ui_idle(priv->handle);
+	handle_update_request(priv->source, &priv->update_request);
+}
+
+void carla_priv_save(struct carla_priv *priv, obs_data_t *settings)
+{
+	char *state = priv->descriptor->get_state(priv->handle);
+	if (state) {
+		obs_data_set_string(settings, "state", state);
+		free(state);
+	}
+}
+
+void carla_priv_load(struct carla_priv *priv, obs_data_t *settings)
+{
+	const char *state = obs_data_get_string(settings, "state");
+	if (state)
+		priv->descriptor->set_state(priv->handle, state);
+}
+
+// ----------------------------------------------------------------------------
+
+void carla_priv_set_buffer_size(struct carla_priv *priv,
+				enum buffer_size_mode bufsize)
+{
+	const uint32_t new_buffer_size = bufsize_mode_to_frames(bufsize);
+	const bool activated = priv->activated;
+
+	if (activated)
+		carla_priv_deactivate(priv);
+
+	priv->bufferSize = new_buffer_size;
+	priv->descriptor->dispatcher(priv->handle,
+				     NATIVE_PLUGIN_OPCODE_BUFFER_SIZE_CHANGED,
+				     new_buffer_size, 0, NULL, 0.f);
+
+	if (activated)
+		carla_priv_activate(priv);
+}
+
+// ----------------------------------------------------------------------------
+
+static bool carla_priv_param_changed(void *data, obs_properties_t *props,
+				     obs_property_t *property,
+				     obs_data_t *settings)
+{
+	UNUSED_PARAMETER(props);
+
+	struct carla_priv *priv = data;
+
+	const char *const pname = obs_property_name(property);
+	if (pname == NULL)
+		return false;
+
+	const char *pname2 = pname + 1;
+	while (*pname2 == '0')
+		++pname2;
+
+	const int pindex = atoi(pname2);
+
+	if (pindex < 0 || pindex >= (int)priv->paramCount)
+		return false;
+
+	const float min = priv->paramDetails[pindex].min;
+	const float max = priv->paramDetails[pindex].max;
+
+	float value;
+	switch (obs_property_get_type(property)) {
+	case OBS_PROPERTY_BOOL:
+		value = obs_data_get_bool(settings, pname) ? max : min;
+		break;
+	case OBS_PROPERTY_INT:
+		value = (float)obs_data_get_int(settings, pname);
+		if (value < min)
+			value = min;
+		else if (value > max)
+			value = max;
+		break;
+	case OBS_PROPERTY_FLOAT:
+		value = (float)obs_data_get_double(settings, pname);
+		if (value < min)
+			value = min;
+		else if (value > max)
+			value = max;
+		break;
+	default:
+		return false;
+	}
+
+	priv->descriptor->set_parameter_value(priv->handle, pindex, value);
+
+	// UI param change notification needs to happen on main thread
+	struct carla_main_thread_param_change mchange = {
+		.descriptor = priv->descriptor,
+		.handle = priv->handle,
+		.index = pindex,
+		.value = value};
+	struct carla_main_thread_param_change *mchangeptr =
+		bmalloc(sizeof(mchange));
+	*mchangeptr = mchange;
+	carla_qt_callback_on_main_thread(carla_main_thread_param_change,
+					 mchangeptr);
+
+	return false;
+}
+
+static bool carla_priv_show_gui_callback(obs_properties_t *props,
+					 obs_property_t *property, void *data)
+{
+	UNUSED_PARAMETER(props);
+	UNUSED_PARAMETER(property);
+
+	struct carla_priv *priv = data;
+
+	priv->descriptor->ui_show(priv->handle, true);
+
+	return false;
+}
+
+void carla_priv_readd_properties(struct carla_priv *priv,
+				 obs_properties_t *props, bool reset)
+{
+	obs_data_t *settings = obs_source_get_settings(priv->source);
+
+	if (priv->descriptor->hints & NATIVE_PLUGIN_HAS_UI) {
+		obs_properties_add_button2(props, PROP_SHOW_GUI,
+					   obs_module_text("Show custom GUI"),
+					   carla_priv_show_gui_callback, priv);
+	}
+
+	uint32_t params = priv->descriptor->get_parameter_count(priv->handle);
+	if (params > MAX_PARAMS)
+		params = MAX_PARAMS;
+
+	bfree(priv->paramDetails);
+	priv->paramCount = params;
+	priv->paramDetails = bzalloc(sizeof(struct carla_param_data) * params);
+
+	char pname[PARAM_NAME_SIZE] = PARAM_NAME_INIT;
+
+	for (uint32_t i = 0; i < params; ++i) {
+		const NativeParameter *const info =
+			priv->descriptor->get_parameter_info(priv->handle, i);
+
+		if ((info->hints & NATIVE_PARAMETER_IS_ENABLED) == 0)
+			continue;
+		if (info->hints & NATIVE_PARAMETER_IS_OUTPUT)
+			continue;
+
+		param_index_to_name(i, pname);
+		priv->paramDetails[i].hints = info->hints;
+		priv->paramDetails[i].min = info->ranges.min;
+		priv->paramDetails[i].max = info->ranges.max;
+
+		obs_property_t *prop;
+
+		if (info->hints & NATIVE_PARAMETER_IS_BOOLEAN) {
+			prop = obs_properties_add_bool(props, pname,
+						       info->name);
+
+			obs_data_set_default_bool(settings, pname,
+						  info->ranges.def ==
+							  info->ranges.max);
+
+			if (reset)
+				obs_data_set_bool(settings, pname,
+						  info->ranges.def ==
+							  info->ranges.max);
+		} else if (info->hints & NATIVE_PARAMETER_IS_INTEGER) {
+			prop = obs_properties_add_int_slider(
+				props, pname, info->name, (int)info->ranges.min,
+				(int)info->ranges.max, (int)info->ranges.step);
+
+			obs_data_set_default_int(settings, pname,
+						 (int)info->ranges.def);
+
+			if (info->unit && *info->unit)
+				obs_property_int_set_suffix(prop, info->unit);
+
+			if (reset)
+				obs_data_set_int(settings, pname,
+						 (int)info->ranges.def);
+		} else {
+			prop = obs_properties_add_float_slider(
+				props, pname, info->name, info->ranges.min,
+				info->ranges.max, info->ranges.step);
+
+			obs_data_set_default_double(settings, pname,
+						    info->ranges.def);
+
+			if (info->unit && *info->unit)
+				obs_property_float_set_suffix(prop, info->unit);
+
+			if (reset)
+				obs_data_set_double(settings, pname,
+						    info->ranges.def);
+		}
+
+		obs_property_set_modified_callback2(
+			prop, carla_priv_param_changed, priv);
+	}
+
+	obs_data_release(settings);
+}
+
+// ----------------------------------------------------------------------------

--- a/plugins/carla/carla-wrapper.h
+++ b/plugins/carla/carla-wrapper.h
@@ -1,0 +1,71 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <obs-module.h>
+
+// maximum buffer used, can be smaller
+#define MAX_AUDIO_BUFFER_SIZE 512
+
+enum buffer_size_mode {
+	buffer_size_direct,
+	buffer_size_buffered_128,
+	buffer_size_buffered_256,
+	buffer_size_buffered_512,
+	buffer_size_buffered_max = buffer_size_buffered_512
+};
+
+// ----------------------------------------------------------------------------
+// helper methods
+
+static inline uint32_t bufsize_mode_to_frames(enum buffer_size_mode bufsize)
+{
+	switch (bufsize) {
+	case buffer_size_buffered_128:
+		return 128;
+	case buffer_size_buffered_256:
+		return 256;
+	default:
+		return MAX_AUDIO_BUFFER_SIZE;
+	}
+}
+
+// ----------------------------------------------------------------------------
+// carla + obs integration methods
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct carla_priv;
+
+struct carla_priv *carla_priv_create(obs_source_t *source,
+				     enum buffer_size_mode bufsize,
+				     uint32_t srate);
+void carla_priv_destroy(struct carla_priv *carla);
+
+void carla_priv_activate(struct carla_priv *carla);
+void carla_priv_deactivate(struct carla_priv *carla);
+void carla_priv_process_audio(struct carla_priv *carla,
+			      float *buffers[MAX_AV_PLANES], uint32_t frames);
+
+void carla_priv_idle(struct carla_priv *carla);
+
+void carla_priv_save(struct carla_priv *carla, obs_data_t *settings);
+void carla_priv_load(struct carla_priv *carla, obs_data_t *settings);
+
+void carla_priv_set_buffer_size(struct carla_priv *carla,
+				enum buffer_size_mode bufsize);
+
+void carla_priv_readd_properties(struct carla_priv *carla,
+				 obs_properties_t *props, bool reset);
+
+#ifdef __cplusplus
+}
+#endif
+
+// ----------------------------------------------------------------------------

--- a/plugins/carla/carla.c
+++ b/plugins/carla/carla.c
@@ -1,0 +1,497 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <obs-module.h>
+#include <util/platform.h>
+
+#ifndef CARLA_MODULE_ID
+#error CARLA_MODULE_ID undefined
+#endif
+
+#ifndef CARLA_MODULE_NAME
+#error CARLA_MODULE_NAME undefined
+#endif
+
+#include "carla-wrapper.h"
+#include "common.h"
+
+// for audio generator thread
+#include <pthread.h>
+
+// ----------------------------------------------------------------------------
+
+struct carla_data {
+	// carla host details, intentionally kept private so we can easily swap internals
+	struct carla_priv *priv;
+
+	// current OBS config
+	bool activated;
+	size_t channels;
+	uint32_t sample_rate;
+	obs_source_t *source;
+
+	// audio generator thread
+	bool audiogen_enabled;
+	volatile bool audiogen_running;
+	pthread_t audiogen_thread;
+
+	// internal buffering
+	float *buffers[MAX_AV_PLANES];
+	uint16_t buffer_head;
+	uint16_t buffer_tail;
+	enum buffer_size_mode buffer_size_mode;
+
+	// dummy buffer for unused audio channels
+	float *dummybuffer;
+};
+
+// ----------------------------------------------------------------------------
+// private methods
+
+static void *carla_obs_audio_gen_thread(void *data)
+{
+	struct carla_data *carla = data;
+
+	struct obs_source_audio out = {
+		.speakers = SPEAKERS_STEREO,
+		.format = AUDIO_FORMAT_FLOAT_PLANAR,
+		.samples_per_sec = carla->sample_rate,
+	};
+
+	for (uint8_t c = 0; c < MAX_AV_PLANES; ++c)
+		out.data[c] = (const uint8_t *)carla->buffers[c];
+
+	const uint32_t sample_rate = carla->sample_rate;
+	const uint64_t start_time = out.timestamp = os_gettime_ns();
+	uint64_t total_samples = 0;
+
+	while (carla->audiogen_running) {
+		const uint32_t buffer_size =
+			bufsize_mode_to_frames(carla->buffer_size_mode);
+
+		out.frames = buffer_size;
+		carla_priv_process_audio(carla->priv, carla->buffers,
+					 buffer_size);
+		obs_source_output_audio(carla->source, &out);
+
+		if (!carla->audiogen_running)
+			break;
+
+		total_samples += buffer_size;
+		out.timestamp = start_time +
+				audio_frames_to_ns(sample_rate, total_samples);
+
+		os_sleepto_ns_fast(out.timestamp);
+	}
+
+	return NULL;
+}
+
+static void carla_obs_idle_callback(void *data, float unused)
+{
+	UNUSED_PARAMETER(unused);
+	struct carla_data *carla = data;
+	carla_priv_idle(carla->priv);
+}
+
+// ----------------------------------------------------------------------------
+// obs plugin methods
+
+static void carla_obs_activate(void *data);
+static void carla_obs_deactivate(void *data);
+
+static const char *carla_obs_get_name(void *data)
+{
+	return !strcmp(data, "filter")
+		       ? obs_module_text(CARLA_MODULE_NAME " (Filter)")
+		       : obs_module_text(CARLA_MODULE_NAME " (Input)");
+}
+
+static void *carla_obs_create(obs_data_t *settings, obs_source_t *source,
+			      bool isFilter)
+{
+	UNUSED_PARAMETER(settings);
+
+	const audio_t *audio = obs_get_audio();
+	const size_t channels = audio_output_get_channels(audio);
+	const uint32_t sample_rate = audio_output_get_sample_rate(audio);
+
+	if (channels == 0 || sample_rate == 0)
+		return NULL;
+
+	struct carla_data *carla = bzalloc(sizeof(*carla));
+	if (carla == NULL)
+		return NULL;
+
+	for (uint8_t c = 0; c < MAX_AV_PLANES; ++c) {
+		carla->buffers[c] =
+			bzalloc(sizeof(float) * MAX_AUDIO_BUFFER_SIZE);
+		if (carla->buffers[c] == NULL)
+			goto fail1;
+	}
+
+	carla->dummybuffer = bzalloc(sizeof(float) * MAX_AUDIO_BUFFER_SIZE);
+	if (carla->dummybuffer == NULL)
+		goto fail2;
+
+	struct carla_priv *priv =
+		carla_priv_create(source, buffer_size_direct, sample_rate);
+	if (carla == NULL)
+		goto fail3;
+
+	carla->priv = priv;
+	carla->source = source;
+	carla->channels = channels;
+	carla->sample_rate = sample_rate;
+
+	carla->buffer_head = 0;
+	carla->buffer_tail = UINT16_MAX;
+	carla->buffer_size_mode = buffer_size_direct;
+
+	// audio generator, aka input source
+	carla->audiogen_enabled = !isFilter;
+
+	obs_add_tick_callback(carla_obs_idle_callback, carla);
+
+	return carla;
+
+fail3:
+	bfree(carla->dummybuffer);
+
+fail2:
+	for (uint8_t c = 0; c < MAX_AV_PLANES; ++c)
+		bfree(carla->buffers[c]);
+
+fail1:
+	bfree(carla);
+	return NULL;
+}
+
+static void *carla_obs_create_filter(obs_data_t *settings, obs_source_t *source)
+{
+	return carla_obs_create(settings, source, true);
+}
+
+static void *carla_obs_create_input(obs_data_t *settings, obs_source_t *source)
+{
+	return carla_obs_create(settings, source, false);
+}
+
+static void carla_obs_destroy(void *data)
+{
+	struct carla_data *carla = data;
+
+	if (carla->activated)
+		carla_obs_deactivate(carla);
+
+	obs_remove_tick_callback(carla_obs_idle_callback, carla);
+
+	carla_priv_destroy(carla->priv);
+
+	bfree(carla->dummybuffer);
+	for (uint8_t c = 0; c < MAX_AV_PLANES; ++c)
+		bfree(carla->buffers[c]);
+	bfree(carla);
+}
+
+static bool carla_obs_bufsize_callback(void *data, obs_properties_t *props,
+				       obs_property_t *list,
+				       obs_data_t *settings)
+{
+	UNUSED_PARAMETER(props);
+	UNUSED_PARAMETER(list);
+
+	struct carla_data *carla = data;
+
+	enum buffer_size_mode bufsize;
+	const char *const value =
+		obs_data_get_string(settings, PROP_BUFFER_SIZE);
+
+	/**/ if (!strcmp(value, "direct"))
+		bufsize = buffer_size_direct;
+	else if (!strcmp(value, "128"))
+		bufsize = buffer_size_buffered_128;
+	else if (!strcmp(value, "256"))
+		bufsize = buffer_size_buffered_256;
+	else if (!strcmp(value, "512"))
+		bufsize = buffer_size_buffered_512;
+	else
+		return false;
+
+	if (carla->buffer_size_mode == bufsize)
+		return false;
+
+	blog(LOG_INFO, "[" CARLA_MODULE_ID "] changing buffer size to %s",
+	     value);
+
+	// deactivate first, to stop audio from processing
+	carla_priv_deactivate(carla->priv);
+
+	// safely change to new buffer size
+	carla->buffer_size_mode = bufsize;
+	carla_priv_set_buffer_size(carla->priv, bufsize);
+
+	// activate again
+	carla_priv_activate(carla->priv);
+
+	return false;
+}
+
+static obs_properties_t *carla_obs_get_properties(void *data)
+{
+	struct carla_data *carla = data;
+
+	obs_properties_t *props = obs_properties_create();
+
+	obs_property_t *list = obs_properties_add_list(
+		props, PROP_BUFFER_SIZE, obs_module_text("Buffer Size"),
+		OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
+
+	obs_property_list_add_string(
+		list, obs_module_text("Direct (variable buffer)"), "direct");
+	obs_property_list_add_string(
+		list,
+		obs_module_text("128 samples (fixed buffer with latency)"),
+		"128");
+	obs_property_list_add_string(
+		list,
+		obs_module_text("256 samples (fixed buffer with latency)"),
+		"256");
+	obs_property_list_add_string(
+		list,
+		obs_module_text("512 samples (fixed buffer with latency)"),
+		"512");
+	obs_property_set_modified_callback2(list, carla_obs_bufsize_callback,
+					    carla);
+
+	carla_priv_readd_properties(carla->priv, props, false);
+
+	return props;
+}
+
+static void carla_obs_activate(void *data)
+{
+	struct carla_data *carla = data;
+	assert(!carla->activated);
+
+	if (carla->activated)
+		return;
+
+	carla->activated = true;
+
+	carla_priv_activate(carla->priv);
+
+	if (carla->audiogen_enabled) {
+		assert(!carla->audiogen_running);
+		carla->audiogen_running = true;
+		pthread_create(&carla->audiogen_thread, NULL,
+			       carla_obs_audio_gen_thread, carla);
+	}
+}
+
+static void carla_obs_deactivate(void *data)
+{
+	struct carla_data *carla = data;
+	assert(carla->activated);
+
+	if (!carla->activated)
+		return;
+
+	carla->activated = false;
+
+	if (carla->audiogen_running) {
+		carla->audiogen_running = false;
+		pthread_join(carla->audiogen_thread, NULL);
+	}
+
+	carla_priv_deactivate(carla->priv);
+}
+
+static void carla_obs_filter_audio_direct(struct carla_data *carla,
+					  struct obs_audio_data *audio)
+{
+	uint32_t frames = audio->frames;
+	float *obsbuffers[MAX_AV_PLANES];
+
+	for (uint32_t i = 0; i < frames;) {
+		const uint32_t stepframes = frames >= MAX_AUDIO_BUFFER_SIZE
+						    ? MAX_AUDIO_BUFFER_SIZE
+						    : frames;
+
+		for (uint8_t c = 0; c < MAX_AV_PLANES; ++c)
+			obsbuffers[c] = audio->data[c]
+						? ((float *)audio->data[c] + i)
+						: carla->dummybuffer;
+
+		carla_priv_process_audio(carla->priv, obsbuffers, stepframes);
+
+		memset(carla->dummybuffer, 0, sizeof(float) * stepframes);
+
+		frames -= stepframes;
+	}
+}
+
+static void carla_obs_filter_audio_buffered(struct carla_data *carla,
+					    struct obs_audio_data *audio)
+{
+	const uint32_t buffer_size =
+		bufsize_mode_to_frames(carla->buffer_size_mode);
+	const size_t channels = carla->channels;
+	const uint32_t frames = audio->frames;
+
+	// cast audio buffers to correct type
+	float *obsbuffers[MAX_AV_PLANES];
+
+	for (uint8_t c = 0; c < MAX_AV_PLANES; ++c)
+		obsbuffers[c] = audio->data[c] ? (float *)audio->data[c]
+					       : carla->dummybuffer;
+
+	// preload some variables before looping section
+	uint16_t buffer_head = carla->buffer_head;
+	uint16_t buffer_tail = carla->buffer_tail;
+
+	for (uint32_t i = 0, h, t; i < frames; ++i) {
+		// OBS -> plugin internal buffering
+		h = buffer_head++;
+
+		for (uint8_t c = 0; c < channels; ++c)
+			carla->buffers[c][h] = obsbuffers[c][i];
+
+		// when we reach the target buffer size, do audio processing
+		if (buffer_head == buffer_size) {
+			buffer_head = 0;
+			carla_priv_process_audio(carla->priv, carla->buffers,
+						 buffer_size);
+			memset(carla->dummybuffer, 0,
+			       sizeof(float) * buffer_size);
+
+			// we can now begin to copy back the buffer into OBS
+			if (buffer_tail == UINT16_MAX)
+				buffer_tail = 0;
+		}
+
+		if (buffer_tail == UINT16_MAX) {
+			// buffering still taking place, skip until first audio cycle
+			for (uint8_t c = 0; c < channels; ++c)
+				obsbuffers[c][i] = 0.f;
+		} else {
+			// plugin -> OBS buffer copy
+			t = buffer_tail++;
+
+			for (uint8_t c = 0; c < channels; ++c)
+				obsbuffers[c][i] = carla->buffers[c][t];
+
+			if (buffer_tail == buffer_size)
+				buffer_tail = 0;
+		}
+	}
+
+	carla->buffer_head = buffer_head;
+	carla->buffer_tail = buffer_tail;
+}
+
+static struct obs_audio_data *
+carla_obs_filter_audio(void *data, struct obs_audio_data *audio)
+{
+	struct carla_data *carla = data;
+
+	switch (carla->buffer_size_mode) {
+	case buffer_size_direct:
+		carla_obs_filter_audio_direct(carla, audio);
+		break;
+	case buffer_size_buffered_128:
+	case buffer_size_buffered_256:
+	case buffer_size_buffered_512:
+		carla_obs_filter_audio_buffered(carla, audio);
+		break;
+	}
+
+	return audio;
+}
+
+static void carla_obs_save(void *data, obs_data_t *settings)
+{
+	struct carla_data *carla = data;
+	carla_priv_save(carla->priv, settings);
+}
+
+static void carla_obs_load(void *data, obs_data_t *settings)
+{
+	struct carla_data *carla = data;
+	carla_priv_load(carla->priv, settings);
+}
+
+// ----------------------------------------------------------------------------
+
+OBS_DECLARE_MODULE()
+OBS_MODULE_USE_DEFAULT_LOCALE("carla", "en-US")
+OBS_MODULE_AUTHOR("Filipe Coelho")
+const char *obs_module_name(void)
+{
+	return CARLA_MODULE_NAME;
+}
+
+bool obs_module_load(void)
+{
+	const char *carla_bin_path = get_carla_bin_path();
+	if (!carla_bin_path) {
+		blog(LOG_WARNING,
+		     "[" CARLA_MODULE_ID "]"
+		     " failed to find binaries, will not load module");
+		return false;
+	}
+	blog(LOG_INFO, "[" CARLA_MODULE_ID "] using binary path %s",
+	     carla_bin_path);
+
+	const char *carla_res_path = get_carla_resource_path();
+	if (!carla_res_path) {
+		blog(LOG_WARNING,
+		     "[" CARLA_MODULE_ID "]"
+		     " failed to find resources, will not load module");
+		return false;
+	}
+	blog(LOG_INFO, "[" CARLA_MODULE_ID "] using resource path %s",
+	     carla_res_path);
+
+	static const struct obs_source_info filter = {
+		.id = CARLA_MODULE_ID "-filter",
+		.type = OBS_SOURCE_TYPE_FILTER,
+		.output_flags = OBS_SOURCE_AUDIO,
+		.get_name = carla_obs_get_name,
+		.create = carla_obs_create_filter,
+		.destroy = carla_obs_destroy,
+		.get_properties = carla_obs_get_properties,
+		.activate = carla_obs_activate,
+		.deactivate = carla_obs_deactivate,
+		.filter_audio = carla_obs_filter_audio,
+		.save = carla_obs_save,
+		.load = carla_obs_load,
+		.type_data = "filter",
+		.icon_type = OBS_ICON_TYPE_PROCESS_AUDIO_OUTPUT,
+	};
+	obs_register_source(&filter);
+
+	static const struct obs_source_info input = {
+		.id = CARLA_MODULE_ID "-input",
+		.type = OBS_SOURCE_TYPE_INPUT,
+		.output_flags = OBS_SOURCE_AUDIO,
+		.get_name = carla_obs_get_name,
+		.create = carla_obs_create_input,
+		.destroy = carla_obs_destroy,
+		.get_properties = carla_obs_get_properties,
+		.activate = carla_obs_activate,
+		.deactivate = carla_obs_deactivate,
+		.save = carla_obs_save,
+		.load = carla_obs_load,
+		.type_data = "input",
+		.icon_type = OBS_ICON_TYPE_AUDIO_OUTPUT,
+	};
+	obs_register_source(&input);
+
+	return true;
+}
+
+// ----------------------------------------------------------------------------

--- a/plugins/carla/cmake/macos/Info.plist.in
+++ b/plugins/carla/cmake/macos/Info.plist.in
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>obs-carla</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.obsproject.carla-patchbay</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>carla-patchbay</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>(c) 2023 Filipe Coelho</string>
+</dict>
+</plist>

--- a/plugins/carla/common.c
+++ b/plugins/carla/common.c
@@ -1,0 +1,121 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "common.h"
+
+#include <util/platform.h>
+
+// ----------------------------------------------------------------------------
+
+static const struct {
+	const char *bin;
+	const char *res;
+} carla_system_paths[] = {
+#if defined(_WIN32)
+// TODO
+#else
+#ifdef __APPLE__
+	{"~/Applications/Carla.app/Contents/MacOS",
+	 "~/Applications/Carla.app/Contents/MacOS/resources"},
+	{"/Applications/Carla.app/Contents/MacOS",
+	 "/Applications/Carla.app/Contents/MacOS/resources"},
+#endif
+	{"/usr/local/lib/carla", "/usr/local/share/carla/resources"},
+	{"/usr/lib/carla", "/usr/share/carla/resources"},
+};
+#endif
+
+	static const char *module_path = NULL;
+static const char *resource_path = NULL;
+
+const char *get_carla_bin_path(void)
+{
+	if (module_path != NULL)
+		return module_path;
+
+	for (size_t i = 0;
+	     i < sizeof(carla_system_paths) / sizeof(carla_system_paths[0]);
+	     ++i) {
+		if (os_file_exists(carla_system_paths[i].bin)) {
+			module_path = carla_system_paths[i].bin;
+			resource_path = carla_system_paths[i].res;
+			break;
+		}
+	}
+
+	return module_path;
+}
+
+const char *get_carla_resource_path(void)
+{
+	if (resource_path != NULL)
+		return resource_path;
+
+	for (size_t i = 0;
+	     i < sizeof(carla_system_paths) / sizeof(carla_system_paths[0]);
+	     ++i) {
+		if (os_file_exists(carla_system_paths[i].res)) {
+			resource_path = carla_system_paths[i].res;
+			break;
+		}
+	}
+
+	return resource_path;
+}
+
+void param_index_to_name(uint32_t index, char name[PARAM_NAME_SIZE])
+{
+	name[1] = '0' + ((index / 100) % 10);
+	name[2] = '0' + ((index / 10) % 10);
+	name[3] = '0' + ((index / 1) % 10);
+}
+
+void remove_all_props(obs_properties_t *props, obs_data_t *settings)
+{
+	obs_data_erase(settings, PROP_SHOW_GUI);
+	obs_properties_remove_by_name(props, PROP_SHOW_GUI);
+
+	char pname[PARAM_NAME_SIZE] = PARAM_NAME_INIT;
+
+	for (uint32_t i = 0; i < MAX_PARAMS; ++i) {
+		param_index_to_name(i, pname);
+		obs_data_erase(settings, pname);
+		obs_data_unset_default_value(settings, pname);
+		obs_properties_remove_by_name(props, pname);
+	}
+}
+
+void postpone_update_request(uint64_t *update_req)
+{
+	*update_req = os_gettime_ns();
+}
+
+void handle_update_request(obs_source_t *source, uint64_t *update_req)
+{
+	const uint64_t old_update_req = *update_req;
+
+	if (old_update_req == 0)
+		return;
+
+	const uint64_t now = os_gettime_ns();
+
+	// request in the future?
+	if (now < old_update_req) {
+		*update_req = now;
+		return;
+	}
+
+	if (now - old_update_req >= 100000000ULL) // 100ms
+	{
+		*update_req = 0;
+
+		signal_handler_t *sighandler =
+			obs_source_get_signal_handler(source);
+		signal_handler_signal(sighandler, "update_properties", NULL);
+	}
+}
+
+// ----------------------------------------------------------------------------

--- a/plugins/carla/common.h
+++ b/plugins/carla/common.h
@@ -1,0 +1,42 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#include <obs-module.h>
+
+#define MAX_PARAMS 100
+
+#define PARAM_NAME_SIZE 5
+#define PARAM_NAME_INIT                  \
+	{                                \
+		'p', '0', '0', '0', '\0' \
+	}
+
+// property names
+#define PROP_BUFFER_SIZE "buffer-size"
+#define PROP_SHOW_GUI "show-gui"
+
+// ----------------------------------------------------------------------------
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char *get_carla_bin_path(void);
+const char *get_carla_resource_path(void);
+
+void param_index_to_name(uint32_t index, char name[PARAM_NAME_SIZE]);
+void remove_all_props(obs_properties_t *props, obs_data_t *settings);
+
+void postpone_update_request(uint64_t *update_req);
+void handle_update_request(obs_source_t *source, uint64_t *update_req);
+
+#ifdef __cplusplus
+}
+#endif
+
+// ----------------------------------------------------------------------------

--- a/plugins/carla/qtutils.cpp
+++ b/plugins/carla/qtutils.cpp
@@ -1,0 +1,55 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "qtutils.h"
+
+#include <QtCore/QTimer>
+#include <QtWidgets/QApplication>
+#include <QtWidgets/QFileDialog>
+#include <QtWidgets/QMainWindow>
+
+void carla_qt_callback_on_main_thread(void (*callback)(void *param),
+				      void *param)
+{
+	QTimer *const maintimer = new QTimer;
+	maintimer->moveToThread(qApp->thread());
+	maintimer->setSingleShot(true);
+	QObject::connect(maintimer, &QTimer::timeout,
+			 [maintimer, callback, param]() {
+				 callback(param);
+				 maintimer->deleteLater();
+			 });
+	QMetaObject::invokeMethod(maintimer, "start", Qt::QueuedConnection,
+				  Q_ARG(int, 0));
+}
+
+const char *carla_qt_file_dialog(bool save, bool isDir, const char *title,
+				 const char *filter)
+{
+	static QByteArray ret;
+
+	QWidget *parent = nullptr;
+	for (QWidget *w : QApplication::topLevelWidgets()) {
+		if (QMainWindow *mw = qobject_cast<QMainWindow *>(w)) {
+			parent = mw;
+			break;
+		}
+	}
+
+	QFileDialog::Options options;
+
+	if (isDir)
+		options |= QFileDialog::ShowDirsOnly;
+
+	ret = save ? QFileDialog::getSaveFileName(parent, title, {}, filter,
+						  nullptr, options)
+			      .toUtf8()
+		   : QFileDialog::getOpenFileName(parent, title, {}, filter,
+						  nullptr, options)
+			      .toUtf8();
+
+	return ret.constData();
+}

--- a/plugins/carla/qtutils.h
+++ b/plugins/carla/qtutils.h
@@ -1,0 +1,26 @@
+/*
+ * Carla plugin for OBS
+ * Copyright (C) 2023 Filipe Coelho <falktx@falktx.com>
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+#include <cstdint>
+#include <QtWidgets/QMainWindow>
+extern "C" {
+#else
+#include <stdint.h>
+typedef struct QMainWindow QMainWindow;
+#endif
+
+void carla_qt_callback_on_main_thread(void (*callback)(void *param),
+				      void *param);
+
+const char *carla_qt_file_dialog(bool save, bool isDir, const char *title,
+				 const char *filter);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This is an alternative to #8919
Please check that PR first for the initial discussion around this.


### Description
This adds a new input filter and input source OBS plugin (combined in a single module) called "carla-patchbay".
It uses publicly-exposed Carla APIs to run the entire thing inside OBS.

It is based on the same code foundation as done for #8919, but instead of having plugin hosting directly integrated in OBS we let Carla take care of all of that.
Code-wise it is basically a bridge between an API that Carla exposes, and OBS filter/source audio APIs.

Behind the scenes a custom Carla engine runs the audio, talking with the PyQt frontend in a separate process using pipes.
Most of the code for this engine is at https://github.com/falkTX/Carla/blob/main/source/backend/engine/CarlaEngineNative.cpp
That engine runs in the same process as OBS, but everything else (plugin hosting and GUI) can be placed in separate processes as to not crash OBS if plugins do something wrong (always-bridge option to be introduced for next major release)

Contrary to #8919 this PR requires to have Carla as a dependency, either on system-level or as part of obs-deps.
For now I made that using pkg-config, which is already in place for Linux systems. macOS and Windows needs manual integration work, builds for them are expected to fail.


### Motivation and Context
This is an alternative to the PR #8919 that uses Carla as dependency instead of tight integration.


### How Has This Been Tested?
I have tested running this Carla-as-dep approach in both Linux and macOS, with Windows not directly tested together with OBS but confirmed to work in a similar fashion inside the [Cardinal](https://github.com/DISTRHO/Cardinal) project that uses the same Carla APIs.
For Cardinal on Windows, a custom Carla build is done directly in CI containing Python, Qt5 and PyQt5.


### Types of changes
Pretty much the same as #8919 we have a new audio filter plus audio source for audio-generation plugins
The same kind of parameter support is possible, but with this approach we show the parameters of all plugins (up to 100 total params)

![image](https://github.com/obsproject/obs-studio/assets/1334853/a1992f2f-4996-4028-aaf0-b53bd0a452d8)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.


### Final notes
While this approach is much cleaner in terms of code and maintenance, it is not as clean for the user in the end because there is always 1 window layer in between. But that layer (Carla main window) also provides a way to have a patchbay and plugin favorites, among other things, so perhaps not a bad compromise?
It does feel a bit alien and out of place though, from users POV it is not OBS loading plugins but OBS loading Carla which then loads plugins. Up to the OBS team to tell how comfortable they are with this idea.

For macOS and Windows where Carla is likely to not be installed/available, OBS would need to include it which brings yet another Qt version (Carla UI is not ready for Qt6 yet), plus PyQt5 too.
While the UI is self-contained (it is a separate process after all, no external deps after everything is packaged correctly), it is still a considerable amount of disk space used for it. From the latest Carla 2.5.4 win64 release binaries the patchbay-plugin UI and all needed DLLs/deps take 115Mb.

Also if it wasn't obvious, this PR is also not meant to be merged as-is, but already provides working code if one uses Linux with Carla installed. Plus I cleaned up the whole cmake stuff with the recommendations made on the previous PR, no more legacy cmake stuff in place.

If this approach and its compromises are good, I can forego the previous attempt and focus on this one.
Let me know what you all think.
