### PR TITLE
Fix non-common services not being selectable

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -140,10 +140,11 @@ void OBSBasicSettings::LoadStream1Settings()
 			QTStr("Basic.Settings.Stream.Custom.Password.ToolTip"));
 	} else {
 		int idx = ui->service->findText(service);
-		/* 29.1 crash workaround: Fall back to "Custom" if service not found. */
-		if (idx == -1)
-			idx = 0;
-
+		if (idx == -1) {
+			if (service && *service)
+				ui->service->insertItem(1, service);
+			idx = 1;
+		}
 		ui->service->setCurrentIndex(idx);
 		lastServiceIdx = idx;
 

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -566,7 +566,10 @@ QString OBSBasicSettings::FindProtocol()
 
 		obs_properties_destroy(props);
 
-		return QT_UTF8(obs_data_get_string(settings, "protocol"));
+		const char *protocol =
+			obs_data_get_string(settings, "protocol");
+		if (protocol && *protocol)
+			return QT_UTF8(protocol);
 	}
 
 	return QString("RTMP");


### PR DESCRIPTION
### Description

#8951 was intended to avoid a crash by resetting the service combobox to default if a service is not on the list. What we missed is that if a service is not shown by default, i.e. not has the `common` flag set, it would not be found and the selection reset.

This fixes the actual reason for the crash by adding a NULL check to `find_output`, which results in the behvaiour being as before where a stub service entry is created in the UI until the user selects a different one.

Note that the second commit (c5714e495d8c1c3a215c55b4b880e1ad393b1733) should probably be picked to master as well.

### Motivation and Context

Users want to be able to stream to services that are not listed by default.

### How Has This Been Tested?

Tested with outdated service file originally used for testing #8951 and selected uncommon service to verify it works as intended.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
