### PR TITLE
UI: Release frontend-api callback object

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -3435,6 +3435,8 @@ int main(int argc, char *argv[])
 	log_blocked_dlls();
 #endif
 
+	obs_frontend_set_callbacks_internal(nullptr);
+
 	blog(LOG_INFO, "Number of memory leaks: %ld", bnum_allocs());
 	base_set_log_handler(nullptr, nullptr);
 	return ret;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -233,6 +233,7 @@ static void AddExtraModulePaths()
 }
 
 extern obs_frontend_callbacks *InitializeAPIInterface(OBSBasic *main);
+extern void APIInterfaceRemoveMainWindow(obs_frontend_callbacks *api);
 
 void assignDockToggle(QDockWidget *dock, QAction *action)
 {
@@ -2932,6 +2933,8 @@ OBSBasic::~OBSBasic()
 	delete cef;
 	cef = nullptr;
 #endif
+
+	APIInterfaceRemoveMainWindow(api);
 }
 
 void OBSBasic::SaveProjectNow()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets `nullptr` to `main` in the front-end API callback instance at the destructor of `OBSBasic`.
Also adds a warning message if an API is called to access the main window after the main window has been deleted.

The implementation of this PR is not thread-safe but this should be ok because the right plugins should not access `main` pointer after the main window has been deleted.

Also releases the callback instance at the end of `main` function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The instance of `OBSStudioAPI` holds a pointer to `OBSBasic`, which will be invalidated after `OBSBasic::~OBSBasic()`. The invalid pointer should not be held by anyone.

This change will detect potential errors in a 3rd party plugin, which tries to access main window after it has been deleted. For example, calling `obs_frontend_get_profile_config` to save something in `obs_module_unload`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Linux

Build with both GCC and Clang. Ran obs, enable obs-websocket, and exited obs for each build, and checked no errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
