### PR TITLE
libobs: Detect and log presence of Lenovo Vantage on Windows

### DIFF
--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -133,6 +133,31 @@ static void log_available_memory(void)
 	     (DWORD)(ms.ullAvailPhys / 1048576), note);
 }
 
+static void log_lenovo_vantage(void)
+{
+	SC_HANDLE manager = OpenSCManager(NULL, NULL, SC_MANAGER_CONNECT);
+
+	if (!manager)
+		return;
+
+	SC_HANDLE service =
+		OpenService(manager, L"FBNetFilter", SERVICE_QUERY_STATUS);
+
+	if (service) {
+		blog(LOG_WARNING,
+		     "Lenovo Vantage / Legion Edge is installed. The \"Network Boost\" "
+		     "feature must be disabled when streaming with OBS.");
+		CloseServiceHandle(service);
+	}
+
+	CloseServiceHandle(manager);
+}
+
+static void log_conflicting_software(void)
+{
+	log_lenovo_vantage();
+}
+
 extern const char *get_win_release_id();
 
 static void log_windows_version(void)
@@ -382,6 +407,7 @@ void log_system_info(void)
 	log_admin_status();
 	log_gaming_features();
 	log_security_products();
+	log_conflicting_software();
 }
 
 struct obs_hotkeys_platform {


### PR DESCRIPTION
### Description
Adds a `log_conflicting_software` function which can be used to check for and log possible 3rd party software interference, in this case, Lenovo Vantage.

I'm not sure if the best place for this is in libobs or OBS, discussion welcome.

### Motivation and Context
Many users have Lenovo PCs and Lenovo Vantage / Legion Edge ("gamer" version) is pre-installed, causing issues with OBS that aren't immediately obvious. By logging this it is easier to handle support cases; ideally when we have a non-critical notification system it can also be raised there.

### How Has This Been Tested?
Not tested very well as I don't have such software installed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
