### PR TITLE
mac-capture: Mark CoreAudio output capture source as deprecated

### DIFF
--- a/plugins/mac-capture/plugin-main.c
+++ b/plugins/mac-capture/plugin-main.c
@@ -16,8 +16,6 @@ extern bool is_screen_capture_available() WEAK_IMPORT_ATTRIBUTE;
 
 bool obs_module_load(void)
 {
-	obs_register_source(&coreaudio_input_capture_info);
-	obs_register_source(&coreaudio_output_capture_info);
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300 // __MAC_12_3
 	if (is_screen_capture_available()) {
 		extern struct obs_source_info sck_video_capture_info;
@@ -27,6 +25,8 @@ bool obs_module_load(void)
 				OBS_SOURCE_DEPRECATED;
 			window_capture_info.output_flags |=
 				OBS_SOURCE_DEPRECATED;
+			coreaudio_output_capture_info.output_flags |=
+				OBS_SOURCE_DEPRECATED;
 			extern struct obs_source_info sck_audio_capture_info;
 			obs_register_source(&sck_audio_capture_info);
 		}
@@ -34,5 +34,7 @@ bool obs_module_load(void)
 #endif
 	obs_register_source(&display_capture_info);
 	obs_register_source(&window_capture_info);
+	obs_register_source(&coreaudio_input_capture_info);
+	obs_register_source(&coreaudio_output_capture_info);
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Marks the CoreAudio output capture source as deprecated when on macOS 13 or newer, hiding it away in the "Deprecated" folder of the Add Source menu along with the old screen capture sources.

<img width="378" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/403f1dfd-776b-4c86-aafd-3b3fbf0ff19b">


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With macOS Audio Capture merged, users now have a clear and obvious way to capture desktop audio, which does not require any virtual audio cables shenanigans or alternatively hiding a screen capture source.
To avoid confusion, I think it makes sense to hide the old capture source away in the deprecated category and only show the new capture method when supported (macOS 13+). *Technically* the new source doesn't cover 100% of the use cases of the old method (you can't split a programs audio stream into different sources, which in theory could be achieved with the old method and supported applications) but I think it still makes to hide the old one.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14. The old source is now in the deprecated category.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
