### PR TITLE
Define types of DARRAY macro to carry element types

### DIFF
--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -79,8 +79,6 @@ struct ep_param {
 	ep_param_array_t annotations;
 };
 
-extern void ep_param_writevar(struct dstr *dst, struct darray *use_params);
-
 static inline void ep_param_init(struct ep_param *epp, char *type, char *name,
 				 bool is_property, bool is_const,
 				 bool is_uniform)

--- a/libobs/graphics/effect-parser.h
+++ b/libobs/graphics/effect-parser.h
@@ -28,6 +28,9 @@ extern "C" {
 
 struct dstr;
 
+typedef DARRAY(struct ep_param) ep_param_array_t;
+typedef DARRAY(struct ep_var) ep_var_array_t;
+
 /*
  * The effect parser takes an effect file and converts it into individual
  * shaders for each technique's pass.  It automatically writes all dependent
@@ -73,7 +76,7 @@ struct ep_param {
 	struct gs_effect_param *param;
 	bool is_const, is_property, is_uniform, is_texture, written;
 	int writeorder, array_count;
-	DARRAY(struct ep_param) annotations;
+	ep_param_array_t annotations;
 };
 
 extern void ep_param_writevar(struct dstr *dst, struct darray *use_params);
@@ -113,7 +116,7 @@ static inline void ep_param_free(struct ep_param *epp)
 
 struct ep_struct {
 	char *name;
-	DARRAY(struct ep_var) vars; /* struct ep_var */
+	ep_var_array_t vars; /* struct ep_var */
 	bool written;
 };
 
@@ -175,8 +178,8 @@ static inline void ep_sampler_free(struct ep_sampler *eps)
 
 struct ep_pass {
 	char *name;
-	DARRAY(struct cf_token) vertex_program;
-	DARRAY(struct cf_token) fragment_program;
+	cf_token_array_t vertex_program;
+	cf_token_array_t fragment_program;
 	struct gs_effect_pass *pass;
 };
 
@@ -222,7 +225,7 @@ static inline void ep_technique_free(struct ep_technique *ept)
 struct ep_func {
 	char *name, *ret_type, *mapping;
 	struct dstr contents;
-	DARRAY(struct ep_var) param_vars;
+	ep_var_array_t param_vars;
 	DARRAY(char *) func_deps;
 	DARRAY(char *) struct_deps;
 	DARRAY(char *) param_deps;
@@ -259,7 +262,7 @@ static inline void ep_func_free(struct ep_func *epf)
 struct effect_parser {
 	gs_effect_t *effect;
 
-	DARRAY(struct ep_param) params;
+	ep_param_array_t params;
 	DARRAY(struct ep_struct) structs;
 	DARRAY(struct ep_func) funcs;
 	DARRAY(struct ep_sampler) samplers;
@@ -267,7 +270,7 @@ struct effect_parser {
 
 	/* internal vars */
 	DARRAY(struct cf_lexer) files;
-	DARRAY(struct cf_token) tokens;
+	cf_token_array_t tokens;
 	struct gs_effect_pass *cur_pass;
 
 	struct cf_parser cfp;

--- a/libobs/graphics/effect.c
+++ b/libobs/graphics/effect.c
@@ -136,7 +136,7 @@ void gs_technique_end(gs_technique_t *tech)
 	}
 }
 
-static inline void reset_params(struct darray *shaderparams)
+static inline void reset_params(pass_shaderparam_array_t *shaderparams)
 {
 	struct pass_shaderparam *params = shaderparams->array;
 	size_t i;
@@ -145,7 +145,8 @@ static inline void reset_params(struct darray *shaderparams)
 		params[i].eparam->changed = false;
 }
 
-static void upload_shader_params(struct darray *pass_params, bool changed_only)
+static void upload_shader_params(pass_shaderparam_array_t *pass_params,
+				 bool changed_only)
 {
 	struct pass_shaderparam *params = pass_params->array;
 	size_t i;
@@ -177,13 +178,13 @@ static void upload_shader_params(struct darray *pass_params, bool changed_only)
 static inline void upload_parameters(struct gs_effect *effect,
 				     bool changed_only)
 {
-	struct darray *vshader_params, *pshader_params;
+	pass_shaderparam_array_t *vshader_params, *pshader_params;
 
 	if (!effect->cur_pass)
 		return;
 
-	vshader_params = &effect->cur_pass->vertshader_params.da;
-	pshader_params = &effect->cur_pass->pixelshader_params.da;
+	vshader_params = &effect->cur_pass->vertshader_params;
+	pshader_params = &effect->cur_pass->pixelshader_params;
 
 	upload_shader_params(vshader_params, changed_only);
 	upload_shader_params(pshader_params, changed_only);
@@ -232,7 +233,7 @@ bool gs_technique_begin_pass_by_name(gs_technique_t *tech, const char *name)
 	return false;
 }
 
-static inline void clear_tex_params(struct darray *in_params)
+static inline void clear_tex_params(pass_shaderparam_array_t *in_params)
 {
 	struct pass_shaderparam *params = in_params->array;
 
@@ -255,8 +256,8 @@ void gs_technique_end_pass(gs_technique_t *tech)
 	if (!pass)
 		return;
 
-	clear_tex_params(&pass->vertshader_params.da);
-	clear_tex_params(&pass->pixelshader_params.da);
+	clear_tex_params(&pass->vertshader_params);
+	clear_tex_params(&pass->pixelshader_params);
 	tech->effect->cur_pass = NULL;
 }
 

--- a/libobs/graphics/effect.h
+++ b/libobs/graphics/effect.h
@@ -192,12 +192,6 @@ static inline void effect_free(gs_effect_t *effect)
 	effect->effect_dir = NULL;
 }
 
-EXPORT void effect_upload_params(gs_effect_t *effect, bool changed_only);
-EXPORT void effect_upload_shader_params(gs_effect_t *effect,
-					gs_shader_t *shader,
-					struct darray *pass_params,
-					bool changed_only);
-
 #ifdef __cplusplus
 }
 #endif

