### PR TITLE
cmake: Fix configuration errors with Windows legacy path

### DIFF
--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -324,6 +324,21 @@ if(OS_WINDOWS)
     target_compile_options(libobs PRIVATE "$<$<COMPILE_LANGUAGE:C>:/EHc->" "$<$<COMPILE_LANGUAGE:CXX>:/EHc->")
 
     target_link_options(libobs PRIVATE "LINKER:/IGNORE:4098" "LINKER:/SAFESEH:NO")
+
+    add_library(obs-obfuscate INTERFACE)
+    add_library(OBS::obfuscate ALIAS obs-obfuscate)
+    target_sources(obs-obfuscate INTERFACE util/windows/obfuscate.c util/windows/obfuscate.h)
+    target_include_directories(obs-obfuscate INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    add_library(obs-comutils INTERFACE)
+    add_library(OBS::COMutils ALIAS obs-comutils)
+    target_sources(obs-comutils INTERFACE util/windows/ComPtr.hpp)
+    target_include_directories(obs-comutils INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+    add_library(obs-winhandle INTERFACE)
+    add_library(OBS::winhandle ALIAS obs-winhandle)
+    target_sources(obs-winhandle INTERFACE util/windows/WinHandle.hpp)
+    target_include_directories(obs-winhandle INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
   endif()
 
 elseif(OS_MACOS)

--- a/plugins/obs-ffmpeg/obs-nvenc-test/cmake/legacy.cmake
+++ b/plugins/obs-ffmpeg/obs-nvenc-test/cmake/legacy.cmake
@@ -5,6 +5,7 @@ add_executable(obs-nvenc-test)
 find_package(FFnvcodec 12 REQUIRED)
 
 target_sources(obs-nvenc-test PRIVATE obs-nvenc-test.c ../obs-nvenc-ver.h)
+target_compile_definitions(obs-nvenc-test PRIVATE OBS_LEGACY)
 target_link_libraries(obs-nvenc-test d3d11 dxgi dxguid FFnvcodec::FFnvcodec)
 
 set_target_properties(obs-nvenc-test PROPERTIES FOLDER "plugins/obs-ffmpeg")

--- a/plugins/win-capture/cmake/legacy.cmake
+++ b/plugins/win-capture/cmake/legacy.cmake
@@ -52,7 +52,7 @@ if(MSVC)
 endif()
 
 target_compile_definitions(win-capture PRIVATE UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS
-                                               OBS_VERSION="${OBS_VERSION_CANONICAL}")
+                                               OBS_VERSION="${OBS_VERSION_CANONICAL}" OBS_LEGACY)
 
 set_property(GLOBAL APPEND PROPERTY OBS_MODULE_LIST "win-capture")
 

--- a/plugins/win-dshow/cmake/legacy.cmake
+++ b/plugins/win-dshow/cmake/legacy.cmake
@@ -201,7 +201,8 @@ if(ENABLE_VIRTUALCAM AND VIRTUALCAM_AVAILABLE)
 
   target_include_directories(win-dshow PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config)
 
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/virtualcam-guid.h.in ${CMAKE_CURRENT_BINARY_DIR}/config/virtualcam-guid.h)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/virtualcam-module/virtualcam-guid.h.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/config/virtualcam-guid.h)
 
   target_sources(win-dshow PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config/virtualcam-guid.h)
 


### PR DESCRIPTION
### Description
Adds necessary code to allow legacy code paths to configure without changes to existing configurations.

### Motivation and Context
By default Windows builds use the legacy CMake code paths, which ideally work as-is with existing build directories. Switching to the new code paths should be opt-in (via preset selection), so at least for the time being existing configurations should continue to work after the code update.

### How Has This Been Tested?
Tested on Windows 11 with existing build configuration from _before_ the CMake 3.0 merge and reconfigured in place after updating to current master commit.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
