### PR TITLE
libobs/util: Fix use-after-free in darray_insert_new

### DIFF
--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -269,10 +269,11 @@ static inline void *darray_insert_new(const size_t element_size,
 	if (idx == dst->num)
 		return darray_push_back_new(element_size, dst);
 
+	darray_ensure_capacity(element_size, dst, ++dst->num);
+
 	item = darray_item(element_size, dst, idx);
 
 	move_count = dst->num - idx;
-	darray_ensure_capacity(element_size, dst, ++dst->num);
 	memmove(darray_item(element_size, dst, idx + 1), item,
 		move_count * element_size);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
After the array is allocated in `darray_ensure_capacity`, the pointer `item` is invalid.

This PR moves `darray_ensure_capacity` earlier than starting to modify the contents of the array.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was checking code coverage, adding a test code, and found the bug.

The function `darray_insert_new` is called from only `obs_property_frame_rate_option_insert` and `obs_property_frame_rate_fps_range_insert`. Both of them are never used in the obs-studio repository and it's submodules.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora

Tested with a modified test code.
https://github.com/norihiro/obs-studio/blob/test-darray/test/cmocka/test_darray.c

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
