### PR TITLE
CI: Remove Ubuntu 20.04 build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,10 +233,7 @@ jobs:
     runs-on: ${{ matrix.ubuntu }}
     strategy:
       matrix:
-        ubuntu: ['ubuntu-20.04', 'ubuntu-22.04']
-        include:
-          - ubuntu: 'ubuntu-20.04'
-            script_options: '--disable-pipewire'
+        ubuntu: ['ubuntu-22.04']
     if: always()
     needs: [config, clang_check]
     defaults:


### PR DESCRIPTION
### Description

Removes 20.04 as per https://github.com/obsproject/obs-studio/discussions/9055.

### Motivation and Context

Want #9061 and #9062 to build.

### How Has This Been Tested?

N/A

### Types of changes

 Code cleanup (non-breaking change which makes code smaller or more readable)
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
