### PR TITLE
docs: Fix param name

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -361,7 +361,7 @@ Functions
 
 .. function:: void obs_frontend_set_current_scene_collection(const char *collection)
 
-   :param profile: Name of the scene collection to activate
+   :param collection: Name of the scene collection to activate
 
 ---------------------------------------
 


### PR DESCRIPTION
### Description
In the Docs the parameter name is wrong ("collection" vs "profile"). See how it looks:
https://docs.obsproject.com/reference-frontend-api#c.obs_frontend_set_current_scene_collection

Screenshot

![obs_docs_wrong_param_name](https://github.com/obsproject/obs-studio/assets/19683044/38fec686-3d56-422e-a2ef-a1ccfb7aefb0)

### Motivation and Context
Documentation should be clear from misinterpretations

### How Has This Been Tested?
It wasn't.

### Types of changes
 - Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
