### PR TITLE
libobs: Don't keep the sources mutex in tick_sources

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -420,6 +420,7 @@ struct obs_core_data {
 	volatile bool valid;
 
 	DARRAY(char *) protocols;
+	DARRAY(obs_source_t *) sources_to_tick;
 };
 
 /* user hotkeys */

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1083,6 +1083,7 @@ static void obs_free_data(void)
 	for (size_t i = 0; i < data->protocols.num; i++)
 		bfree(data->protocols.array[i]);
 	da_free(data->protocols);
+	da_free(data->sources_to_tick);
 }
 
 static const char *obs_signals[] = {


### PR DESCRIPTION
### Description
Don't keep the sources mutex in tick_sources

### Motivation and Context
Allow other threads to use sources while the graphics thread does video_tick, update, activate and deactivate on sources
For example in a gdi+ text source the update and video_tick (when reading file from slow disk or network) can take long.
All this time the sources_mutex was locked, blocking other threads like obs websocket calls.

### How Has This Been Tested?
On windows 64 bit by trying to update a gdi+ text source via obs websocket multiple times a second.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
