### PR TITLE
libobs: Add OS keychain API

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -57,6 +57,7 @@
         "modules/40-usrsctp.json",
         "modules/50-jansson.json",
         "modules/50-libdatachannel.json",
+        "modules/50-libsecret.json",
         "modules/50-ntv2.json",
         "modules/50-pipewire.json",
         "modules/50-swig.json",

--- a/build-aux/modules/50-libsecret.json
+++ b/build-aux/modules/50-libsecret.json
@@ -1,0 +1,23 @@
+{
+    "name": "libsecret",
+    "buildsystem": "meson",
+    "config-opts": [
+        "-Dmanpage=false",
+        "-Dvapi=false",
+        "-Dgtk_doc=false",
+        "-Dintrospection=false"
+    ],
+    "cleanup": [
+        "/bin",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    "sources": [
+        {
+            "type": "archive",
+            "url": "https://download.gnome.org/sources/libsecret/0.20/libsecret-0.20.5.tar.xz",
+            "sha256": "3fb3ce340fcd7db54d87c893e69bfc2b1f6e4d4b279065ffe66dac9f0fd12b4d"
+        }
+    ]
+}

--- a/cmake/Modules/FindLibsecret.cmake
+++ b/cmake/Modules/FindLibsecret.cmake
@@ -1,0 +1,111 @@
+#[=======================================================================[.rst
+FindLibsecret
+-------------
+
+FindModule for libsecret and the associated library
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.0
+
+This module defines the :prop_tgt:`IMPORTED` target ``Libsecret::Libsecret``.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module sets the following variables:
+
+``Libsecret_FOUND``
+  True, if the library was found.
+``Libsecret_VERSION``
+  Detected version of found Libsecret library.
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Libsecret_INCLUDE_DIR``
+  Directory containing ``secret.h``.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_search_module(PC_Libsecret QUIET libsecret-1)
+endif()
+
+# Libsecret_set_soname: Set SONAME on imported library target
+macro(Libsecret_set_soname)
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
+    execute_process(
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Libsecret_LIBRARY}' | grep SONAME"
+      OUTPUT_VARIABLE _output
+      RESULT_VARIABLE _result)
+
+    if(_result EQUAL 0)
+      string(REGEX REPLACE "[ \t]+SONAME[ \t]+([^ \t]+)" "\\1" _soname "${_output}")
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_SONAME "${_soname}")
+      unset(_soname)
+    endif()
+  endif()
+  unset(_output)
+  unset(_result)
+endmacro()
+
+find_path(
+  Libsecret_INCLUDE_DIR
+  NAMES libsecret/secret.h
+  HINTS ${PC_Libsecret_INCLUDE_DIRS}
+  PATHS /usr/include /usr/local/include
+  PATH_SUFFIXES libsecret-1
+  DOC "Libsecret include directory")
+
+find_library(
+  Libsecret_LIBRARY
+  NAMES secret secret-1 libsecret libsecret-1
+  HINTS ${PC_Libsecret_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib
+  DOC "Libsecret location")
+
+if(PC_Libsecret_VERSION VERSION_GREATER 0)
+  set(Libsecret_VERSION ${PC_Libsecret_VERSION})
+elseif(EXISTS "${Libsecret_INCLUDE_DIR}/secret-version.h")
+  file(STRINGS "${Libsecret_INCLUDE_DIR}/secret-version.h" _version_string)
+  string(REGEX REPLACE "SECRET_[A-Z]+_VERSION \\(([0-9]+)\\)" "\\1\\.\\2\\.\\3" Libsecret_VERSION "${_version_string}")
+else()
+  if(NOT Libsecret_FIND_QUIETLY)
+    message(AUTHOR_WARNING "Failed to find Libsecret version.")
+  endif()
+  set(Libsecret_VERSION 0.0.0)
+endif()
+
+find_package_handle_standard_args(
+  Libsecret
+  REQUIRED_VARS Libsecret_INCLUDE_DIR Libsecret_LIBRARY
+  VERSION_VAR Libsecret_VERSION REASON_FAILURE_MESSAGE "Ensure libsecret-1 is installed on the system.")
+mark_as_advanced(Libsecret_INCLUDE_DIR Libsecret_LIBRARY)
+
+if(Libsecret_FOUND)
+  if(NOT TARGET Libsecret::Libsecret)
+    if(IS_ABSOLUTE "${Libsecret_LIBRARY}")
+      add_library(Libsecret::Libsecret UNKNOWN IMPORTED)
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_LOCATION "${Libsecret_LIBRARY}")
+    else()
+      add_library(Libsecret::Libsecret INTERFACE IMPORTED)
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_LIBNAME "${Libsecret_LIBRARY}")
+    endif()
+
+    libsecret_set_soname()
+    set_target_properties(Libsecret::Libsecret PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Libsecret_INCLUDE_DIR}")
+  endif()
+endif()
+
+include(FeatureSummary)
+set_package_properties(
+  Libsecret PROPERTIES
+  URL "https://gnome.pages.gitlab.gnome.org/libsecret/index.html"
+  DESCRIPTION "Secret Service D-Bus client library")

