### PR TITLE
libobs: Change return type for getting filter index

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -1301,7 +1301,7 @@ void OBSBasicFilters::FiltersMoved(const QModelIndex &, int srcIdxStart, int,
 		neighborIdx = 0;
 
 	OBSSource neighbor = GetFilter(neighborIdx, isAsync);
-	size_t idx = obs_source_filter_get_index(source, neighbor);
+	int idx = obs_source_filter_get_index(source, neighbor);
 
 	OBSSource filter = GetFilter(list->currentRow(), isAsync);
 	obs_source_filter_set_index(source, filter, idx);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3294,12 +3294,12 @@ void obs_source_filter_set_order(obs_source_t *source, obs_source_t *filter,
 		obs_source_dosignal(source, NULL, "reorder_filters");
 }
 
-size_t obs_source_filter_get_index(obs_source_t *source, obs_source_t *filter)
+int obs_source_filter_get_index(obs_source_t *source, obs_source_t *filter)
 {
 	if (!obs_source_valid(source, "obs_source_filter_get_index"))
-		return DARRAY_INVALID;
+		return -1;
 	if (!obs_ptr_valid(filter, "obs_source_filter_get_index"))
-		return DARRAY_INVALID;
+		return -1;
 
 	size_t idx;
 
@@ -3307,7 +3307,7 @@ size_t obs_source_filter_get_index(obs_source_t *source, obs_source_t *filter)
 	idx = da_find(source->filters, &filter, 0);
 	pthread_mutex_unlock(&source->filter_mutex);
 
-	return idx;
+	return idx != DARRAY_INVALID ? (int)idx : -1;
 }
 
 static bool set_filter_index(obs_source_t *source, obs_source_t *filter,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1131,8 +1131,8 @@ EXPORT void obs_source_filter_set_order(obs_source_t *source,
 					enum obs_order_movement movement);
 
 /** Gets filter index */
-EXPORT size_t obs_source_filter_get_index(obs_source_t *source,
-					  obs_source_t *filter);
+EXPORT int obs_source_filter_get_index(obs_source_t *source,
+				       obs_source_t *filter);
 
 /** Sets filter index */
 EXPORT void obs_source_filter_set_index(obs_source_t *source,


### PR DESCRIPTION
### Description
This changes the return type for getting the filter index from a size_t to an int. This makes it easier for developers to use, as an invalid index just returns a -1.

### Motivation and Context
Wanted to change this before an actual release, so we don't break api.

### How Has This Been Tested?
Tested by printing out the index in a script.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
