### PR TITLE
docs: Add documentation for filter index functions

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1586,6 +1586,19 @@ Filters
 
 ---------------------
 
+.. function:: void obs_source_filter_set_index(obs_source_t *source, obs_source_t *filter, size_t index)
+
+   Moves a filter to the specified index in the filters array.
+
+   :param index: | The index to move the filter to.
+
+---------------------
+
+.. function:: int obs_source_filter_get_index(obs_source_t *source, obs_source_t *filter)
+
+   Gets the index of the specified filter.
+
+   :return: Index of the filter or -1 if it is invalid/not found.
 
 Functions used by filters
 -------------------------


### PR DESCRIPTION
### Description
Adds documentation for the obs_source_filter_set_index and obs_source_filter_get_index functions.

### Motivation and Context
Inadvertently omitted in #2105 

Needs #9148 to be merged, as this references the new return type of the get index function. 

### How Has This Been Tested?
Made sure docs looked good.

### Types of changes
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
