### PR TITLE
UI: Clean the Audio menus redundancy

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -508,6 +508,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/refresh.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Dark/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Dark/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Dark/cogs.svg);
 }

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -325,6 +325,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/dots-vert.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Dark/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Dark/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Dark/cogs.svg);
 }

--- a/UI/data/themes/Dark/mixer-layout.svg
+++ b/UI/data/themes/Dark/mixer-layout.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="mixer-layout.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="14.363106"
+     inkscape:cy="11.578873"
+     inkscape:window-width="1366"
+     inkscape:window-height="697"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 16.079562,1.5248063 1.4168945,15.985375 0.00268088,14.571161 14.665349,0.11059276 Z"
+     fill="#202020"
+     id="path3053"
+     style="display:none;fill:#450ba5"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="g3069"
+     transform="matrix(0,-1,-1,0,16.169824,15.947934)"
+     style="fill:#fefefe;fill-opacity:1">
+    <path
+       id="path3061"
+       style="fill:#fefefe;fill-opacity:1"
+       d="m 0.98046875,12.964844 v 0.640625 L 1.6308594,12.964844 Z" />
+    <path
+       id="path3063"
+       style="fill:#fefefe;fill-opacity:1"
+       d="M 0.98046875,8.9296875 V 10.929688 H 3.6933594 L 5.7226562,8.9296875 Z" />
+    <path
+       id="path3065"
+       style="fill:#fefefe;fill-opacity:1"
+       d="m 0.98046875,5.0429688 v 2 H 7.6367188 l 2.0273437,-2 z" />
+    <path
+       id="path3067"
+       style="fill:#fefefe;fill-opacity:1"
+       d="m 0.98046875,1.0332031 v 2 H 11.703125 l 2.027344,-2 z" />
+  </g>
+  <g
+     id="g3059"
+     style="fill:#fefefe;fill-opacity:1">
+    <path
+       id="path2-4-4-9-8-8-0-8-0"
+       style="fill:#fefefe;fill-opacity:1"
+       d="M 0.98046875 12.964844 L 0.98046875 13.605469 L 1.6308594 12.964844 L 0.98046875 12.964844 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5"
+       style="fill:#fefefe;fill-opacity:1"
+       d="M 0.98046875 8.9296875 L 0.98046875 10.929688 L 3.6933594 10.929688 L 5.7226562 8.9296875 L 0.98046875 8.9296875 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5-9"
+       style="fill:#fefefe;fill-opacity:1"
+       d="M 0.98046875 5.0429688 L 0.98046875 7.0429688 L 7.6367188 7.0429688 L 9.6640625 5.0429688 L 0.98046875 5.0429688 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8"
+       style="fill:#fefefe;fill-opacity:1"
+       d="M 0.98046875 1.0332031 L 0.98046875 3.0332031 L 11.703125 3.0332031 L 13.730469 1.0332031 L 0.98046875 1.0332031 z " />
+  </g>
+</svg>

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -506,6 +506,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/refresh.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Dark/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Dark/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Dark/cogs.svg);
 }

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -506,6 +506,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Light/refresh.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Light/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Light/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Light/cogs.svg);
 }

