### PR TITLE
mac-virtualcam: Fix use of collection without explicit type

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
+++ b/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
@@ -63,7 +63,7 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
             kCVPixelBufferWidthKey: dimensions.width,
             kCVPixelBufferHeightKey: dimensions.height,
             kCVPixelBufferPixelFormatTypeKey: _videoDescription.mediaSubType,
-            kCVPixelBufferIOSurfacePropertiesKey: [:],
+            kCVPixelBufferIOSurfacePropertiesKey: [CFString: CFTypeRef](),
         ]
 
         CVPixelBufferPoolCreate(kCFAllocatorDefault, nil, pixelBufferAttributes, &_bufferPool)


### PR DESCRIPTION
### Description
Adds explicit types to empty collection passed as pixel buffer IOSurface properties.

### Motivation and Context
Swift 5.0 requires empty collections to carry explicit type definitions.

### How Has This Been Tested?
Tested on macOS 13.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
