### PR TITLE
libobs,plugins: Remove new obs_output_*2 functions

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -882,32 +882,38 @@ Functions used by outputs
 
 ---------------------
 
-.. function:: bool obs_output_can_begin_data_capture2(const obs_output_t *output)
+.. function:: bool obs_output_can_begin_data_capture(const obs_output_t *output, int flags)
 
    Determines whether video/audio capture (encoded or raw) is able to
    start.  Call this before initializing any output state to ensure that
    the output can start.
 
+   :param output: The output
+   :param flags: Reserved. Set this to 0.
    :return:      *true* if data capture can begin
 
 ---------------------
 
-.. function:: bool obs_output_initialize_encoders2(obs_output_t *output)
+.. function:: bool obs_output_initialize_encoders(obs_output_t *output, int flags)
 
    Initializes any encoders/services associated with the output.  This
    must be called for encoded outputs before calling
-   :c:func:`obs_output_begin_data_capture2()`.
+   :c:func:`obs_output_begin_data_capture()`.
 
+   :param output: The output
+   :param flags: Reserved. Set this to 0.
    :return:      *true* if successful, *false* otherwise
 
 ---------------------
 
-.. function:: bool obs_output_begin_data_capture2(obs_output_t *output)
+.. function:: bool obs_output_begin_data_capture(obs_output_t *output, int flags)
 
    Begins data capture from raw media or encoders.  This is typically
    when the output actually activates (starts) internally.  Video/audio
    data will start being sent to the callbacks of the output.
 
+   :param output: The output
+   :param flags: Reserved. Set this to 0.
    :return:      *true* if successful, *false* otherwise.  Typically the
                  return value does not need to be checked if
                  :c:func:`obs_output_can_begin_data_capture2()` was

--- a/libobs/obs-output-delay.c
+++ b/libobs/obs-output-delay.c
@@ -157,10 +157,10 @@ bool obs_output_delay_start(obs_output_t *output)
 	};
 
 	if (!delay_active(output)) {
-		bool can_begin = obs_output_can_begin_data_capture2(output);
+		bool can_begin = obs_output_can_begin_data_capture(output, 0);
 		if (!can_begin)
 			return false;
-		if (!obs_output_initialize_encoders2(output))
+		if (!obs_output_initialize_encoders(output, 0))
 			return false;
 	}
 
@@ -175,7 +175,7 @@ bool obs_output_delay_start(obs_output_t *output)
 		return true;
 	}
 
-	if (!obs_output_begin_data_capture2(output)) {
+	if (!obs_output_begin_data_capture(output, 0)) {
 		obs_output_cleanup_delay(output);
 		return false;
 	}

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2107,8 +2107,11 @@ static inline void signal_stop(struct obs_output *output)
 	calldata_free(&params);
 }
 
-bool obs_output_can_begin_data_capture2(const obs_output_t *output)
+bool obs_output_can_begin_data_capture(const obs_output_t *output,
+				       uint32_t flags)
 {
+	UNUSED_PARAMETER(flags);
+
 	if (!obs_output_valid(output, "obs_output_can_begin_data_capture"))
 		return false;
 
@@ -2121,13 +2124,6 @@ bool obs_output_can_begin_data_capture2(const obs_output_t *output)
 		pthread_join(output->end_data_capture_thread, NULL);
 
 	return can_begin_data_capture(output);
-}
-
-bool obs_output_can_begin_data_capture(const obs_output_t *output,
-				       uint32_t flags)
-{
-	UNUSED_PARAMETER(flags);
-	return obs_output_can_begin_data_capture2(output);
 }
 
 static inline bool initialize_audio_encoders(obs_output_t *output)
@@ -2179,8 +2175,10 @@ static inline void pair_encoders(obs_output_t *output)
 	}
 }
 
-bool obs_output_initialize_encoders2(obs_output_t *output)
+bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)
 {
+	UNUSED_PARAMETER(flags);
+
 	if (!obs_output_valid(output, "obs_output_initialize_encoders"))
 		return false;
 	if (!log_flag_encoded(output, __FUNCTION__, false))
@@ -2199,12 +2197,6 @@ bool obs_output_initialize_encoders2(obs_output_t *output)
 		return false;
 
 	return true;
-}
-
-bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)
-{
-	UNUSED_PARAMETER(flags);
-	return obs_output_initialize_encoders2(output);
 }
 
 static bool begin_delayed_capture(obs_output_t *output)
@@ -2263,8 +2255,10 @@ static void reset_raw_output(obs_output_t *output)
 	pause_reset(&output->pause);
 }
 
