### PR TITLE
UI: Adjust properties view size policy

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -138,7 +138,8 @@ void OBSPropertiesView::RefreshProperties()
 	layout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	widget->setLayout(layout);
 
-	QSizePolicy mainPolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+	QSizePolicy mainPolicy(QSizePolicy::MinimumExpanding,
+			       QSizePolicy::MinimumExpanding);
 
 	layout->setLabelAlignment(Qt::AlignRight);
 


### PR DESCRIPTION
### Description
Prevents buttons from squishing when dialog gets too small.

Before:
![Screenshot from 2023-05-21 12-44-54](https://github.com/obsproject/obs-studio/assets/19962531/8c2a7e87-bf54-449c-ab7e-81f9513c79a1)

After:
![Screenshot from 2023-05-24 15-18-07](https://github.com/obsproject/obs-studio/assets/19962531/8fb374a3-ab9c-48bb-aa94-d6ba18eef28d)

### Motivation and Context
Suggestion from @Warchamp7 for https://github.com/obsproject/obs-studio/pull/8236

### How Has This Been Tested?
Changed size of dialog

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
