### PR TITLE
cmake: Add flags for reproducible builds on Windows

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -33,8 +33,15 @@ if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION VERSION_LESS 10.0.20348)
                       "Please download and install the most recent Windows SDK.")
 endif()
 
+set(_obs_msvc_c_options /Brepro /MP /permissive- /Zc:__cplusplus /Zc:preprocessor)
+
+set(_obs_msvc_cpp_options /Brepro /MP /permissive- /Zc:__cplusplus /Zc:preprocessor)
+
 add_compile_options(
-  /W3 /utf-8 "$<$<COMPILE_LANG_AND_ID:C,MSVC>:/MP>" "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:/MP>"
+  /W3
+  /utf-8
+  "$<$<COMPILE_LANG_AND_ID:C,MSVC>:${_obs_msvc_c_options}>"
+  "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:${_obs_msvc_cpp_options}>"
   "$<$<COMPILE_LANG_AND_ID:C,Clang>:${_obs_clang_c_options}>"
   "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>")
 
@@ -42,7 +49,7 @@ add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO
                         $<$<CONFIG:DEBUG>:_DEBUG>)
 
 add_link_options("$<$<NOT:$<CONFIG:Debug>>:/OPT\:REF>" "$<$<CONFIG:Debug>:/INCREMENTAL\:NO>"
-                 "$<$<CONFIG:RelWithDebInfo>:/INCREMENTAL\:NO>" "$<$<CONFIG:RelWithDebInfo>:/OPT\:ICF>")
+                 "$<$<CONFIG:RelWithDebInfo>:/INCREMENTAL\:NO>" "$<$<CONFIG:RelWithDebInfo>:/OPT\:ICF>" /Brepro)
 
 if(CMAKE_COMPILE_WARNING_AS_ERROR)
   add_link_options(/WX)

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -159,6 +159,7 @@ function(set_target_properties_obs target)
     set_property(GLOBAL APPEND PROPERTY OBS_MODULES_ENABLED ${target})
   endif()
 
+  target_link_options(${target} PRIVATE "/PDBALTPATH:$<TARGET_PDB_FILE_NAME:${target}>")
   target_install_resources(${target})
 endfunction()
 


### PR DESCRIPTION
### Description
Compiler and linker flags for reproducible builds on Windows were omitted from the recent CMake rework in error. This commit adds those flags back.

### Motivation and Context
Restores desired ability to create reproducible builds on Windows.

### How Has This Been Tested?
Will be tested by CI run on Windows.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
