### PR TITLE
updater: Refactor and cleanup

### DIFF
--- a/UI/win-update/updater/hash.cpp
+++ b/UI/win-update/updater/hash.cpp
@@ -21,33 +21,33 @@
 
 using namespace std;
 
-void HashToString(const uint8_t *in, wchar_t *out)
+void HashToString(const B2Hash &in, string &out)
 {
-	const wchar_t alphabet[] = L"0123456789abcdef";
+	const char alphabet[] = "0123456789abcdef";
+	out.resize(kBlake2StrLength);
 
-	for (int i = 0; i != BLAKE2_HASH_LENGTH; ++i) {
-		out[2 * i] = alphabet[in[i] / 16];
-		out[2 * i + 1] = alphabet[in[i] % 16];
+	for (int i = 0; i != kBlake2HashLength; ++i) {
+		out[2 * i] = alphabet[(uint8_t)in[i] / 16];
+		out[2 * i + 1] = alphabet[(uint8_t)in[i] % 16];
 	}
-
-	out[BLAKE2_HASH_LENGTH * 2] = 0;
 }
 
-void StringToHash(const wchar_t *in, BYTE *out)
+void StringToHash(const string &in, B2Hash &out)
 {
 	unsigned int temp;
+	const char *str = in.c_str();
 
-	for (int i = 0; i < BLAKE2_HASH_LENGTH; i++) {
-		swscanf_s(in + i * 2, L"%02x", &temp);
-		out[i] = (BYTE)temp;
+	for (int i = 0; i < kBlake2HashLength; i++) {
+		sscanf_s(str + i * 2, "%02x", &temp);
+		out[i] = (std::byte)temp;
 	}
 }
 
-bool CalculateFileHash(const wchar_t *path, BYTE *hash)
+bool CalculateFileHash(const wchar_t *path, B2Hash &hash)
 {
 	static __declspec(thread) vector<BYTE> hashBuffer;
 	blake2b_state blake2;
-	if (blake2b_init(&blake2, BLAKE2_HASH_LENGTH) != 0)
+	if (blake2b_init(&blake2, kBlake2HashLength) != 0)
 		return false;
 
 	hashBuffer.resize(1048576);
@@ -70,7 +70,7 @@ bool CalculateFileHash(const wchar_t *path, BYTE *hash)
 			return false;
 	}
 
-	if (blake2b_final(&blake2, hash, BLAKE2_HASH_LENGTH) != 0)
+	if (blake2b_final(&blake2, &hash[0], hash.size()) != 0)
 		return false;
 
 	return true;

--- a/UI/win-update/updater/http.cpp
+++ b/UI/win-update/updater/http.cpp
@@ -352,3 +352,131 @@ bool HTTPGetFile(HINTERNET hConnect, const wchar_t *url,
 
 	return true;
 }
+
+bool HTTPGetBuffer(HINTERNET hConnect, const wchar_t *url,
+		   const wchar_t *extraHeaders, vector<std::byte> &out,
+		   int *responseCode)
+{
+	HttpHandle hRequest;
+
+	const wchar_t *acceptTypes[] = {L"*/*", nullptr};
+
+	URL_COMPONENTS urlComponents = {};
+	bool secure = false;
+
+	wchar_t hostName[256];
+	wchar_t path[1024];
+
+	/* -------------------------------------- *
+	 * get URL components                     */
+
+	urlComponents.dwStructSize = sizeof(urlComponents);
+
+	urlComponents.lpszHostName = hostName;
+	urlComponents.dwHostNameLength = _countof(hostName);
+
+	urlComponents.lpszUrlPath = path;
+	urlComponents.dwUrlPathLength = _countof(path);
+
+	WinHttpCrackUrl(url, 0, 0, &urlComponents);
+
+	if (urlComponents.nPort == 443)
+		secure = true;
+
+	/* -------------------------------------- *
+	 * request data                           */
+
+	hRequest = WinHttpOpenRequest(hConnect, L"GET", path, nullptr,
+				      WINHTTP_NO_REFERER, acceptTypes,
+				      secure ? WINHTTP_FLAG_SECURE |
+						       WINHTTP_FLAG_REFRESH
+					     : WINHTTP_FLAG_REFRESH);
+	if (!hRequest) {
+		*responseCode = -3;
+		return false;
+	}
+
+	bool bResults = !!WinHttpSendRequest(hRequest, extraHeaders,
+					     extraHeaders ? -1 : 0,
+					     WINHTTP_NO_REQUEST_DATA, 0, 0, 0);
+
+	/* -------------------------------------- *
+	 * end request                            */
+
+	if (bResults) {
+		bResults = !!WinHttpReceiveResponse(hRequest, nullptr);
+	} else {
+		*responseCode = GetLastError();
+		return false;
+	}
+
+	/* -------------------------------------- *
+	 * get headers                            */
+
+	wchar_t statusCode[8];
+	DWORD statusCodeLen;
+
+	statusCodeLen = sizeof(statusCode);
+	if (!WinHttpQueryHeaders(hRequest, WINHTTP_QUERY_STATUS_CODE,
+				 WINHTTP_HEADER_NAME_BY_INDEX, &statusCode,
+				 &statusCodeLen, WINHTTP_NO_HEADER_INDEX)) {
+		*responseCode = -4;
+		return false;
+	} else {
+		statusCode[_countof(statusCode) - 1] = 0;
+	}
+
+	/* -------------------------------------- *
+	 * read data                              */
+
+	*responseCode = wcstoul(statusCode, nullptr, 10);
+
+	/* are we supposed to return true here? */
+	if (!bResults || *responseCode != 200)
+		return true;
+
+	BYTE buffer[READ_BUF_SIZE];
+	DWORD dwSize, outSize;
+	int lastPosition = 0;
+
+	do {
+		/* Check for available data. */
+		dwSize = 0;
+		if (!WinHttpQueryDataAvailable(hRequest, &dwSize)) {
+			*responseCode = -8;
+			return false;
+		}
+
+		dwSize = std::min(dwSize, (DWORD)sizeof(buffer));
+
+		if (!WinHttpReadData(hRequest, (void *)buffer, dwSize,
+				     &outSize)) {
+			*responseCode = -9;
+			return false;
+		} else {
+			if (!outSize)
+				break;
+
+			out.insert(out.end(), (std::byte *)buffer,
+				   (std::byte *)buffer + outSize);
+
+			completedFileSize += outSize;
+			int position = (int)(((float)completedFileSize /
+					      (float)totalFileSize) *
+					     100.0f);
+			if (position > lastPosition) {
+				lastPosition = position;
+				SendDlgItemMessage(hwndMain, IDC_PROGRESS,
+						   PBM_SETPOS, position, 0);
+			}
+		}
+
+		if (WaitForSingleObject(cancelRequested, 0) == WAIT_OBJECT_0) {
+			*responseCode = -14;
+			return false;
+		}
+
+	} while (dwSize > 0);
+
+	return true;
+}

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -21,14 +21,23 @@
 #include <util/windows/CoTaskMemPtr.hpp>
 
 #include <future>
-#include <vector>
 #include <string>
+#include <string_view>
 #include <mutex>
 #include <unordered_set>
 #include <queue>
 
 using namespace std;
 using namespace json11;
+
+/* ----------------------------------------------------------------------- */
+
+constexpr const string_view kCDNUrl = "https://cdn-fastly.obsproject.com/";
+constexpr const wchar_t *kCDNHostname = L"cdn-fastly.obsproject.com";
+constexpr const wchar_t *kCDNUpdateBaseUrl =
+	L"https://cdn-fastly.obsproject.com/update_studio";
+constexpr const wchar_t *kPatchManifestURL =
+	L"https://obsproject.com/update_studio/getpatchmanifest";
 
 /* ----------------------------------------------------------------------- */
 
@@ -235,7 +244,38 @@ static string QuickReadFile(const wchar_t *path)
 	return data;
 }
 
+static bool QuickWriteFile(const wchar_t *file, const void *data, size_t size)
+try {
+	WinHandle handle = CreateFile(file, GENERIC_WRITE, 0, nullptr,
+				      CREATE_ALWAYS, FILE_FLAG_WRITE_THROUGH,
+				      nullptr);
+
+	if (handle == INVALID_HANDLE_VALUE)
+		throw GetLastError();
+
+	DWORD written;
+	if (!WriteFile(handle, data, (DWORD)size, &written, nullptr))
+		throw GetLastError();
+
+	return true;
+
+} catch (LastError error) {
+	SetLastError(error.code);
+	return false;
+}
+
 /* ----------------------------------------------------------------------- */
+
+/* Extend std::hash for B2Hash */
+namespace std {
+template<> struct hash<B2Hash> {
+	size_t operator()(B2Hash value) const
+	{
+		return hash<string_view>{}(
+			string_view((const char *)value.data(), value.size()));
+	}
+};
+}
 
 enum state_t {
 	STATE_INVALID,
@@ -250,46 +290,45 @@ enum state_t {
 struct update_t {
 	wstring sourceURL;
 	wstring outputPath;
-	wstring tempPath;
 	wstring previousFile;
-	wstring basename;
 	string packageName;
 
+	B2Hash hash;
+	B2Hash my_hash;
+	B2Hash downloadHash;
+
 	DWORD fileSize = 0;
-	BYTE hash[BLAKE2_HASH_LENGTH];
-	BYTE downloadhash[BLAKE2_HASH_LENGTH];
-	BYTE my_hash[BLAKE2_HASH_LENGTH];
 	state_t state = STATE_INVALID;
 	bool has_hash = false;
 	bool patchable = false;
 	bool compressed = false;
 
 	inline update_t() {}
+
 	inline update_t(const update_t &from)
 		: sourceURL(from.sourceURL),
 		  outputPath(from.outputPath),
-		  tempPath(from.tempPath),
 		  previousFile(from.previousFile),
-		  basename(from.basename),
 		  packageName(from.packageName),
+		  hash(from.hash),
+		  my_hash(from.my_hash),
+		  downloadHash(from.downloadHash),
 		  fileSize(from.fileSize),
 		  state(from.state),
 		  has_hash(from.has_hash),
 		  patchable(from.patchable),
 		  compressed(from.compressed)
 	{
-		memcpy(hash, from.hash, sizeof(hash));
-		memcpy(downloadhash, from.downloadhash, sizeof(downloadhash));
-		memcpy(my_hash, from.my_hash, sizeof(my_hash));
 	}
 
 	inline update_t(update_t &&from)
 		: sourceURL(std::move(from.sourceURL)),
 		  outputPath(std::move(from.outputPath)),
-		  tempPath(std::move(from.tempPath)),
 		  previousFile(std::move(from.previousFile)),
-		  basename(std::move(from.basename)),
 		  packageName(std::move(from.packageName)),
+		  hash(from.hash),
+		  my_hash(from.my_hash),
+		  downloadHash(std::move(from.downloadHash)),
 		  fileSize(from.fileSize),
 		  state(from.state),
 		  has_hash(from.has_hash),
@@ -297,10 +336,6 @@ struct update_t {
 		  compressed(from.compressed)
 	{
 		from.state = STATE_INVALID;
-
-		memcpy(hash, from.hash, sizeof(hash));
-		memcpy(downloadhash, from.downloadhash, sizeof(downloadhash));
-		memcpy(my_hash, from.my_hash, sizeof(my_hash));
 	}
 
 	void CleanPartialUpdate()
@@ -314,10 +349,6 @@ struct update_t {
 			} else {
 				DeleteFile(outputPath.c_str());
 			}
-			if (state == STATE_INSTALL_FAILED)
-				DeleteFile(tempPath.c_str());
-		} else if (state == STATE_DOWNLOADED) {
-			DeleteFile(tempPath.c_str());
 		}
 	}
 
@@ -325,19 +356,16 @@ struct update_t {
 	{
 		sourceURL = from.sourceURL;
 		outputPath = from.outputPath;
-		tempPath = from.tempPath;
 		previousFile = from.previousFile;
-		basename = from.basename;
 		packageName = from.packageName;
+		hash = from.hash;
+		my_hash = from.my_hash;
+		downloadHash = from.downloadHash;
 		fileSize = from.fileSize;
 		state = from.state;
 		has_hash = from.has_hash;
 		patchable = from.patchable;
 		compressed = from.compressed;
-
-		memcpy(hash, from.hash, sizeof(hash));
-		memcpy(downloadhash, from.downloadhash, sizeof(downloadhash));
-		memcpy(my_hash, from.my_hash, sizeof(my_hash));
 
 		return *this;
 	}
@@ -355,7 +383,8 @@ struct deletion_t {
 	}
 };
 
-static unordered_map<string, wstring> hashes;
+static unordered_map<B2Hash, vector<std::byte>> download_data;
+static unordered_map<string, B2Hash> hashes;
 static vector<update_t> updates;
 static vector<deletion_t> deletions;
 static mutex updateMutex;
@@ -370,6 +399,29 @@ static inline void CleanupPartialUpdates()
 }
 
 /* ----------------------------------------------------------------------- */
+
+static int Decompress(ZSTD_DCtx *ctx, std::vector<std::byte> &buf, size_t size)
+{
+	// Copy compressed data
+	vector<std::byte> comp(buf.begin(), buf.end());
+
+	try {
+		buf.resize(size);
+	} catch (...) {
+		return -1;
+	}
+
+	// Overwrite buffer with decompressed data
+	size_t result = ZSTD_decompressDCtx(ctx, &buf[0], buf.size(),
+					    comp.data(), comp.size());
+
+	if (result != size)
+		return -9;
+	if (ZSTD_isError(result))
+		return -10;
+
+	return 0;
+}
 
 bool DownloadWorkerThread()
 {
@@ -399,12 +451,11 @@ bool DownloadWorkerThread()
 	WinHttpSetOption(hSession, WINHTTP_OPTION_DECOMPRESSION,
 			 (LPVOID)&compressionFlags, sizeof(compressionFlags));
 
-	HttpHandle hConnect = WinHttpConnect(hSession,
-					     L"cdn-fastly.obsproject.com",
+	HttpHandle hConnect = WinHttpConnect(hSession, kCDNHostname,
 					     INTERNET_DEFAULT_HTTPS_PORT, 0);
 	if (!hConnect) {
 		downloadThreadFailure = true;
-		Status(L"Update failed: Couldn't connect to cdn-fastly.obsproject.com");
+		Status(L"Update failed: Couldn't connect to %S", kCDNHostname);
 		return false;
 	}
 
@@ -439,13 +490,14 @@ bool DownloadWorkerThread()
 
 			Status(L"Downloading %s", update.outputPath.c_str());
 
-			if (!HTTPGetFile(hConnect, update.sourceURL.c_str(),
-					 update.tempPath.c_str(),
-					 L"Accept-Encoding: gzip",
-					 &responseCode)) {
+			auto &buf = download_data[update.downloadHash];
+			/* Reserve required memory */
+			buf.reserve(update.fileSize);
 
+			if (!HTTPGetBuffer(hConnect, update.sourceURL.c_str(),
+					   L"Accept-Encoding: gzip", buf,
+					   &responseCode)) {
 				downloadThreadFailure = true;
-				DeleteFile(update.tempPath.c_str());
 				Status(L"Update failed: Could not download "
 				       L"%s (error code %d)",
 				       update.outputPath.c_str(), responseCode);
@@ -454,40 +506,31 @@ bool DownloadWorkerThread()
 
 			if (responseCode != 200) {
 				downloadThreadFailure = true;
-				DeleteFile(update.tempPath.c_str());
 				Status(L"Update failed: Could not download "
 				       L"%s (error code %d)",
 				       update.outputPath.c_str(), responseCode);
 				return 1;
 			}
 
-			BYTE downloadHash[BLAKE2_HASH_LENGTH];
-			if (!CalculateFileHash(update.tempPath.c_str(),
-					       downloadHash)) {
-				downloadThreadFailure = true;
-				DeleteFile(update.tempPath.c_str());
-				Status(L"Update failed: Couldn't verify "
-				       L"integrity of %s",
-				       update.outputPath.c_str());
-				return 1;
-			}
+			/* Validate hash of downloaded data. */
+			B2Hash dataHash;
+			blake2b(&dataHash[0], dataHash.size(), buf.data(),
+				buf.size(), NULL, 0);
 
-			if (memcmp(update.downloadhash, downloadHash, 20)) {
+			if (dataHash != update.downloadHash) {
 				downloadThreadFailure = true;
-				DeleteFile(update.tempPath.c_str());
 				Status(L"Update failed: Integrity check "
 				       L"failed on %s",
 				       update.outputPath.c_str());
 				return 1;
 			}
 
+			/* Decompress data in compressed buffer. */
 			if (update.compressed && !update.patchable) {
-				int res = DecompressFile(
-					zCtx, update.tempPath.c_str(),
-					update.fileSize);
+				int res =
+					Decompress(zCtx, buf, update.fileSize);
 				if (res) {
 					downloadThreadFailure = true;
-					DeleteFile(update.tempPath.c_str());
 					Status(L"Update failed: Decompression "
 					       L"failed on %s (error code %d)",
 					       update.outputPath.c_str(), res);
@@ -650,13 +693,10 @@ void HasherThread()
 		if (!IsSafeFilename(updateFileName))
 			continue;
 
-		BYTE existingHash[BLAKE2_HASH_LENGTH];
-		wchar_t fileHashStr[BLAKE2_HASH_STR_LENGTH];
-
+		B2Hash existingHash;
 		if (CalculateFileHash(updateFileName, existingHash)) {
-			HashToString(existingHash, fileHashStr);
 			ulock.lock();
-			hashes.emplace(fileName, fileHashStr);
+			hashes.emplace(fileName, existingHash);
 			ulock.unlock();
 		}
 	}
@@ -707,13 +747,9 @@ static bool NonCorePackageInstalled(const char *name)
 	return false;
 }
 
-#define UPDATE_URL L"https://cdn-fastly.obsproject.com/update_studio"
-
-static bool AddPackageUpdateFiles(const Json &root, size_t idx,
-				  const wchar_t *tempPath,
+static bool AddPackageUpdateFiles(const Json &package, const wchar_t *tempPath,
 				  const wchar_t *branch)
 {
-	const Json &package = root[idx];
 	const Json &name = package["name"];
 	const Json &files = package["files"];
 
@@ -752,29 +788,21 @@ static bool AddPackageUpdateFiles(const Json &root, size_t idx,
 		const string &dlHashUTF8 = dlHash.string_value();
 		int fileSize = size.int_value();
 
-		if (hashUTF8.size() != BLAKE2_HASH_LENGTH * 2)
+		if (hashUTF8.size() != kBlake2StrLength)
 			continue;
 
 		/* The download hash may not exist if a file is uncompressed */
 
 		bool compressed = false;
-		if (dlHashUTF8.size() == BLAKE2_HASH_LENGTH * 2)
+		if (dlHashUTF8.size() == kBlake2StrLength)
 			compressed = true;
 
 		/* convert strings to wide */
 
 		wchar_t sourceURL[1024];
 		wchar_t updateFileName[MAX_PATH];
-		wchar_t updateHashStr[BLAKE2_HASH_STR_LENGTH];
-		wchar_t downloadHashStr[BLAKE2_HASH_STR_LENGTH];
-		wchar_t tempFilePath[MAX_PATH];
 
 		if (!UTF8ToWideBuf(updateFileName, fileUTF8.c_str()))
-			continue;
-		if (!UTF8ToWideBuf(updateHashStr, hashUTF8.c_str()))
-			continue;
-		if (compressed &&
-		    !UTF8ToWideBuf(downloadHashStr, dlHashUTF8.c_str()))
 			continue;
 
 		/* make sure paths are safe */
@@ -787,54 +815,47 @@ static bool AddPackageUpdateFiles(const Json &root, size_t idx,
 		}
 
 		StringCbPrintf(sourceURL, sizeof(sourceURL), L"%s/%s/%s/%s",
-			       UPDATE_URL, branch, wPackageName,
+			       kCDNUpdateBaseUrl, branch, wPackageName,
 			       updateFileName);
-		StringCbPrintf(tempFilePath, sizeof(tempFilePath), L"%s\\%s",
-			       tempPath, updateHashStr);
 
-		/* Check file hash */
-
-		wstring fileHashStr;
-		bool has_hash;
+		/* Convert hashes */
+		B2Hash updateHash;
+		StringToHash(hashUTF8, updateHash);
 
 		/* We don't really care if this fails, it's just to avoid
 		 * wasting bandwidth by downloading unmodified files */
+		B2Hash localFileHash;
+		bool has_hash = false;
+
 		if (hashes.count(fileUTF8)) {
-			fileHashStr = hashes[fileUTF8];
-			if (fileHashStr == updateHashStr)
+			localFileHash = hashes[fileUTF8];
+			if (localFileHash == updateHash)
 				continue;
 
 			has_hash = true;
-		} else {
-			has_hash = false;
 		}
 
 		/* Add update file */
-
 		update_t update;
 		update.fileSize = fileSize;
-		update.basename = updateFileName;
 		update.outputPath = updateFileName;
-		update.tempPath = tempFilePath;
 		update.sourceURL = sourceURL;
 		update.packageName = packageName;
 		update.state = STATE_PENDING_DOWNLOAD;
 		update.patchable = false;
 		update.compressed = compressed;
-
-		StringToHash(updateHashStr, update.hash);
+		update.hash = updateHash;
 
 		if (compressed) {
 			update.sourceURL += L".zst";
-			StringToHash(downloadHashStr, update.downloadhash);
+			StringToHash(dlHashUTF8, update.downloadHash);
 		} else {
-			memcpy(update.downloadhash, update.hash,
-			       sizeof(update.downloadhash));
+			update.downloadHash = updateHash;
 		}
 
 		update.has_hash = has_hash;
 		if (has_hash)
-			StringToHash(fileHashStr.data(), update.my_hash);
+			update.my_hash = localFileHash;
 
 		updates.push_back(move(update));
 
@@ -885,11 +906,16 @@ static bool RenameRemovedFile(deletion_t &deletion)
 	_TCHAR randomStr[MAX_PATH];
 
 	BYTE junk[40];
-	BYTE hash[BLAKE2_HASH_LENGTH];
+	B2Hash hash;
+	string temp;
 
 	CryptGenRandom(hProvider, sizeof(junk), junk);
-	blake2b(hash, sizeof(hash), junk, sizeof(junk), NULL, 0);
-	HashToString(hash, randomStr);
+	blake2b(&hash[0], hash.size(), junk, sizeof(junk), NULL, 0);
+	HashToString(hash, temp);
+
+	if (!UTF8ToWideBuf(randomStr, temp.c_str()))
+		return false;
+
 	randomStr[8] = 0;
 
 	StringCbCopy(deleteMeName, sizeof(deleteMeName),
@@ -908,56 +934,59 @@ static bool RenameRemovedFile(deletion_t &deletion)
 	return false;
 }
 
-static void UpdateWithPatchIfAvailable(const char *name, const char *hash,
-				       const char *source, int size)
+static void UpdateWithPatchIfAvailable(const Json &patch)
 {
+	const Json &name_json = patch["name"];
+	const Json &hash_json = patch["hash"];
+	const Json &source_json = patch["source"];
+	const Json &size_json = patch["size"];
+
+	if (!name_json.is_string())
+		return;
+	if (!hash_json.is_string())
+		return;
+	if (!source_json.is_string())
+		return;
+	if (!size_json.is_number())
+		return;
+
+	const string &name = name_json.string_value();
+	const string &hash = hash_json.string_value();
+	const string &source = source_json.string_value();
+	int size = size_json.int_value();
+
 	wchar_t widePatchableFilename[MAX_PATH];
-	wchar_t widePatchHash[MAX_PATH];
 	wchar_t sourceURL[1024];
-	wchar_t patchHashStr[BLAKE2_HASH_STR_LENGTH];
 
-	if (strncmp(source, "https://cdn-fastly.obsproject.com/", 34) != 0)
+	if (source.compare(0, kCDNUrl.size(), kCDNUrl) != 0)
 		return;
 
-	string patchPackageName = name;
-
-	const char *slash = strchr(name, '/');
-	if (!slash)
+	if (name.find("/") == string::npos)
 		return;
 
-	patchPackageName.resize(slash - name);
-	name = slash + 1;
+	string patchPackageName(name, 0, name.find("/"));
+	string fileName(name, name.find("/") + 1);
 
-	if (!UTF8ToWideBuf(widePatchableFilename, name))
+	if (!UTF8ToWideBuf(widePatchableFilename, fileName.c_str()))
 		return;
-	if (!UTF8ToWideBuf(widePatchHash, hash))
-		return;
-	if (!UTF8ToWideBuf(sourceURL, source))
-		return;
-	if (!UTF8ToWideBuf(patchHashStr, hash))
+	if (!UTF8ToWideBuf(sourceURL, source.c_str()))
 		return;
 
 	for (update_t &update : updates) {
 		if (update.packageName != patchPackageName)
 			continue;
-		if (update.basename != widePatchableFilename)
+		if (update.outputPath != widePatchableFilename)
 			continue;
 
-		StringToHash(patchHashStr, update.downloadhash);
-
-		/* Replace the source URL with the patch file, mark it as
-		 * patchable, and re-calculate download size */
-		totalFileSize -= (update.fileSize - size);
-		update.sourceURL = sourceURL;
-		update.fileSize = size;
 		update.patchable = true;
 
-		/* Since the patch depends on the previous version, we can
-		 * no longer rely on the temp name being unique to the
-		 * new file's hash */
-		update.tempPath = tempPath;
-		update.tempPath += L"\\";
-		update.tempPath += patchHashStr;
+		/* Replace the source URL with the patch file, update
+	         * the download hash, and re-calculate download size */
+		StringToHash(hash, update.downloadHash);
+		update.sourceURL = sourceURL;
+		totalFileSize -= (update.fileSize - size);
+		update.fileSize = size;
+
 		break;
 	}
 }
@@ -968,11 +997,16 @@ static bool MoveInUseFileAway(update_t &file)
 	_TCHAR randomStr[MAX_PATH];
 
 	BYTE junk[40];
-	BYTE hash[BLAKE2_HASH_LENGTH];
+	B2Hash hash;
+	string temp;
 
 	CryptGenRandom(hProvider, sizeof(junk), junk);
-	blake2b(hash, sizeof(hash), junk, sizeof(junk), NULL, 0);
-	HashToString(hash, randomStr);
+	blake2b(&hash[0], hash.size(), junk, sizeof(junk), NULL, 0);
+	HashToString(hash, temp);
+
+	if (!UTF8ToWideBuf(randomStr, temp.c_str()))
+		return false;
+
 	randomStr[8] = 0;
 
 	StringCbCopy(deleteMeName, sizeof(deleteMeName),
@@ -1005,6 +1039,9 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 		Status(L"Updating %s...", file.outputPath.c_str());
 	else
 		Status(L"Installing %s...", file.outputPath.c_str());
+
+	/* Grab the patch/file data from the global cache. */
+	vector<std::byte> &patch_data = download_data[file.downloadHash];
 
 	/* Check if we're replacing an existing file or just installing a new
 	 * one */
@@ -1054,12 +1091,14 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 	retryAfterMovingFile:
 
 		if (file.patchable) {
-			error_code = ApplyPatch(ctx, file.tempPath.c_str(),
+			error_code = ApplyPatch(ctx, patch_data.data(),
+						file.fileSize,
 						file.outputPath.c_str());
+
 			installed_ok = (error_code == 0);
 
 			if (installed_ok) {
-				BYTE patchedFileHash[BLAKE2_HASH_LENGTH];
+				B2Hash patchedFileHash;
 				if (!CalculateFileHash(file.outputPath.c_str(),
 						       patchedFileHash)) {
 					Status(L"Update failed: Couldn't "
@@ -1070,8 +1109,7 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 					return false;
 				}
 
-				if (memcmp(file.hash, patchedFileHash,
-					   BLAKE2_HASH_LENGTH) != 0) {
+				if (file.hash != patchedFileHash) {
 					Status(L"Update failed: Integrity "
 					       L"check of patched "
 					       L"%s failed",
@@ -1082,8 +1120,8 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 				}
 			}
 		} else {
-			installed_ok = MyCopyFile(file.tempPath.c_str(),
-						  file.outputPath.c_str());
+			QuickWriteFile(file.outputPath.c_str(),
+				       patch_data.data(), patch_data.size());
 			error_code = GetLastError();
 		}
 
@@ -1130,8 +1168,9 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 
 		file.previousFile = L"";
 
-		bool success = !!MyCopyFile(file.tempPath.c_str(),
-					    file.outputPath.c_str());
+		bool success = !!QuickWriteFile(file.outputPath.c_str(),
+						patch_data.data(),
+						patch_data.size());
 		if (!success) {
 			Status(L"Update failed: Couldn't install %s (error %d)",
 			       file.outputPath.c_str(), GetLastError());
@@ -1187,9 +1226,8 @@ static bool UpdateWorker()
 
 static bool RunUpdateWorkers(int num)
 try {
-	for (update_t &update : updates) {
+	for (update_t &update : updates)
 		updateQueue.push(update);
-	}
 
 	vector<future<bool>> thread_success_results;
 	thread_success_results.resize(num);
@@ -1208,10 +1246,6 @@ try {
 } catch (...) {
 	return false;
 }
-
-#define PATCH_MANIFEST_URL \
-	L"https://obsproject.com/update_studio/getpatchmanifest"
-#define HASH_NULL L"0000000000000000000000000000000000000000"
 
 static bool UpdateVS2019Redists(const Json &root)
 {
@@ -1237,11 +1271,10 @@ static bool UpdateVS2019Redists(const Json &root)
 	WinHttpSetOption(hSession, WINHTTP_OPTION_DECOMPRESSION,
 			 (LPVOID)&compressionFlags, sizeof(compressionFlags));
 
-	HttpHandle hConnect = WinHttpConnect(hSession,
-					     L"cdn-fastly.obsproject.com",
+	HttpHandle hConnect = WinHttpConnect(hSession, kCDNHostname,
 					     INTERNET_DEFAULT_HTTPS_PORT, 0);
 	if (!hConnect) {
-		Status(L"Update failed: Couldn't connect to cdn-fastly.obsproject.com");
+		Status(L"Update failed: Couldn't connect to %S", kCDNHostname);
 		return false;
 	}
 
@@ -1284,23 +1317,14 @@ static bool UpdateVS2019Redists(const Json &root)
 	}
 
 	const string &expectedHashUTF8 = redistJson.string_value();
-	wchar_t expectedHashWide[BLAKE2_HASH_STR_LENGTH];
-	BYTE expectedHash[BLAKE2_HASH_LENGTH];
+	B2Hash expectedHash;
 
-	if (!UTF8ToWideBuf(expectedHashWide, expectedHashUTF8.c_str())) {
-		DeleteFile(destPath.c_str());
-		Status(L"Update failed: Couldn't convert Json for redist hash");
-		return false;
-	}
-
-	StringToHash(expectedHashWide, expectedHash);
-
-	wchar_t downloadHashWide[BLAKE2_HASH_STR_LENGTH];
-	BYTE downloadHash[BLAKE2_HASH_LENGTH];
+	StringToHash(expectedHashUTF8, expectedHash);
 
 	/* ------------------------------------------ *
 	 * Get download hash                          */
 
+	B2Hash downloadHash;
 	if (!CalculateFileHash(destPath.c_str(), downloadHash)) {
 		DeleteFile(destPath.c_str());
 		Status(L"Update failed: Couldn't verify integrity of %s",
@@ -1311,8 +1335,7 @@ static bool UpdateVS2019Redists(const Json &root)
 	/* ------------------------------------------ *
 	 * If hashes do not match, integrity failed   */
 
-	HashToString(downloadHash, downloadHashWide);
-	if (wcscmp(expectedHashWide, downloadHashWide) != 0) {
+	if (downloadHash == expectedHash) {
 		DeleteFile(destPath.c_str());
 		Status(L"Update failed: Couldn't verify integrity of %s",
 		       L"Visual C++ 2019 Redistributable");
@@ -1544,15 +1567,14 @@ static bool Update(wchar_t *cmdLine)
 	 * Parse current manifest update files   */
 
 	const Json::array &packages = root["packages"].array_items();
-	for (size_t i = 0; i < packages.size(); i++) {
-		if (!AddPackageUpdateFiles(packages, i, tempPath,
-					   branch.c_str())) {
+	for (const Json &package : packages) {
+		if (!AddPackageUpdateFiles(package, tempPath, branch.c_str())) {
 			Status(L"Update failed: Failed to process update packages");
 			return false;
 		}
 
 		/* Add removed files to deletion queue (if any) */
-		AddPackageRemovedFiles(packages[i]);
+		AddPackageRemovedFiles(package);
 	}
 
 	SendDlgItemMessage(hwndMain, IDC_PROGRESS, PBM_SETMARQUEE, 0, 0);
@@ -1582,22 +1604,15 @@ static bool Update(wchar_t *cmdLine)
 	Json::array files;
 
 	for (update_t &update : updates) {
-		wchar_t whash_string[BLAKE2_HASH_STR_LENGTH];
-		char hash_string[BLAKE2_HASH_STR_LENGTH];
-		char outputPath[MAX_PATH];
-
 		if (!update.has_hash)
 			continue;
 
-		/* check hash */
-		HashToString(update.my_hash, whash_string);
-		if (wcscmp(whash_string, HASH_NULL) == 0)
+		char outputPath[MAX_PATH];
+		if (!WideToUTF8Buf(outputPath, update.outputPath.c_str()))
 			continue;
 
-		if (!WideToUTF8Buf(hash_string, whash_string))
-			continue;
-		if (!WideToUTF8Buf(outputPath, update.basename.c_str()))
-			continue;
+		string hash_string;
+		HashToString(update.my_hash, hash_string);
 
 		string package_path;
 		package_path = update.packageName;
@@ -1637,7 +1652,7 @@ static bool Update(wchar_t *cmdLine)
 
 		compressedJson.resize(result);
 
-		wstring manifestUrl(PATCH_MANIFEST_URL);
+		wstring manifestUrl(kPatchManifestURL);
 		if (branch != L"stable")
 			manifestUrl += L"?branch=" + branch;
 
@@ -1676,52 +1691,28 @@ static bool Update(wchar_t *cmdLine)
 		return false;
 	}
 
-	size_t packageCount = root.array_items().size();
-
-	for (size_t i = 0; i < packageCount; i++) {
-		const Json &patch = root[i];
-
+	/* Update updates with patch information. */
+	for (const Json &patch : root.array_items()) {
 		if (!patch.is_object()) {
 			Status(L"Update failed: Invalid patch manifest");
 			return false;
 		}
 
-		const Json &name_json = patch["name"];
-		const Json &hash_json = patch["hash"];
-		const Json &source_json = patch["source"];
-		const Json &size_json = patch["size"];
-
-		if (!name_json.is_string())
-			continue;
-		if (!hash_json.is_string())
-			continue;
-		if (!source_json.is_string())
-			continue;
-		if (!size_json.is_number())
-			continue;
-
-		const string &name = name_json.string_value();
-		const string &hash = hash_json.string_value();
-		const string &source = source_json.string_value();
-		int size = size_json.int_value();
-
-		UpdateWithPatchIfAvailable(name.c_str(), hash.c_str(),
-					   source.c_str(), size);
+		UpdateWithPatchIfAvailable(patch);
 	}
 
 	/* ------------------------------------- *
 	 * Deduplicate Downloads                 */
 
-	unordered_set<wstring> tempFiles;
+	unordered_set<B2Hash> downloadHashes;
 	for (update_t &update : updates) {
-		if (tempFiles.count(update.tempPath)) {
+		if (downloadHashes.count(update.downloadHash)) {
 			update.state = STATE_ALREADY_DOWNLOADED;
 			totalFileSize -= update.fileSize;
 			completedUpdates++;
-			continue;
+		} else {
+			downloadHashes.insert(update.downloadHash);
 		}
-
-		tempFiles.insert(update.tempPath);
 	}
 
 	/* ------------------------------------- *
@@ -1819,10 +1810,6 @@ static bool Update(wchar_t *cmdLine)
 	for (update_t &update : updates) {
 		if (!update.previousFile.empty())
 			DeleteFile(update.previousFile.c_str());
-
-		/* We delete here not above in case of duplicate hashes */
-		if (!update.tempPath.empty())
-			DeleteFile(update.tempPath.c_str());
 	}
 
 	/* Delete all removed files mentioned in the manifest */

--- a/UI/win-update/updater/updater.hpp
+++ b/UI/win-update/updater/updater.hpp
@@ -36,12 +36,15 @@
 #include <blake2.h>
 #include <zstd.h>
 
+#include <array>
 #include <string>
+#include <vector>
 
 #include "helpers.hpp"
 
-#define BLAKE2_HASH_LENGTH 20
-#define BLAKE2_HASH_STR_LENGTH ((BLAKE2_HASH_LENGTH * 2) + 1)
+constexpr uint8_t kBlake2HashLength = 20;
+constexpr uint8_t kBlake2StrLength = kBlake2HashLength * 2;
+using B2Hash = std::array<std::byte, kBlake2HashLength>;
 
 #if defined _M_IX86
 #pragma comment(linker, "/manifestdependency:\"type='win32' "       \
@@ -79,17 +82,20 @@
 bool HTTPGetFile(HINTERNET hConnect, const wchar_t *url,
 		 const wchar_t *outputPath, const wchar_t *extraHeaders,
 		 int *responseCode);
+bool HTTPGetBuffer(HINTERNET hConnect, const wchar_t *url,
+		   const wchar_t *extraHeaders, std::vector<std::byte> &out,
+		   int *responseCode);
 bool HTTPPostData(const wchar_t *url, const BYTE *data, int dataLen,
 		  const wchar_t *extraHeaders, int *responseCode,
 		  std::string &response);
 
-void HashToString(const BYTE *in, wchar_t *out);
-void StringToHash(const wchar_t *in, BYTE *out);
+void HashToString(const B2Hash &in, std::string &out);
+void StringToHash(const std::string &in, B2Hash &out);
 
-bool CalculateFileHash(const wchar_t *path, BYTE *hash);
+bool CalculateFileHash(const wchar_t *path, B2Hash &hash);
 
-int ApplyPatch(ZSTD_DCtx *ctx, LPCTSTR patchFile, LPCTSTR targetFile);
-int DecompressFile(ZSTD_DCtx *ctx, LPCTSTR tempFile, size_t newSize);
+int ApplyPatch(ZSTD_DCtx *zstdCtx, std::byte *patch_data,
+	       const size_t patch_size, const wchar_t *targetFile);
 
 extern HWND hwndMain;
 extern HCRYPTPROV hProvider;


### PR DESCRIPTION
### Description

This is essentially the same as #8815 but without support for bundles as they do not provide enough of a benefit with our fast CDN, and we want to move to curl + HTTP/2 multiplexing soon.

**Changes:**
- New `B2Hash` typedef for blake 2 hashes (`std::array<std::byte, 20>`)
  + Also added `std::hash` specialisation to allow using it in maps or sets
- Stop using temporary files for downloads (uses RAM instead)
  + VC redistributables installation still uses a temp file, so the folder in `%TEMP%` will still be created/removed
- Moved some defines to global `constexpr` variables
- Moved some hardcoded values to global variables
- Removed a lot of utf8<->wide conversions that were unnecessary now that temporary files aren't used anymore
- Changed some for loops to use iterators instead of indices

### Motivation and Context

Cleanup and simplification of existing code

### How Has This Been Tested?

Updated portable 29.1.0 build to 29.1.1

### Types of changes

 - New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
