### PR TITLE
Remove support for legacy FFmpeg versions

### DIFF
--- a/deps/libff/libff/ff-util.c
+++ b/deps/libff/libff/ff-util.c
@@ -56,11 +56,6 @@ struct ff_codec_desc {
 
 void ff_init()
 {
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-	//avdevice_register_all();
-	avcodec_register_all();
-#endif
 	avformat_network_init();
 }
 
@@ -103,7 +98,6 @@ static bool get_codecs(const AVCodecDescriptor ***descs, unsigned int *size)
 
 static const AVCodec *next_codec_for_id(enum AVCodecID id, const AVCodec *prev)
 {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 9, 100)
 	const AVCodec *cur = NULL;
 	void *i = 0;
 	bool found_prev = false;
@@ -121,12 +115,7 @@ static const AVCodec *next_codec_for_id(enum AVCodecID id, const AVCodec *prev)
 			}
 		}
 	}
-#else
-	while ((prev = av_codec_next(prev)) != NULL) {
-		if (prev->id == id && av_codec_is_encoder(prev))
-			return prev;
-	}
-#endif
+
 	return NULL;
 }
 
@@ -306,14 +295,9 @@ const struct ff_format_desc *ff_format_supported()
 	const AVOutputFormat *output_format = NULL;
 	struct ff_format_desc *desc = NULL;
 	struct ff_format_desc *current = NULL;
-
-#if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 9, 100)
+	
 	void *i = 0;
