### PR TITLE
UI：Fix display capture fails after minimizing and restoring OBS window

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9638,6 +9638,16 @@ void OBSBasic::ToggleShowHide()
 		EnumDialogs();
 		if (!modalDialogs.isEmpty() || !visMsgBoxes.isEmpty())
 			return;
+		
+#ifdef _WIN32
+		//Cleans the SetDisplayAffinity setting property
+		HWND hwnd = (HWND)this->winId();
+		DWORD curAffinity;
+		if (GetWindowDisplayAffinity(hwnd, &curAffinity)) {
+			if (curAffinity != WDA_NONE)
+				SetWindowDisplayAffinity(hwnd, WDA_NONE);
+		}
+#endif
 	}
 	SetShowing(!showing);
 }


### PR DESCRIPTION
### Description
When shading an obs window, the SetWindowDisplayAffinity is set to WDA_NONE

### Motivation and Context
fixed: [#9155](https://github.com/obsproject/obs-studio/issues/9155)
Display capture fails to hide OBS window and menu after minimizing and restoring OBS window.

### How Has This Been Tested?
Windows Version: 10.0 Build 19045 (release: 22H2; revision: 3086; 64-bit)
Perform operations as described in the problem。

### Types of changes
issues: https://github.com/obsproject/obs-studio/issues/9155

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
