### PR TITLE
UI: Also toggle mixer toolbar in view menu

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -790,7 +790,7 @@ Basic.MainMenu.Edit.AdvAudio="&Advanced Audio Properties"
 # basic mode view menu
 Basic.MainMenu.View="&View"
 Basic.MainMenu.View.Toolbars="&Toolbars"
-Basic.MainMenu.View.ListboxToolbars="Scene/Source List Buttons"
+Basic.MainMenu.View.ListboxToolbars="Dock Toolbars"
 Basic.MainMenu.View.ContextBar="Source Toolbar"
 Basic.MainMenu.View.SourceIcons="Source &Icons"
 Basic.MainMenu.View.StatusBar="&Status Bar"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9387,6 +9387,7 @@ void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)
 {
 	ui->sourcesToolbar->setVisible(visible);
 	ui->scenesToolbar->setVisible(visible);
+	ui->mixerToolbar->setVisible(visible);
 
 	config_set_bool(App()->GlobalConfig(), "BasicWindow",
 			"ShowListboxToolbars", visible);


### PR DESCRIPTION
### Description
This change makes the mixer toolbar also show/hide when toggling the source toolbars in the view menu.

### Motivation and Context
Make it consistent with the scene/source toolbars, so the user can maximize space if they so choose.

### How Has This Been Tested?
Toggled toolbars

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
