### PR TITLE
frontend: Add frontend event and output signal for replay buffer saving

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -150,6 +150,10 @@ Structures/Enumerations
 
      Triggered when the replay buffer has fully stopped.
 
+   - **OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVING**
+
+     Triggered when the replay buffer is saving.
+
    - **OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED**
 
      Triggered when the replay buffer has been saved.

--- a/frontend/api/obs-frontend-api.h
+++ b/frontend/api/obs-frontend-api.h
@@ -65,6 +65,8 @@ enum obs_frontend_event {
 
 	OBS_FRONTEND_EVENT_CANVAS_ADDED,
 	OBS_FRONTEND_EVENT_CANVAS_REMOVED,
+
+	OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVING,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -492,7 +492,7 @@ private:
 
 	obs_hotkey_pair_id streamingHotkeys, recordingHotkeys, pauseHotkeys, replayBufHotkeys, vcamHotkeys,
 		togglePreviewHotkeys, contextBarHotkeys;
-	obs_hotkey_id forceStreamingStopHotkey, splitFileHotkey, addChapterHotkey;
+	obs_hotkey_id forceStreamingStopHotkey, splitFileHotkey, addChapterHotkey, replayBufSaveHotkey;
 
 	void InitHotkeys();
 	void CreateHotkeys();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -492,7 +492,7 @@ private:
 
 	obs_hotkey_pair_id streamingHotkeys, recordingHotkeys, pauseHotkeys, replayBufHotkeys, vcamHotkeys,
 		togglePreviewHotkeys, contextBarHotkeys;
-	obs_hotkey_id forceStreamingStopHotkey, splitFileHotkey, addChapterHotkey;
+	obs_hotkey_id forceStreamingStopHotkey, splitFileHotkey, addChapterHotkey, saveReplayBufferHotkey;
 
 	void InitHotkeys();
 	void CreateHotkeys();

--- a/frontend/widgets/OBSBasic_Hotkeys.cpp
+++ b/frontend/widgets/OBSBasic_Hotkeys.cpp
@@ -206,6 +206,30 @@ void OBSBasic::CreateHotkeys()
 						  this, this);
 	LoadHotkeyPair(replayBufHotkeys, "OBSBasic.StartReplayBuffer", "OBSBasic.StopReplayBuffer");
 
