### PR TITLE
win-capture: Enable compatability data updates by default

### DIFF
--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 legacy_check()
 
-option(ENABLE_COMPAT_UPDATES "Checks for service updates" OFF)
+option(ENABLE_COMPAT_UPDATES "Checks for capture compatibility data updates" ON)
 
 # cmake-format: off
 set(COMPAT_URL "https://obsproject.com/obs2_update/win-capture" CACHE STRING "Default services package URL")

--- a/plugins/win-capture/cmake/legacy.cmake
+++ b/plugins/win-capture/cmake/legacy.cmake
@@ -1,6 +1,6 @@
 project(win-capture)
 
-option(ENABLE_COMPAT_UPDATES "Checks for service updates" OFF)
+option(ENABLE_COMPAT_UPDATES "Checks for capture compatibility data updates" ON)
 
 set(COMPAT_URL
     "https://obsproject.com/obs2_update/win-capture"


### PR DESCRIPTION
### Description

Changes compatibility data updates in win-capture to be enabled by default.

### Motivation and Context

This was meant to be enabled by default like service updates, but wasn't.

### How Has This Been Tested?

N/A

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