--- a/UI/data/themes/Light/mixer-layout.svg
+++ b/UI/data/themes/Light/mixer-layout.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="mixer-layout.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="14.274718"
+     inkscape:cy="11.490485"
+     inkscape:window-width="1366"
+     inkscape:window-height="697"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 16.079562,1.5248063 1.4168945,15.985375 0.00268088,14.571161 14.665349,0.11059276 Z"
+     fill="#202020"
+     id="path3053"
+     style="display:none;fill:#450ba5"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="g3069"
+     transform="matrix(0,-1,-1,0,16.169824,15.947934)"
+     style="fill:#202020;fill-opacity:1">
+    <path
+       id="path3061"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,12.964844 v 0.640625 L 1.6308594,12.964844 Z" />
+    <path
+       id="path3063"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875,8.9296875 V 10.929688 H 3.6933594 L 5.7226562,8.9296875 Z" />
+    <path
+       id="path3065"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,5.0429688 v 2 H 7.6367188 l 2.0273437,-2 z" />
+    <path
+       id="path3067"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,1.0332031 v 2 H 11.703125 l 2.027344,-2 z" />
+  </g>
+  <g
+     id="g3059"
+     style="fill:#202020;fill-opacity:1">
+    <path
+       id="path2-4-4-9-8-8-0-8-0"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 12.964844 L 0.98046875 13.605469 L 1.6308594 12.964844 L 0.98046875 12.964844 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 8.9296875 L 0.98046875 10.929688 L 3.6933594 10.929688 L 5.7226562 8.9296875 L 0.98046875 8.9296875 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5-9"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 5.0429688 L 0.98046875 7.0429688 L 7.6367188 7.0429688 L 9.6640625 5.0429688 L 0.98046875 5.0429688 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 1.0332031 L 0.98046875 3.0332031 L 11.703125 3.0332031 L 13.730469 1.0332031 L 0.98046875 1.0332031 z " />
+  </g>
+</svg>

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -514,6 +514,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/refresh.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Dark/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Dark/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Dark/cogs.svg);
 }

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -54,6 +54,14 @@ OBSThemeMeta {
     qproperty-icon: url(:res/images/dots-vert.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(:res/images/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(:/res/images/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(:/res/images/cogs.svg);
 }

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -510,6 +510,14 @@ QToolButton:pressed {
     qproperty-icon: url(./Dark/refresh.svg);
 }
 
+* [themeID="visibleIcon"] {
+    qproperty-icon: url(./Dark/visible.svg);
+}
+
+* [themeID="mixerIcon"] {
+    qproperty-icon: url(./Dark/mixer-layout.svg);
+}
+
 * [themeID="cogsIcon"] {
     qproperty-icon: url(./Dark/cogs.svg);
 }

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1186,9 +1186,11 @@
           <property name="floatable">
            <bool>false</bool>
           </property>
-          <addaction name="actionMixerToolbarAdvAudio"/>
+          <addaction name="actionMixerToolbarUnhideAll"/>
           <addaction name="separator"/>
-          <addaction name="actionMixerToolbarMenu"/>
+          <addaction name="actionMixerToolbarVerticalLayout"/>
+          <addaction name="separator"/>
+          <addaction name="actionMixerToolbarAdvAudio"/>
          </widget>
         </item>
        </layout>
@@ -2284,6 +2286,36 @@
     <string>Undo.Redo</string>
    </property>
   </action>
+  <action name="actionMixerToolbarUnhideAll">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/visible.svg</normaloff>:/res/images/visible.svg</iconset>
+   </property>
+   <property name="text">
+    <string>UnhideAll</string>
+   </property>
+   <property name="toolTip">
+    <string>UnhideAll</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string>visibleIcon</string>
+   </property>
+  </action>
+  <action name="actionMixerToolbarVerticalLayout">
+   <property name="icon">
+    <iconset resource="obs.qrc">
+     <normaloff>:/res/images/mixer-layout.svg</normaloff>:/res/images/mixer-layout.svg</iconset>
+   </property>
+   <property name="text">
+    <string>VerticalLayout</string>
+   </property>
+   <property name="toolTip">
+    <string>VerticalLayout</string>
+   </property>
+   <property name="themeID" stdset="0">
+    <string>mixerIcon</string>
+   </property>
+  </action>
   <action name="actionMixerToolbarAdvAudio">
    <property name="icon">
     <iconset resource="obs.qrc">
@@ -2297,18 +2329,6 @@
    </property>
    <property name="themeID" stdset="0">
     <string>cogsIcon</string>
-   </property>
-  </action>
-  <action name="actionMixerToolbarMenu">
-   <property name="icon">
-    <iconset resource="obs.qrc">
-     <normaloff>:/res/images/dots-vert.svg</normaloff>:/res/images/dots-vert.svg</iconset>
-   </property>
-   <property name="text">
-    <string>MixerToolbarMenu</string>
-   </property>
-   <property name="themeID" stdset="0">
-    <string>menuIconSmall</string>
    </property>
   </action>
   <action name="actionSceneFilters">

--- a/UI/forms/images/mixer-layout.svg
+++ b/UI/forms/images/mixer-layout.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16px"
+   viewBox="0 0 16 16"
+   width="16px"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="mixer-layout.svg"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="14.274718"
+     inkscape:cy="11.490485"
+     inkscape:window-width="1366"
+     inkscape:window-height="697"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 16.079562,1.5248063 1.4168945,15.985375 0.00268088,14.571161 14.665349,0.11059276 Z"
+     fill="#202020"
+     id="path3053"
+     style="display:none;fill:#450ba5"
+     sodipodi:nodetypes="ccccc" />
+  <g
+     id="g3069"
+     transform="matrix(0,-1,-1,0,16.169824,15.947934)"
+     style="fill:#202020;fill-opacity:1">
+    <path
+       id="path3061"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,12.964844 v 0.640625 L 1.6308594,12.964844 Z" />
+    <path
+       id="path3063"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875,8.9296875 V 10.929688 H 3.6933594 L 5.7226562,8.9296875 Z" />
+    <path
+       id="path3065"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,5.0429688 v 2 H 7.6367188 l 2.0273437,-2 z" />
+    <path
+       id="path3067"
+       style="fill:#202020;fill-opacity:1"
+       d="m 0.98046875,1.0332031 v 2 H 11.703125 l 2.027344,-2 z" />
+  </g>
+  <g
+     id="g3059"
+     style="fill:#202020;fill-opacity:1">
+    <path
+       id="path2-4-4-9-8-8-0-8-0"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 12.964844 L 0.98046875 13.605469 L 1.6308594 12.964844 L 0.98046875 12.964844 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 8.9296875 L 0.98046875 10.929688 L 3.6933594 10.929688 L 5.7226562 8.9296875 L 0.98046875 8.9296875 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8-0-5-9"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 5.0429688 L 0.98046875 7.0429688 L 7.6367188 7.0429688 L 9.6640625 5.0429688 L 0.98046875 5.0429688 z " />
+    <path
+       id="path2-4-4-9-8-8-0-8"
+       style="fill:#202020;fill-opacity:1"
+       d="M 0.98046875 1.0332031 L 0.98046875 3.0332031 L 11.703125 3.0332031 L 13.730469 1.0332031 L 0.98046875 1.0332031 z " />
+  </g>
+</svg>

--- a/UI/forms/obs.qrc
+++ b/UI/forms/obs.qrc
@@ -64,6 +64,7 @@
     <file>images/expand.svg</file>
     <file>images/collapse.svg</file>
     <file>images/entry-clear.svg</file>
+    <file>images/mixer-layout.svg</file>
   </qresource>
   <qresource prefix="/settings">
     <file>images/settings/output.svg</file>

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3653,7 +3653,6 @@ void OBSBasic::VolControlContextMenu()
 	lockAction.setChecked(SourceVolumeLocked(vol->GetSource()));
 
 	QAction hideAction(QTStr("Hide"), this);
-	QAction unhideAllAction(QTStr("UnhideAll"), this);
 	QAction mixerRenameAction(QTStr("Rename"), this);
 
 	QAction copyFiltersAction(QTStr("Copy.Filters"), this);
@@ -3672,8 +3671,6 @@ void OBSBasic::VolControlContextMenu()
 
 	connect(&hideAction, &QAction::triggered, this,
 		&OBSBasic::HideAudioControl, Qt::DirectConnection);
-	connect(&unhideAllAction, &QAction::triggered, this,
-		&OBSBasic::UnhideAllAudioControls, Qt::DirectConnection);
 	connect(&lockAction, &QAction::toggled, this,
 		&OBSBasic::LockVolumeControl, Qt::DirectConnection);
 	connect(&mixerRenameAction, &QAction::triggered, this,
@@ -3733,7 +3730,6 @@ void OBSBasic::VolControlContextMenu()
 	vol->SetContextMenu(&popup);
 	popup.addAction(&lockAction);
 	popup.addSeparator();
-	popup.addAction(&unhideAllAction);
 	popup.addAction(&hideAction);
 	popup.addAction(&mixerRenameAction);
 	popup.addSeparator();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3662,11 +3662,6 @@ void OBSBasic::VolControlContextMenu()
 	QAction propertiesAction(QTStr("Properties"), this);
 	QAction advPropAction(QTStr("Basic.MainMenu.Edit.AdvAudio"), this);
 
-	QAction toggleControlLayoutAction(QTStr("VerticalLayout"), this);
-	toggleControlLayoutAction.setCheckable(true);
-	toggleControlLayoutAction.setChecked(config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "VerticalVolControl"));
-
 	/* ------------------- */
 
 	connect(&hideAction, &QAction::triggered, this,
@@ -3688,11 +3683,6 @@ void OBSBasic::VolControlContextMenu()
 	connect(&advPropAction, &QAction::triggered, this,
 		&OBSBasic::on_actionAdvAudioProperties_triggered,
 		Qt::DirectConnection);
-
-	/* ------------------- */
-
-	connect(&toggleControlLayoutAction, &QAction::changed, this,
-		&OBSBasic::ToggleVolControlLayout, Qt::DirectConnection);
 
 	/* ------------------- */
 
@@ -3727,7 +3717,6 @@ void OBSBasic::VolControlContextMenu()
 	}
 
 	QMenu popup;
-	vol->SetContextMenu(&popup);
 	popup.addAction(&lockAction);
 	popup.addSeparator();
 	popup.addAction(&hideAction);
@@ -3736,16 +3725,10 @@ void OBSBasic::VolControlContextMenu()
 	popup.addAction(&copyFiltersAction);
 	popup.addAction(&pasteFiltersAction);
 	popup.addSeparator();
-	popup.addAction(&toggleControlLayoutAction);
-	popup.addSeparator();
 	popup.addAction(&filtersAction);
 	popup.addAction(&propertiesAction);
 	popup.addAction(&advPropAction);
-
-	// toggleControlLayoutAction deletes and re-creates the volume controls
-	// meaning that "vol" would be pointing to freed memory.
-	if (popup.exec(QCursor::pos()) != &toggleControlLayoutAction)
-		vol->SetContextMenu(nullptr);
+	popup.exec(QCursor::pos());
 }
 
 void OBSBasic::on_hMixerScrollArea_customContextMenuRequested()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3660,7 +3660,6 @@ void OBSBasic::VolControlContextMenu()
 
 	QAction filtersAction(QTStr("Filters"), this);
 	QAction propertiesAction(QTStr("Properties"), this);
-	QAction advPropAction(QTStr("Basic.MainMenu.Edit.AdvAudio"), this);
 
 	/* ------------------- */
 
@@ -3680,9 +3679,6 @@ void OBSBasic::VolControlContextMenu()
 		&OBSBasic::GetAudioSourceFilters, Qt::DirectConnection);
 	connect(&propertiesAction, &QAction::triggered, this,
 		&OBSBasic::GetAudioSourceProperties, Qt::DirectConnection);
-	connect(&advPropAction, &QAction::triggered, this,
-		&OBSBasic::on_actionAdvAudioProperties_triggered,
-		Qt::DirectConnection);
 
 	/* ------------------- */
 
@@ -3727,7 +3723,6 @@ void OBSBasic::VolControlContextMenu()
 	popup.addSeparator();
 	popup.addAction(&filtersAction);
 	popup.addAction(&propertiesAction);
-	popup.addAction(&advPropAction);
 	popup.exec(QCursor::pos());
 }
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5258,29 +5258,19 @@ void OBSBasic::on_actionAdvAudioProperties_triggered()
 	advAudioWindow->SetIconsVisible(iconsVisible);
 }
 
