### PR TITLE
API: Add signals and procs exposing the hook state of various sources

### DIFF
--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -53,6 +53,7 @@ struct xcompcap {
 
 	float window_check_time;
 	bool window_changed;
+	bool window_hooked;
 
 	uint32_t width;
 	uint32_t height;
@@ -552,6 +553,27 @@ void watcher_unload()
 	da_free(watcher_registry);
 }
 
+static void xcompcap_get_hooked(void *data, calldata_t *cd)
+{
+	struct xcompcap *s = data;
+	if (!s)
+		return;
+
+	calldata_set_bool(cd, "hooked", s->window_hooked);
+
+	if (s->window_hooked) {
+		struct dstr wname = xcomp_window_name(conn, disp, s->win);
+		struct dstr wcls = xcomp_window_class(conn, s->win);
+		calldata_set_string(cd, "name", wname.array);
+		calldata_set_string(cd, "class", wcls.array);
+		dstr_free(&wname);
+		dstr_free(&wcls);
+	} else {
+		calldata_set_string(cd, "name", "");
+		calldata_set_string(cd, "class", "");
+	}
+}
+
 static uint32_t xcompcap_get_width(void *data)
 {
 	struct xcompcap *s = (struct xcompcap *)data;
@@ -581,10 +603,22 @@ static void *xcompcap_create(obs_data_t *settings, obs_source_t *source)
 	pthread_mutex_init(&s->lock, NULL);
 	s->show_cursor = true;
 	s->source = source;
+	s->window_hooked = false;
 
 	obs_enter_graphics();
 	s->cursor = xcb_xcursor_init(conn);
 	obs_leave_graphics();
+
+	signal_handler_t *sh = obs_source_get_signal_handler(source);
+	signal_handler_add(sh, "void unhooked(ptr source)");
+	signal_handler_add(
+		sh, "void hooked(ptr source, string name, string class)");
+
+	proc_handler_t *ph = obs_source_get_proc_handler(source);
+	proc_handler_add(
+		ph,
+		"void get_hooked(out bool hooked, out string name, out string class)",
+		xcompcap_get_hooked, s);
 
 	xcompcap_update(s, settings);
 	return s;
@@ -624,6 +658,17 @@ static void xcompcap_video_tick(void *data, float seconds)
 	while ((event = xcb_poll_for_queued_event(conn)))
 		watcher_process(event);
 
+	// Send an unhooked signal if the window isn't found anymore
+	if (s->window_hooked && !xcomp_window_exists(conn, s->win)) {
+		s->window_hooked = false;
+
+		signal_handler_t *sh = obs_source_get_signal_handler(s->source);
+		calldata_t data = {0};
+		calldata_set_ptr(&data, "source", s->source);
+		signal_handler_signal(sh, "unhooked", &data);
+		calldata_free(&data);
+	}
+
 	// Reacquire window after interval or immediately if reconfigured.
 	s->window_check_time += seconds;
 	bool window_lost = !xcomp_window_exists(conn, s->win) || !s->gltex;
@@ -634,6 +679,25 @@ static void xcompcap_video_tick(void *data, float seconds)
 		s->window_changed = false;
 		s->window_check_time = 0.0;
 		s->win = xcomp_find_window(conn, disp, s->windowName);
+
+		// Send a hooked signal if a new window has been found
+		if (!s->window_hooked && xcomp_window_exists(conn, s->win)) {
+			s->window_hooked = true;
+
+			signal_handler_t *sh =
+				obs_source_get_signal_handler(s->source);
+			calldata_t data = {0};
+			calldata_set_ptr(&data, "source", s->source);
+			struct dstr wname =
+				xcomp_window_name(conn, disp, s->win);
+			struct dstr wcls = xcomp_window_class(conn, s->win);
+			calldata_set_string(&data, "name", wname.array);
+			calldata_set_string(&data, "class", wcls.array);
+			signal_handler_signal(sh, "hooked", &data);
+			dstr_free(&wname);
+			dstr_free(&wcls);
+			calldata_free(&data);
+		}
 
 		watcher_register(conn, s);
 		xcomp_cleanup_pixmap(disp, s);
@@ -813,6 +877,7 @@ static void xcompcap_update(void *data, obs_data_t *settings)
 
 	obs_enter_graphics();
 	pthread_mutex_lock(&s->lock);
+	char *prev_name = bstrdup(s->windowName);
 
 	s->crop_top = obs_data_get_int(settings, "cut_top");
 	s->crop_left = obs_data_get_int(settings, "cut_left");
@@ -824,7 +889,34 @@ static void xcompcap_update(void *data, obs_data_t *settings)
 	s->exclude_alpha = obs_data_get_bool(settings, "exclude_alpha");
 
 	s->windowName = obs_data_get_string(settings, "capture_window");
+	if (s->window_hooked && strcmp(prev_name, s->windowName) != 0) {
+		s->window_hooked = false;
+
+		signal_handler_t *sh = obs_source_get_signal_handler(s->source);
+		calldata_t data = {0};
+		calldata_set_ptr(&data, "source", s->source);
+		signal_handler_signal(sh, "unhooked", &data);
+		calldata_free(&data);
+	}
+	bfree(prev_name);
+
 	s->win = xcomp_find_window(conn, disp, s->windowName);
+	if (!s->window_hooked && xcomp_window_exists(conn, s->win)) {
+		s->window_hooked = true;
+
+		signal_handler_t *sh = obs_source_get_signal_handler(s->source);
+		calldata_t data = {0};
+		calldata_set_ptr(&data, "source", s->source);
+		struct dstr wname = xcomp_window_name(conn, disp, s->win);
+		struct dstr wcls = xcomp_window_class(conn, s->win);
+		calldata_set_string(&data, "name", wname.array);
+		calldata_set_string(&data, "class", wcls.array);
+		signal_handler_signal(sh, "hooked", &data);
+		dstr_free(&wname);
+		dstr_free(&wcls);
+		calldata_free(&data);
+	}
+
 	if (s->win && s->windowName) {
 		struct dstr wname = xcomp_window_name(conn, disp, s->win);
 		struct dstr wcls = xcomp_window_class(conn, s->win);

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -87,6 +87,7 @@ struct window_capture {
 	bool compatibility;
 	bool client_area;
 	bool force_sdr;
+	bool hooked;
 
 	struct dc_capture capture;
 
@@ -220,6 +221,34 @@ static void update_settings(struct window_capture *wc, obs_data_t *s)
 
 /* ------------------------------------------------------------------------- */
 
+static void wc_get_hooked(void *data, calldata_t *cd)
+{
+	struct window_capture *wc = data;
+	if (!wc)
+		return;
+
+	if (wc->hooked && wc->window) {
+		calldata_set_bool(cd, "hooked", true);
+		struct dstr title = {0};
+		struct dstr class = {0};
+		struct dstr executable = {0};
+		ms_get_window_title(&title, wc->window);
+		ms_get_window_class(&class, wc->window);
+		ms_get_window_exe(&executable, wc->window);
+		calldata_set_string(cd, "title", title.array);
+		calldata_set_string(cd, "class", class.array);
+		calldata_set_string(cd, "executable", executable.array);
+		dstr_free(&title);
+		dstr_free(&class);
+		dstr_free(&executable);
+	} else {
+		calldata_set_bool(cd, "hooked", false);
+		calldata_set_string(cd, "title", "");
+		calldata_set_string(cd, "class", "");
+		calldata_set_string(cd, "executable", "");
+	}
+}
+
 static const char *wc_getname(void *unused)
 {
 	UNUSED_PARAMETER(unused);
@@ -303,6 +332,19 @@ static void *wc_create(obs_data_t *settings, obs_source_t *source)
 				get_window_dpi_awareness_context;
 		}
 	}
+	wc->hooked = false;
+
+	signal_handler_t *sh = obs_source_get_signal_handler(source);
+	signal_handler_add(sh, "void unhooked(ptr source)");
+	signal_handler_add(
+		sh,
+		"void hooked(ptr source, string title, string class, string executable)");
+
+	proc_handler_t *ph = obs_source_get_proc_handler(source);
+	proc_handler_add(
+		ph,
+		"void get_hooked(out bool hooked, out string title, out string class, out string executable)",
+		wc_get_hooked, wc);
 
 	update_settings(wc, settings);
 	log_settings(wc, settings);
@@ -532,6 +574,17 @@ static void wc_hide(void *data)
 	}
 
 	memset(&wc->last_rect, 0, sizeof(wc->last_rect));
+
+	if (wc->hooked) {
+		wc->hooked = false;
+
+		signal_handler_t *sh =
+			obs_source_get_signal_handler(wc->source);
+		calldata_t data = {0};
+		calldata_set_ptr(&data, "source", wc->source);
+		signal_handler_signal(sh, "unhooked", &data);
+		calldata_free(&data);
+	}
 }
 
 static void wc_tick(void *data, float seconds)
