### PR TITLE
libobs: Fix struct type usage before actual include

### DIFF
--- a/libobs/util/windows/window-helpers.c
+++ b/libobs/util/windows/window-helpers.c
@@ -1,6 +1,5 @@
 #include "window-helpers.h"
 
-#include <util/dstr.h>
 #include <util/windows/obfuscate.h>
 
 #include <dwmapi.h>

--- a/libobs/util/windows/window-helpers.h
+++ b/libobs/util/windows/window-helpers.h
@@ -2,6 +2,7 @@
 
 #include <obs-properties.h>
 #include <util/c99defs.h>
+#include <util/dstr.h>
 #include <Windows.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description
Move header inclusion of `dstr.h` into `window-helpers.h` to fix breaking use of `struct dstr` before the type definition.

### Motivation and Context
In its current form `struct dstr` is used in functions declarations in the header file before the actual type is included (as `dstr.h` is included after in `window-helpers.c`.

`clang-cl` is unable to compile this code because the function signature defined in the header will not match the implementation in the source code due to the implicit forward-declaration of `struct dstr` before the type is included in the actual header.

### How Has This Been Tested?
Tested with `clang-cl.exe` and `cl.exe` on Windows 11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
