### PR TITLE
libobs-d3d11: More detailed HAGS logging

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -504,63 +504,76 @@ static bool set_priority(ID3D11Device *device, bool hags_enabled)
 }
 #endif
 
-typedef enum {
-	ALWAYS_OFF,
-	ALWAYS_ON,
-	EXPERIMENTAL,
-	STABLE,
-	UNKNOWN
-} HagsSupportType;
-
-static const char *HagsSupportTypeToString(HagsSupportType support)
-{
-	switch (support) {
-	case ALWAYS_OFF:
-		return "Unsupported";
-	case ALWAYS_ON:
-		return "Always On";
-	case EXPERIMENTAL:
-		return "Experimental";
-	case STABLE:
-		return "Supported";
-	default:
-		return "Unknown";
-	}
-}
-
 struct HagsStatus {
+	enum DriverSupport {
+		ALWAYS_OFF,
+		ALWAYS_ON,
+		EXPERIMENTAL,
+		STABLE,
+		UNKNOWN
+	};
+
 	bool enabled;
 	bool enabled_by_default;
-	HagsSupportType support;
+	DriverSupport support;
+
+	explicit HagsStatus(const D3DKMT_WDDM_2_7_CAPS *caps)
+	{
+		enabled = caps->HwSchEnabled;
+		enabled_by_default = caps->HwSchEnabledByDefault;
+		support = caps->HwSchSupported ? DriverSupport::STABLE
+					       : DriverSupport::ALWAYS_OFF;
+	}
+
+	void SetDriverSupport(const UINT DXGKVal)
+	{
+		switch (DXGKVal) {
+		case DXGK_FEATURE_SUPPORT_ALWAYS_OFF:
+			support = ALWAYS_OFF;
+			break;
+		case DXGK_FEATURE_SUPPORT_ALWAYS_ON:
+			support = ALWAYS_ON;
+			break;
+		case DXGK_FEATURE_SUPPORT_EXPERIMENTAL:
+			support = EXPERIMENTAL;
+			break;
+		case DXGK_FEATURE_SUPPORT_STABLE:
+			support = STABLE;
+			break;
+		default:
+			support = UNKNOWN;
+		}
+	}
 
 	string ToString() const
 	{
 		string status = enabled ? "Enabled" : "Disabled";
 		status += " (Default: ";
 		status += enabled_by_default ? "Yes" : "No";
-		status += ", Driver support: ";
-		status += HagsSupportTypeToString(support);
+		status += ", Driver status: ";
+		status += DriverSupportToString();
 		status += ")";
 
 		return status;
 	}
-};
 
-static HagsSupportType WinApiToHagsSupportState(const UINT SupportState)
-{
-	switch (SupportState) {
-	case DXGK_FEATURE_SUPPORT_ALWAYS_OFF:
-		return ALWAYS_OFF;
-	case DXGK_FEATURE_SUPPORT_ALWAYS_ON:
-		return ALWAYS_ON;
-	case DXGK_FEATURE_SUPPORT_EXPERIMENTAL:
-		return EXPERIMENTAL;
-	case DXGK_FEATURE_SUPPORT_STABLE:
-		return STABLE;
-	default:
-		return UNKNOWN;
+private:
+	const char *DriverSupportToString() const
+	{
+		switch (support) {
+		case ALWAYS_OFF:
+			return "Unsupported";
+		case ALWAYS_ON:
+			return "Always On";
+		case EXPERIMENTAL:
+			return "Experimental";
+		case STABLE:
+			return "Supported";
+		default:
+			return "Unknown";
+		}
 	}
-}
+};
 
 static optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
 {
@@ -571,7 +584,7 @@ static optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
 	NTSTATUS res = D3DKMTOpenAdapterFromLuid(&d3dkmt_openluid);
 	if (FAILED(res)) {
 		blog(LOG_DEBUG, "Failed opening D3DKMT adapter: %x", res);
-		return std::nullopt;
+		return ret;
 	}
 
 	D3DKMT_WDDM_2_7_CAPS caps = {};
@@ -585,14 +598,11 @@ static optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
 	/* If this still fails we're likely on Windows 10 pre-2004
 	 * where HAGS is not supported anyway. */
 	if (SUCCEEDED(res)) {
-		HagsStatus status{};
-		status.enabled = caps.HwSchEnabled;
-		status.enabled_by_default = caps.HwSchEnabledByDefault;
-		status.support = caps.HwSchSupported ? STABLE : ALWAYS_OFF;
+		HagsStatus status(&caps);
 
 		/* Starting with Windows 10 21H2 we can query more detailed
-		 * support information (e.g. experimental status). This
-		 * Is optional and failure doesn't matter. */
+		 * support information (e.g. experimental status).
+		 * This Is optional and failure doesn't matter. */
 		D3DKMT_WDDM_2_9_CAPS ext_caps = {};
 		args.hAdapter = d3dkmt_openluid.hAdapter;
 		args.Type = KMTQAITYPE_WDDM_2_9_CAPS;
@@ -600,10 +610,8 @@ static optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
 		args.PrivateDriverDataSize = sizeof(ext_caps);
 		res = D3DKMTQueryAdapterInfo(&args);
 
-		if (SUCCEEDED(res)) {
-			status.support = WinApiToHagsSupportState(
-				ext_caps.HwSchSupportState);
-		}
+		if (SUCCEEDED(res))
+			status.SetDriverSupport(ext_caps.HwSchSupportState);
 
 		ret = status;
 	} else {
@@ -670,9 +678,10 @@ void gs_device::InitDevice(uint32_t adapterIdx)
 	}
 
 	/* Log HAGS status */
-	auto hags_status = GetAdapterHagsStatus(&desc);
-	bool hags_enabled = hags_status.has_value() ? hags_status->enabled
-						    : false;
+	bool hags_enabled = false;
+	if (auto hags_status = GetAdapterHagsStatus(&desc))
+		hags_enabled = hags_status->enabled;
+
 	if (hags_enabled) {
 		blog(LOG_WARNING,
 		     "Hardware-Accelerated GPU Scheduling enabled on adapter!");
@@ -1452,9 +1461,7 @@ static inline void LogD3DAdapters()
 		blog(LOG_INFO, "\t  PCI ID:         %x:%x", desc.VendorId,
 		     desc.DeviceId);
 
-		auto hags_support = GetAdapterHagsStatus(&desc);
-
-		if (hags_support.has_value()) {
+		if (auto hags_support = GetAdapterHagsStatus(&desc)) {
 			blog(LOG_INFO, "\t  HAGS Status:    %s",
 			     hags_support->ToString().c_str());
 		} else {


### PR DESCRIPTION
### Description

Adds more detailed logging for HAGS status, including whether or not it is supported, enabled by default, and if support in the driver is considered "experimental".

### Motivation and Context

All the info for all the supporters.

### How Has This Been Tested?

Ran locally, could probably use tests from others.

Results:
```
04:14:54.763: Initializing D3D11...
04:14:54.763: Available Video Adapters: 
04:14:54.766: 	Adapter 0: NVIDIA GeForce RTX 4090
04:14:54.766: 	  Dedicated VRAM: 25329401856
04:14:54.766: 	  Shared VRAM:    34219354112
04:14:54.766: 	  PCI ID:         10de:2684
04:14:54.766: 	  HAGS Status:    Disabled (Default: No, Driver status: Supported)
04:14:54.766: 	  Driver Version: 31.0.15.3179
```

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
