### PR TITLE
mac-virtualcam: Fix admin password locale string

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
+++ b/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
@@ -5,4 +5,4 @@ Error.SystemExtension.CameraNotStarted="Unable to start virtual camera.\n\nPleas
 Error.SystemExtension.InstallationError="An error has occured while installing the virtual camera:"
 Error.SystemExtension.WrongLocation="OBS cannot install the virtual camera if it's not in \"/Applications\". Please move OBS to the \"/Applications\" directory."
 Error.DAL.NotInstalled="The virtual camera could not be installed or updated.\n\nPlease try again and enter your administrator password when prompted."
-Error.DAL.NotUninstalled="Could not remove the legacy virtual camera.\n\nPlease try again and enter your account password when prompted."
+Error.DAL.NotUninstalled="Could not remove the legacy virtual camera.\n\nPlease try again and enter your administrator password when prompted."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a string to say "administrator password" instead of "account password". A non-admin password wouldn't be enough here as we need admin permissions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this when looking through crowdin and seeing wrong translations - or at least I thought the translations were wrong until I saw that the source sting was actually the problem.
I suspect that when I originally wrote this string it was probably 4 AM, can't explain this otherwise.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
String change, so n/a.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
