### PR TITLE
mac-capture: Fix  show hidden windows option which doesn't work immediately.

### DIFF
--- a/plugins/mac-capture/mac-screen-capture.m
+++ b/plugins/mac-capture/mac-screen-capture.m
@@ -904,15 +904,14 @@ static bool content_settings_changed(void *data, obs_properties_t *props, obs_pr
         }
     }
 
+    sc->show_empty_names = obs_data_get_bool(settings, "show_empty_names");
+    sc->show_hidden_windows = obs_data_get_bool(settings, "show_hidden_windows");
+    sc->hide_obs = obs_data_get_bool(settings, "hide_obs");
+
     screen_capture_build_content_list(sc, capture_type_id == ScreenCaptureDisplayStream);
     build_display_list(sc, props);
     build_window_list(sc, props);
     build_application_list(sc, props);
-
-    sc->show_empty_names = obs_data_get_bool(settings, "show_empty_names");
-    sc->show_hidden_windows = obs_data_get_bool(settings, "show_hidden_windows");
-
-    sc->hide_obs = obs_data_get_bool(settings, "hide_obs");
 
     return true;
 }


### PR DESCRIPTION
### Description
This patch fixes "Show fullscreen and hidden windows/applications", "Show windows with empty names" options works immediately on properties pane as UI behaviors expected.

### Motivation and Context

macOS Screen Capture properties pane has various check box but these are not working as expected until it's opend again. 

### How Has This Been Tested?

Add macOS Screen Capture to the Sources, grant Screen Capture permissions (and restart the application if necessary,) then open property pane.
Toggle these check mars and observe list of windows or applications are immediately updated.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

`screen_capture_build_content_list` or similar calls uses updated `sc->show_hidden_windows` or similar flags, but these are not set before calling these functions. Changing order of calls to solve the problem.

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.