### PR TITLE
libobs: Fix obs_output_get_height2 returning width

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1226,7 +1226,7 @@ uint32_t obs_output_get_height2(const obs_output_t *output, size_t idx)
 
 	if (flag_encoded(output)) {
 		if (output->video_encoders[idx])
-			return obs_encoder_get_width(
+			return obs_encoder_get_height(
 				output->video_encoders[idx]);
 		else
 			return 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Amends 6ec0b2db11d5fde051d533609a974fb0fa81ff05 to have the `obs_output_get_height2` function actually return the height of the output instead of the width.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
yam on Discord brought up that their recordings were square, and reported as 1920*1920.
I tested it and it turned out my recordings are square as well.
I don't like having square recordings when I configure them to not be square.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.
Tested that all players now play back the recording in the correct resolution and aspect ratio.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
