### PR TITLE
CI: Fix call to base64 on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,7 +149,7 @@ jobs:
             CERTIFICATE_PATH="${RUNNER_TEMP}/build_certificate.p12"
             KEYCHAIN_PATH="${RUNNER_TEMP}/app-signing.keychain-db"
 
-            echo -n "${MACOS_SIGNING_CERT}" | base64 --decode --output "${CERTIFICATE_PATH}"
+            echo -n "${MACOS_SIGNING_CERT}" | base64 --decode --output="${CERTIFICATE_PATH}"
 
             : "${MACOS_KEYCHAIN_PASSWORD:="$(echo ${RANDOM} | sha1sum | head -c 32)"}"
 
@@ -175,7 +175,7 @@ jobs:
 
           if [[ "${MACOS_PROVISIONING_PROFILE}" ]]; then
             PROFILE_PATH="${RUNNER_TEMP}/build_profile.provisionprofile"
-            echo -n "${MACOS_PROVISIONING_PROFILE}" | base64 --decode --output "${PROFILE_PATH}"
+            echo -n "${MACOS_PROVISIONING_PROFILE}" | base64 --decode --output="${PROFILE_PATH}"
 
             mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
             security cms -D -i "${PROFILE_PATH}" -o "${RUNNER_TEMP}/build_profile.plist"
@@ -430,7 +430,7 @@ jobs:
             CERTIFICATE_PATH="${RUNNER_TEMP}/build_certificate.p12"
             KEYCHAIN_PATH="${RUNNER_TEMP}/app-signing.keychain-db"
 
-            echo -n "${MACOS_SIGNING_CERT}" | base64 --decode --output "${CERTIFICATE_PATH}"
+            echo -n "${MACOS_SIGNING_CERT}" | base64 --decode --output="${CERTIFICATE_PATH}"
 
             : "${MACOS_KEYCHAIN_PASSWORD:="$(echo ${RANDOM} | sha1sum | head -c 32)"}"
 
@@ -456,7 +456,7 @@ jobs:
 
           if [[ "${MACOS_PROVISIONING_PROFILE}" ]]; then
             PROFILE_PATH="${RUNNER_TEMP}/build_profile.provisionprofile"
-            echo -n "${MACOS_PROVISIONING_PROFILE}" | base64 --decode --output "${PROFILE_PATH}"
+            echo -n "${MACOS_PROVISIONING_PROFILE}" | base64 --decode --output="${PROFILE_PATH}"
 
             mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
             security cms -D -i "${PROFILE_PATH}" -o "${RUNNER_TEMP}/build_profile.plist"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When using long options with `base64` on macOS, you must separate the option from the value with an equal sign.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
CI is currently broken. Want CI to work.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
