### PR TITLE
mac-capture: Fix wrong CFString to NSNumber cast

### DIFF
--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -5,7 +5,7 @@
 #define WINDOW_NAME   ((NSString *) kCGWindowName)
 #define WINDOW_NUMBER ((NSString *) kCGWindowNumber)
 #define OWNER_NAME    ((NSString *) kCGWindowOwnerName)
-#define OWNER_PID     ((NSNumber *) kCGWindowOwnerPID)
+#define OWNER_PID     ((NSString *) kCGWindowOwnerPID)
 
 static NSComparator win_info_cmp = ^(NSDictionary *o1, NSDictionary *o2) {
     NSComparisonResult res = [o1[OWNER_NAME] compare:o2[OWNER_NAME]];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a new warning where the CFString `kCGWindowOwnerPID` is casted to an `NSNumber`.
This is wrong. Things most likely currently works because I think when using it it's implicitly casted to `NSString` but really it should never be casted to a number in the first place.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Warning popped up, don't like warnings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Checked that in the dictionaries where `OWNER_PID` is used that the key is indeed a string.
Tested in a debugger that the comparisons still work the same as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
