### PR TITLE
obs-ffmpeg: Fix AMF encoder reconfiguration

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1254,13 +1254,17 @@ try {
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_avc_rate_control(rc_str);
-	AMF_RESULT res;
+	AMF_RESULT res = AMF_OK;
 
 	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
 
+	res = enc->amf_encoder->Flush();
+	if (res != AMF_OK)
+		throw amf_error("AMFComponent::Flush failed", res);
+
 	res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
 	if (res != AMF_OK)
-		throw amf_error("AMFComponent::Init failed", res);
+		throw amf_error("AMFComponent::ReInit failed", res);
 
 	return true;
 
@@ -1488,8 +1492,7 @@ static void register_avc()
 	amf_encoder_info.get_name = amf_avc_get_name;
 	amf_encoder_info.create = amf_avc_create_texencode;
 	amf_encoder_info.destroy = amf_destroy;
-	/* FIXME: Figure out why encoder does not survive reconfiguration
-	amf_encoder_info.update = amf_avc_update; */
+	amf_encoder_info.update = amf_avc_update;
 	amf_encoder_info.encode_texture = amf_encode_tex;
 	amf_encoder_info.get_defaults = amf_defaults;
 	amf_encoder_info.get_properties = amf_avc_properties;
@@ -1581,13 +1584,17 @@ try {
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_hevc_rate_control(rc_str);
-	AMF_RESULT res;
+	AMF_RESULT res = AMF_OK;
 
 	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
 
+	res = enc->amf_encoder->Flush();
+	if (res != AMF_OK)
+		throw amf_error("AMFComponent::Flush failed", res);
+
 	res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
 	if (res != AMF_OK)
-		throw amf_error("AMFComponent::Init failed", res);
+		throw amf_error("AMFComponent::ReInit failed", res);
 
 	return true;
 
@@ -1835,8 +1842,7 @@ static void register_hevc()
 	amf_encoder_info.get_name = amf_hevc_get_name;
 	amf_encoder_info.create = amf_hevc_create_texencode;
 	amf_encoder_info.destroy = amf_destroy;
-	/* FIXME: Figure out why encoder does not survive reconfiguration
-	amf_encoder_info.update = amf_hevc_update; */
+	amf_encoder_info.update = amf_hevc_update;
 	amf_encoder_info.encode_texture = amf_encode_tex;
 	amf_encoder_info.get_defaults = amf_defaults;
 	amf_encoder_info.get_properties = amf_hevc_properties;
@@ -1947,12 +1953,17 @@ try {
 	int64_t cq_level = obs_data_get_int(settings, "cqp");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_av1_rate_control(rc_str);
+	AMF_RESULT res = AMF_OK;
 
 	amf_av1_update_data(enc, rc, bitrate * 1000, cq_level);
 
-	AMF_RESULT res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
+	res = enc->amf_encoder->Flush();
 	if (res != AMF_OK)
-		throw amf_error("AMFComponent::Init failed", res);
+		throw amf_error("AMFComponent::Flush failed", res);
+
+	res = enc->amf_encoder->ReInit(enc->cx, enc->cy);
+	if (res != AMF_OK)
+		throw amf_error("AMFComponent::ReInit failed", res);
 
 	return true;
 
@@ -2153,8 +2164,7 @@ static void register_av1()
 	amf_encoder_info.get_name = amf_av1_get_name;
 	amf_encoder_info.create = amf_av1_create_texencode;
 	amf_encoder_info.destroy = amf_destroy;
-	/* FIXME: Figure out why encoder does not survive reconfiguration
-	amf_encoder_info.update = amf_av1_update; */
+	amf_encoder_info.update = amf_av1_update;
 	amf_encoder_info.encode_texture = amf_encode_tex;
 	amf_encoder_info.get_defaults = amf_av1_defaults;
 	amf_encoder_info.get_properties = amf_av1_properties;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For AMF, before a component can be reinitialized with the `ReInit` method, either `Flush` or `Drain` needs to be called on the same object to remove any frames which are still in the component for processing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Calls to either `Flush` or `Drain` must be done before any calls to `ReInit` for AMF. This was missing in the current code and would cause encoding to break if the bitrate was changed for example while recording or streaming. This resolves issue #8548.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 with an AMD Radeon RX 7900 XTX.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix for issue #8548 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
