### PR TITLE
UI: Reset service selection to custom if name not found

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -140,11 +140,10 @@ void OBSBasicSettings::LoadStream1Settings()
 			QTStr("Basic.Settings.Stream.Custom.Password.ToolTip"));
 	} else {
 		int idx = ui->service->findText(service);
-		if (idx == -1) {
-			if (service && *service)
-				ui->service->insertItem(1, service);
-			idx = 1;
-		}
+		/* 29.1 crash workaround: Fall back to "Custom" if service not found. */
+		if (idx == -1)
+			idx = 0;
+
 		ui->service->setCurrentIndex(idx);
 		lastServiceIdx = idx;
 


### PR DESCRIPTION
### Description

Resets service selection to "Custom" if the previously selected service is not found in the dropdown.

### Motivation and Context

Prevents the crash from #8949 for a hotfix, but doesn't address the underlying design issues.

### How Has This Been Tested?

Opened settings; No crash.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- 
### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
