### PR TITLE
Fix NULL pointer access introduced in #8093

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1896,7 +1896,8 @@ static bool initialize_interleaved_packets(struct obs_output *output)
 	output->highest_audio_ts -= audio[first_audio_idx]->dts_usec;
 
 	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
-		output->highest_video_ts[i] -= video[i]->dts_usec;
+		if (video[i])
+			output->highest_video_ts[i] -= video[i]->dts_usec;
 	}
 
 	/* apply new offsets to all existing packet DTS/PTS values */

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1829,9 +1829,9 @@ static bool get_audio_and_video_packets(struct obs_output *output,
 
 static bool initialize_interleaved_packets(struct obs_output *output)
 {
-	struct encoder_packet *video[MAX_OUTPUT_VIDEO_ENCODERS];
-	struct encoder_packet *audio[MAX_OUTPUT_AUDIO_ENCODERS];
-	struct encoder_packet *last_audio[MAX_OUTPUT_AUDIO_ENCODERS];
+	struct encoder_packet *video[MAX_OUTPUT_VIDEO_ENCODERS] = {0};
+	struct encoder_packet *audio[MAX_OUTPUT_AUDIO_ENCODERS] = {0};
+	struct encoder_packet *last_audio[MAX_OUTPUT_AUDIO_ENCODERS] = {0};
 	size_t start_idx;
 	size_t first_audio_idx;
 	size_t first_video_idx;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