--- a/cmake/finders/FindLibsecret.cmake
+++ b/cmake/finders/FindLibsecret.cmake
@@ -1,0 +1,111 @@
+#[=======================================================================[.rst
+FindLibsecret
+-------------
+
+FindModule for libsecret and the associated library
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+.. versionadded:: 2.0
+
+This module defines the :prop_tgt:`IMPORTED` target ``Libsecret::Libsecret``.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module sets the following variables:
+
+``Libsecret_FOUND``
+  True, if the library was found.
+``Libsecret_VERSION``
+  Detected version of found Libsecret library.
+
+Cache variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``Libsecret_INCLUDE_DIR``
+  Directory containing ``secret.h``.
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_search_module(PC_Libsecret QUIET libsecret-1)
+endif()
+
+# Libsecret_set_soname: Set SONAME on imported library target
+macro(Libsecret_set_soname)
+  if(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux")
+    execute_process(
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Libsecret_LIBRARY}' | grep SONAME"
+      OUTPUT_VARIABLE _output
+      RESULT_VARIABLE _result)
+
+    if(_result EQUAL 0)
+      string(REGEX REPLACE "[ \t]+SONAME[ \t]+([^ \t]+)" "\\1" _soname "${_output}")
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_SONAME "${_soname}")
+      unset(_soname)
+    endif()
+  endif()
+  unset(_output)
+  unset(_result)
+endmacro()
+
+find_path(
+  Libsecret_INCLUDE_DIR
+  NAMES libsecret/secret.h
+  HINTS ${PC_Libsecret_INCLUDE_DIRS}
+  PATHS /usr/include /usr/local/include
+  PATH_SUFFIXES libsecret-1
+  DOC "Libsecret include directory")
+
+find_library(
+  Libsecret_LIBRARY
+  NAMES secret secret-1 libsecret libsecret-1
+  HINTS ${PC_Libsecret_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib
+  DOC "Libsecret location")
+
+if(PC_Libsecret_VERSION VERSION_GREATER 0)
+  set(Libsecret_VERSION ${PC_Libsecret_VERSION})
+elseif(EXISTS "${Libsecret_INCLUDE_DIR}/secret-version.h")
+  file(STRINGS "${Libsecret_INCLUDE_DIR}/secret-version.h" _version_string)
+  string(REGEX REPLACE "SECRET_[A-Z]+_VERSION \\(([0-9]+)\\)" "\\1\\.\\2\\.\\3" Libsecret_VERSION "${_version_string}")
+else()
+  if(NOT Libsecret_FIND_QUIETLY)
+    message(AUTHOR_WARNING "Failed to find Libsecret version.")
+  endif()
+  set(Libsecret_VERSION 0.0.0)
+endif()
+
+find_package_handle_standard_args(
+  Libsecret
+  REQUIRED_VARS Libsecret_INCLUDE_DIR Libsecret_LIBRARY
+  VERSION_VAR Libsecret_VERSION REASON_FAILURE_MESSAGE "Ensure libsecret-1 is installed on the system.")
+mark_as_advanced(Libsecret_INCLUDE_DIR Libsecret_LIBRARY)
+
+if(Libsecret_FOUND)
+  if(NOT TARGET Libsecret::Libsecret)
+    if(IS_ABSOLUTE "${Libsecret_LIBRARY}")
+      add_library(Libsecret::Libsecret UNKNOWN IMPORTED)
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_LOCATION "${Libsecret_LIBRARY}")
+    else()
+      add_library(Libsecret::Libsecret INTERFACE IMPORTED)
+      set_property(TARGET Libsecret::Libsecret PROPERTY IMPORTED_LIBNAME "${Libsecret_LIBRARY}")
+    endif()
+
+    libsecret_set_soname()
+    set_target_properties(Libsecret::Libsecret PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Libsecret_INCLUDE_DIR}")
+  endif()
+endif()
+
+include(FeatureSummary)
+set_package_properties(
+  Libsecret PROPERTIES
+  URL "https://gnome.pages.gitlab.gnome.org/libsecret/index.html"
+  DESCRIPTION "Secret Service D-Bus client library")

--- a/docs/sphinx/reference-libobs-util-platform.rst
+++ b/docs/sphinx/reference-libobs-util-platform.rst
@@ -505,3 +505,34 @@ Other Functions
    Must be freed with :c:func:`bfree()`.
 
    .. versionadded:: 29.1
