### PR TITLE
UI: Fix crash when receiving multiple SIGINT

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -3264,7 +3264,8 @@ void OBSApp::ProcessSigInt(void)
 	recv(sigintFd[1], &tmp, sizeof(tmp), 0);
 
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(GetMainWindow());
-	main->close();
+	if (main)
+		main->close();
 #endif
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Don't call `close` after the main window gets deleted.

I tried another implementation deleting `snInt` when `main->close()` returns true as below.
Unfortunately, this does not work. If sending 2nd SIGINT to obs while ConfirmExit dialog is open, `close()` returns true so that `snInt` is deleted. Then, if the exit is canceled by a user, `SIGINT` cannot terminate obs again.
```cpp
	if(main->close()) {
		delete snInt;
		snInt = nullptr;
	}
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When I ran a command below on GitHub Actions runner `ubuntu-22.04`, sometimes obs crashes with `SIGSEGV`.
```sh
xvfb-run timeout -s SIGINT --preserve-status -k 30 10 obs
```

When I added `blog` message in `ProcessSigInt`, sometimes `ProcessSigInt` is called multiple times in a short time such as within 80 ms. That results `main->close()` is called after the main window has been deleted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS Ubuntu 22.04 docker running on Fedora
Hardware: Core i7-7700.

Built obs and run a command below several times.
```sh
xvfb-run timeout -s SIGINT --preserve-status -k 30 10 obs
```

Also tested `SIGINT` while recording, and cancel by the dialog. Then, send `SIGINT` and confirmed the close event is invoked again.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
