### PR TITLE
libobs: Fix crash when properties are deleted in callback

### DIFF
--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -363,9 +363,9 @@ void obs_properties_apply_settings_internal(obs_properties_t *props,
 					    obs_data_t *settings,
 					    obs_properties_t *realprops)
 {
-	struct obs_property *p, *tmp;
+	struct obs_property *p = props->properties;
 
-	HASH_ITER (hh, props->properties, p, tmp) {
+	while (p) {
 		if (p->type == OBS_PROPERTY_GROUP) {
 			obs_properties_apply_settings_internal(
 				obs_property_group_content(p), settings,
@@ -375,6 +375,8 @@ void obs_properties_apply_settings_internal(obs_properties_t *props,
 			p->modified(realprops, p, settings);
 		else if (p->modified2)
 			p->modified2(p->priv, realprops, p, settings);
+
+		p = p->hh.next;
 	}
 }
 


### PR DESCRIPTION
### Description

Fixes the same issue as #9019 but in a minimal way that restores pre-29.1 behaviour.

As mentioned in https://github.com/obsproject/obs-studio/pull/9019#issuecomment-1575590865 this may still be problematic if the property whose callback is being executed is deleted during the callback. For that reason this is only targeting the `release/29.1` branch to leave discussion for an alternative approach open while mitigating possible crashes in 29.1.x.

### Motivation and Context

Fix crash.

### How Has This Been Tested?

Hasn't been.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
