### PR TITLE
obs-ffmpeg: Fix media source playing when inactive

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -495,9 +495,8 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 	/* If media has ended and user enables looping, user expects that it restarts.
 	 * Should still check if is_looping was changed, because users may stop them
 	 * intentionally, which is why we only check for ENDED and not STOPPED. */
-	if (s->state == OBS_MEDIA_STATE_ENDED && is_looping == true &&
+	if (active && s->state == OBS_MEDIA_STATE_ENDED && is_looping == true &&
 	    s->is_looping == false) {
-		active = true;
 		should_restart_media = true;
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Quick fix for https://github.com/obsproject/obs-studio/pull/7455, as I only realized the flaw in my logic a few hours after i pushed. The issue is that when looping is turned on but the source is inactive, `ffmpeg_source_start` will be called, causing the video to play in the background (but not actually shown).

Do note that the comment above the looping change check does not currently do what was intended, because media source sets the state to ENDED regardless of whether the user stopped it manually or reached the end. I plan to fix the media source state in a future PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
My mistake, sorry!

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Played the file, then hid the scene item of the source. Then turned on the Loop option. The video and progress bar didn't play.
- Tested other options that would trigger a forced restart, like speed, and verified that the video is not played when the source is hidden, but will play if the scene item is visible.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
