### PR TITLE
UI: Don't use ellipses in permissions window title

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -481,7 +481,8 @@ MissingFiles.NoMissing.Title="Missing Files Check"
 MissingFiles.NoMissing.Text="No files appear to be missing."
 
 # macOS permissions dialog
-MacPermissions.Title="Review App Permissions..."
+MacPermissions.MenuAction="Review App Permissions..."
+MacPermissions.Title="Review App Permissions"
 MacPermissions.Description="OBS Studio requires your permission to be able to provide certain features. It is recommended to enable these permissions, but they are not required to use the app. You can always enable them later."
 MacPermissions.Description.OpenDialog="You can re-open this dialog via the OBS Studio menu."
 MacPermissions.AccessGranted="Access Granted"

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1989,7 +1989,7 @@
   </action>
   <action name="actionShowMacPermissions">
    <property name="text">
-    <string>MacPermissions.Title</string>
+    <string>MacPermissions.MenuAction</string>
    </property>
   </action>
   <action name="actionRepair">


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
beab803599e5b9e90e306b2da1f0484064ad9748 changed the string to add ellipses as recommend for menu items that require further action, however the same string was used as the window title (in fact, the key is `MacPermissions.Title`) so the ellipses would also appear in the window title:
<img width="726" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/cae8e16b-1054-472b-a509-6423851c8918">
That is not desired.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want ellipses in window title.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.4
Ellipses is still in menu item but no longer in dialog title.
<img width="730" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/8627d019-c563-475d-804f-3ed35de181a7">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
