### PR TITLE
cmake: Set bundle name to "OBS Studio"

### DIFF
--- a/cmake/Modules/ObsDefaults_macOS.cmake
+++ b/cmake/Modules/ObsDefaults_macOS.cmake
@@ -116,7 +116,7 @@ macro(setup_obs_project)
   string(TIMESTAMP CURRENT_YEAR "%Y")
 
   # Set paths for distribution bundling
-  set(OBS_BUNDLE_NAME "OBS")
+  set(OBS_BUNDLE_NAME "OBS Studio")
   set(OBS_EXECUTABLE_DESTINATION "${CMAKE_INSTALL_BINDIR}")
   set(OBS_INCLUDE_DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/obs")
   set(OBS_LIBRARY_DESTINATION "${CMAKE_INSTALL_LIBDIR}")

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -71,6 +71,7 @@ function(set_target_properties_obs target)
                    CLANG_ENABLE_OBJC_ARC YES
                    SKIP_INSTALL NO
                    INSTALL_PATH "$(LOCAL_APPS_DIR)"
+                   INFOPLIST_KEY_CFBundleName "OBS Studio"
                    INFOPLIST_KEY_CFBundleDisplayName "OBS Studio"
                    INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2012-${CURRENT_YEAR} Lain Bailey"
                    INFOPLIST_KEY_NSCameraUsageDescription "OBS needs to access the camera to enable camera sources to work."
@@ -259,6 +260,7 @@ function(set_target_properties_obs target)
                    MARKETING_VERSION ${OBS_VERSION_CANONICAL}
                    GENERATE_INFOPLIST_FILE YES
                    INFOPLIST_FILE ""
+                   INFOPLIST_KEY_CFBundleName ${target}
                    INFOPLIST_KEY_CFBundleDisplayName ${target}
                    INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2012-${CURRENT_YEAR} Lain Bailey")
       # cmake-format: on
@@ -296,6 +298,7 @@ function(set_target_properties_obs target)
                    CURRENT_PROJECT_VERSION ${OBS_BUILD_NUMBER}
                    MARKETING_VERSION ${OBS_VERSION_CANONICAL}
                    GENERATE_INFOPLIST_FILE YES
+                   INFOPLIST_KEY_CFBundleName ${target}
                    INFOPLIST_KEY_CFBundleDisplayName ${target}
                    INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2012-${CURRENT_YEAR} Lain Bailey")
       # cmake-format: on


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets the bundle name to "OBS Studio" instead of "OBS".
Also adds `CFBundleName` everywhere that cmake generates `CFShortBundleName`s. This isn't technically needed for this PR but seems like it should be set as well.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Recent changes to cmake appear to have set it to "OBS" again. We changed it to "OBS Studio" starting in OBS 28.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested that the menu bar app menu says "OBS Studio" again.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
