### PR TITLE
Add GPU based output scaling

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -310,6 +310,9 @@ struct obs_core_video_mix {
 	float conversion_height_i;
 
 	float color_matrix[16];
+
+	bool encoder_only_mix;
+	long encoder_refs;
 };
 
 extern struct obs_core_video_mix *
@@ -1205,6 +1208,9 @@ struct obs_encoder {
 	size_t framesize_bytes;
 
 	size_t mixer_idx;
+
+	/* OBS_SCALE_DISABLE indicates GPU scaling is disabled */
+	enum obs_scale_type gpu_scale_type;
 
 	uint32_t scaled_width;
 	uint32_t scaled_height;

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2411,6 +2411,15 @@ EXPORT enum obs_encoder_type obs_encoder_get_type(const obs_encoder_t *encoder);
 EXPORT void obs_encoder_set_scaled_size(obs_encoder_t *encoder, uint32_t width,
 					uint32_t height);
 
+/**
+ * Enable/disable GPU based scaling for a video encoder.
+ * OBS_SCALE_DISABLE disables GPU based scaling (default),
+ * any other value enables GPU based scaling. If the encoder
+ * is active, this function will trigger a warning, and do nothing.
+ */
+EXPORT void obs_encoder_set_gpu_scale_type(obs_encoder_t *encoder,
+					   enum obs_scale_type gpu_scale_type);
+
 /** For video encoders, returns true if pre-encode scaling is enabled */
 EXPORT bool obs_encoder_scaling_enabled(const obs_encoder_t *encoder);
 
@@ -2419,6 +2428,12 @@ EXPORT uint32_t obs_encoder_get_width(const obs_encoder_t *encoder);
 
 /** For video encoders, returns the height of the encoded image */
 EXPORT uint32_t obs_encoder_get_height(const obs_encoder_t *encoder);
+
+/** For video encoders, returns whether GPU scaling is enabled */
+EXPORT bool obs_encoder_gpu_scaling_enabled(obs_encoder_t *encoder);
+
+/** For video encoders, returns GPU scaling type */
+EXPORT enum obs_scale_type obs_encoder_get_scale_type(obs_encoder_t *encoder);
 
 /** For audio encoders, returns the sample rate of the audio */
 EXPORT uint32_t obs_encoder_get_sample_rate(const obs_encoder_t *encoder);

--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -452,8 +452,8 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings,
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
 
-	enc->cx = voi->width;
-	enc->cy = voi->height;
+	enc->cx = obs_encoder_get_width(enc->encoder);
+	enc->cy = obs_encoder_get_height(enc->encoder);
 
 	/* -------------------------- */
 	/* get preset                 */
@@ -1140,9 +1140,12 @@ static void *nvenc_create_base(enum codec_type codec, obs_data_t *settings,
 	}
 
 	if (obs_encoder_scaling_enabled(encoder)) {
-		blog(LOG_INFO,
-		     "[obs-nvenc] scaling enabled, falling back to ffmpeg");
-		goto reroute;
+		if (!obs_encoder_gpu_scaling_enabled(encoder)) {
+			blog(LOG_INFO,
+			     "[obs-nvenc] CPU scaling enabled, falling back to ffmpeg");
+			goto reroute;
+		}
+		blog(LOG_INFO, "[obs-nvenc] GPU scaling enabled");
 	}
 
 	if (!obs_p010_tex_active() && !obs_nv12_tex_active()) {

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1026,7 +1026,8 @@ static void check_texture_encode_capability(obs_encoder_t *encoder,
 	bool hevc = amf_codec_type::HEVC == codec;
 	bool av1 = amf_codec_type::AV1 == codec;
 
-	if (obs_encoder_scaling_enabled(encoder))
+	if (obs_encoder_scaling_enabled(encoder) &&
+	    !obs_encoder_gpu_scaling_enabled(encoder))
 		throw "Encoder scaling is active";
 
 	if (hevc || av1) {

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -1000,10 +1000,13 @@ static void *obs_qsv_create_tex(enum qsv_codec codec, obs_data_t *settings,
 	}
 
 	if (obs_encoder_scaling_enabled(encoder)) {
-		blog(LOG_INFO,
-		     ">>> encoder scaling active, fall back to old qsv encoder");
-		return obs_encoder_create_rerouted(encoder,
-						   (const char *)fallback_id);
+		if (!obs_encoder_gpu_scaling_enabled(encoder)) {
+			blog(LOG_INFO,
+			     ">>> encoder CPU scaling active, fall back to old qsv encoder");
+			return obs_encoder_create_rerouted(
+				encoder, (const char *)fallback_id);
+		}
+		blog(LOG_INFO, ">>> encoder GPU scaling active");
 	}
 
 	blog(LOG_INFO, ">>> new qsv encoder");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Allow GPU based scaling of output (textures) using on-demand created `obs_core_video_mix`es

### Motivation and Context
Currently if multiple outputs require different output resolution there's only one resolution that gets converted (and downloaded) on the GPU, which caused people to stream at 720p and upscale 720p to 1080p for recording in the past (not sure if that still happens).

Additionally, this allows encoders that take texture inputs to also be rescaled.

### How Has This Been Tested?
Modified `window-basic-outputs.cpp` to enable GPU scaling for the streaming encoder, set streaming encoder to rescale to 720p with a base output resolution of 1080p and observed `obs-nvenc` (as opposed to `FFmpeg NVENC`) log messages; also checked the resulting output file for proper resolution

### Types of changes
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
