### PR TITLE
mac-syphon: Remove unused OBSSyphonKVObserver

### DIFF
--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -41,30 +41,6 @@ static inline void update_properties(syphon_t s)
     obs_source_update_properties(s->source);
 }
 
-@interface OBSSyphonKVObserver : NSObject
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context;
-@end
-
-@implementation OBSSyphonKVObserver
-- (void)observeValueForKeyPath:(NSString *)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary *)change
-                       context:(void *)context
-{
-    syphon_t s = context;
-    if (!s)
-        return;
-
-    if (!change[NSKeyValueChangeNewKey])
-        return;
-
-    update_properties(s);
-}
-@end
-
 static const char *syphon_get_name(void *unused __attribute((unused)))
 {
     return obs_module_text("Syphon");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`OBSSyphonKVObserver` was once used to listen to announce/retire events (?) but that has been changed at some later point. Since then, this code is unused.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed after the recent syphon changes (which, to be clear, did not remove the usage of OBSSyphonKVObserver, that was earlier).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14, still compiles
Did a `git grep` for `OBSSyphonKVObserver` without any results.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