@@ -544,6 +597,17 @@ static void wc_tick(void *data, float seconds)
 		return;
 
 	if (!wc->window || !IsWindow(wc->window)) {
+		if (wc->hooked) {
+			wc->hooked = false;
+
+			signal_handler_t *sh =
+				obs_source_get_signal_handler(wc->source);
+			calldata_t data = {0};
+			calldata_set_ptr(&data, "source", wc->source);
+			signal_handler_signal(sh, "unhooked", &data);
+			calldata_free(&data);
+		}
+
 		if (!wc->title && !wc->class) {
 			if (wc->capture.valid)
 				dc_capture_free(&wc->capture);
@@ -606,6 +670,17 @@ static void wc_tick(void *data, float seconds)
 		    !wc->exports.winrt_capture_show_cursor(wc->capture_winrt,
 							   !cursor_hidden)) {
 			force_reset(wc);
+			if (wc->hooked) {
+				wc->hooked = false;
+
+				signal_handler_t *sh =
+					obs_source_get_signal_handler(
+						wc->source);
+				calldata_t data = {0};
+				calldata_set_ptr(&data, "source", wc->source);
+				signal_handler_signal(sh, "unhooked", &data);
+				calldata_free(&data);
+			}
 			return;
 		}
 
@@ -650,6 +725,35 @@ static void wc_tick(void *data, float seconds)
 					rect.right - rect.left,
 					rect.bottom - rect.top, wc->cursor,
 					wc->compatibility);
