### PR TITLE
cmake: Add support for unobfuscated OAuth secrets

### DIFF
--- a/UI/cmake/feature-restream.cmake
+++ b/UI/cmake/feature-restream.cmake
@@ -1,5 +1,5 @@
 if(RESTREAM_CLIENTID
-   AND RESTREAM_HASH
+   AND RESTREAM_HASH MATCHES "(0|[a-fA-F0-9]+)"
    AND TARGET OBS::browser-panels)
   target_sources(obs-studio PRIVATE auth-restream.cpp auth-restream.hpp)
   target_enable_feature(obs-studio "Restream API connection" RESTREAM_ENABLED)

--- a/UI/cmake/feature-twitch.cmake
+++ b/UI/cmake/feature-twitch.cmake
@@ -1,5 +1,5 @@
 if(TWITCH_CLIENTID
-   AND TWITCH_HASH
+   AND TWITCH_HASH MATCHES "(0|[a-fA-F0-9]+)"
    AND TARGET OBS::browser-panels)
   target_sources(obs-studio PRIVATE auth-twitch.cpp auth-twitch.hpp)
   target_enable_feature(obs-studio "Twitch API connection" TWITCH_ENABLED)

--- a/UI/cmake/feature-youtube.cmake
+++ b/UI/cmake/feature-youtube.cmake
@@ -1,7 +1,7 @@
 if(YOUTUBE_CLIENTID
    AND YOUTUBE_SECRET
-   AND YOUTUBE_CLIENTID_HASH
-   AND YOUTUBE_SECRET_HASH)
+   AND YOUTUBE_CLIENTID_HASH MATCHES "(0|[a-fA-F0-9]+)"
+   AND YOUTUBE_SECRET_HASH MATCHES "(0|[a-fA-F0-9]+)")
   target_sources(obs-studio PRIVATE auth-youtube.cpp auth-youtube.hpp window-youtube-actions.cpp
                                     window-youtube-actions.hpp youtube-api-wrappers.cpp youtube-api-wrappers.hpp)
 


### PR DESCRIPTION
### Description
Unobfuscated secrets require the hash values to be set to 0, by default CMake will treat 0 as a falsy value. This commit adds support for _either_ 0 _or_ a valid hexadecimal hash.

### Motivation and Context
Allow maintainers and forks to provide their own unobfuscated OAuth credentials.

### How Has This Been Tested?
Tested locally with variants of empty hash values, using `0`, and using actual hash values.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