+void OBSBasic::on_actionMixerToolbarUnhideAll_triggered()
+{
+	UnhideAllAudioControls();
+}
+
+void OBSBasic::on_actionMixerToolbarVerticalLayout_triggered()
+{
+	ToggleVolControlLayout();
+}
+
 void OBSBasic::on_actionMixerToolbarAdvAudio_triggered()
 {
 	on_actionAdvAudioProperties_triggered();
-}
-
-void OBSBasic::on_actionMixerToolbarMenu_triggered()
-{
-	QAction unhideAllAction(QTStr("UnhideAll"), this);
-	connect(&unhideAllAction, &QAction::triggered, this,
-		&OBSBasic::UnhideAllAudioControls, Qt::DirectConnection);
-
-	QAction toggleControlLayoutAction(QTStr("VerticalLayout"), this);
-	toggleControlLayoutAction.setCheckable(true);
-	toggleControlLayoutAction.setChecked(config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "VerticalVolControl"));
-	connect(&toggleControlLayoutAction, &QAction::changed, this,
-		&OBSBasic::ToggleVolControlLayout, Qt::DirectConnection);
-
-	QMenu popup;
-	popup.addAction(&unhideAllAction);
-	popup.addSeparator();
-	popup.addAction(&toggleControlLayoutAction);
-	popup.exec(QCursor::pos());
 }
 
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1038,8 +1038,9 @@ private slots:
 	void on_actionShowMacPermissions_triggered();
 	void on_actionShowMissingFiles_triggered();
 	void on_actionAdvAudioProperties_triggered();
