### PR TITLE
cmake: Disable char8_t when using C++20

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -74,6 +74,10 @@ set(_obs_clang_cxx_options
     -Werror=block-capture-autoreleasing
     -Wrange-loop-analysis)
 
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+  list(APPEND _obs_clang_cxx_options -fno-char8_t)
+endif()
+
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -37,6 +37,10 @@ set(_obs_msvc_c_options /Brepro /MP /permissive- /Zc:__cplusplus /Zc:preprocesso
 
 set(_obs_msvc_cpp_options /Brepro /MP /permissive- /Zc:__cplusplus /Zc:preprocessor)
 
+if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
+  list(APPEND _obs_msvc_cpp_options /Zc:char8_t-)
+endif()
+
 add_compile_options(
   /W3
   /utf-8


### PR DESCRIPTION
### Description

Fixes compilation when setting the C++ standard to 20+ by disabling `char8_t`.

Note that while #9183 introduces a deprecation warning in C++20 that gets treated as error, `char8_t` also causes failure in other cases where `std::filesystem` is used, such as `obs-app.cpp`.

### Motivation and Context

We might want to start using C++20 at some point, and the less said about `char8_t` the better.

### How Has This Been Tested?

Compiled on Windows with `CMAKE_CXX_STANDARD` set to 20.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
