### PR TITLE
mac-virtualcam: Adjust admin privilege strings to use Apple terminology

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
+++ b/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
@@ -4,5 +4,5 @@ Error.SystemExtension.CameraUnavailable="Could not find virtual camera.\n\nPleas
 Error.SystemExtension.CameraNotStarted="Unable to start virtual camera.\n\nPlease try again."
 Error.SystemExtension.InstallationError="An error has occured while installing the virtual camera:"
 Error.SystemExtension.WrongLocation="OBS cannot install the virtual camera if it's not in \"/Applications\". Please move OBS to the \"/Applications\" directory."
-Error.DAL.NotInstalled="The virtual camera could not be installed or updated.\n\nPlease try again and enter your administrator password when prompted."
-Error.DAL.NotUninstalled="Could not remove the legacy virtual camera.\n\nPlease try again and enter your administrator password when prompted."
+Error.DAL.NotInstalled="The virtual camera could not be installed or updated.\n\nPlease try again and enter the name and password of an administrator when prompted."
+Error.DAL.NotUninstalled="Could not remove the legacy virtual camera.\n\nPlease try again and enter the name and password of an administrator when prompted."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adjusts the virtualcam strings regarding how the user should act when prompted to install or uninstall the DAL plugin.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It was brought up that there is no "administrator password" on macOS, just accounts with administrator rights.
After a bit of back and fourth it was decided to use the Apple terminology that's also used in the popup that follows, which is "the name and password of an administrator".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Strings change so N/A, but discussed with @PatTheMav.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
