### PR TITLE
UI: Soft-delete scene collections

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -343,11 +343,8 @@ void OBSBasic::on_actionRemoveSceneCollection_triggered()
 		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
 
 	oldFile.insert(0, path);
-	oldFile += ".json";
-
-	os_unlink(oldFile.c_str());
-	oldFile += ".bak";
-	os_unlink(oldFile.c_str());
+	/* os_rename() overwrites if necessary, only the .bak file will remain. */
+	os_rename((oldFile + ".json").c_str(), (oldFile + ".json.bak").c_str());
 
 	Load(newPath.c_str());
 	RefreshSceneCollections();


### PR DESCRIPTION
### Description

Instead of actually removing the file, simply rename it to the .bak version which OBS ignores in most cases.

That allows users to recover accidentally deleted collections more easily, while only taking up a few kilobytes of disk space at most.

### Motivation and Context

Save users from themselves, at least a little. Suggested by @notr1ch on Discord.

### How Has This Been Tested?

Deleted collection, file was just renamed, and trivial to recover (just remove the `.bak`).

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
