### PR TITLE
cmake: Fix copy to rundir in Release and MinSizeRel configurations

### DIFF
--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -228,7 +228,8 @@ function(_target_install_obs target)
     TARGET ${target}
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
-    COMMAND "${CMAKE_COMMAND}" -E copy ${target_file} "$<$<CONFIG:Debug,RelWithDebInfo>:${target_pdb_file}>"
+    COMMAND "${CMAKE_COMMAND}" -E copy ${target_file} "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
+    COMMAND "${CMAKE_COMMAND}" -E $<IF:$<CONFIG:Debug,RelWithDebInfo>,copy,true> ${target_pdb_file}
             "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
     COMMENT "${comment}"
     VERBATIM)


### PR DESCRIPTION
### Description
Generated post build action batch scripts retained an empty token to the copy command with the used generator expression (as PDBs are only generated for Debug and RelWithDebInfo configurations).

Moving their copy step into its own command (and using the `true` CMake command, which is a no-op) ensures that builds in Release and MinSizeRel correctly finish this step.

### Motivation and Context
Fix builds in Release and MinSizeRel configurations.

### How Has This Been Tested?
Tested on Windows 11 with all 4 configurations.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
