### PR TITLE
UI: Remove Qt 5 ifdef guards and code

### DIFF
--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -439,11 +439,7 @@ static inline void updateStyle(QWidget *widget)
 	widget->update();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void OBSHotkeyWidget::enterEvent(QEnterEvent *event)
-#else
-void OBSHotkeyWidget::enterEvent(QEvent *event)
-#endif
 {
 	if (!label)
 		return;
@@ -472,11 +468,7 @@ void OBSHotkeyLabel::highlightPair(bool highlight)
 	updateStyle(this);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void OBSHotkeyLabel::enterEvent(QEnterEvent *event)
-#else
-void OBSHotkeyLabel::enterEvent(QEvent *event)
-#endif
 {
 
 	if (!pairPartner)

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -49,11 +49,7 @@ public:
 	QPointer<OBSHotkeyLabel> pairPartner;
 	QPointer<OBSHotkeyWidget> widget;
 	void highlightPair(bool highlight);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	void enterEvent(QEnterEvent *event) override;
-#else
-	void enterEvent(QEvent *event) override;
-#endif
 	void leaveEvent(QEvent *event) override;
 	void setToolTip(const QString &toolTip);
 };
@@ -172,11 +168,7 @@ public:
 	void Save();
 	void Save(std::vector<obs_key_combination_t> &combinations);
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	void enterEvent(QEnterEvent *event) override;
-#else
-	void enterEvent(QEvent *event) override;
-#endif
 	void leaveEvent(QEvent *event) override;
 
 private:

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -66,9 +66,6 @@ void OBSLogViewer::InitLog()
 
 	if (file.open(QIODevice::ReadOnly)) {
 		QTextStream in(&file);
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-		in.setCodec("UTF-8");
-#endif
 
 		QTextDocument *doc = ui->textArea->document();
 		QTextCursor cursor(doc);

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -98,9 +98,6 @@ bool opt_start_virtualcam = false;
 bool opt_minimize_tray = false;
 bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-bool opt_disable_high_dpi_scaling = false;
-#endif
 bool opt_disable_updater = false;
 bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
@@ -1659,10 +1656,6 @@ bool OBSApp::OBSInit()
 {
 	ProfileScope("OBSApp::OBSInit");
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
-
 	qRegisterMetaType<VoidFunc>("VoidFunc");
 
 #if !defined(_WIN32) && !defined(__APPLE__)
@@ -2319,13 +2312,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	ScopeProfiler prof{run_program_init};
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)) && \
-	(QT_VERSION < QT_VERSION_CHECK(6, 0, 0))
-	QGuiApplication::setAttribute(opt_disable_high_dpi_scaling
-					      ? Qt::AA_DisableHighDpiScaling
-					      : Qt::AA_EnableHighDpiScaling);
-#endif
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)) && defined(_WIN32)
+#ifdef _WIN32
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(
 		Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
@@ -3344,11 +3331,6 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--steam", nullptr)) {
 			steam = true;
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-		} else if (arg_is(argv[i], "--disable-high-dpi-scaling",
-				  nullptr)) {
-			opt_disable_high_dpi_scaling = true;
-#endif
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::string help =
 				"--help, -h: Get list of available commands.\n\n"
@@ -3370,11 +3352,7 @@ int main(int argc, char *argv[])
 				"--always-on-top: Start in 'always on top' mode.\n\n"
 				"--unfiltered_log: Make log unfiltered.\n\n"
 				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n"
-				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n"
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-				"--disable-high-dpi-scaling: Disable automatic high-DPI scaling\n\n"
-#endif
-				;
+				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n";
 
 #ifdef _WIN32
 			MessageBoxA(NULL, help.c_str(), "Help",

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -276,9 +276,6 @@ extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
 extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-extern bool opt_disable_high_dpi_scaling;
-#endif
 extern std::string opt_starting_scene;
 extern bool restart;
 

--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -195,11 +195,7 @@ void OBSQTDisplay::moveEvent(QMoveEvent *event)
 	OnMove();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool OBSQTDisplay::nativeEvent(const QByteArray &, void *message, qintptr *)
-#else
-bool OBSQTDisplay::nativeEvent(const QByteArray &, void *message, long *)
-#endif
 {
 #ifdef _WIN32
 	const MSG &msg = *static_cast<MSG *>(message);

--- a/UI/qt-display.hpp
+++ b/UI/qt-display.hpp
@@ -16,13 +16,8 @@ class OBSQTDisplay : public QWidget {
 	virtual void paintEvent(QPaintEvent *event) override;
 	virtual void moveEvent(QMoveEvent *event) override;
 	virtual void resizeEvent(QResizeEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;
-#else
-	virtual bool nativeEvent(const QByteArray &eventType, void *message,
-				 long *result) override;
-#endif
 
 signals:
 	void DisplayCreated(OBSQTDisplay *window);

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -125,11 +125,7 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 		float wid = contentsRect().width() - scrollWid - 1;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QPoint point = event->position().toPoint();
-#else
-		QPoint point = event->pos();
-#endif
 
 		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
 		int y = (point.y() + firstItemY) / itemHeight;
@@ -170,11 +166,7 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 	float wid = contentsRect().width() - scrollWid - 1;
 
 	if (event) {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 		QPoint point = event->position().toPoint();
-#else
-		QPoint point = event->pos();
-#endif
 
 		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
 		int y = (point.y() + firstItemY) / itemHeight;

--- a/UI/slider-ignorewheel.cpp
+++ b/UI/slider-ignorewheel.cpp
@@ -101,17 +101,7 @@ void SliderIgnoreClick::mousePressEvent(QMouseEvent *event)
 	initStyleOption(&styleOption);
 	QRect handle = style()->subControlRect(QStyle::CC_Slider, &styleOption,
 					       QStyle::SC_SliderHandle, this);
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-	QPointF pointExact = event->position();
-#endif
-	if (handle.contains(
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-		    QPoint(pointExact.x(), pointExact.y())
-#else
-		    // Ubuntu 20.04. Sigh.
-		    QPoint(event->x(), event->y())
-#endif
-			    )) {
+	if (handle.contains(event->position().toPoint())) {
 		SliderIgnoreScroll::mousePressEvent(event);
 		dragging = true;
 	} else {

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -334,11 +334,7 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 	}
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 void SourceTreeItem::enterEvent(QEnterEvent *event)
-#else
-void SourceTreeItem::enterEvent(QEvent *event)
-#endif
 {
 	QWidget::enterEvent(event);
 
@@ -1184,14 +1180,7 @@ void SourceTree::dropEvent(QDropEvent *event)
 	QModelIndexList indices = selectedIndexes();
 
 	DropIndicatorPosition indicator = dropIndicatorPosition();
-	int row = indexAt(
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-			  event->position().toPoint()
-#else
-			  event->pos()
-#endif
-				  )
-			  .row();
+	int row = indexAt(event->position().toPoint()).row();
 	bool emptyDrop = row == -1;
 
 	if (emptyDrop) {

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -33,11 +33,7 @@ class SourceTreeItem : public QFrame {
 	friend class SourceTreeModel;
 
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	void enterEvent(QEnterEvent *event) override;
-#else
-	void enterEvent(QEvent *event) override;
-#endif
 	void leaveEvent(QEvent *event) override;
 
 	virtual bool eventFilter(QObject *object, QEvent *event) override;

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -687,11 +687,7 @@ void OBSBasicFilters::closeEvent(QCloseEvent *event)
 	main->SaveProject();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool OBSBasicFilters::nativeEvent(const QByteArray &, void *message, qintptr *)
-#else
-bool OBSBasicFilters::nativeEvent(const QByteArray &, void *message, long *)
-#endif
 {
 #ifdef _WIN32
 	const MSG &msg = *static_cast<MSG *>(message);

--- a/UI/window-basic-filters.hpp
+++ b/UI/window-basic-filters.hpp
@@ -135,11 +135,6 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;
-#else
-	virtual bool nativeEvent(const QByteArray &eventType, void *message,
-				 long *result) override;
-#endif
 };

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -176,12 +176,8 @@ void OBSBasicInteraction::closeEvent(QCloseEvent *event)
 					 this);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool OBSBasicInteraction::nativeEvent(const QByteArray &, void *message,
 				      qintptr *)
-#else
-bool OBSBasicInteraction::nativeEvent(const QByteArray &, void *message, long *)
-#endif
 {
 #ifdef _WIN32
 	const MSG &msg = *static_cast<MSG *>(message);
@@ -366,14 +362,9 @@ bool OBSBasicInteraction::HandleMouseWheelEvent(QWheelEvent *event)
 			yDelta = angleDelta.y();
 	}
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
 	const QPointF position = event->position();
 	const int x = position.x();
 	const int y = position.y();
-#else
-	const int x = event->x();
-	const int y = event->y();
-#endif
 
 	if (GetSourceRelativeXY(x, y, mouseEvent.x, mouseEvent.y)) {
 		obs_source_send_mouse_wheel(source, &mouseEvent, xDelta,

--- a/UI/window-basic-interaction.hpp
+++ b/UI/window-basic-interaction.hpp
@@ -65,13 +65,8 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;
-#else
-	virtual bool nativeEvent(const QByteArray &eventType, void *message,
-				 long *result) override;
-#endif
 };
 
 typedef std::function<bool(QObject *, QEvent *)> EventFilterFunc;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -271,11 +271,7 @@ void setupDockAction(QDockWidget *dock)
 	dock->connect(action, &QAction::triggered, newToggleView);
 
 	// Make the action unable to be disabled
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	action->connect(action, &QAction::changed, neverDisable);
-#else
 	action->connect(action, &QAction::enabledChanged, neverDisable);
-#endif
 }
 
 extern void RegisterTwitchAuth();
@@ -287,11 +283,6 @@ extern void RegisterYoutubeAuth();
 OBSBasic::OBSBasic(QWidget *parent)
 	: OBSMainWindow(parent), undo_s(ui), ui(new Ui::OBSBasic)
 {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	qRegisterMetaTypeStreamOperators<SignalContainer<OBSScene>>(
-		"SignalContainer<OBSScene>");
-#endif
-
 	setAttribute(Qt::WA_NativeWindow);
 
 #if TWITCH_ENABLED
@@ -339,12 +330,6 @@ OBSBasic::OBSBasic(QWidget *parent)
 	qRegisterMetaType<OBSSource>("OBSSource");
 	qRegisterMetaType<obs_hotkey_id>("obs_hotkey_id");
 	qRegisterMetaType<SavedProjectorInfo *>("SavedProjectorInfo *");
-
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	qRegisterMetaTypeStreamOperators<std::vector<std::shared_ptr<OBSSignal>>>(
-		"std::vector<std::shared_ptr<OBSSignal>>");
-	qRegisterMetaTypeStreamOperators<OBSScene>("OBSScene");
-#endif
 
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);
 	ui->sources->setAttribute(Qt::WA_MacShowFocusRect, false);
@@ -1971,11 +1956,7 @@ void OBSBasic::OBSInit()
 	/* hack to prevent elgato from loading its own QtNetwork that it tries
 	 * to ship with */
 #if defined(_WIN32) && !defined(_DEBUG)
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-	LoadLibraryW(L"Qt5Network");
-#else
 	LoadLibraryW(L"Qt6Network");
-#endif
 #endif
 	struct obs_module_failure_info mfi;
 
@@ -5094,11 +5075,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool OBSBasic::nativeEvent(const QByteArray &, void *message, qintptr *)
-#else
-bool OBSBasic::nativeEvent(const QByteArray &, void *message, long *)
-#endif
 {
 #ifdef _WIN32
 	const MSG &msg = *static_cast<MSG *>(message);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1020,13 +1020,8 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;
-#else
-	virtual bool nativeEvent(const QByteArray &eventType, void *message,
-				 long *result) override;
-#endif
 	virtual void changeEvent(QEvent *event) override;
 
 private slots:

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -573,11 +573,7 @@ void OBSBasicPreview::wheelEvent(QWheelEvent *event)
 
 void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPointF pos = event->position();
-#else
-	QPointF pos = event->localPos();
-#endif
 
 	if (scrollMode && IsFixedScaling() &&
 	    event->button() == Qt::LeftButton) {
@@ -1595,11 +1591,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	changed = true;
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	QPointF qtPos = event->position();
-#else
-	QPointF qtPos = event->localPos();
-#endif
 
 	float pixelRatio = main->GetDevicePixelRatio();
 

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -490,12 +490,8 @@ void OBSBasicProperties::closeEvent(QCloseEvent *event)
 	Cleanup();
 }
 
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 bool OBSBasicProperties::nativeEvent(const QByteArray &, void *message,
 				     qintptr *)
-#else
-bool OBSBasicProperties::nativeEvent(const QByteArray &, void *message, long *)
-#endif
 {
 #ifdef _WIN32
 	const MSG &msg = *static_cast<MSG *>(message);

--- a/UI/window-basic-properties.hpp
+++ b/UI/window-basic-properties.hpp
@@ -74,12 +74,7 @@ public:
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 	virtual bool nativeEvent(const QByteArray &eventType, void *message,
 				 qintptr *result) override;
-#else
-	virtual bool nativeEvent(const QByteArray &eventType, void *message,
-				 long *result) override;
-#endif
 	virtual void reject() override;
 };

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -974,7 +974,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	connect(ui->advOutRecFormat, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(AdvOutRecCheckCodecs()));
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
 	// Set placeholder used when selection was reset due to incompatibilities
 	ui->advOutRecEncoder->setPlaceholderText(
 		QTStr("CodecCompat.CodecPlaceholder"));
@@ -986,7 +985,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		QTStr("CodecCompat.CodecPlaceholder"));
 	ui->simpleOutRecFormat->setPlaceholderText(
 		QTStr("CodecCompat.ContainerPlaceholder"));
-#endif
 
 	SimpleRecordingQualityChanged();
 	AdvOutSplitFileChanged();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR removes all code exclusive to Qt 5 (which at the same time is all code exclusive to Qt < 6.2, there was no code exclusive to 6.0 or 6.1 in obs-studio).
I plan to create a companion PR to obs-browser later today.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
See the announcement:
- https://github.com/obsproject/obs-studio/discussions/9055

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14 Beta
Tested that it still compiles. Explicitly double-checked that the slider-ignorescroll code still works.
CI is expected to fail on Ubuntu 20.04 for obvious reasons. I have not removed the run as part of this PR as I am not sure whether there's more to that than removing it from the strategy matrix.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
