### PR TITLE
libobs/util: Do not include SIMDe for MinGW targets.

### DIFF
--- a/libobs/util/sse-intrin.h
+++ b/libobs/util/sse-intrin.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#if defined(_MSC_VER) && \
+#if (defined(_MSC_VER) || defined(__MINGW32__)) && \
 	((defined(_M_X64) && !defined(_M_ARM64EC)) || defined(_M_IX86))
 #include <emmintrin.h>
 #else


### PR DESCRIPTION
MinGW comes with it's own intrinsics macros as regular MSVC does. On MinGW the inclusion of SIMDe would cause multiple definitions of the same macro names.

Since sse-intrin.h leaks into the public header space this will cause 3rd party plugins build with MinGW tool-chains emit redeclaration warnings when including obs-module.h.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Change an #ifdef to change behavior when compiling with MinGW tool-chains.

Another way would be to just switch out the original `_MSC_VER` check with `_WIN32`, but I'm not sure which approach is more desired.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I like to build my plugins from non-Windows platforms without having to use MSVC.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Compile a noop C app with including `obs-module.h`.
Compiling with a common available MinGW compiler.

```C
// x86_64-w64-mingw32-gcc -I ../obs-studio/libobs main.c
// x86_64-w64-mingw32-clang -I ../obs-studio/libobs main.c

#include "obs-module.h"

int main()
{
    return 0;
}
```

Without patch compiler produces many warnings like this one (probably for all MMX/SSE functions):

```
In file included from main.c:4:
In file included from ../obs-studio/libobs/obs-module.h:20:
In file included from ../obs-studio/libobs/obs.h:26:
In file included from ../obs-studio/libobs/graphics/vec3.h:21:
In file included from ../obs-studio/libobs/graphics/vec4.h:23:
In file included from ../obs-studio/libobs/graphics/../util/sse-intrin.h:28:
In file included from ../obs-studio/libobs/util/simde/x86/sse2.h:35:
In file included from ../obs-studio/libobs/util/simde/x86/sse.h:33:
../obs-studio/libobs/util/simde/x86/mmx.h:2449:9: warning: '_m_to_int' macro redefined [-Wmacro-redefined]
#define _m_to_int(a) simde_m_to_int(a)
        ^
/opt/llvm-mingw/lib/clang/15.0.0/include/mmintrin.h:1506:9: note: previous definition is here
#define _m_to_int _mm_cvtsi64_si32
```

With the patch the application gets compiled without warning.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
