### PR TITLE
UI: Don't update text source when nothing changed

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -726,12 +726,15 @@ void TextSourceToolbar::on_text_textChanged()
 	if (!source) {
 		return;
 	}
-
+	std::string newText = QT_TO_UTF8(ui->text->text());
+	OBSDataAutoRelease settings = obs_source_get_settings(source);
+	if (newText == obs_data_get_string(settings, "text")) {
+		return;
+	}
 	SaveOldProperties(source);
 
-	OBSDataAutoRelease settings = obs_data_create();
-	obs_data_set_string(settings, "text", QT_TO_UTF8(ui->text->text()));
-	obs_source_update(source, settings);
+	obs_data_set_string(settings, "text", newText.c_str());
+	obs_source_update(source, nullptr);
 
 	SetUndoProperties(source, true);
 }


### PR DESCRIPTION
### Description
Don't update text source when nothing changed

### Motivation and Context
When selecting different text sources the source toolbar would create undo records and update the source while nothing was changed.

### How Has This Been Tested?
On windows 64 bit by selecting different text sources

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