-bool obs_output_begin_data_capture2(obs_output_t *output)
+bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
 {
+	UNUSED_PARAMETER(flags);
+
 	if (!obs_output_valid(output, "obs_output_begin_data_capture"))
 		return false;
 
@@ -2305,12 +2299,6 @@ bool obs_output_begin_data_capture2(obs_output_t *output)
 	}
 
 	return true;
-}
-
-bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags)
-{
-	UNUSED_PARAMETER(flags);
-	return obs_output_begin_data_capture2(output);
 }
 
 static inline void stop_audio_encoders(obs_output_t *output,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2249,15 +2249,13 @@ EXPORT void
 obs_output_set_audio_conversion(obs_output_t *output,
 				const struct audio_convert_info *conversion);
 
-/** Returns whether data capture can begin with the specified flags */
-EXPORT bool obs_output_can_begin_data_capture2(const obs_output_t *output);
-OBS_DEPRECATED EXPORT bool
-obs_output_can_begin_data_capture(const obs_output_t *output, uint32_t flags);
+/** Returns whether data capture can begin  */
+EXPORT bool obs_output_can_begin_data_capture(const obs_output_t *output,
+					      uint32_t flags);
 
 /** Initializes encoders (if any) */
-EXPORT bool obs_output_initialize_encoders2(obs_output_t *output);
-OBS_DEPRECATED EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
-							  uint32_t flags);
+EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
+					   uint32_t flags);
 
 /**
  * Begins data capture from media/encoders.
@@ -2265,9 +2263,7 @@ OBS_DEPRECATED EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
  * @param  output  Output context
  * @return         true if successful, false otherwise.
  */
-EXPORT bool obs_output_begin_data_capture2(obs_output_t *output);
-OBS_DEPRECATED EXPORT bool obs_output_begin_data_capture(obs_output_t *output,
-							 uint32_t flags);
+EXPORT bool obs_output_begin_data_capture(obs_output_t *output, uint32_t flags);
 
 /** Ends data capture from media/encoders */
 EXPORT void obs_output_end_data_capture(obs_output_t *output);

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -1229,7 +1229,7 @@ static bool aja_output_start(void *data)
 
 	obs_output_set_audio_conversion(ajaOutput->GetOBSOutput(), &conversion);
 
-	if (!obs_output_begin_data_capture2(ajaOutput->GetOBSOutput())) {
+	if (!obs_output_begin_data_capture(ajaOutput->GetOBSOutput(), 0)) {
 		blog(LOG_ERROR,
 		     "aja_output_start: Begin OBS data capture failed!");
 		return false;

--- a/plugins/decklink/decklink-output.cpp
+++ b/plugins/decklink/decklink-output.cpp
@@ -110,7 +110,7 @@ static bool decklink_output_start(void *data)
 
 	obs_output_set_audio_conversion(decklink->GetOutput(), &conversion);
 
-	if (!obs_output_begin_data_capture2(decklink->GetOutput()))
+	if (!obs_output_begin_data_capture(decklink->GetOutput(), 0))
 		return false;
 
 	return true;

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -173,7 +173,7 @@ static bool try_connect(void *data, const char *device)
 	}
 
 	blog(LOG_INFO, "Virtual camera started");
-	obs_output_begin_data_capture2(vcam->output);
+	obs_output_begin_data_capture(vcam->output, 0);
 
 	return true;
 

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -523,7 +523,7 @@ static bool virtualcam_output_start(void *data)
 		[vcam->machServer run];
 	}
 
