### PR TITLE
UI: Fix changed state of audio settings

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4643,17 +4643,15 @@ void OBSBasicSettings::AudioChangedRestart()
 		if (currentChannelIndex != channelIndex ||
 		    currentSampleRateIndex != sampleRateIndex ||
 		    currentLLAudioBufVal != llBufferingEnabled) {
-			audioChanged = true;
 			ui->audioMsg->setText(
 				QTStr("Basic.Settings.ProgramRestart"));
-			sender()->setProperty("changed", QVariant(true));
-			EnableApplyButton(true);
 		} else {
-			audioChanged = false;
 			ui->audioMsg->setText("");
-			sender()->setProperty("changed", QVariant(false));
-			EnableApplyButton(false);
 		}
+
+		audioChanged = true;
+		sender()->setProperty("changed", QVariant(true));
+		EnableApplyButton(true);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Set the changed state when changed something, but do not clear the changed state.

The member variable `channelIndex`, `sampleRateIndex`, and `llBufferingEnabled` hold the settings that was read from the configuration when the settings was opened.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When changing audio channels, sample rate, or audio buffering settings multiple times by hitting `Apply` button, the internal `changed` state got corrupted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested with these two scenarios.

- Changed sample rate multiple times.
  1. Open the settings dialog.
  2. Change the sample rate to 44.1 kHz.
  3. Hit `Apply` button.
  4. Change the sample rate to 48 kHz.
     - Expected `Apply` button is enabled but actually left disabled.
  5. Hit `OK` button, restart OBS manually, and open the settings dialog.
     - Expected the sample rate is 48 kHz but actually 44.1 kHz.

- Changed unrelated settings and then changed and reverted the sample rate.
  1. Open the settings dialog.
  2. Change something unrelated to audio, such as `Show confirmation dialog when starting streams`.
  3. Change the sample rate to 44.1 kHz.
  4. Change the sample rate to 48 kHz.
     - Expected `Apply` button is still enabled because the confirmation settings has changed. However, it actually gets disabled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


I noticed one more scenario causing inconsistency of the warning message. Maybe this should be ok because it's user's fault to ignore the restart.
1. Open the settings dialog.
2. Change the sample rate to 44.1 kHz.
3. Hit `OK` button.
4. Hit `No` when suggested to restart obs.
5. Open the settings dialog.
6. Change the sample rate to 48 kHz.
   - The sample rate warning should not appear because the audio-thread is running at 48 kHz but actually the warning appears.