+	auto replayBufferCallback = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+		OBSBasic *basic = static_cast<OBSBasic *>(data);
+		if (basic->outputHandler->ReplayBufferActive() && pressed) {
+			blog(LOG_INFO, "Saving replay buffer due to hotkey");
+			basic->ReplayBufferSave();
+		}
+	};
+
+	replayBufSaveHotkey = obs_hotkey_register_frontend("OBSBasic.SaveReplayBuffer", Str("Basic.Main.SaveReplay"),
+							   replayBufferCallback, this);
+
+	const char *exists = config_get_string(activeConfiguration, "Hotkeys", "OBSBasic.SaveReplayBuffer");
+	if (exists) {
+		LoadHotkey(replayBufSaveHotkey, "OBSBasic.SaveReplayBuffer");
+	} else {
+		OBSDataArrayAutoRelease array = obs_data_get_array(LoadHotkeyData("ReplayBuffer"), "ReplayBuffer.Save");
+		obs_hotkey_load(replayBufSaveHotkey, array);
+
+		OBSDataAutoRelease newData = obs_data_create();
+		obs_data_set_array(newData, "bindings", array);
+		config_set_string(activeConfiguration, "Hotkeys", "OBSBasic.SaveReplayBuffer",
+				  obs_data_get_json(newData));
+	}
+
 	if (vcamEnabled) {
 		vcamHotkeys = obs_hotkey_pair_register_frontend(
 			"OBSBasic.StartVirtualCam", Str("Basic.Main.StartVirtualCam"), "OBSBasic.StopVirtualCam",

--- a/frontend/widgets/OBSBasic_Hotkeys.cpp
+++ b/frontend/widgets/OBSBasic_Hotkeys.cpp
@@ -206,6 +206,30 @@ void OBSBasic::CreateHotkeys()
 						  this, this);
 	LoadHotkeyPair(replayBufHotkeys, "OBSBasic.StartReplayBuffer", "OBSBasic.StopReplayBuffer");
 
+	auto replayBufferCallback = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
+		OBSBasic *basic = static_cast<OBSBasic *>(data);
+		if (basic->outputHandler->ReplayBufferActive() && pressed) {
+			blog(LOG_INFO, "Saving replay buffer due to hotkey");
+			basic->ReplayBufferSave();
+		}
+	};
+
+	saveReplayBufferHotkey = obs_hotkey_register_frontend("OBSBasic.SaveReplayBuffer", Str("Basic.Main.SaveReplay"),
+							      replayBufferCallback, this);
+
+	bool hasSaveReplayHotkey = config_has_user_value(activeConfiguration, "Hotkeys", "OBSBasic.SaveReplayBuffer");
+	if (hasSaveReplayHotkey) {
+		LoadHotkey(saveReplayBufferHotkey, "OBSBasic.SaveReplayBuffer");
+	} else {
+		OBSDataArrayAutoRelease array = obs_data_get_array(LoadHotkeyData("ReplayBuffer"), "ReplayBuffer.Save");
+		obs_hotkey_load(saveReplayBufferHotkey, array);
+
+		OBSDataAutoRelease newData = obs_data_create();
+		obs_data_set_array(newData, "bindings", array);
+		config_set_string(activeConfiguration, "Hotkeys", "OBSBasic.SaveReplayBuffer",
+				  obs_data_get_json(newData));
+	}
+
 	if (vcamEnabled) {
 		vcamHotkeys = obs_hotkey_pair_register_frontend(
 			"OBSBasic.StartVirtualCam", Str("Basic.Main.StartVirtualCam"), "OBSBasic.StopVirtualCam",

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -147,6 +147,8 @@ void OBSBasic::ReplayBufferSave()
 	if (!outputHandler->ReplayBufferActive())
 		return;
 
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVING);
+
 	calldata_t cd = {0};
 	proc_handler_t *ph = obs_output_get_proc_handler(outputHandler->replayBuffer);
 	proc_handler_call(ph, "save", &cd);

--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -100,7 +100,6 @@ MediaFileFilter.AudioFiles="Audio Files"
 MediaFileFilter.AllFiles="All Files"
 
 ReplayBuffer="Replay Buffer"
-ReplayBuffer.Save="Save Replay"
 
 HelperProcessFailed="Unable to start the recording helper process. Check that OBS files have not been blocked or removed by any 3rd party antivirus / security software."
 UnableToWritePath="Unable to write to %1. Make sure you're using a recording path which your user account is allowed to write to and that there is sufficient disk space."

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -914,30 +914,20 @@ static const char *replay_buffer_getname(void *type)
 	return obs_module_text("ReplayBuffer");
 }
 
-static void replay_buffer_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
+static void save_replay_proc(void *data, calldata_t *cd)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
-
-	if (!pressed)
-		return;
 
 	struct ffmpeg_muxer *stream = data;
 
 	if (os_atomic_load_bool(&stream->active)) {
 		obs_encoder_t *vencoder = obs_output_get_video_encoder(stream->output);
 		if (obs_encoder_paused(vencoder)) {
-			info("Could not save buffer because encoders paused");
+			info("Could not save buffer because the encoder is paused");
 			return;
 		}
 
 		stream->save_ts = os_gettime_ns() / 1000LL;
 	}
-}
-
-static void save_replay_proc(void *data, calldata_t *cd)
-{
-	replay_buffer_hotkey(data, 0, NULL, true);
 	UNUSED_PARAMETER(cd);
 }
 
@@ -954,9 +944,6 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 	struct ffmpeg_muxer *stream = bzalloc(sizeof(*stream));
 	stream->output = output;
 
-	stream->hotkey = obs_hotkey_register_output(output, "ReplayBuffer.Save", obs_module_text("ReplayBuffer.Save"),
-						    replay_buffer_hotkey, stream);
-
 	proc_handler_t *ph = obs_output_get_proc_handler(output);
 	proc_handler_add(ph, "void save()", save_replay_proc, stream);
 	proc_handler_add(ph, "void get_last_replay(out string path)", get_last_replay, stream);
@@ -970,9 +957,6 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 
 static void replay_buffer_destroy(void *data)
 {
-	struct ffmpeg_muxer *stream = data;
-	if (stream->hotkey)
-		obs_hotkey_unregister(stream->hotkey);
 	ffmpeg_mux_destroy(data);
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -963,6 +963,7 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 
 	signal_handler_t *sh = obs_output_get_signal_handler(output);
 	signal_handler_add(sh, "void saved()");
+	signal_handler_add(sh, "void saving(ptr output)");
 
 	return stream;
 }
@@ -1153,6 +1154,12 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 	int64_t video_pts_offset = 0;
 	int64_t audio_offsets[MAX_AUDIO_MIXES] = {0};
 	int64_t audio_dts_offsets[MAX_AUDIO_MIXES] = {0};