--- a/libobs/graphics/effect.h
+++ b/libobs/graphics/effect.h
@@ -24,6 +24,9 @@
 extern "C" {
 #endif
 
+typedef DARRAY(struct gs_effect_param) gs_effect_param_array_t;
+typedef DARRAY(struct pass_shaderparam) pass_shaderparam_array_t;
+
 /*
  * Effects introduce a means of bundling together shader text into one
  * file with shared functions and parameters.  This is done because often
@@ -62,7 +65,7 @@ struct gs_effect_param {
 
 	/*char *full_name;
 	float scroller_min, scroller_max, scroller_inc, scroller_mul;*/
-	DARRAY(struct gs_effect_param) annotations;
+	gs_effect_param_array_t annotations;
 };
 
 static inline void effect_param_init(struct gs_effect_param *param)
@@ -101,8 +104,8 @@ struct gs_effect_pass {
 
 	gs_shader_t *vertshader;
 	gs_shader_t *pixelshader;
-	DARRAY(struct pass_shaderparam) vertshader_params;
-	DARRAY(struct pass_shaderparam) pixelshader_params;
+	pass_shaderparam_array_t vertshader_params;
+	pass_shaderparam_array_t pixelshader_params;
 };
 
 static inline void effect_pass_init(struct gs_effect_pass *pass)
