### PR TITLE
rtmp-services: Add Livepeer Studio

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 225,
+    "version": 226,
     "files": [
         {
             "name": "services.json",
-            "version": 225
+            "version": 226
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2808,6 +2808,35 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Livepeer Studio",
+            "more_info_link": "https://docs.livepeer.org/guides/developing/stream-via-obs",
+            "stream_key_link": "https://livepeer.studio/dashboard/streams",
+            "servers": [
+                {
+                    "name": "Global (RTMP)",
+                    "url": "rtmp://rtmp.livepeer.com/live"
+                },
+                {
+                    "name": "Global (RTMP Primary)",
+                    "url": "rtmp://rtmp-a.livepeer.com/live"
+                },
+                {
+                    "name": "Global (RTMP Backup)",
+                    "url": "rtmp://rtmp-b.livepeer.com/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 1,
+                "profile": "high",
+                "bframes": 0,
+                "max video bitrate": 20000,
+                "max audio bitrate": 512
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
[Livepeer](https://livepeer.org) is a decentralized video infrastructure protocol which is designed to power the new creator economy. [Livepeer Studio](https://livepeer.studio) is our flagship product to let users easily interact with the protocol and start a livestream.

### Motivation and Context
We have many users currently streaming into Livepeer Studio using a custom RTMP setup. Similar to other RTMP providers who have added configs to OBS, we have [custom documentation](https://docs.livepeer.org/guides/developing/stream-via-obs#configuring-obs-for-low-latency)/support for users who are setting up OBS and trying to get low latency out of the box. We are hoping to add this so that we don't need to educate users on b-frames and keyframe intervals, and they can just select our preset and start streaming.

### How Has This Been Tested?
We have recommended these setting to our users and have used these settings internally. They provide the best performance for latency and quality with our media server.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.