### PR TITLE
UI: Fix icon paths of transition buttons

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1346,7 +1346,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>:/res/images/add.png</normaloff>:/res/images/add.png</iconset>
+              <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
             </property>
             <property name="flat">
              <bool>false</bool>
@@ -1378,7 +1378,7 @@
             </property>
             <property name="icon">
              <iconset>
-              <normaloff>:/res/images/list_remove.png</normaloff>:/res/images/list_remove.png</iconset>
+              <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
             </property>
             <property name="flat">
              <bool>false</bool>


### PR DESCRIPTION
### Description
In Qt Creator, the transition add/remove buttons had no icons, as the paths were incorrect.

### Motivation and Context
Make sure the icons were correct

### How Has This Been Tested?
Opened Qt Creator to make sure the icons showed up

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