@@ -152,7 +155,7 @@ struct gs_effect {
 	bool cached;
 	char *effect_path, *effect_dir;
 
-	DARRAY(struct gs_effect_param) params;
+	gs_effect_param_array_t params;
 	DARRAY(struct gs_effect_technique) techniques;
 
 	struct gs_effect_technique *cur_technique;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -458,14 +458,16 @@ struct obs_core_hotkeys {
 	char *sceneitem_hide;
 };
 
+typedef DARRAY(struct obs_source_info) obs_source_info_array_t;
+
 struct obs_core {
 	struct obs_module *first_module;
 	DARRAY(struct obs_module_path) module_paths;
 
-	DARRAY(struct obs_source_info) source_types;
-	DARRAY(struct obs_source_info) input_types;
-	DARRAY(struct obs_source_info) filter_types;
-	DARRAY(struct obs_source_info) transition_types;
+	obs_source_info_array_t source_types;
+	obs_source_info_array_t input_types;
+	obs_source_info_array_t filter_types;
+	obs_source_info_array_t transition_types;
 	DARRAY(struct obs_output_info) output_types;
 	DARRAY(struct obs_encoder_info) encoder_types;
 	DARRAY(struct obs_service_info) service_types;

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -716,14 +716,14 @@ cleanup:
 void obs_register_source_s(const struct obs_source_info *info, size_t size)
 {
 	struct obs_source_info data = {0};
-	struct darray *array = NULL;
+	obs_source_info_array_t *array = NULL;
 
 	if (info->type == OBS_SOURCE_TYPE_INPUT) {
-		array = &obs->input_types.da;
+		array = &obs->input_types;
 	} else if (info->type == OBS_SOURCE_TYPE_FILTER) {
-		array = &obs->filter_types.da;
+		array = &obs->filter_types;
 	} else if (info->type == OBS_SOURCE_TYPE_TRANSITION) {
-		array = &obs->transition_types.da;
+		array = &obs->transition_types;
 	} else if (info->type != OBS_SOURCE_TYPE_SCENE) {
 		source_warn("Tried to register unknown source type: %u",
 			    info->type);
@@ -811,7 +811,7 @@ void obs_register_source_s(const struct obs_source_info *info, size_t size)
 	}
 
 	if (array)
-		darray_push_back(sizeof(struct obs_source_info), array, &data);
+		da_push_back(*array, &data);
 	da_push_back(obs->source_types, &data);
 	return;
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -35,6 +35,8 @@ static inline bool item_texture_enabled(const struct obs_scene_item *item);
 static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item,
 			 const char *name);
 
+typedef DARRAY(struct obs_scene_item *) obs_scene_item_ptr_array_t;
+
 /* NOTE: For proper mutex lock order (preventing mutual cross-locks), never
  * lock the graphics mutex inside either of the scene mutexes.
  *
@@ -214,7 +216,7 @@ static inline void remove_without_release(struct obs_scene_item *item)
 static void remove_all_items(struct obs_scene *scene)
 {
 	struct obs_scene_item *item;
-	DARRAY(struct obs_scene_item *) items;
+	obs_scene_item_ptr_array_t items;
 
 	da_init(items);
 
@@ -852,7 +854,7 @@ static void scene_video_tick(void *data, float seconds)
 /* assumes video lock */
 static void
 update_transforms_and_prune_sources(obs_scene_t *scene,
-				    struct darray *remove_items,
+				    obs_scene_item_ptr_array_t *remove_items,
 				    obs_sceneitem_t *group_sceneitem)
 {
 	struct obs_scene_item *item = scene->first_item;
@@ -866,8 +868,7 @@ update_transforms_and_prune_sources(obs_scene_t *scene,
 			item = item->next;
 
 			remove_without_release(del_item);
-			darray_push_back(sizeof(struct obs_scene_item *),
-					 remove_items, &del_item);
+			da_push_back(*remove_items, &del_item);
 			rebuild_group = true;
 			continue;
 		}
@@ -897,7 +898,7 @@ update_transforms_and_prune_sources(obs_scene_t *scene,
 
 static void scene_video_render(void *data, gs_effect_t *effect)
 {
-	DARRAY(struct obs_scene_item *) remove_items;
+	obs_scene_item_ptr_array_t remove_items;
 	struct obs_scene *scene = data;
 	struct obs_scene_item *item;
 
@@ -906,8 +907,7 @@ static void scene_video_render(void *data, gs_effect_t *effect)
 	video_lock(scene);
 
 	if (!scene->is_group) {
-		update_transforms_and_prune_sources(scene, &remove_items.da,
-						    NULL);
+		update_transforms_and_prune_sources(scene, &remove_items, NULL);
 	}
 
 	gs_blend_state_push();
@@ -1603,21 +1603,19 @@ static obs_source_t *get_child_at_idx(obs_scene_t *scene, size_t idx)
 	return item ? item->source : NULL;
 }
 
-static inline obs_source_t *dup_child(struct darray *array, size_t idx,
-				      obs_scene_t *new_scene, bool private)
+static inline obs_source_t *dup_child(obs_scene_item_ptr_array_t *old_items,
+				      size_t idx, obs_scene_t *new_scene,
+				      bool private)
 {
-	DARRAY(struct obs_scene_item *) old_items;
 	obs_source_t *source;
 
-	old_items.da = *array;
-
-	source = old_items.array[idx]->source;
+	source = old_items->array[idx]->source;
 
 	/* if the old item is referenced more than once in the old scene,
 	 * make sure they're referenced similarly in the new scene to reduce
 	 * load times */
 	for (size_t i = 0; i < idx; i++) {
-		struct obs_scene_item *item = old_items.array[i];
+		struct obs_scene_item *item = old_items->array[i];
 		if (item->source == source) {
 			source = get_child_at_idx(new_scene, i);
 			return obs_source_get_ref(source);
@@ -1704,7 +1702,7 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 {
 	bool make_unique = ((int)type & (1 << 0)) != 0;
 	bool make_private = ((int)type & (1 << 1)) != 0;
-	DARRAY(struct obs_scene_item *) items;
+	obs_scene_item_ptr_array_t items;
 	struct obs_scene *new_scene;
 	struct obs_scene_item *item;
 	struct obs_source *source;
@@ -1744,9 +1742,9 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name,
 
 	for (size_t i = 0; i < items.num; i++) {
 		item = items.array[i];
-		source = make_unique ? dup_child(&items.da, i, new_scene,
-						 make_private)
-				     : new_ref(item->source);
+		source = make_unique
+				 ? dup_child(&items, i, new_scene, make_private)
+				 : new_ref(item->source);
 
 		if (source) {
 			struct obs_scene_item *new_item =
@@ -3953,11 +3951,11 @@ obs_data_t *obs_sceneitem_transition_save(struct obs_scene_item *item,
 
 void obs_scene_prune_sources(obs_scene_t *scene)
 {
-	DARRAY(struct obs_scene_item *) remove_items;
+	obs_scene_item_ptr_array_t remove_items;
 	da_init(remove_items);
 
 	video_lock(scene);
-	update_transforms_and_prune_sources(scene, &remove_items.da, NULL);
+	update_transforms_and_prune_sources(scene, &remove_items, NULL);
 	video_unlock(scene);
 
 	for (size_t i = 0; i < remove_items.num; i++)

--- a/libobs/util/cf-lexer.c
+++ b/libobs/util/cf-lexer.c
@@ -471,7 +471,7 @@ bool cf_lexer_lex(struct cf_lexer *lex, const char *str, const char *file)
 
 struct macro_param {
 	struct cf_token name;
-	DARRAY(struct cf_token) tokens;
+	cf_token_array_t tokens;
 };
 
 static inline void macro_param_init(struct macro_param *param)
@@ -814,7 +814,7 @@ cf_preprocess_get_def(struct cf_preprocessor *pp, const struct strref *def_name)
 static char space_filler[2] = " ";
 
 static inline void append_space(struct cf_preprocessor *pp,
-				struct darray *tokens,
+				cf_token_array_t *tokens,
 				const struct cf_token *base)
 {
 	struct cf_token token;
@@ -829,14 +829,14 @@ static inline void append_space(struct cf_preprocessor *pp,
 		strref_copy(&token.unmerged_str, &token.str);
 	}
 
-	darray_push_back(sizeof(struct cf_token), tokens, &token);
+	da_push_back(*tokens, &token);
 }
 
-static inline void append_end_token(struct darray *tokens)
+static inline void append_end_token(cf_token_array_t *tokens)
 {
 	struct cf_token end;
 	cf_token_clear(&end);
-	darray_push_back(sizeof(struct cf_token), tokens, &end);
+	da_push_back(*tokens, &end);
 }
 
 static void cf_preprocess_define(struct cf_preprocessor *pp,
@@ -859,7 +859,7 @@ static void cf_preprocess_define(struct cf_preprocessor *pp,
 		goto exit;
 	}
 
-	append_space(pp, &def.tokens.da, NULL);
+	append_space(pp, &def.tokens, NULL);
 	cf_token_copy(&def.name, cur_token);
 
 	if (!next_token(&cur_token, true))
@@ -876,8 +876,8 @@ static void cf_preprocess_define(struct cf_preprocessor *pp,
 		cf_def_addtoken(&def, cur_token++);
 
 complete:
-	append_end_token(&def.tokens.da);
-	append_space(pp, &def.tokens.da, NULL);
+	append_end_token(&def.tokens);
+	append_space(pp, &def.tokens, NULL);
 	da_push_back(pp->defines, &def);
 	goto exit;
 
@@ -1032,7 +1032,7 @@ static bool cf_preprocessor(struct cf_preprocessor *pp, bool if_block,
 }
 
 static void cf_preprocess_addtoken(struct cf_preprocessor *pp,
-				   struct darray *dst, /* struct cf_token */
+				   cf_token_array_t *dst,
 				   struct cf_token **p_cur_token,
 				   const struct cf_token *base,
 				   const struct macro_params *params);
@@ -1052,7 +1052,7 @@ static void cf_preprocess_save_macro_param(
 	struct cf_token *cur_token = *p_cur_token;
 	int brace_count = 0;
 
-	append_space(pp, &param->tokens.da, base);
+	append_space(pp, &param->tokens, base);
 
 	while (cur_token->type != CFTOKEN_NONE) {
 		if (*cur_token->str.array == '(') {
@@ -1067,15 +1067,15 @@ static void cf_preprocess_save_macro_param(
 				break;
 		}
 
-		cf_preprocess_addtoken(pp, &param->tokens.da, &cur_token, base,
+		cf_preprocess_addtoken(pp, &param->tokens, &cur_token, base,
 				       cur_params);
 	}
 
 	if (cur_token->type == CFTOKEN_NONE)
 		cf_adderror_unexpected_eof(pp, cur_token);
 
-	append_space(pp, &param->tokens.da, base);
-	append_end_token(&param->tokens.da);
+	append_space(pp, &param->tokens, base);
+	append_end_token(&param->tokens);
 
 	*p_cur_token = cur_token;
 }
@@ -1153,10 +1153,11 @@ exit:
 	*p_cur_token = cur_token;
 }
 
-static inline void cf_preprocess_unwrap_param(
-	struct cf_preprocessor *pp, struct darray *dst, /* struct cf_token */
-	struct cf_token **p_cur_token, const struct cf_token *base,
-	const struct macro_param *param)
+static inline void cf_preprocess_unwrap_param(struct cf_preprocessor *pp,
+					      cf_token_array_t *dst,
+					      struct cf_token **p_cur_token,
+					      const struct cf_token *base,
+					      const struct macro_param *param)
 {
 	struct cf_token *cur_token = *p_cur_token;
 	struct cf_token *cur_param_token = param->tokens.array;
@@ -1169,7 +1170,7 @@ static inline void cf_preprocess_unwrap_param(
 }
 
 static inline void cf_preprocess_unwrap_define(
-	struct cf_preprocessor *pp, struct darray *dst, /* struct cf_token */
+	struct cf_preprocessor *pp, cf_token_array_t *dst,
 	struct cf_token **p_cur_token, const struct cf_token *base,
 	const struct cf_def *def, const struct macro_params *cur_params)
 {
@@ -1194,7 +1195,7 @@ static inline void cf_preprocess_unwrap_define(
 }
 
 static void cf_preprocess_addtoken(struct cf_preprocessor *pp,
-				   struct darray *dst, /* struct cf_token */
+				   cf_token_array_t *dst,
 				   struct cf_token **p_cur_token,
 				   const struct cf_token *base,
 				   const struct macro_params *params)
@@ -1226,7 +1227,7 @@ static void cf_preprocess_addtoken(struct cf_preprocessor *pp,
 		}
 	}
 
-	darray_push_back(sizeof(struct cf_token), dst, cur_token);
+	da_push_back(*dst, cur_token);
 
 ignore:
 	cur_token++;
@@ -1270,8 +1271,7 @@ static void cf_preprocess_tokens(struct cf_preprocessor *pp, bool if_block,
 			break;
 		}
 
-		cf_preprocess_addtoken(pp, &pp->tokens.da, &cur_token, NULL,
-				       NULL);
+		cf_preprocess_addtoken(pp, &pp->tokens, &cur_token, NULL, NULL);
 	}
 
 	*p_cur_token = cur_token;

--- a/libobs/util/cf-lexer.h
+++ b/libobs/util/cf-lexer.h
@@ -51,6 +51,8 @@ struct cf_token {
 	enum cf_token_type type;
 };
 
+typedef DARRAY(struct cf_token) cf_token_array_t;
+
 static inline void cf_token_clear(struct cf_token *t)
 {
 	memset(t, 0, sizeof(struct cf_token));
@@ -86,7 +88,7 @@ struct cf_lexer {
 	char *file;
 	struct lexer base_lexer;
 	char *reformatted, *write_offset;
-	DARRAY(struct cf_token) tokens;
+	cf_token_array_t tokens;
 	bool unexpected_eof; /* unexpected multi-line comment eof */
 };
 
@@ -106,8 +108,8 @@ EXPORT bool cf_lexer_lex(struct cf_lexer *lex, const char *str,
 
 struct cf_def {
 	struct cf_token name;
-	DARRAY(struct cf_token) params;
-	DARRAY(struct cf_token) tokens;
+	cf_token_array_t params;
+	cf_token_array_t tokens;
 	bool macro;
 };
 
@@ -173,7 +175,7 @@ struct cf_preprocessor {
 	DARRAY(struct cf_def) defines;
 	DARRAY(char *) sys_include_dirs;
 	DARRAY(struct cf_lexer) dependencies;
-	DARRAY(struct cf_token) tokens;
+	cf_token_array_t tokens;
 	bool ignore_state;
 };
 

--- a/libobs/util/darray.h
+++ b/libobs/util/darray.h
@@ -479,70 +479,73 @@ static inline void darray_swap(const size_t element_size, struct darray *dst,
 		};                       \
 	}
 
-#define da_init(v) darray_init(&v.da)
+#define da_init(v) darray_init(&(v).da)
 
-#define da_free(v) darray_free(&v.da)
+#define da_free(v) darray_free(&(v).da)
 
-#define da_alloc_size(v) (sizeof(*v.array) * v.num)
+#define da_alloc_size(v) (sizeof(*(v).array) * (v).num)
 
-#define da_end(v) darray_end(sizeof(*v.array), &v.da)
+#define da_end(v) darray_end(sizeof(*(v).array), &(v).da)
 
 #define da_reserve(v, capacity) \
-	darray_reserve(sizeof(*v.array), &v.da, capacity)
+	darray_reserve(sizeof(*(v).array), &(v).da, capacity)
 
-#define da_resize(v, size) darray_resize(sizeof(*v.array), &v.da, size)
+#define da_resize(v, size) darray_resize(sizeof(*(v).array), &(v).da, size)
 
-#define da_clear(v) darray_clear(&v.da)
+#define da_clear(v) darray_clear(&(v).da)
 
-#define da_copy(dst, src) darray_copy(sizeof(*dst.array), &dst.da, &src.da)
+#define da_copy(dst, src) \
+	darray_copy(sizeof(*(dst).array), &(dst).da, &(src).da)
 
 #define da_copy_array(dst, src_array, n) \
-	darray_copy_array(sizeof(*dst.array), &dst.da, src_array, n)
+	darray_copy_array(sizeof(*(dst).array), &(dst).da, src_array, n)
 
-#define da_move(dst, src) darray_move(&dst.da, &src.da)
+#define da_move(dst, src) darray_move(&(dst).da, &(src).da)
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
 #ifdef __cplusplus
 #define da_type_test(v, item)                 \
 	({                                    \
 		if (false) {                  \
-			auto _t = v.array;    \
+			auto _t = (v).array;  \
 			_t = (item);          \
 			(void)_t;             \
 			*(v).array = *(item); \
 		}                             \
 	})
 #else
-#define da_type_test(v, item)                       \
-	({                                          \
-		if (false) {                        \
-			const typeof(*v.array) *_t; \
-			_t = (item);                \
-			(void)_t;                   \
-			*(v).array = *(item);       \
-		}                                   \
+#define da_type_test(v, item)                         \
+	({                                            \
+		if (false) {                          \
+			const typeof(*(v).array) *_t; \
+			_t = (item);                  \
+			(void)_t;                     \
+			*(v).array = *(item);         \
+		}                                     \
 	})
 #endif
 #endif // ENABLE_DARRAY_TYPE_TEST
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_find(v, item, idx)                                    \
-	({                                                       \
-		da_type_test(v, item);                           \
-		darray_find(sizeof(*v.array), &v.da, item, idx); \
+#define da_find(v, item, idx)                                        \
+	({                                                           \
+		da_type_test(v, item);                               \
+		darray_find(sizeof(*(v).array), &(v).da, item, idx); \
 	})
 #else
-#define da_find(v, item, idx) darray_find(sizeof(*v.array), &v.da, item, idx)
+#define da_find(v, item, idx) \
+	darray_find(sizeof(*(v).array), &(v).da, item, idx)
 #endif
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_push_back(v, item)                                    \
-	({                                                       \
-		da_type_test(v, item);                           \
-		darray_push_back(sizeof(*v.array), &v.da, item); \
+#define da_push_back(v, item)                                        \
+	({                                                           \
+		da_type_test(v, item);                               \
+		darray_push_back(sizeof(*(v).array), &(v).da, item); \
 	})
 #else
-#define da_push_back(v, item) darray_push_back(sizeof(*v.array), &v.da, item)
+#define da_push_back(v, item) \
+	darray_push_back(sizeof(*(v).array), &(v).da, item)
 #endif
 
 #ifdef __GNUC__
@@ -557,96 +560,101 @@ static inline void darray_swap(const size_t element_size, struct darray *dst,
 		&d->array[d->num - 1];                                       \
 	})
 #else
-#define da_push_back_new(v) darray_push_back_new(sizeof(*v.array), &v.da)
+#define da_push_back_new(v) darray_push_back_new(sizeof(*(v).array), &(v).da)
 #endif
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_push_back_array(dst, src_array, n)                                  \
-	({                                                                     \
-		da_type_test(dst, src_array);                                  \
-		darray_push_back_array(sizeof(*dst.array), &dst.da, src_array, \
-				       n);                                     \
+#define da_push_back_array(dst, src_array, n)                           \
+	({                                                              \
+		da_type_test(dst, src_array);                           \
+		darray_push_back_array(sizeof(*(dst).array), &(dst).da, \
+				       src_array, n);                   \
 	})
 #else
 #define da_push_back_array(dst, src_array, n) \
-	darray_push_back_array(sizeof(*dst.array), &dst.da, src_array, n)
+	darray_push_back_array(sizeof(*(dst).array), &(dst).da, src_array, n)
 #endif
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_push_back_da(dst, src)                                              \
-	({                                                                     \
-		da_type_test(dst, src.array);                                  \
-		darray_push_back_darray(sizeof(*dst.array), &dst.da, &src.da); \
+#define da_push_back_da(dst, src)                                        \
+	({                                                               \
+		da_type_test(dst, (src).array);                          \
+		darray_push_back_darray(sizeof(*(dst).array), &(dst).da, \
+					&(src).da);                      \
 	})
 #else
 #define da_push_back_da(dst, src) \
-	darray_push_back_darray(sizeof(*dst.array), &dst.da, &src.da)
+	darray_push_back_darray(sizeof(*(dst).array), &(dst).da, &(src).da)
 #endif
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_insert(v, idx, item)                                    \
-	({                                                         \
-		da_type_test(v, item);                             \
-		darray_insert(sizeof(*v.array), &v.da, idx, item); \
+#define da_insert(v, idx, item)                                        \
+	({                                                             \
+		da_type_test(v, item);                                 \
+		darray_insert(sizeof(*(v).array), &(v).da, idx, item); \
 	})
 #else
 #define da_insert(v, idx, item) \
-	darray_insert(sizeof(*v.array), &v.da, idx, item)
+	darray_insert(sizeof(*(v).array), &(v).da, idx, item)
 #endif
 
-#define da_insert_new(v, idx) darray_insert_new(sizeof(*v.array), &v.da, idx)
+#define da_insert_new(v, idx) \
+	darray_insert_new(sizeof(*(v).array), &(v).da, idx)
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_insert_array(dst, idx, src_array, n)                       \
-	({                                                            \
-		da_type_test(dst, src_array);                         \
-		darray_insert_array(sizeof(*dst.array), &dst.da, idx, \
-				    src_array, n);                    \
+#define da_insert_array(dst, idx, src_array, n)                           \
+	({                                                                \
+		da_type_test(dst, src_array);                             \
+		darray_insert_array(sizeof(*(dst).array), &(dst).da, idx, \
+				    src_array, n);                        \
 	})
 #else
 #define da_insert_array(dst, idx, src_array, n) \
-	darray_insert_array(sizeof(*dst.array), &dst.da, idx, src_array, n)
+	darray_insert_array(sizeof(*(dst).array), &(dst).da, idx, src_array, n)
 #endif
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_insert_da(dst, idx, src)                                    \
-	({                                                             \
-		da_type_test(dst, src.array);                          \
-		darray_insert_darray(sizeof(*dst.array), &dst.da, idx, \
-				     &src.da);                         \
+#define da_insert_da(dst, idx, src)                                        \
+	({                                                                 \
+		da_type_test(dst, (src).array);                            \
+		darray_insert_darray(sizeof(*(dst).array), &(dst).da, idx, \
+				     &(src).da);                           \
 	})
 #else
 #define da_insert_da(dst, idx, src) \
-	darray_insert_darray(sizeof(*dst.array), &dst.da, idx, &src.da)
+	darray_insert_darray(sizeof(*(dst).array), &(dst).da, idx, &(src).da)
 #endif
 
-#define da_erase(dst, idx) darray_erase(sizeof(*dst.array), &dst.da, idx)
+#define da_erase(dst, idx) darray_erase(sizeof(*(dst).array), &(dst).da, idx)
 
 #ifdef ENABLE_DARRAY_TYPE_TEST
-#define da_erase_item(dst, item)                                      \
-	({                                                            \
-		da_type_test(dst, item);                              \
-		darray_erase_item(sizeof(*dst.array), &dst.da, item); \
+#define da_erase_item(dst, item)                                          \
+	({                                                                \
+		da_type_test(dst, item);                                  \
+		darray_erase_item(sizeof(*(dst).array), &(dst).da, item); \
 	})
 #else
 #define da_erase_item(dst, item) \
-	darray_erase_item(sizeof(*dst.array), &dst.da, item)
+	darray_erase_item(sizeof(*(dst).array), &(dst).da, item)
 #endif
 
 #define da_erase_range(dst, from, to) \
-	darray_erase_range(sizeof(*dst.array), &dst.da, from, to)
+	darray_erase_range(sizeof(*(dst).array), &(dst).da, from, to)
 
-#define da_pop_back(dst) darray_pop_back(sizeof(*dst.array), &dst.da);
+#define da_pop_back(dst) darray_pop_back(sizeof(*(dst).array), &(dst).da);
 
-#define da_join(dst, src) darray_join(sizeof(*dst.array), &dst.da, &src.da)
+#define da_join(dst, src) \
+	darray_join(sizeof(*(dst).array), &(dst).da, &(src).da)
 
-#define da_split(dst1, dst2, src, idx) \
-	darray_split(sizeof(*src.array), &dst1.da, &dst2.da, &src.da, idx)
+#define da_split(dst1, dst2, src, idx)                                        \
+	darray_split(sizeof(*(src).array), &(dst1).da, &(dst2).da, &(src).da, \
+		     idx)
 
 #define da_move_item(v, from, to) \
-	darray_move_item(sizeof(*v.array), &v.da, from, to)
+	darray_move_item(sizeof(*(v).array), &(v).da, from, to)
 
-#define da_swap(v, idx1, idx2) darray_swap(sizeof(*v.array), &v.da, idx1, idx2)
+#define da_swap(v, idx1, idx2) \
+	darray_swap(sizeof(*(v).array), &(v).da, idx1, idx2)
 
 #ifdef __cplusplus
 }

--- a/libobs/util/profiler.c
+++ b/libobs/util/profiler.c
@@ -452,8 +452,8 @@ static uint64_t copy_map_to_array(profile_times_table *map,
 {
 	migrate_old_entries(map, false);
 
-	da_reserve((*entry_buffer), map->occupied);
-	da_resize((*entry_buffer), 0);
+	da_reserve(*entry_buffer, map->occupied);
+	da_resize(*entry_buffer, 0);
 
 	uint64_t min__ = ~(uint64_t)0;
 	uint64_t max__ = 0;
@@ -465,7 +465,7 @@ static uint64_t copy_map_to_array(profile_times_table *map,
 
 		profiler_time_entry *entry = &map->entries[i].entry;
 
-		da_push_back((*entry_buffer), entry);
+		da_push_back(*entry_buffer, entry);
 
 		calls += entry->count;
 		min__ = (min__ < entry->time_delta) ? min__ : entry->time_delta;

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -71,6 +71,8 @@ struct image_file_data {
 	obs_source_t *source;
 };
 
+typedef DARRAY(struct image_file_data) image_file_array_t;
+
 enum behavior {
 	BEHAVIOR_STOP_RESTART,
 	BEHAVIOR_PAUSE_UNPAUSE,
@@ -104,7 +106,7 @@ struct slideshow {
 	uint64_t mem_usage;
 
 	pthread_mutex_t mutex;
-	DARRAY(struct image_file_data) files;
+	image_file_array_t files;
 
 	enum behavior behavior;
 
@@ -140,18 +142,15 @@ static obs_source_t *get_transition(struct slideshow *ss)
 	return tr;
 }
 
-static obs_source_t *get_source(struct darray *array, const char *path)
+static obs_source_t *get_source(image_file_array_t *files, const char *path)
 {
-	DARRAY(struct image_file_data) files;
 	obs_source_t *source = NULL;
 
-	files.da = *array;
-
-	for (size_t i = 0; i < files.num; i++) {
-		const char *cur_path = files.array[i].path;
+	for (size_t i = 0; i < files->num; i++) {
+		const char *cur_path = files->array[i].path;
 
 		if (strcmp(path, cur_path) == 0) {
-			source = obs_source_get_ref(files.array[i].source);
+			source = obs_source_get_ref(files->array[i].source);
 			break;
 		}
 	}
@@ -172,17 +171,14 @@ static obs_source_t *create_source_from_file(const char *file)
 	return source;
 }
 
-static void free_files(struct darray *array)
+static void free_files(image_file_array_t *files)
 {
-	DARRAY(struct image_file_data) files;
-	files.da = *array;
-
-	for (size_t i = 0; i < files.num; i++) {
-		bfree(files.array[i].path);
-		obs_source_release(files.array[i].source);
+	for (size_t i = 0; i < files->num; i++) {
+		bfree(files->array[i].path);
+		obs_source_release(files->array[i].source);
 	}
 
-	da_free(files);
+	da_free(*files);
 }
 
 static inline size_t random_file(struct slideshow *ss)
@@ -205,21 +201,18 @@ static const char *ss_getname(void *unused)
 	return obs_module_text("SlideShow");
 }
 
-static void add_file(struct slideshow *ss, struct darray *array,
+static void add_file(struct slideshow *ss, image_file_array_t *new_files,
 		     const char *path, uint32_t *cx, uint32_t *cy)
 {
-	DARRAY(struct image_file_data) new_files;
 	struct image_file_data data;
 	obs_source_t *new_source;
 
-	new_files.da = *array;
-
 	pthread_mutex_lock(&ss->mutex);
-	new_source = get_source(&ss->files.da, path);
+	new_source = get_source(&ss->files, path);
 	pthread_mutex_unlock(&ss->mutex);
 
 	if (!new_source)
-		new_source = get_source(&new_files.da, path);
+		new_source = get_source(new_files, path);
 	if (!new_source)
 		new_source = create_source_from_file(path);
 
@@ -229,7 +222,7 @@ static void add_file(struct slideshow *ss, struct darray *array,
 
 		data.path = bstrdup(path);
 		data.source = new_source;
-		da_push_back(new_files, &data);
+		da_push_back(*new_files, &data);
 
 		if (new_cx > *cx)
 			*cx = new_cx;
@@ -239,8 +232,6 @@ static void add_file(struct slideshow *ss, struct darray *array,
 		void *source_data = obs_obj_get_data(new_source);
 		ss->mem_usage += image_source_get_memory_usage(source_data);
 	}
-
-	*array = new_files.da;
 }
 
 static bool valid_extension(const char *ext)
@@ -295,8 +286,8 @@ static void do_transition(void *data, bool to_null)
 
 static void ss_update(void *data, obs_data_t *settings)
 {
-	DARRAY(struct image_file_data) new_files;
-	DARRAY(struct image_file_data) old_files;
+	image_file_array_t new_files;
+	image_file_array_t old_files;
 	obs_source_t *new_tr = NULL;
 	obs_source_t *old_tr = NULL;
 	struct slideshow *ss = data;
@@ -386,7 +377,7 @@ static void ss_update(void *data, obs_data_t *settings)
 				dstr_copy(&dir_path, path);
 				dstr_cat_ch(&dir_path, '/');
 				dstr_cat(&dir_path, ent->d_name);
-				add_file(ss, &new_files.da, dir_path.array, &cx,
+				add_file(ss, &new_files, dir_path.array, &cx,
 					 &cy);
 
 				if (ss->mem_usage >= MAX_MEM_USAGE)
@@ -396,7 +387,7 @@ static void ss_update(void *data, obs_data_t *settings)
 			dstr_free(&dir_path);
 			os_closedir(dir);
 		} else {
-			add_file(ss, &new_files.da, path, &cx, &cy);
+			add_file(ss, &new_files, path, &cx, &cy);
 		}
 
 		obs_data_release(item);
@@ -410,8 +401,8 @@ static void ss_update(void *data, obs_data_t *settings)
 
 	pthread_mutex_lock(&ss->mutex);
 
-	old_files.da = ss->files.da;
-	ss->files.da = new_files.da;
+	old_files = ss->files;
+	ss->files = new_files;
 	if (new_tr) {
 		old_tr = ss->transition;
 		ss->transition = new_tr;
@@ -438,7 +429,7 @@ static void ss_update(void *data, obs_data_t *settings)
 
 	if (old_tr)
 		obs_source_release(old_tr);
-	free_files(&old_files.da);
+	free_files(&old_files);
 
 	/* ------------------------- */
 
@@ -670,7 +661,7 @@ static void ss_destroy(void *data)
 	struct slideshow *ss = data;
 
 	obs_source_release(ss->transition);
-	free_files(&ss->files.da);
+	free_files(&ss->files);
 	pthread_mutex_destroy(&ss->mutex);
 	calldata_free(&ss->cd);
 	bfree(ss);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -9,6 +9,8 @@
 #include <util/platform.h>
 #include <util/threading.h>
 
+typedef DARRAY(struct encoder_packet) mux_packets_t;
+
 struct ffmpeg_muxer {
 	obs_output_t *output;
 	os_process_pipe_t *pipe;
@@ -34,7 +36,7 @@ struct ffmpeg_muxer {
 	int keyframes;
 	obs_hotkey_id hotkey;
 	volatile bool muxing;
-	DARRAY(struct encoder_packet) mux_packets;
+	mux_packets_t mux_packets;
 
 	/* split file */
 	bool found_video;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Defines type of DARRAY macros and changes function parameter types using `struct darray *` to the newly defined types.

Also add parentheses in DARRAY macros so that any expression can be passed to the macro as if it is a usual function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Inspired by #9048.

Currently, a pointer of `struct darray *` is passed to some functions because the unnamed union types cannot be identified as the same type even though the union definition is actually same.
However, using the type `struct darray *` looses the types of the element so that it requires type casts.

To avoid the type-casts, I'd like to suggest defining the DARRAY macro types at one place using `typedef` for each usage.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Linux
Compiled with GCC and Clang. CI will also test the code can be built.

Image slideshow and VLC source are tested.

These files also have usages of `.da` but I didn't change because the amount is not so large or I don't have environment to test carefully.
- deps/file-updater/file-updater/file-updater.c
- libobs-d3d11/d3d11-shaderprocessor.cpp
- plugins/linux-capture/xcomposite-input.c
- plugins/mac-videotoolbox/encoder.c
- plugins/obs-ffmpeg/obs-ffmpeg-video-encoders.c

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