-
 	while ((output_format = av_muxer_iterate(&i)) != NULL) {
-#else
-	while ((output_format = av_oformat_next(output_format)) != NULL) {
-#endif
 		struct ff_format_desc *d;
 		if (is_output_device(output_format->priv_class))
 			continue;

--- a/deps/media-playback/media-playback/decode.h
+++ b/deps/media-playback/media-playback/decode.h
@@ -36,14 +36,9 @@ extern "C" {
 #pragma warning(pop)
 #endif
 
-#if LIBAVCODEC_VERSION_MAJOR >= 58
 #if LIBAVCODEC_VERSION_MAJOR < 60
 #define CODEC_CAP_TRUNC AV_CODEC_CAP_TRUNCATED
 #define CODEC_FLAG_TRUNC AV_CODEC_FLAG_TRUNCATED
-#endif
-#else
-#define CODEC_CAP_TRUNC CODEC_CAP_TRUNCATED
-#define CODEC_FLAG_TRUNC CODEC_FLAG_TRUNCATED
 #endif
 
 struct mp_media;

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -938,10 +938,6 @@ bool mp_media_init(mp_media_t *media, const struct mp_media_info *info)
 
 	static bool initialized = false;
 	if (!initialized) {
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-		av_register_all();
-		avcodec_register_all();
-#endif
 		avdevice_register_all();
 		avformat_network_init();
 		initialized = true;

--- a/libobs/obs-ffmpeg-compat.h
+++ b/libobs/obs-ffmpeg-compat.h
@@ -12,24 +12,9 @@
 	 (LIBAVCODEC_VERSION_MICRO >= 100 &&                    \
 	  LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(a, d, e)))
 
-#if !LIBAVCODEC_VERSION_CHECK(54, 28, 0, 59, 100)
-#define avcodec_free_frame av_freep
-#endif
-
-#if LIBAVCODEC_VERSION_INT < 0x371c01
-#define av_frame_alloc avcodec_alloc_frame
-#define av_frame_unref avcodec_get_frame_defaults
-#define av_frame_free avcodec_free_frame
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR >= 58
 #if LIBAVCODEC_VERSION_MAJOR < 60
 #define CODEC_CAP_TRUNC AV_CODEC_CAP_TRUNCATED
 #define CODEC_FLAG_TRUNC AV_CODEC_FLAG_TRUNCATED
 #endif
+
 #define INPUT_BUFFER_PADDING_SIZE AV_INPUT_BUFFER_PADDING_SIZE
-#else
-#define CODEC_CAP_TRUNC CODEC_CAP_TRUNCATED
-#define CODEC_FLAG_TRUNC CODEC_FLAG_TRUNCATED
-#define INPUT_BUFFER_PADDING_SIZE FF_INPUT_BUFFER_PADDING_SIZE
-#endif

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -39,12 +39,6 @@
 #define ANSI_COLOR_MAGENTA "\x1b[0;95m"
 #define ANSI_COLOR_RESET "\x1b[0m"
 
-#if LIBAVCODEC_VERSION_MAJOR >= 58
-#define CODEC_FLAG_GLOBAL_H AV_CODEC_FLAG_GLOBAL_HEADER
-#else
-#define CODEC_FLAG_GLOBAL_H CODEC_FLAG_GLOBAL_HEADER
-#endif
-
 #define AVIO_BUFFER_SIZE 65536
 
 /* ------------------------------------------------------------------------- */
@@ -529,7 +523,7 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 	}
 
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
-		context->flags |= CODEC_FLAG_GLOBAL_H;
+		context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
 	avcodec_parameters_from_context(ffm->video_stream->codecpar, context);
 
@@ -598,7 +592,7 @@ static void create_audio_stream(struct ffmpeg_mux *ffm, int idx)
 		context->ch_layout = (AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
 #endif
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
-		context->flags |= CODEC_FLAG_GLOBAL_H;
+		context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
 
 	avcodec_parameters_from_context(stream->codecpar, context);
 
@@ -1095,10 +1089,6 @@ static int ffmpeg_mux_init_internal(struct ffmpeg_mux *ffm, int argc,
 		ffm->audio_header =
 			calloc(ffm->params.tracks, sizeof(*ffm->audio_header));
 	}
-
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-#endif
 
 	if (!ffmpeg_mux_get_extra_data(ffm))
 		return FFM_ERROR;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-compat.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-compat.h
@@ -12,28 +12,7 @@
 	 (LIBAVCODEC_VERSION_MICRO >= 100 &&                    \
 	  LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(a, d, e)))
 
-#if !LIBAVCODEC_VERSION_CHECK(54, 28, 0, 59, 100)
-#define avcodec_free_frame av_freep
-#endif
-
-#if LIBAVCODEC_VERSION_INT < 0x371c01
-#define av_frame_alloc avcodec_alloc_frame
-#define av_frame_unref avcodec_get_frame_defaults
-#define av_frame_free avcodec_free_frame
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR >= 57
-#define av_free_packet av_packet_unref
-#endif
-
-#if LIBAVCODEC_VERSION_MAJOR >= 58
 #if LIBAVCODEC_VERSION_MAJOR < 60
 #define CODEC_CAP_TRUNC AV_CODEC_CAP_TRUNCATED
 #define CODEC_FLAG_TRUNC AV_CODEC_FLAG_TRUNCATED
-#endif
-#define CODEC_FLAG_GLOBAL_H AV_CODEC_FLAG_GLOBAL_HEADER
-#else
-#define CODEC_CAP_TRUNC CODEC_CAP_TRUNCATED
-#define CODEC_FLAG_TRUNC CODEC_FLAG_TRUNCATED
-#define CODEC_FLAG_GLOBAL_H CODEC_FLAG_GLOBAL_HEADER
 #endif

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -645,9 +645,6 @@ bool ffmpeg_mpegts_data_init(struct ffmpeg_output *stream,
 	if (!config->url || !*config->url)
 		return false;
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-#endif
 	avformat_network_init();
 
 #if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -216,7 +216,6 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 
 static bool nvenc_reconfigure(void *data, obs_data_t *settings)
 {
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 19, 101)
 	struct nvenc_encoder *enc = data;
 
 	const int64_t bitrate = obs_data_get_int(settings, "bitrate");
@@ -228,10 +227,6 @@ static bool nvenc_reconfigure(void *data, obs_data_t *settings)
 		enc->ffve.context->bit_rate = rate;
 		enc->ffve.context->rc_max_rate = rate;
 	}
-#else
-	UNUSED_PARAMETER(data);
-	UNUSED_PARAMETER(settings);
-#endif
 	return true;
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -12,8 +12,7 @@
 #include "obs-nvenc.h"
 #endif
 
-#if !defined(_WIN32) && !defined(__APPLE__) && \
-	LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(55, 27, 100)
+#if !defined(_WIN32) && !defined(__APPLE__)
 #include "vaapi-utils.h"
 
 #define LIBAVUTIL_VAAPI_AVAILABLE
@@ -282,10 +281,6 @@ static bool nvenc_codec_exists(const char *name, const char *fallback)
 static bool nvenc_supported(bool *out_h264, bool *out_hevc, bool *out_av1)
 {
 	profile_start(nvenc_check_name);
-
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	av_register_all();
-#endif
 
 	const bool h264 = nvenc_codec_exists("h264_nvenc", "nvenc_h264");
 #ifdef ENABLE_HEVC

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -22,11 +22,6 @@
 #include <obs-hevc.h>
 #endif
 
-#if LIBAVCODEC_VERSION_INT > AV_VERSION_INT(58, 4, 100)
-#define USE_NEW_HARDWARE_CODEC_METHOD
-#endif
-
-#ifdef USE_NEW_HARDWARE_CODEC_METHOD
 enum AVHWDeviceType hw_priority[] = {
 	AV_HWDEVICE_TYPE_D3D11VA,
 	AV_HWDEVICE_TYPE_DXVA2,
@@ -72,16 +67,12 @@ static void init_hw_decoder(struct ffmpeg_decode *d)
 		d->hw = true;
 	}
 }
-#endif
 
 int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id,
 		       bool use_hw)
 {
 	int ret;
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58, 9, 100)
-	avcodec_register_all();
-#endif
 	memset(decode, 0, sizeof(*decode));
 
 	decode->codec = avcodec_find_decoder(id);
@@ -92,12 +83,8 @@ int ffmpeg_decode_init(struct ffmpeg_decode *decode, enum AVCodecID id,
 
 	decode->decoder->thread_count = 0;
 
-#ifdef USE_NEW_HARDWARE_CODEC_METHOD
 	if (use_hw)
 		init_hw_decoder(decode);
-#else
-	(void)use_hw;
-#endif
 
 	ret = avcodec_open2(decode->decoder, decode->codec, NULL);
 	if (ret < 0) {
@@ -374,14 +361,12 @@ bool ffmpeg_decode_video(struct ffmpeg_decode *decode, uint8_t *data,
 	else if (!got_frame)
 		return true;
 
-#ifdef USE_NEW_HARDWARE_CODEC_METHOD
 	if (got_frame && decode->hw) {
 		ret = av_hwframe_transfer_data(decode->frame, out_frame, 0);
 		if (ret < 0) {
 			return false;
 		}
 	}
-#endif
 
 	for (size_t i = 0; i < MAX_AV_PLANES; i++) {
 		frame->data[i] = decode->frame->data[i];


### PR DESCRIPTION
### Description

In accordance with https://github.com/obsproject/obs-studio/discussions/9055 this drops support for libav* version prior to what ships with Ubuntu 22.04.

### Motivation and Context

Remove some legacy baggage.

### How Has This Been Tested?

Compiled on Windows with recent obs-deps.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
