### PR TITLE
UI: Fix crash radio list without items

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -631,12 +631,15 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 		for (size_t idx = 0; idx < count; idx++)
 			AddRadioItem(buttonGroup, subLayout, prop, value, idx);
 
-		buttonGroup->setExclusive(true);
-		WidgetInfo *info =
-			new WidgetInfo(this, prop, buttonGroup->buttons()[0]);
-		children.emplace_back(info);
-		connect(buttonGroup, SIGNAL(buttonClicked(QAbstractButton *)),
-			info, SLOT(ControlChanged()));
+		if (count > 0) {
+			buttonGroup->setExclusive(true);
+			WidgetInfo *info = new WidgetInfo(
+				this, prop, buttonGroup->buttons()[0]);
+			children.emplace_back(info);
+			connect(buttonGroup,
+				SIGNAL(buttonClicked(QAbstractButton *)), info,
+				SLOT(ControlChanged()));
+		}
 
 		QWidget *widget = new QWidget();
 		widget->setLayout(subLayout);


### PR DESCRIPTION
### Description

Using `OBS_COMBO_TYPE_RADIO` but not adding any items app will crash
due to out-of-bound access.

### Motivation and Context

In case the conditional list UI component setup for example, and there are no items
assigned to the list with `OBS_COMBO_TYPE_RADIO`, app will crash due to
out-of-bounds access without checking nubmer of items.

This patch cheks number of items before accessing first item of items array to prevent
out-of-bounds access.

### How Has This Been Tested?

Create list property with `OBS_COMBO_TYPE_RADIO`, for example, changing existing
`OBS_COMBO_TYPE_LIST` to `OBS_COMBO_TYPE_RADIO`
and see if application works in case application doesn't have any items in the list.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.