### PR TITLE
win-capture: Skip compat helper matching if properties are null

### DIFF
--- a/plugins/win-capture/compat-helpers.c
+++ b/plugins/win-capture/compat-helpers.c
@@ -145,16 +145,17 @@ struct compat_result *check_compatibility(const char *win_title,
 		const char *j_title = get_string_val(entry, "window_title");
 		const char *j_class = get_string_val(entry, "window_class");
 
-		if (win_class && (match_flags & MATCH_CLASS) &&
-		    strcmp(win_class, j_class) != 0)
+		if ((match_flags & MATCH_CLASS) &&
+		    (!win_class || strcmp(win_class, j_class) != 0))
 			continue;
-		if (exe && (match_flags & MATCH_EXE) &&
-		    astrcmpi(exe, j_exe) != 0)
+		if ((match_flags & MATCH_EXE) &&
+		    (!exe || astrcmpi(exe, j_exe) != 0))
 			continue;
 		/* Title supports partial matches as some games append additional
 		 * information after the title, e.g., "Minecraft 1.18". */
-		if (win_title && (match_flags & MATCH_TITLE) &&
-		    astrcmpi_n(win_title, j_title, strlen(j_title)) != 0)
+		if ((match_flags & MATCH_TITLE) &&
+		    (!win_title ||
+		     astrcmpi_n(win_title, j_title, strlen(j_title)) != 0))
 			continue;
 
 		/* Attempt to translate and compile message */


### PR DESCRIPTION
### Description
Fixes compatibility messages appearing when no window is selected in window capture properties.

### Motivation and Context
First matching message appearing when no window is selected is weird.

![image (12)](https://github.com/obsproject/obs-studio/assets/876345/20b1451e-d6d9-4fe7-bdfb-2f789dbc9901)

### How Has This Been Tested?
Ran OBS and tested with an empty window capture source.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