+
+---------------------
+
+.. function:: bool *os_keychain_available(void)
+
+   Indicates whether or not the keychain APIs are implemented on this platform.
+   
+   On Windows/macOS this will always return `true` and the keychain is guaranteed to be available.
+   On Linux it will return `true` if OBS is compiled with libsecret, but keychain operations may still fail if no Secret Service (e.g. kwaller or gnome-keyring) is available.
+
+---------------------
+
+.. function:: bool os_keychain_save(const char *label, const char *key, const char *data)
+
+   Saves the string `data` into the OS keychain as key `key` with user-visible name `label`.
+   
+   `label` should be a short descriptor of the kind of data being saved (e.g. "OBS Studio OAuth Credentials"), must not be translated, and must be identical when attempting to save/load/delete the same `key`.
+
+---------------------
+
+.. function:: bool os_keychain_load(const char *label, const char *key, char **data)
+
+   Attempt to read the string saved with key `key` in and with label `label` from the keychain.
+   
+   If successful, `data´ must be freed with :c:func:`bfree()`.
+
+---------------------
+
+.. function:: bool os_keychain_delete(const char *label, const char *key)
+
+   Deletes an item from the keychain.

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -316,7 +316,7 @@ if(OS_WINDOWS)
   target_compile_definitions(libobs PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS)
   set_source_files_properties(obs-win-crash-handler.c PROPERTIES COMPILE_DEFINITIONS
                                                                  OBS_VERSION="${OBS_VERSION_CANONICAL}")
-  target_link_libraries(libobs PRIVATE dxgi Avrt Dwmapi winmm Rpcrt4)
+  target_link_libraries(libobs PRIVATE dxgi Advapi32 Avrt Dwmapi winmm Rpcrt4)
 
   if(MSVC)
     target_link_libraries(libobs PUBLIC OBS::w32-pthreads)

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -424,6 +424,14 @@ elseif(OS_POSIX)
     target_link_libraries(libobs PRIVATE GIO::GIO)
 
     target_sources(libobs PRIVATE util/platform-nix-dbus.c util/platform-nix-portal.c)
+
+    find_package(Libsecret)
+    if(TARGET Libsecret::Libsecret)
+      obs_status(STATUS "-> libsecret found, enabling keychain API")
+      target_link_libraries(libobs PRIVATE Libsecret::Libsecret)
+      target_compile_definitions(libobs PRIVATE USE_LIBSECRET)
+      target_sources(libobs PRIVATE util/platform-nix-libsecret.c)
+    endif()
   endif()
 
   if(TARGET XCB::XINPUT)

--- a/libobs/cmake/os-linux.cmake
+++ b/libobs/cmake/os-linux.cmake
@@ -5,6 +5,7 @@ find_package(x11-xcb REQUIRED)
 find_package(xcb COMPONENTS xcb OPTIONAL_COMPONENTS xcb-xinput QUIET)
 # cmake-format: on
 find_package(gio)
+find_package(Libsecret)
 
 target_sources(
   libobs
@@ -43,6 +44,15 @@ endif()
 if(TARGET gio::gio)
   target_sources(libobs PRIVATE util/platform-nix-dbus.c util/platform-nix-portal.c)
   target_link_libraries(libobs PRIVATE gio::gio)
+
+  if(TARGET Libsecret::Libsecret)
+    target_compile_definitions(libobs PRIVATE USE_LIBSECRET)
+    target_sources(libobs PRIVATE util/platform-nix-libsecret.c)
+    target_link_libraries(libobs PRIVATE Libsecret::Libsecret)
+    target_enable_feature(libobs "Libsecret Keychain API (Linux)")
+  else()
+    target_disable_feature(libobs "Libsecret Keychain API (Linux)")
+  endif()
 endif()
 
 if(ENABLE_WAYLAND)

--- a/libobs/cmake/os-macos.cmake
+++ b/libobs/cmake/os-macos.cmake
@@ -6,7 +6,8 @@ target_link_libraries(
           "$<LINK_LIBRARY:FRAMEWORK,AudioUnit.framework>"
           "$<LINK_LIBRARY:FRAMEWORK,AppKit.framework>"
           "$<LINK_LIBRARY:FRAMEWORK,IOKit.framework>"
-          "$<LINK_LIBRARY:FRAMEWORK,Carbon.framework>")
+          "$<LINK_LIBRARY:FRAMEWORK,Carbon.framework>"
+          "$<LINK_LIBRARY:FRAMEWORK,Security.framework>")
 
 target_sources(
   libobs

--- a/libobs/cmake/os-windows.cmake
+++ b/libobs/cmake/os-windows.cmake
@@ -46,6 +46,7 @@ set_source_files_properties(obs-win-crash-handler.c PROPERTIES COMPILE_DEFINITIO
 target_link_libraries(
   libobs
   PRIVATE Avrt
+          Advapi32
           Dwmapi
           Dxgi
           winmm

--- a/libobs/util/platform-nix-libsecret.c
+++ b/libobs/util/platform-nix-libsecret.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <gio/gio.h>
+#include <libsecret/secret.h>
+
+#include "platform.h"
+#include "bmem.h"
+
+static const SecretSchema obs_schema = {
+	"com.obsproject.libobs.Secret",
+	SECRET_SCHEMA_NONE,
+	{
+		{"key", SECRET_SCHEMA_ATTRIBUTE_STRING},
+		{"NULL", 0},
+	}};
+
+bool os_keychain_available(void)
+{
+	return true;
+}
+
+bool os_keychain_save(const char *label, const char *key, const char *data)
+{
+	if (!label || !key || !data)
+		return false;
+
+	GError *error = NULL;
+	secret_password_store_sync(&obs_schema, SECRET_COLLECTION_DEFAULT,
+				   label, data, NULL, &error, "key", key, NULL);
+	if (error != NULL) {
+		blog(LOG_ERROR,
+		     "Keychain item \"%s::%s\" could not be saved: %s", label,
+		     key, error->message);
+		g_error_free(error);
+		return false;
+	}
+
+	return true;
+}
+
+bool os_keychain_load(const char *label, const char *key, char **data)
+{
+	if (!label || !key || !data)
+		return false;
+
+	GError *error = NULL;
+	gchar *password = secret_password_lookup_sync(&obs_schema, NULL, &error,
+						      "key", key, NULL);
+
+	if (error != NULL) {
+		blog(LOG_ERROR,
+		     "Keychain item \"%s::%s\" could not be read: %s", label,
+		     key, error->message);
+		g_error_free(error);
+		return false;
+	} else if (password == NULL) {
+		return false;
+	}
+
+	*data = bstrdup(password);
+	secret_password_free(password);
+	return true;
+}
+
+bool os_keychain_delete(const char *label, const char *key)
+{
+	if (!label || !key)
+		return false;
+
+	GError *error = NULL;
+	gboolean removed = secret_password_clear_sync(&obs_schema, NULL, &error,
+						      "key", key, NULL);
+
+	if (error != NULL) {
+		if (error->code == SECRET_ERROR_NO_SUCH_OBJECT) {
+			removed = true;
+		} else {
+			blog(LOG_ERROR,
+			     "Keychain item \"%s::%s\" could not be deleted: %s",
+			     label, key, error->message);
+		}
+
+		g_error_free(error);
+	}
+
+	return removed;
+}

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -1149,7 +1149,7 @@ char *os_generate_uuid(void)
 	return out;
 }
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(USE_LIBSECRET)
 bool os_keychain_available(void)
 {
 	return false;

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -1148,3 +1148,36 @@ char *os_generate_uuid(void)
 	uuid_unparse_lower(uuid, out);
 	return out;
 }
+
+#ifndef __APPLE__
+bool os_keychain_available(void)
+{
+	return false;
+}
+
+bool os_keychain_save(const char *label, const char *key, const char *data)
+{
+	/* Not implemented */
+	UNUSED_PARAMETER(label);
+	UNUSED_PARAMETER(key);
+	UNUSED_PARAMETER(data);
+	return false;
+}
+
+bool os_keychain_load(const char *label, const char *key, char **data)
+{
+	/* Not implemented */
+	UNUSED_PARAMETER(label);
+	UNUSED_PARAMETER(key);
+	UNUSED_PARAMETER(data);
+	return false;
+}
+
+bool os_keychain_delete(const char *label, const char *key)
+{
+	/* Not implemented */
+	UNUSED_PARAMETER(label);
+	UNUSED_PARAMETER(key);
+	return false;
+}
+#endif

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -205,6 +205,12 @@ EXPORT uint64_t os_get_proc_virtual_size(void);
 
 EXPORT char *os_generate_uuid(void);
 
+EXPORT bool os_keychain_available(void);
+EXPORT bool os_keychain_save(const char *label, const char *key,
+			     const char *data);
+EXPORT bool os_keychain_load(const char *label, const char *key, char **data);
+EXPORT bool os_keychain_delete(const char *label, const char *key);
+
 /* clang-format off */
 #ifdef __APPLE__
 # define ARCH_BITS 64


### PR DESCRIPTION
### Description

Implements OS keychain APIs per https://github.com/obsproject/rfcs/pull/54 for Windows, macOS, and Linux (via libsecret).

### Motivation and Context

Secure storage for sensitive data.

### How Has This Been Tested?

Tested on Windows, macOS, and Ubuntu 22.04 with # applied on top.

### Types of changes

- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