+
+	calldata_t cd = {0};
+	calldata_set_ptr(&cd, "output", stream->output);
+	signal_handler_t *sh = obs_output_get_signal_handler(stream->output);
+	signal_handler_signal(sh, "saving", &cd);
+	calldata_free(&cd);
 
 	for (size_t i = 0; i < num_packets; i++) {
 		struct encoder_packet *pkt;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -914,31 +914,21 @@ static const char *replay_buffer_getname(void *type)
 	return obs_module_text("ReplayBuffer");
 }
 
-static void replay_buffer_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
+static void save_replay_proc(void *data, calldata_t *cd)
 {
-	UNUSED_PARAMETER(id);
-	UNUSED_PARAMETER(hotkey);
 
-	if (!pressed)
-		return;
-
+	UNUSED_PARAMETER(cd);
 	struct ffmpeg_muxer *stream = data;
 
 	if (os_atomic_load_bool(&stream->active)) {
 		obs_encoder_t *vencoder = obs_output_get_video_encoder(stream->output);
 		if (obs_encoder_paused(vencoder)) {
-			info("Could not save buffer because encoders paused");
+			info("Could not save buffer because the encoder is paused");
 			return;
 		}
 
 		stream->save_ts = os_gettime_ns() / 1000LL;
 	}
-}
-
-static void save_replay_proc(void *data, calldata_t *cd)
-{
-	replay_buffer_hotkey(data, 0, NULL, true);
-	UNUSED_PARAMETER(cd);
 }
 
 static void get_last_replay(void *data, calldata_t *cd)
@@ -954,9 +944,6 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 	struct ffmpeg_muxer *stream = bzalloc(sizeof(*stream));
 	stream->output = output;
 
-	stream->hotkey = obs_hotkey_register_output(output, "ReplayBuffer.Save", obs_module_text("ReplayBuffer.Save"),
-						    replay_buffer_hotkey, stream);
-
 	proc_handler_t *ph = obs_output_get_proc_handler(output);
 	proc_handler_add(ph, "void save()", save_replay_proc, stream);
 	proc_handler_add(ph, "void get_last_replay(out string path)", get_last_replay, stream);
@@ -970,9 +957,6 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 
 static void replay_buffer_destroy(void *data)
 {
-	struct ffmpeg_muxer *stream = data;
-	if (stream->hotkey)
-		obs_hotkey_unregister(stream->hotkey);
 	ffmpeg_mux_destroy(data);
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -963,6 +963,7 @@ static void *replay_buffer_create(obs_data_t *settings, obs_output_t *output)
 
 	signal_handler_t *sh = obs_output_get_signal_handler(output);
 	signal_handler_add(sh, "void saved()");
+	signal_handler_add(sh, "void saving(ptr output)");
 
 	return stream;
 }
@@ -1175,6 +1176,12 @@ static void replay_buffer_save(struct ffmpeg_muxer *stream)
 		insert_packet(&stream->mux_packets, pkt, video_offset, audio_offsets, video_pts_offset,
 			      audio_dts_offsets);
 	}
+
+	calldata_t cd = {0};
+	calldata_set_ptr(&cd, "output", stream->output);
+	signal_handler_t *sh = obs_output_get_signal_handler(stream->output);
+	signal_handler_signal(sh, "saving", &cd);
+	calldata_free(&cd);
 
 	generate_filename(stream, &stream->path, true);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds a frontend event and a signal on the replay buffer's signal 
handler that trigger when the replay buffer is saving (i.e. when a save 
has been requested, but before it saves).
The frontend event triggers the moment the frontend requests a save 
(either through hotkey or the button), whereas the signal triggers when 
the replay buffer actually starts saving (separated by the encoding delay).

N.B.: Allowing the save hotkey to trigger a frontend event required 
moving its registration from obs-ffmpeg (in the definition of the replay 
buffer output) to the UI (with all the frontend hotkeys for outputs).
This actually constitutes the biggest change in this PR.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Motivation is mainly to bring replay buffer save to feature parity with 
other output events, which almost all have both "before" and "after" events.
A specific usecase envisionned was to allow the dynamic changing of 
replay buffer saving path/filename rather than having one set-in-stone
save formatting for the whole session, but many other usecases could be 
possible.

Moving over the hotkey registration also has the added benefit of moving 
its location next to the other replay buffer hotkeys in the settings UI, 
which creates a more consistent UX.




### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has been tested on Ubuntu 22.04.
Changes to hotkey registration seem to not have affected its behaviour.
Event and signal trigger correctly from hotkey and button.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
