### PR TITLE
UI: Sort encoders alphabetically

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1546,9 +1546,7 @@ void OBSBasicSettings::ResetEncoders(bool streamOnly)
 
 	if (!streamOnly) {
 		ui->advOutRecEncoder->clear();
-		ui->advOutRecEncoder->addItem(TEXT_USE_STREAM_ENC, "none");
 		ui->advOutRecAEncoder->clear();
-		ui->advOutRecAEncoder->addItem(TEXT_USE_STREAM_ENC, "none");
 	}
 
 	/* ------------------------------------------------- */
@@ -1578,6 +1576,18 @@ void OBSBasicSettings::ResetEncoders(bool streamOnly)
 			if (!streamOnly)
 				ui->advOutRecAEncoder->addItem(qName, qType);
 		}
+	}
+
+	ui->advOutEncoder->model()->sort(0);
+	ui->advOutAEncoder->model()->sort(0);
+
+	if (!streamOnly) {
+		ui->advOutRecEncoder->model()->sort(0);
+		ui->advOutRecEncoder->insertItem(0, TEXT_USE_STREAM_ENC,
+						 "none");
+		ui->advOutRecAEncoder->model()->sort(0);
+		ui->advOutRecAEncoder->insertItem(0, TEXT_USE_STREAM_ENC,
+						  "none");
 	}
 
 	/* ------------------------------------------------- */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Currently, encoders are displayed in the UI in the order they are registered to libobs. In practice, this means in whatever order their modules are loaded and, if a module registeres multiple encoders, in which order it does that.
This leads to the order appearing to be basically random to the end user.

<p>
<img width="400" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/049c9511-13cd-4f16-ba27-3dfc1bd1ee31">
<img width="400" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/4744ac34-e4da-4bf1-a80a-d529dc85cb36">
</p>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
In the videotoolbox plugin, we had to implement custom sorting in the plugin before registering the encoders to libobs because they were discovered by macOS in an inconsistent order. This has always been a thorn in my eye, and I want to get rid of it. I don't think how things are displayed in the UI should depend on the order they were added to libobs in.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.4
Made sure both audio and video encoders are all still there, and that they are now sorted.
Made a few test recordings to check that the selected encoder still gets used.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
