### PR TITLE
obs-webrtc: Add user-agent, timestamp, and ssrc generation

### DIFF
--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -14,7 +14,8 @@ find_package(CURL REQUIRED)
 add_library(obs-webrtc MODULE)
 add_library(OBS::webrtc ALIAS obs-webrtc)
 
-target_sources(obs-webrtc PRIVATE obs-webrtc.cpp whip-output.cpp whip-output.h whip-service.cpp whip-service.h)
+target_sources(obs-webrtc PRIVATE obs-webrtc.cpp whip-output.cpp whip-output.h whip-service.cpp whip-service.h
+                                  whip-utils.h)
 
 target_link_libraries(obs-webrtc PRIVATE OBS::libobs LibDataChannel::LibDataChannel CURL::libcurl)
 

--- a/plugins/obs-webrtc/cmake/legacy.cmake
+++ b/plugins/obs-webrtc/cmake/legacy.cmake
@@ -12,7 +12,8 @@ find_package(CURL REQUIRED)
 add_library(obs-webrtc MODULE)
 add_library(OBS::webrtc ALIAS obs-webrtc)
 
-target_sources(obs-webrtc PRIVATE obs-webrtc.cpp whip-output.cpp whip-output.h whip-service.cpp whip-service.h)
+target_sources(obs-webrtc PRIVATE obs-webrtc.cpp whip-output.cpp whip-output.h whip-service.cpp whip-service.h
+                                  whip-utils.h)
 
 target_link_libraries(obs-webrtc PRIVATE OBS::libobs LibDataChannel::LibDataChannel CURL::libcurl)
 

--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <obs-module.h>
 #include <util/curl/curl-helper.h>
 #include <util/platform.h>
@@ -11,13 +12,6 @@
 #include <thread>
 
 #include <rtc/rtc.h>
-
-#define do_log(level, format, ...)                              \
-	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
-	     obs_output_get_name(output), ##__VA_ARGS__)
-#define do_log_s(level, format, ...)                            \
-	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
-	     obs_output_get_name(whipOutput->output), ##__VA_ARGS__)
 
 class WHIPOutput {
 public:
@@ -37,10 +31,10 @@ private:
 				 std::string cname);
 	void ConfigureVideoTrack(std::string media_stream_id,
 				 std::string cname);
+	bool Init();
 	bool Setup();
 	bool Connect();
 	void StartThread();
-
 	void SendDelete();
 	void StopThread(bool signal);
 
@@ -57,6 +51,7 @@ private:
 	std::mutex start_stop_mutex;
 	std::thread start_stop_thread;
 
+	uint32_t base_ssrc;
 	int peer_connection;
 	int audio_track;
 	int video_track;
@@ -69,43 +64,3 @@ private:
 };
 
 void register_whip_output();
-
-static std::string trim_string(const std::string &source)
-{
-	std::string ret(source);
-	ret.erase(0, ret.find_first_not_of(" \n\r\t"));
-	ret.erase(ret.find_last_not_of(" \n\r\t") + 1);
-	return ret;
-}
-
-static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
-				 void *priv_data)
-{
-	auto read_buffer = static_cast<std::string *>(priv_data);
-
-	size_t real_size = size * nmemb;
-
-	read_buffer->append(data, real_size);
-	return real_size;
-}
-
-#define LOCATION_HEADER_LENGTH 10
-
-static size_t curl_headerfunction(char *data, size_t size, size_t nmemb,
-				  void *priv_data)
-{
-	auto header_buffer = static_cast<std::string *>(priv_data);
-
-	size_t real_size = size * nmemb;
-
-	if (real_size < LOCATION_HEADER_LENGTH)
-		return real_size;
-
-	if (!astrcmpi_n(data, "location: ", LOCATION_HEADER_LENGTH)) {
-		char *val = data + LOCATION_HEADER_LENGTH;
-		header_buffer->append(val, real_size - LOCATION_HEADER_LENGTH);
-		*header_buffer = trim_string(*header_buffer);
-	}
-
-	return real_size;
-}

--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <obs.h>
+
+#include <string>
+#include <random>
+#include <sstream>
+
+#define do_log(level, format, ...)                              \
+	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
+	     obs_output_get_name(output), ##__VA_ARGS__)
+#define do_log_s(level, format, ...)                            \
+	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
+	     obs_output_get_name(whipOutput->output), ##__VA_ARGS__)
+
+static uint32_t generate_random_u32()
+{
+	std::random_device rd;
+	std::mt19937 gen(rd());
+	std::uniform_int_distribution<uint32_t> dist(1, (UINT32_MAX - 1));
+	return dist(gen);
+}
+
+static std::string trim_string(const std::string &source)
+{
+	std::string ret(source);
+	ret.erase(0, ret.find_first_not_of(" \n\r\t"));
+	ret.erase(ret.find_last_not_of(" \n\r\t") + 1);
+	return ret;
+}
+
+static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
+				 void *priv_data)
+{
+	auto read_buffer = static_cast<std::string *>(priv_data);
+
+	size_t real_size = size * nmemb;
+
+	read_buffer->append(data, real_size);
+	return real_size;
+}
+
+#define LOCATION_HEADER_LENGTH 10
+
+static size_t curl_header_location_function(char *data, size_t size,
+					    size_t nmemb, void *priv_data)
+{
+	auto header_buffer = static_cast<std::string *>(priv_data);
+
+	size_t real_size = size * nmemb;
+
+	if (real_size < LOCATION_HEADER_LENGTH)
+		return real_size;
+
+	if (!astrcmpi_n(data, "location: ", LOCATION_HEADER_LENGTH)) {
+		char *val = data + LOCATION_HEADER_LENGTH;
+		header_buffer->append(val, real_size - LOCATION_HEADER_LENGTH);
+		*header_buffer = trim_string(*header_buffer);
+	}
+
+	return real_size;
+}
+
+static inline std::string generate_user_agent()
+{
+#ifdef _WIN64
+#define OS_NAME "Windows x86_64"
+#elif __APPLE__
+#define OS_NAME "Mac OS X"
+#elif __OpenBSD__
+#define OS_NAME "OpenBSD"
+#elif __FreeBSD__
+#define OS_NAME "FreeBSD"
+#elif __linux__ && __LP64__
+#define OS_NAME "Linux x86_64"
+#else
+#define OS_NAME "Linux"
+#endif
+
+	// Build the user-agent string
+	std::stringstream ua;
+	// User agent header prefix
+	ua << "User-Agent: Mozilla/5.0 ";
+	// OBS version info
+	ua << "(OBS-Studio/" << obs_get_version_string() << "; ";
+	// Operating system version info
+	ua << OS_NAME << "; " << obs_get_locale() << ")";
+
+	return ua.str();
+}


### PR DESCRIPTION
### Description

The following changes were made to provide compatibility and increase usability behind NAT / Firewall. Specific modifications and additions are as follows:

- Creates a User-Agent string for application identification
- Implements a maximum fragment size for video packetization
- Uses a randomized u32 generation routine for SSRC and RTP timestamps to fit RFC-3550
- Adds additional life-cycle methods for clearer flow; Init, Setup...

### Motivation and Context

My motivation is to remove hard-coded SSRC values and to set starting RTP timestamps to match RFC-3550.

### How Has This Been Tested?

All testing during development was performed on Windows 11 x64 against a modified private pre-release version of Red5 Pro Server. As of generation of this PR, I cannot build on this branch in current windows environment and I'm not sure why; its an error in the PowerShell extension within VS Code that does not appear in my separate fork.

### Types of changes

- New feature
- Tweak
- Code cleanup

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