-	if (!obs_output_begin_data_capture2(vcam->output)) {
+	if (!obs_output_begin_data_capture(vcam->output, 0)) {
 		return false;
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -118,9 +118,9 @@ bool ffmpeg_hls_mux_start(void *data)
 	obs_data_t *settings;
 	int keyint_sec;
 
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	service = obs_output_get_service(stream->output);
@@ -170,7 +170,7 @@ bool ffmpeg_hls_mux_start(void *data)
 	stream->dropped_frames = 0;
 	stream->min_priority = 0;
 
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	dstr_copy(&stream->printable_path, path_str);
 	info("Writing to path '%s'...", stream->printable_path.array);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1025,9 +1025,9 @@ static bool set_config(struct ffmpeg_output *stream)
 		}
 		av_dump_format(ff_data->output, 0, NULL, 1);
 	}
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	ret = pthread_create(&stream->write_thread, NULL, write_thread, stream);
@@ -1042,7 +1042,7 @@ static bool set_config(struct ffmpeg_output *stream)
 	os_atomic_set_bool(&stream->active, true);
 	stream->write_thread_active = true;
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	return true;
 fail:

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -411,9 +411,9 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 
 	update_encoder_settings(stream, path);
 
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	if (stream->is_network) {
@@ -468,7 +468,7 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	info("Writing file '%s'...", stream->path.array);
 	return true;
@@ -1039,9 +1039,9 @@ static bool replay_buffer_start(void *data)
 {
 	struct ffmpeg_muxer *stream = data;
 
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	obs_data_t *s = obs_output_get_settings(stream->output);
@@ -1052,7 +1052,7 @@ static bool replay_buffer_start(void *data)
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
 	stream->total_bytes = 0;
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	return true;
 }

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1209,7 +1209,7 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	output->active = true;
 
-	if (!obs_output_can_begin_data_capture2(output->output))
+	if (!obs_output_can_begin_data_capture(output->output, 0))
 		return false;
 
 	ret = pthread_create(&output->write_thread, NULL, write_thread, output);
@@ -1223,7 +1223,7 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	obs_output_set_video_conversion(output->output, NULL);
 	obs_output_set_audio_conversion(output->output, &aci);
-	obs_output_begin_data_capture2(output->output);
+	obs_output_begin_data_capture(output->output, 0);
 	output->write_thread_active = true;
 	return true;
 }

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -154,9 +154,9 @@ static bool flv_output_start(void *data)
 	obs_data_t *settings;
 	const char *path;
 
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	stream->got_first_video = false;
@@ -177,7 +177,7 @@ static bool flv_output_start(void *data)
 
 	/* write headers and start capture */
 	os_atomic_set_bool(&stream->active, true);
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	info("Writing FLV file '%s'...", stream->path.array);
 	return true;

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -593,7 +593,7 @@ static int init_send(struct ftl_stream *stream)
 
 	os_atomic_set_bool(&stream->active, true);
 
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	return OBS_OUTPUT_SUCCESS;
 }
@@ -649,10 +649,10 @@ static bool ftl_stream_start(void *data)
 	obs_data_set_int(video_settings, "bf", 0);
 	obs_data_release(video_settings);
 
-	if (!obs_output_can_begin_data_capture2(stream->output)) {
+	if (!obs_output_can_begin_data_capture(stream->output, 0)) {
 		return false;
 	}
-	if (!obs_output_initialize_encoders2(stream->output)) {
+	if (!obs_output_initialize_encoders(stream->output, 0)) {
 		return false;
 	}
 

--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -51,15 +51,15 @@ static bool null_output_start(void *data)
 {
 	struct null_output *context = data;
 
-	if (!obs_output_can_begin_data_capture2(context->output))
+	if (!obs_output_can_begin_data_capture(context->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(context->output))
+	if (!obs_output_initialize_encoders(context->output, 0))
 		return false;
 
 	if (context->stop_thread_active)
 		pthread_join(context->stop_thread, NULL);
 
-	obs_output_begin_data_capture2(context->output);
+	obs_output_begin_data_capture(context->output, 0);
 	return true;
 }
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1071,7 +1071,7 @@ static int init_send(struct rtmp_stream *stream)
 		return OBS_OUTPUT_DISCONNECTED;
 	}
 
-	obs_output_begin_data_capture2(stream->output);
+	obs_output_begin_data_capture(stream->output, 0);
 
 	return OBS_OUTPUT_SUCCESS;
 }
@@ -1373,9 +1373,9 @@ static bool rtmp_stream_start(void *data)
 {
 	struct rtmp_stream *stream = data;
 
-	if (!obs_output_can_begin_data_capture2(stream->output))
+	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
-	if (!obs_output_initialize_encoders2(stream->output))
+	if (!obs_output_initialize_encoders(stream->output, 0))
 		return false;
 
 	os_atomic_set_bool(&stream->connecting, true);

--- a/plugins/win-dshow/virtualcam.c
+++ b/plugins/win-dshow/virtualcam.c
@@ -68,7 +68,7 @@ static bool virtualcam_start(void *data)
 	os_atomic_set_bool(&vcam->active, true);
 	os_atomic_set_bool(&vcam->stopping, false);
 	blog(LOG_INFO, "Virtual output started");
-	obs_output_begin_data_capture2(vcam->output);
+	obs_output_begin_data_capture(vcam->output, 0);
 	return true;
 }
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Effectively reverting parts of d314d47, this commit removes the new functions that got added to remove the flags parameter. Instead, it just marks the parameter as unused and documents this. Having what is effectively an API break just to remove a parameter is a bit overkill. The other parts of d314d47 which cleaned up the usage of the flags parameter are untouched here.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
People brought up that this effective API break is a bit extreme, and I agree.
If we want to merge this, we'll have to do so before the first beta of the next release, so opening this now to get the discussion going.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 13.4
Tested that it still compiles, as well as making sure that recording and streaming still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
