### PR TITLE
UI: Fix scenes only multiview label position

### DIFF
--- a/UI/multiview.cpp
+++ b/UI/multiview.cpp
@@ -192,13 +192,16 @@ static inline uint32_t labelOffset(MultiviewLayout multiviewLayout,
 		n = 6;
 		break;
 	case MultiviewLayout::SCENES_ONLY_25_SCENES:
-		n = 5;
+		n = 10;
+		break;
+	case MultiviewLayout::SCENES_ONLY_16_SCENES:
+		n = 8;
 		break;
 	case MultiviewLayout::SCENES_ONLY_9_SCENES:
-		n = 3;
+		n = 6;
 		break;
 	case MultiviewLayout::SCENES_ONLY_4_SCENES:
-		n = 2;
+		n = 4;
 		break;
 	default:
 		n = 4;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix the X coordinates for the labels on Scenes Only multiview.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The multiview labels are off from the center when set to `Scenes only (4 Scenes)`, `Scenes only (9 Scenes)`, `Scenes only (16 Scenes)`, `Scenes only (25 Scenes)`.



### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested all the settings of multiview.

An orange line shows the center for each scene.




|Setting | Without this PR | With this PR |
|---|---|---|
| Scenes only (25 Scenes) | ![multiview-25](https://github.com/obsproject/obs-studio/assets/780600/32401aff-b8ca-4320-a541-bb81015fd93f) | ![Screenshot 2023-06-18 00-24-07](https://github.com/obsproject/obs-studio/assets/780600/2ff0ea06-bb62-4395-b0c8-0423d0b4f77c) |
| Scenes only (16 Scenes) |![Screenshot 2023-06-18 00-32-59](https://github.com/obsproject/obs-studio/assets/780600/346bb3a1-0976-49bf-9a0e-f1e122aea91b) | ![Screenshot 2023-06-18 00-24-02](https://github.com/obsproject/obs-studio/assets/780600/29de2953-6ea3-4f4f-9369-1d35c924b6f9) |
| Scenes only (9 Scenes) |![Screenshot 2023-06-18 00-33-04](https://github.com/obsproject/obs-studio/assets/780600/3ae75c28-8e2a-4ece-a420-286b1a2a7f50) | ![Screenshot 2023-06-18 00-23-55](https://github.com/obsproject/obs-studio/assets/780600/a20ee885-5ff1-4e80-baff-293143cf6237) |
| Scenes only (4 Scenes) | ![Screenshot 2023-06-18 00-33-08](https://github.com/obsproject/obs-studio/assets/780600/3fda2938-1646-46c2-b51f-d0914539cb0d) | ![Screenshot 2023-06-18 00-23-48](https://github.com/obsproject/obs-studio/assets/780600/b2ce727e-31fa-4c8d-abde-d1b8eb330449) |
| Horizontal, Top (24 Scenes) | ![Screenshot 2023-06-18 00-35-09](https://github.com/obsproject/obs-studio/assets/780600/0d46caee-c699-45e7-8bcf-9744a43940fa) | ![Screenshot 2023-06-18 00-23-44](https://github.com/obsproject/obs-studio/assets/780600/8a1f7a0c-112e-458f-8507-acd93eec4070) |
| Horizontal, Top (18 Scenes) | ![Screenshot 2023-06-18 00-35-17](https://github.com/obsproject/obs-studio/assets/780600/505c2626-c6eb-4558-8668-81227f9d3fce) | ![Screenshot 2023-06-18 00-23-37](https://github.com/obsproject/obs-studio/assets/780600/44ef5c7a-0b99-4325-ae67-e693afcb9c66) |
| Vertical, Right (8 Scenes) | ![Screenshot 2023-06-18 00-35-23](https://github.com/obsproject/obs-studio/assets/780600/26e6e84d-c358-4d72-932f-280bdc766b50) | ![Screenshot 2023-06-18 00-23-29](https://github.com/obsproject/obs-studio/assets/780600/d5e1bbdc-2419-465a-b114-d22b532785d0) |
| Vertical, Left (8 Scenes)| ![Screenshot 2023-06-18 00-35-29](https://github.com/obsproject/obs-studio/assets/780600/e5fa1af2-c65f-486a-9a46-361d0511e42c) | ![Screenshot 2023-06-18 00-23-22](https://github.com/obsproject/obs-studio/assets/780600/592d8087-0621-4bcb-9792-90aae93ad1ed) |
| Horizontal, Bottom (8 Scenes) | ![Screenshot 2023-06-18 00-35-39](https://github.com/obsproject/obs-studio/assets/780600/29137bf1-1552-430b-a037-1da1996d9fc9) | ![Screenshot 2023-06-18 00-23-12](https://github.com/obsproject/obs-studio/assets/780600/11a4c5d2-9de1-4bd6-80eb-fd66aad40d02) |
| Horizontal, Top (8 Scenes) | ![Screenshot 2023-06-18 00-35-46](https://github.com/obsproject/obs-studio/assets/780600/e225debe-4cac-4384-acd5-b429b189451e) | ![Screenshot 2023-06-18 00-23-03](https://github.com/obsproject/obs-studio/assets/780600/f4168817-d26a-4db6-abee-c43a4e942cff) |


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
