### PR TITLE
UI: Fix utf-8 paths in shared updater components

### DIFF
--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <filesystem>
 
 #include <QRandomGenerator>
 #include <QByteArray>
@@ -47,9 +48,10 @@ extern QCef *cef;
 
 /* ------------------------------------------------------------------------ */
 
-static bool QuickWriteFile(const char *file, std::string &data)
+static bool QuickWriteFile(const char *file, const std::string &data)
 try {
-	std::ofstream fileStream(file, std::ios::binary);
+	std::ofstream fileStream(std::filesystem::u8path(file),
+				 std::ios::binary);
 	if (fileStream.fail())
 		throw strprintf("Failed to open file '%s': %s", file,
 				strerror(errno));
@@ -68,7 +70,8 @@ try {
 
 static bool QuickReadFile(const char *file, std::string &data)
 try {
-	std::ifstream fileStream(file, std::ifstream::binary);
+	std::ifstream fileStream(std::filesystem::u8path(file),
+				 std::ios::binary);
 	if (!fileStream.is_open() || fileStream.fail())
 		throw strprintf("Failed to open file '%s': %s", file,
 				strerror(errno));
@@ -97,7 +100,7 @@ try {
 	if (blake2b_init(&blake2, BLAKE2_HASH_LENGTH) != 0)
 		return false;
 
-	std::ifstream file(path, std::ios::binary);
+	std::ifstream file(std::filesystem::u8path(path), std::ios::binary);
 	if (!file.is_open() || file.fail())
 		return false;
 


### PR DESCRIPTION
### Description

Fixes reading/writing files with non-ASCII characters in their path in the shared code of the update framework.

### Motivation and Context

AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

### How Has This Been Tested?

Compiled and ran on my machine. Still needs to be tested on an affected system.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