+			if (!wc->hooked && wc->capture.valid) {
+				wc->hooked = true;
+
+				signal_handler_t *sh =
+					obs_source_get_signal_handler(
+						wc->source);
+				calldata_t data = {0};
+				struct dstr title = {0};
+				struct dstr class = {0};
+				struct dstr executable = {0};
+
+				ms_get_window_title(&title, wc->window);
+				ms_get_window_class(&class, wc->window);
+				ms_get_window_exe(&executable, wc->window);
+
+				calldata_set_ptr(&data, "source", wc->source);
+				calldata_set_string(&data, "title",
+						    title.array);
+				calldata_set_string(&data, "class",
+						    class.array);
+				calldata_set_string(&data, "executable",
+						    executable.array);
+				signal_handler_signal(sh, "hooked", &data);
+
+				dstr_free(&title);
+				dstr_free(&class);
+				dstr_free(&executable);
+				calldata_free(&data);
+			}
 		}
 
 		dc_capture_capture(&wc->capture, wc->window);
@@ -666,6 +770,37 @@ static void wc_tick(void *data, float seconds)
 
 				if (!wc->capture_winrt) {
 					wc->previously_failed = true;
+				} else if (!wc->hooked) {
+					wc->hooked = true;
+
+					signal_handler_t *sh =
+						obs_source_get_signal_handler(
+							wc->source);
+					calldata_t data = {0};
+					struct dstr title = {0};
+					struct dstr class = {0};
+					struct dstr executable = {0};
+
+					ms_get_window_title(&title, wc->window);
+					ms_get_window_class(&class, wc->window);
+					ms_get_window_exe(&executable,
+							  wc->window);
+
+					calldata_set_ptr(&data, "source",
+							 wc->source);
+					calldata_set_string(&data, "title",
+							    title.array);
+					calldata_set_string(&data, "class",
+							    class.array);
+					calldata_set_string(&data, "executable",
+							    executable.array);
+					signal_handler_signal(sh, "hooked",
+							      &data);
+
+					dstr_free(&title);
+					dstr_free(&class);
+					dstr_free(&executable);
+					calldata_free(&data);
 				}
 			}
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds signals and procedures to various sources that allow tracking whether said sources have hooked into a window and are capturing data from it.
The sources affected are :
- Xcomposite window capture
- Windows window capture
- Windows game capture
- Windows application audio capture

Each source recieves two signals : 
- "hooked", fired when a window has been successfully hooked, with calldata containing a pointer to the source as well as information about the window hooked (title, class, executable)
- "unhooked", fired when a window has unhooked, with calldata containing a pointer to the source

and one procedure :
- "get_hooked", which returns a boolean of the hooked state of the source, as well as information on the window hooked (title, class, executable)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently there is no way to know from the API whether or not such sources are actively capturing a window, and if yes, which window, such information is strictly internal to the source's structure.
Allowing access to that information through the API would greatly simplify a lot of automation processes if not outright enable them.
It is also the first step in implementing suggestions like [Application-specific audio capture pick Game Capture automatically](https://ideas.obsproject.com/posts/1923) or [Name files after window titles](https://ideas.obsproject.com/posts/272).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Changes have been tested on Ubuntu 22.04 and Windows 11 22H2, by using a script to watch for events and manually trigger procedures.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
