### PR TITLE
rtmp-services: Enforce encoder settings according to protocol

### DIFF
--- a/plugins/rtmp-services/rtmp-custom.c
+++ b/plugins/rtmp-services/rtmp-custom.c
@@ -134,18 +134,21 @@ static const char *rtmp_custom_get_protocol(void *data)
 	return "RTMP";
 }
 
-#define RTMP_PROTOCOL "rtmp"
-
 static void rtmp_custom_apply_settings(void *data, obs_data_t *video_settings,
 				       obs_data_t *audio_settings)
 {
 	struct rtmp_custom *service = data;
-	if (service->server != NULL && video_settings != NULL &&
-	    strncmp(service->server, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) !=
-		    0) {
+	const char *protocol = rtmp_custom_get_protocol(service);
+	bool has_mpegts = false;
+	bool is_rtmp = false;
+	if (strcmp(protocol, "SRT") == 0 || strcmp(protocol, "RIST") == 0)
+		has_mpegts = true;
+	if (strcmp(protocol, "RTMP") == 0 || strcmp(protocol, "RTMPS") == 0)
+		is_rtmp = true;
+	if (!is_rtmp && video_settings != NULL)
 		obs_data_set_bool(video_settings, "repeat_headers", true);
+	if (has_mpegts && audio_settings != NULL)
 		obs_data_set_bool(audio_settings, "set_to_ADTS", true);
-	}
 }
 
 static const char *rtmp_custom_get_connect_info(void *data, uint32_t type)


### PR DESCRIPTION
### Description
For mpegts output, used in rtmp-custom service, encoder settings
require:
- ADTS with fdk-aac.    

For all non-rtmp protocols, one also requires:
- video encoder header repetition;
This future proofs the code against protocol addition.

Additionally, I've added a check against NULL audio settings, which was
in my fork but that I forgot to add in the PR [1] to my utter shame.
🙈

[1] https://github.com/obsproject/obs-studio/pull/6163

### Motivation and Context
Force audio encoder settings only for SRT and RIST.
Force header repetition for all non-RTMP protocols.

### How Has This Been Tested?
Checked that an srt stream with nvenc h264 / fdk-aac does not errors out meaning
the encoders settings were enforced.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
