### PR TITLE
Allow encoders to output at partial frame rates compared to main compositing frame rate

### DIFF
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -46,6 +46,16 @@ struct video_input {
 	struct video_frame frame[MAX_CONVERT_BUFFERS];
 	int cur_frame;
 
+	// allow outputting at fractions of main composition FPS,
+	// e.g. 60 FPS with frame_rate_divisor = 1 turns into 30 FPS
+	//
+	// a separate counter is used in favor of using remainder calculations
+	// to allow "inputs" started at the same time to start on the same frame
+	// whereas with remainder calculation the frame alignment would depend on
+	// the total frame count at the time the encoder was started
+	uint32_t frame_rate_divisor;
+	uint32_t frame_rate_divisor_counter;
+
 	void (*callback)(void *param, struct video_data *frame);
 	void *param;
 };
@@ -76,6 +86,8 @@ struct video_output {
 	size_t first_added;
 	size_t last_added;
 	struct cached_frame_info cache[MAX_CACHE_SIZE];
+
+	struct video_output *parent;
 
 	volatile bool raw_active;
 	volatile long gpu_refs;
@@ -135,6 +147,17 @@ static inline bool video_output_cur_frame(struct video_output *video)
 	for (size_t i = 0; i < video->inputs.num; i++) {
 		struct video_input *input = video->inputs.array + i;
 		struct video_data frame = frame_info->frame;
+
+		// an explicit counter is used instead of remainder calculation
+		// to allow multiple encoders started at the same time to start on
+		// the same frame
+		uint32_t skip = input->frame_rate_divisor_counter++;
+		if (input->frame_rate_divisor_counter ==
+		    input->frame_rate_divisor)
+			input->frame_rate_divisor_counter = 0;
+
+		if (skip)
+			continue;
 
 		if (scale_video_output(input, &frame))
 			input->callback(input->param, &frame);
@@ -371,13 +394,37 @@ static inline void reset_frames(video_t *video)
 	os_atomic_set_long(&video->total_frames, 0);
 }
 
+static const video_t *get_const_root(const video_t *video)
+{
+	while (video->parent)
+		video = video->parent;
+	return video;
+}
+
+static video_t *get_root(video_t *video)
+{
+	while (video->parent)
+		video = video->parent;
+	return video;
+}
+
 bool video_output_connect(
 	video_t *video, const struct video_scale_info *conversion,
 	void (*callback)(void *param, struct video_data *frame), void *param)
 {
+	return video_output_connect2(video, conversion, 1, callback, param);
+}
+
+bool video_output_connect2(
+	video_t *video, const struct video_scale_info *conversion,
+	uint32_t frame_rate_divisor,
+	void (*callback)(void *param, struct video_data *frame), void *param)
+{
 	bool success = false;
 
-	if (!video || !callback)
+	video = get_root(video);
+
+	if (!video || !callback || frame_rate_divisor == 0)
 		return false;
 
 	pthread_mutex_lock(&video->input_mutex);
@@ -388,6 +435,8 @@ bool video_output_connect(
 
 		input.callback = callback;
 		input.param = param;
+
+		input.frame_rate_divisor = frame_rate_divisor;
 
 		if (conversion) {
 			input.conversion = *conversion;
@@ -446,6 +495,8 @@ void video_output_disconnect(video_t *video,
 	if (!video || !callback)
 		return;
 
+	video = get_root(video);
+
 	pthread_mutex_lock(&video->input_mutex);
 
 	size_t idx = video_get_input_idx(video, callback, param);
@@ -468,7 +519,7 @@ bool video_output_active(const video_t *video)
 {
 	if (!video)
 		return false;
-	return os_atomic_load_bool(&video->raw_active);
+	return os_atomic_load_bool(&get_const_root(video)->raw_active);
 }
 
 const struct video_output_info *video_output_get_info(const video_t *video)
@@ -484,6 +535,8 @@ bool video_output_lock_frame(video_t *video, struct video_frame *frame,
 
 	if (!video)
 		return false;
+
+	video = get_root(video);
 
 	pthread_mutex_lock(&video->data_mutex);
 
@@ -518,6 +571,8 @@ void video_output_unlock_frame(video_t *video)
 	if (!video)
 		return;
 
+	video = get_root(video);
+
 	pthread_mutex_lock(&video->data_mutex);
 
 	video->available_frames--;
@@ -538,6 +593,8 @@ void video_output_stop(video_t *video)
 	if (!video)
 		return;
 
+	video = get_root(video);
+
 	if (!video->stop) {
 		video->stop = true;
 		os_sem_post(video->update_semaphore);
@@ -550,22 +607,22 @@ bool video_output_stopped(video_t *video)
 	if (!video)
 		return true;
 
-	return video->stop;
+	return get_root(video)->stop;
 }
 
 enum video_format video_output_get_format(const video_t *video)
 {
-	return video ? video->info.format : VIDEO_FORMAT_NONE;
+	return video ? get_const_root(video)->info.format : VIDEO_FORMAT_NONE;
 }
 
 uint32_t video_output_get_width(const video_t *video)
 {
-	return video ? video->info.width : 0;
+	return video ? get_const_root(video)->info.width : 0;
 }
 
 uint32_t video_output_get_height(const video_t *video)
 {
-	return video ? video->info.height : 0;
+	return video ? get_const_root(video)->info.height : 0;
 }
 
 double video_output_get_frame_rate(const video_t *video)
@@ -573,17 +630,21 @@ double video_output_get_frame_rate(const video_t *video)
 	if (!video)
 		return 0.0;
 
+	video = get_const_root(video);
+
 	return (double)video->info.fps_num / (double)video->info.fps_den;
 }
 
 uint32_t video_output_get_skipped_frames(const video_t *video)
 {
-	return (uint32_t)os_atomic_load_long(&video->skipped_frames);
+	return (uint32_t)os_atomic_load_long(
+		&get_const_root(video)->skipped_frames);
 }
 
 uint32_t video_output_get_total_frames(const video_t *video)
 {
-	return (uint32_t)os_atomic_load_long(&video->total_frames);
+	return (uint32_t)os_atomic_load_long(
+		&get_const_root(video)->total_frames);
 }
 
 /* Note: These four functions below are a very slight bit of a hack.  If the
@@ -594,6 +655,8 @@ uint32_t video_output_get_total_frames(const video_t *video)
 
 void video_output_inc_texture_encoders(video_t *video)
 {
+	video = get_root(video);
+
 	if (os_atomic_inc_long(&video->gpu_refs) == 1 &&
 	    !os_atomic_load_bool(&video->raw_active)) {
 		reset_frames(video);
@@ -602,6 +665,8 @@ void video_output_inc_texture_encoders(video_t *video)
 
 void video_output_dec_texture_encoders(video_t *video)
 {
+	video = get_root(video);
+
 	if (os_atomic_dec_long(&video->gpu_refs) == 0 &&
 	    !os_atomic_load_bool(&video->raw_active)) {
 		log_skipped(video);
@@ -610,10 +675,32 @@ void video_output_dec_texture_encoders(video_t *video)
 
 void video_output_inc_texture_frames(video_t *video)
 {
-	os_atomic_inc_long(&video->total_frames);
+	os_atomic_inc_long(&get_root(video)->total_frames);
 }
 
 void video_output_inc_texture_skipped_frames(video_t *video)
 {
-	os_atomic_inc_long(&video->skipped_frames);
+	os_atomic_inc_long(&get_root(video)->skipped_frames);
+}
+
+video_t *video_output_create_with_frame_rate_divisor(video_t *video,
+						     uint32_t divisor)
+{
+	// `divisor == 1` would result in the same frame rate,
+	// resulting in an unnecessary additional video output
+	if (!video || divisor == 0 || divisor == 1)
+		return NULL;
+
+	video_t *new_video = bzalloc(sizeof(video_t));
+	memcpy(new_video, video, sizeof(*new_video));
+	new_video->parent = video;
+	new_video->info.fps_den *= divisor;
+
+	return new_video;
+}
+
+void video_output_free_frame_rate_divisor(video_t *video)
+{
+	if (video && video->parent)
+		bfree(video);
 }

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -302,6 +302,11 @@ EXPORT bool
 video_output_connect(video_t *video, const struct video_scale_info *conversion,
 		     void (*callback)(void *param, struct video_data *frame),
 		     void *param);
+EXPORT bool
+video_output_connect2(video_t *video, const struct video_scale_info *conversion,
+		      uint32_t frame_rate_divisor,
+		      void (*callback)(void *param, struct video_data *frame),
+		      void *param);
 EXPORT void video_output_disconnect(video_t *video,
 				    void (*callback)(void *param,
 						     struct video_data *frame),
@@ -330,6 +335,10 @@ extern void video_output_inc_texture_encoders(video_t *video);
 extern void video_output_dec_texture_encoders(video_t *video);
 extern void video_output_inc_texture_frames(video_t *video);
 extern void video_output_inc_texture_skipped_frames(video_t *video);
+
+extern video_t *video_output_create_with_frame_rate_divisor(video_t *video,
+							    uint32_t divisor);
+extern void video_output_free_frame_rate_divisor(video_t *video);
 
 #ifdef __cplusplus
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -526,6 +526,7 @@ extern struct obs_core_video_mix *get_mix_for_video(video_t *video);
 
 extern void
 start_raw_video(video_t *video, const struct video_scale_info *conversion,
+		uint32_t frame_rate_divisor,
 		void (*callback)(void *param, struct video_data *frame),
 		void *param);
 extern void stop_raw_video(video_t *video,
@@ -1227,6 +1228,17 @@ struct obs_encoder {
 
 	uint32_t timebase_num;
 	uint32_t timebase_den;
+
+	// allow outputting at fractions of main composition FPS,
+	// e.g. 60 FPS with frame_rate_divisor = 1 turns into 30 FPS
+	//
+	// a separate counter is used in favor of using remainder calculations
+	// to allow "inputs" started at the same time to start on the same frame
+	// whereas with remainder calculation the frame alignment would depend on
+	// the total frame count at the time the encoder was started
+	uint32_t frame_rate_divisor;
+	uint32_t frame_rate_divisor_counter; // only used for GPU encoders
+	video_t *fps_override;
 
 	int64_t cur_pts;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2264,7 +2264,7 @@ static void hook_data_capture(struct obs_output *output)
 		if (has_video)
 			start_raw_video(output->video,
 					obs_output_get_video_conversion(output),
-					default_raw_video_callback, output);
+					1, default_raw_video_callback, output);
 		if (has_audio)
 			start_raw_audio(output);
 	}

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -70,11 +70,13 @@ static void *gpu_encode_thread(struct obs_core_video_mix *video)
 			struct encoder_packet pkt = {0};
 			bool received = false;
 			bool success;
+			uint32_t skip = 0;
 
 			obs_encoder_t *encoder = encoders.array[i];
 			struct obs_encoder *pair = encoder->paired_encoder;
 
-			pkt.timebase_num = encoder->timebase_num;
+			pkt.timebase_num = encoder->timebase_num *
+					   encoder->frame_rate_divisor;
 			pkt.timebase_den = encoder->timebase_den;
 			pkt.encoder = encoder;
 
@@ -94,6 +96,16 @@ static void *gpu_encode_thread(struct obs_core_video_mix *video)
 						     encoder->context.settings);
 			}
 
+			// an explicit counter is used instead of remainder calculation
+			// to allow multiple encoders started at the same time to start on
+			// the same frame
+			skip = encoder->frame_rate_divisor_counter++;
+			if (encoder->frame_rate_divisor_counter ==
+			    encoder->frame_rate_divisor)
+				encoder->frame_rate_divisor_counter = 0;
+			if (skip)
+				continue;
+
 			if (!encoder->start_ts)
 				encoder->start_ts = timestamp;
 
@@ -111,7 +123,8 @@ static void *gpu_encode_thread(struct obs_core_video_mix *video)
 
 			lock_key = next_key;
 
-			encoder->cur_pts += encoder->timebase_num;
+			encoder->cur_pts += encoder->timebase_num *
+					    encoder->frame_rate_divisor;
 		}
 
 		/* -------------- */

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3132,13 +3132,15 @@ struct obs_core_video_mix *get_mix_for_video(video_t *v)
 }
 
 void start_raw_video(video_t *v, const struct video_scale_info *conversion,
+		     uint32_t frame_rate_divisor,
 		     void (*callback)(void *param, struct video_data *frame),
 		     void *param)
 {
 	struct obs_core_video_mix *video = get_mix_for_video(v);
 	if (video)
 		os_atomic_inc_long(&video->raw_active);
-	video_output_connect(v, conversion, callback, param);
+	video_output_connect2(v, conversion, frame_rate_divisor, callback,
+			      param);
 }
 
 void stop_raw_video(video_t *v,
@@ -3156,8 +3158,16 @@ void obs_add_raw_video_callback(const struct video_scale_info *conversion,
 						 struct video_data *frame),
 				void *param)
 {
+	obs_add_raw_video_callback2(conversion, 1, callback, param);
+}
+
+void obs_add_raw_video_callback2(
+	const struct video_scale_info *conversion, uint32_t frame_rate_divisor,
+	void (*callback)(void *param, struct video_data *frame), void *param)
+{
 	struct obs_core_video_mix *video = obs->video.main_mix;
-	start_raw_video(video->video, conversion, callback, param);
+	start_raw_video(video->video, conversion, frame_rate_divisor, callback,
+			param);
 }
 
 void obs_remove_raw_video_callback(void (*callback)(void *param,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -849,6 +849,9 @@ EXPORT void obs_remove_main_rendered_callback(void (*rendered)(void *param),
 EXPORT void obs_add_raw_video_callback(
 	const struct video_scale_info *conversion,
 	void (*callback)(void *param, struct video_data *frame), void *param);
+EXPORT void obs_add_raw_video_callback2(
+	const struct video_scale_info *conversion, uint32_t frame_rate_divisor,
+	void (*callback)(void *param, struct video_data *frame), void *param);
 EXPORT void obs_remove_raw_video_callback(
 	void (*callback)(void *param, struct video_data *frame), void *param);
 
@@ -2420,6 +2423,16 @@ EXPORT void obs_encoder_set_scaled_size(obs_encoder_t *encoder, uint32_t width,
 EXPORT void obs_encoder_set_gpu_scale_type(obs_encoder_t *encoder,
 					   enum obs_scale_type gpu_scale_type);
 
+/**
+ * Set frame rate divisor for a video encoder. This allows recording at
+ * a partial frame rate compared to the base frame rate, e.g. 60 FPS with
+ * divisor = 2 will record at 30 FPS, with divisor = 3 at 20, etc.
+ *
+ * Can only be called on stopped encoders, changing this on the fly is not supported
+ */
+EXPORT bool obs_encoder_set_frame_rate_divisor(obs_encoder_t *encoder,
+					       uint32_t divisor);
+
 /** For video encoders, returns true if pre-encode scaling is enabled */
 EXPORT bool obs_encoder_scaling_enabled(const obs_encoder_t *encoder);
 
@@ -2434,6 +2447,9 @@ EXPORT bool obs_encoder_gpu_scaling_enabled(obs_encoder_t *encoder);
 
 /** For video encoders, returns GPU scaling type */
 EXPORT enum obs_scale_type obs_encoder_get_scale_type(obs_encoder_t *encoder);
+
+/** For video encoders, returns the frame rate divisor (default is 1) */
+EXPORT uint32_t obs_encoder_get_frame_rate_divisor(const obs_encoder_t *encoder);
 
 /** For audio encoders, returns the sample rate of the audio */
 EXPORT uint32_t obs_encoder_get_sample_rate(const obs_encoder_t *encoder);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This allows setting `skip_frames` for encoders, which results in encoded frame rate being some fraction of the composition frame rate; e.g. using a base/composition frame rate of 60 FPS and setting `skip_frames = 1` on an encoder results in 30 FPS encoded stream being generated, `skip_frames = 2` would result in 20 FPS, `skip_frames = 3` gives 15 FPS etc.

### Motivation and Context
Outputting at different frame rates is potentially beneficial to various use cases, such as e.g. high FPS (60 or even 120 FPS) recording while only streaming at lower FPS to fit within bandwidth constraints (while at the same time reducing encoding load from two separate encoders). Another use case discussed on discord was allowing a lower FPS display for remote control.

Compared to enabling arbitrary frame rates, this change is somewhat smaller in scope, while still allowing experimentation with different frame rates, without having to recalculate timing for the composition thread "on the fly" and similar.

### How Has This Been Tested?
This was tested by augmenting output handlers with `obs_encoder_set_skip_frames` calls, using x264 and NVENC. 

### Types of changes
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
