### PR TITLE
libcaption: Optimize branch conditons

### DIFF
--- a/deps/libcaption/src/utf8.c
+++ b/deps/libcaption/src/utf8.c
@@ -51,7 +51,7 @@ size_t utf8_char_length(const utf8_char_t* c)
 int utf8_char_whitespace(const utf8_char_t* c)
 {
     // 0x7F is DEL
-    if (!c || (c[0] >= 0 && c[0] <= ' ') || c[0] == 0x7F) {
+    if (!c || (unsigned char)c[0] <= ' ' || c[0] == 0x7F) {
         return 1;
     }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Optimize the condition expression of `c[0] >= 0 && c[0] <= ' '` to avoid warnings on platforms where `char` is equivalent to  `unsigned char`.

### Motivation and Context
I'm packaging OBS Studio for RISC-V architecture and it fails with an error message:
```
/build/obs-studio/src/obs-studio-29.1.1/deps/libcaption/src/utf8.c: In function ‘utf8_char_whitespace’:
/build/obs-studio/src/obs-studio-29.1.1/deps/libcaption/src/utf8.c:54:21: error: comparison is always true due to limited range of data type [-Werror=type-limits]
   54 |     if (!c || (c[0] >= 0 && c[0] <= ' ') || c[0] == 0x7F) {
      |                     ^~
cc1: all warnings being treated as errors
```
According to C reference:
> `char` - type for character representation. Equivalent to either `signed char` or `unsigned char` (which one is implementation-defined and may be controlled by a compiler commandline switch), but `char` is a distinct type, different from both `signed char` and `unsigned char`.

As we define `utf8_char_t` as `char`, which is equivalent to `unsigned char` in *some* platforms, `c[0] >= 0` will always be true and a warning will be raised, leading to a build failure.

### How Has This Been Tested?
I have tested it on HiFive Unmatched and qemu-user-riscv64, the code compiles correctly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
