### PR TITLE
obs-scripting: Fix python save callback Py_BuildValue

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-frontend.c
+++ b/deps/obs-scripting/obs-scripting-python-frontend.c
@@ -290,7 +290,8 @@ static void frontend_save_callback(obs_data_t *save_data, bool saving,
 	PyObject *py_save_data;
 
 	if (libobs_to_py(obs_data_t, save_data, false, &py_save_data)) {
-		PyObject *args = Py_BuildValue("(Op)", py_save_data, saving);
+		PyObject *args = Py_BuildValue("(ON)", py_save_data,
+					       PyBool_FromLong(saving));
 
 		struct python_obs_callback *last_cb = cur_python_cb;
 		cur_python_cb = cb;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Any frontend_save_callback added through a python script, when triggered,
doesn't recieve any calldata, and the triggering often causes errors in the log.
This is caused byPy_BuildValue being directly passed a C bool, which the function
doesn't accept, causing the building of the arguments passed to the callback to fail.
This fixes the callback by passing instead a Py_Bool object built from the C bool.

To reproduce the issue :
- add the script linked below to obs
- trigger a frontend save event (typically, changing settings and applying them)
- check the log for the arguments the callback recieved and errors

[Log showcasing the issue.](https://obsproject.com/logs/ESIvJQ8N2n4KR5e9)
tester script : [save_cb_tester.zip](https://github.com/obsproject/obs-studio/files/11585412/save_cb_tester.zip)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Those function are included in the scripting API, they should be working as intended.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested on ubuntu 22.04, obs 29.1.1, python 3.10.
Tested with the script linked above, checking that it returns the correct calldata
and no error

<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
