### PR TITLE
test-input: Update CMakeLists for updated CMake path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "(Darwin)" OR OBS_CMAKE_VERSION VERSION_GREATE
   endif()
   add_subdirectory(libobs-opengl)
   add_subdirectory(plugins)
+
+  add_subdirectory(test/test-input)
+
   add_subdirectory(UI)
 
   message_configuration()

--- a/test/test-input/cmake/legacy.cmake
+++ b/test/test-input/cmake/legacy.cmake
@@ -1,16 +1,6 @@
-cmake_minimum_required(VERSION 3.24...3.25)
-
-legacy_check()
-
-option(ENABLE_TEST_INPUT "Build test sources" OFF)
-
-if(NOT ENABLE_TEST_INPUT)
-  target_disable(test-input)
-  return()
-endif()
+project(test-input)
 
 add_library(test-input MODULE)
-add_library(OBS::test-input ALIAS test-input)
 
 target_sources(
   test-input
@@ -25,4 +15,10 @@ target_sources(
 
 target_link_libraries(test-input PRIVATE OBS::libobs)
 
-set_target_properties_obs(test-input PROPERTIES FOLDER "Tests and Examples" PREFIX "")
+if(MSVC)
+  target_link_libraries(test-input PRIVATE OBS::w32-pthreads)
+endif()
+
+set_target_properties(test-input PROPERTIES FOLDER "tests and examples")
+
+setup_plugin_target(test-input)


### PR DESCRIPTION
### Description
Updates the CMake script for the test-input plugin to make it work with the updated CMake path.

### Motivation and Context
Test plugin contains useful test sources and filters for debugging that should be available to build for developers.

The functionality can be enabled specifically by setting `ENABLE_TEST_INPUT` to `ON`.

### How Has This Been Tested?
Built the test input on macOS and checked the test sources and filter.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
