### PR TITLE
libobs: Remove duplicate debug symbol paths in Windows

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -1197,18 +1197,21 @@ void reset_win32_symbol_paths(void)
 
 		*path_end = 0;
 
-		for (size_t i = 0; i < paths.num; i++) {
-			const char *existing_path = paths.array[i];
-			if (astrcmpi(path.array, existing_path) == 0) {
-				found = true;
-				break;
+		abspath = os_get_abs_path_ptr(path.array);
+		if (abspath) {
+			for (size_t i = 0; i < paths.num; i++) {
+				const char *existing_path = paths.array[i];
+				if (astrcmpi(abspath, existing_path) == 0) {
+					found = true;
+					break;
+				}
 			}
-		}
 
-		if (!found) {
-			abspath = os_get_abs_path_ptr(path.array);
-			if (abspath)
+			if (!found) {
 				da_push_back(paths, &abspath);
+			} else {
+				bfree(abspath);
+			}
 		}
 
 		dstr_free(&path);


### PR DESCRIPTION
### Description
The debug symbol path is duplicated in windows. The following is the debug symbol paths set by the program.
```
{array=0x000001db458ddc60 "E:\obs\obs-studio\cmake-build-debug\rundir\Debug\bin\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit", len=929 [0x00000000000003a1], capacity=944 [0x00000000000003b0]}
```

### Test
 The following is the debug symbol paths set by the program after fixed.
```
{array=0x000001f872e78d60 "E:\obs\obs-studio\cmake-build-debug\rundir\Debug\bin\64bit;E:\obs\obs-studio\cmake-build-debug\rundir\Debug\obs-plugins\64bit", len=125 [0x000000000000007d], capacity=236 [0x00000000000000ec]}
```

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
