### PR TITLE
UI: Fix filter shortcuts not showing in context menu

### DIFF
--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -597,6 +597,9 @@
    <property name="shortcut">
     <string>Del</string>
    </property>
+   <property name="iconVisibleInMenu">
+    <bool>false</bool>
+   </property>
   </action>
   <action name="actionMoveUp">
    <property name="icon">
@@ -620,6 +623,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Down</string>
+   </property>
+  </action>
+  <action name="actionRenameFilter">
+   <property name="text">
+    <string>Rename</string>
    </property>
   </action>
  </widget>

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -81,6 +81,7 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 		QApplication::translate("OBSBasicFilters", "Del", nullptr));
 #endif // QT_NO_SHORTCUT
 
+	addAction(ui->actionRenameFilter);
 	addAction(ui->actionRemoveFilter);
 	addAction(ui->actionMoveUp);
 	addAction(ui->actionMoveDown);
@@ -154,24 +155,10 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 		ui->preview->hide();
 	}
 
-	QAction *renameAsync = new QAction(ui->asyncWidget);
-	renameAsync->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-	connect(renameAsync, SIGNAL(triggered()), this,
-		SLOT(RenameAsyncFilter()));
-	ui->asyncWidget->addAction(renameAsync);
-
-	QAction *renameEffect = new QAction(ui->effectWidget);
-	renameEffect->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-	connect(renameEffect, SIGNAL(triggered()), this,
-		SLOT(RenameEffectFilter()));
-	ui->effectWidget->addAction(renameEffect);
-
 #ifdef __APPLE__
-	renameAsync->setShortcut({Qt::Key_Return});
-	renameEffect->setShortcut({Qt::Key_Return});
+	ui->actionRenameFilter->setShortcut({Qt::Key_Return});
 #else
-	renameAsync->setShortcut({Qt::Key_F2});
-	renameEffect->setShortcut({Qt::Key_F2});
+	ui->actionRenameFilter->setShortcut({Qt::Key_F2});
 #endif
 
 	UpdateFilters();
@@ -932,6 +919,14 @@ void OBSBasicFilters::on_actionMoveDown_triggered()
 		on_moveEffectFilterDown_clicked();
 }
 
+void OBSBasicFilters::on_actionRenameFilter_triggered()
+{
+	if (ui->asyncFilters->hasFocus())
+		RenameAsyncFilter();
+	else if (ui->effectFilters->hasFocus())
+		RenameEffectFilter();
+}
+
 void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 {
 	QListWidget *list = async ? ui->asyncFilters : ui->effectFilters;
@@ -948,17 +943,11 @@ void OBSBasicFilters::CustomContextMenu(const QPoint &pos, bool async)
 			async ? SLOT(DuplicateAsyncFilter())
 			      : SLOT(DuplicateEffectFilter());
 
-		const char *renameSlot = async ? SLOT(RenameAsyncFilter())
-					       : SLOT(RenameEffectFilter());
-		const char *removeSlot =
-			async ? SLOT(on_removeAsyncFilter_clicked())
-			      : SLOT(on_removeEffectFilter_clicked());
-
 		popup.addSeparator();
 		popup.addAction(QTStr("Duplicate"), this, dulpicateSlot);
 		popup.addSeparator();
-		popup.addAction(QTStr("Rename"), this, renameSlot);
-		popup.addAction(QTStr("Remove"), this, removeSlot);
+		popup.addAction(ui->actionRenameFilter);
+		popup.addAction(ui->actionRemoveFilter);
 		popup.addSeparator();
 
 		QAction *copyAction = new QAction(QTStr("Copy"));

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -113,6 +113,8 @@ private slots:
 	void on_actionMoveUp_triggered();
 	void on_actionMoveDown_triggered();
 
+	void on_actionRenameFilter_triggered();
+
 	void AsyncFilterNameEdited(QWidget *editor);
 	void EffectFilterNameEdited(QWidget *editor);
 


### PR DESCRIPTION
### Description
This fixes the shortcuts not showing up in the filters context menu for rename and remove. This also has a code cleanup for the rename action, as now it is created in the ui file.

Before:
![Screenshot from 2023-06-02 20-49-29](https://github.com/obsproject/obs-studio/assets/19962531/e20929c2-ac5d-4715-abdb-76ad458126d5)

After:
![Screenshot from 2023-06-02 20-48-48](https://github.com/obsproject/obs-studio/assets/19962531/278eaa16-6cd4-4d52-83c1-2b2a4d566a28)

### Motivation and Context
Helps users know what the shortcuts are.

### How Has This Been Tested?
Renamed/removed filters

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
