### PR TITLE
libobs: Fix flip calculations in bounding box

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -401,13 +401,19 @@ static void calculate_bounds_data(struct obs_scene_item *item,
 
 	width = (float)(*cx) * scale->x;
 	height = (float)(*cy) * scale->y;
-	width_diff = item->bounds.x - width;
-	height_diff = item->bounds.y - height;
+
+	/* Disregards flip when calculating size diff */
+	width_diff = item->bounds.x - fabsf(width);
+	height_diff = item->bounds.y - fabsf(height);
 	*cx = (uint32_t)item->bounds.x;
 	*cy = (uint32_t)item->bounds.y;
 
 	add_alignment(origin, item->bounds_align, (int)-width_diff,
 		      (int)-height_diff);
+
+	/* Makes the item stay in-place in the box if flipped */
+	origin->x += (width < 0.0f) ? width : 0.0f;
+	origin->y += (height < 0.0f) ? height : 0.0f;
 }
 
 static inline uint32_t calc_cx(const struct obs_scene_item *item,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This fixes flipping behaviour when positional alignement inside the bounding box is other than centered, so that the item gets flipped in-place within the bounding box, instead of being thrown out of the bounding box.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, when a sceneitem set in a bounding box with an alignment other than "center" gets flipped, it is thrown out of the bounding box, which does not feel like the expected behaviour of a bounding box.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 22.04
Tested various combinations of positional alignement and bounding box types, checked that all correctly flipped the item in-place on x and y.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
