### PR TITLE
CI: Update main workflow to enable building with macOS 13 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
 
   macos_build:
     name: '02 - macOS'
-    runs-on: [macos-12]
+    runs-on: [macos-13]
     strategy:
       matrix:
         arch: ['x86_64', 'arm64']
@@ -200,6 +200,7 @@ jobs:
         env:
           PROVISIONING_PROFILE: ${{ steps.macos-codesign.outputs.provisionprofileUUID }}
         run: |
+          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
           if [[ '${{ steps.github-check.outputs.generator }}' == 'Xcode' ]]; then
             SEEKING_TESTERS=1 CI/macos/02_build_obs.sh --codesign --architecture "${{ matrix.arch }}"
           else
@@ -216,6 +217,11 @@ jobs:
           esac
 
           if [[ "${PACKAGE}" ]]; then
+            sudo sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db \
+              "INSERT OR REPLACE INTO access VALUES('kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552);"
+            sudo sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db \
+              "INSERT OR REPLACE INTO access VALUES('kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552);"
+
             CI/macos/03_package_obs.sh --codesign --architecture "${{ matrix.arch }}"
             ARTIFACT_NAME=$(basename $(/usr/bin/find build_macos -type f -name "obs-studio-*.dmg" -depth 1 | head -1))
             echo "FILE_NAME=${ARTIFACT_NAME}" >> $GITHUB_ENV
@@ -482,7 +488,7 @@ jobs:
 
   macos_release:
     name: '03 - macOS notarized image'
-    runs-on: [macos-12]
+    runs-on: [macos-13]
     needs: [macos_build]
     env:
       BUILD_FOR_DISTRIBUTION: 'ON'
@@ -601,7 +607,7 @@ jobs:
 
   macos_sparkle:
     name: '04 - macOS Sparkle Updates'
-    runs-on: [macos-12]
+    runs-on: [macos-13]
     needs: [macos_release]
     if: fromJSON(needs.macos_release.outputs.run_sparkle)
     strategy:

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -48,18 +48,5 @@ set(OBS_LIBRARY_DESTINATION "lib")
 set(OBS_INCLUDE_DESTINATION "include/obs")
 set(OBS_CMAKE_DESTINATION "lib/cmake")
 
-set(_dmg_package_name "OBS")
-set(_dmg_background_filename "background.tiff")
-set(_dmg_window_x 100)
-set(_dmg_window_y 100)
-set(_dmg_window_width 540)
-set(_dmg_window_height 380)
-set(_dmg_icon_size 96)
-set(_dmg_text_size 16)
-set(_dmg_obs_x 124)
-set(_dmg_obs_y 180)
-set(_dmg_app_link_x 416)
-set(_dmg_app_link_y 180)
-
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/resources/package.applescript.in"
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/resources/package.applescript"
                "${CMAKE_CURRENT_BINARY_DIR}/package.applescript" @ONLY)

--- a/cmake/macos/resources/package.applescript
+++ b/cmake/macos/resources/package.applescript
@@ -3,10 +3,10 @@ on run (volumeName)
         tell disk (volumeName as string)
             open
 
-            set theXOrigin to @_dmg_window_x@
-            set theYOrigin to @_dmg_window_y@
-            set theWidth to @_dmg_window_width@
-            set theHeight to @_dmg_window_height@
+            set theXOrigin to 100
+            set theYOrigin to 100
+            set theWidth to 540
+            set theHeight to 380
 
             set theBottomRightX to (theXOrigin + theWidth)
             set theBottomRightY to (theYOrigin + theHeight)
@@ -23,13 +23,13 @@ on run (volumeName)
 
             set opts to the icon view options of container window
             tell opts
-                set icon size to @_dmg_icon_size@
-                set text size to @_dmg_text_size@
+                set icon size to 96
+                set text size to 16
                 set arrangement to not arranged
             end tell
-            set background picture of opts to file ".background:@_dmg_background_filename@"
-            set position of item "@_dmg_package_name@.app" to {@_dmg_obs_x@, @_dmg_obs_y@}
-            set position of item "Applications" to {@_dmg_app_link_x@, @_dmg_app_link_y@}
+            set background picture of opts to file ".background:background.tiff"
+            set position of item "OBS.app" to {124, 180}
+            set position of item "Applications" to {416, 180}
             close
             open
             -- Force saving of the size


### PR DESCRIPTION
### Description
Splits up macOS builds on CI between a macOS 13-based runner for building the project and a macOS 12-based runner for generating disk images for distribution.

### Motivation and Context
Since early 2023, Xcode 14.3 and later requires macOS 13 to run. This requires switching to macOS 13-based runners for support of macOS 14 and beyond.

Unfortunately macOS 13-based runners are still considered "beta" by GitHub themselves (though many issues are fixed purely by switching to a more recent macOS version). For obs-studio specifically, AppleScript support is required to create the disk images used for release, but this support is not available in those runners.

The common workaround to this issue is to generate application bundles on macOS 13 runners, upload them as artefacts, then download and package them on a macOS 12 runner.

### How Has This Been Tested?
Needs to be tested via CI runs as it mainly concerns CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