+	void on_actionMixerToolbarUnhideAll_triggered();
+	void on_actionMixerToolbarVerticalLayout_triggered();
 	void on_actionMixerToolbarAdvAudio_triggered();
-	void on_actionMixerToolbarMenu_triggered();
 	void on_actionShowLogs_triggered();
 	void on_actionUploadCurrentLog_triggered();
 	void on_actionUploadLastLog_triggered();


### PR DESCRIPTION
### Description
- Removes Unhide All entry from volume context menu
- Removes Vertical Layout entry from volume context menu
- Removes Advanced Audio Properties entry from volume context menu
- Improves discoverability of these options in the mixer toolbar

### Motivation and Context
Until today, OBS audio options are few, however, repeated too much in different parts of the interface (e.g., it is possible to access Advanced Audio Options from 4 different places). 
While it is understandable and common for professional programs to have more than one way to access a function, as it is currently implemented., however, it doesn't makes to the user experience better, just duplicated.

---

One way to better "please everyone" would be to 1) keep the menu bar entry; 2) remove redundant entries of volume's context menu; 3) improve the mixer toolbar turning entries into buttons and with the mixer context menu order, like this:

https://github.com/obsproject/obs-studio/assets/136904537/33ab56d2-7e69-41ee-bb20-0d2aad0180de

(Ignore the wrong icons, they are not in the final version of MR)


### How Has This Been Tested?
Compiled via new cmake commands and tested
Windows 11

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
