### PR TITLE
UI: Fixes to preview drawing and interactions with flipped sceneitems

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -1361,9 +1361,13 @@ void OBSBasicPreview::CropItem(const vec2 &pos)
 	vec3_transform(&pos3, &pos3, &screenToItem);
 
 	obs_sceneitem_crop crop = startCrop;
-	vec2 scale;
+	vec2 scale, rawscale;
 
-	obs_sceneitem_get_scale(stretchItem, &scale);
+	obs_sceneitem_get_scale(stretchItem, &rawscale);
+	vec2_set(&scale,
+		 boundsType == OBS_BOUNDS_NONE ? rawscale.x : fabsf(rawscale.x),
+		 boundsType == OBS_BOUNDS_NONE ? rawscale.y
+					       : fabsf(rawscale.y));
 
 	vec2 max_tl;
 	vec2 max_br;
@@ -1375,10 +1379,18 @@ void OBSBasicPreview::CropItem(const vec2 &pos)
 
 	typedef std::function<float(float, float)> minmax_func_t;
 
-	minmax_func_t min_x = scale.x < 0.0f ? maxfunc : minfunc;
-	minmax_func_t min_y = scale.y < 0.0f ? maxfunc : minfunc;
-	minmax_func_t max_x = scale.x < 0.0f ? minfunc : maxfunc;
-	minmax_func_t max_y = scale.y < 0.0f ? minfunc : maxfunc;
+	minmax_func_t min_x = scale.x < 0.0f && boundsType == OBS_BOUNDS_NONE
+				      ? maxfunc
+				      : minfunc;
+	minmax_func_t min_y = scale.y < 0.0f && boundsType == OBS_BOUNDS_NONE
+				      ? maxfunc
+				      : minfunc;
+	minmax_func_t max_x = scale.x < 0.0f && boundsType == OBS_BOUNDS_NONE
+				      ? minfunc
+				      : maxfunc;
+	minmax_func_t max_y = scale.y < 0.0f && boundsType == OBS_BOUNDS_NONE
+				      ? minfunc
+				      : maxfunc;
 
 	pos3.x = min_x(pos3.x, max_br.x);
 	pos3.x = max_x(pos3.x, max_tl.x);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -387,24 +387,23 @@ static bool FindHandleAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 	TestHandle(0.5f, 1.0f, ItemHandle::BottomCenter);
 	TestHandle(1.0f, 1.0f, ItemHandle::BottomRight);
 
+	vec2 scale;
+	obs_sceneitem_get_scale(item, &scale);
 	vec2 rotHandleOffset;
 	vec2_set(&rotHandleOffset, 0.0f,
 		 HANDLE_RADIUS * data.radius * 1.5 - data.radius);
-	RotatePos(&rotHandleOffset, atan2(transform.x.y, transform.x.x));
+	float angle =
+		atan2(scale.x < 0.0f ? transform.x.y * -1.0f : transform.x.y,
+		      scale.x < 0.0f ? transform.x.x * -1.0f : transform.x.x);
+	RotatePos(&rotHandleOffset, angle);
 	RotatePos(&rotHandleOffset, RAD(data.angleOffset));
 
-	vec2 scale;
-	obs_sceneitem_get_scale(item, &scale);
 	bool invert = scale.y < 0.0f;
 	vec3 handlePos =
 		GetTransformedPos(0.5f, invert ? 1.0f : 0.0f, transform);
 	vec3_transform(&handlePos, &handlePos, &data.parent_xform);
 	handlePos.x -= rotHandleOffset.x;
-
-	if (scale.x < 0.0f)
-		handlePos.y += rotHandleOffset.y;
-	else
-		handlePos.y -= rotHandleOffset.y;
+	handlePos.y -= rotHandleOffset.y;
 
 	float dist = vec3_dist(&handlePos, &pos3);
 	if (dist < data.radius) {

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -13,7 +13,7 @@
 
 #define HANDLE_RADIUS 4.0f
 #define HANDLE_SEL_RADIUS (HANDLE_RADIUS * 1.5f)
-#define HELPER_ROT_BREAKPONT 45.0f
+#define HELPER_ROT_BREAKPOINT 45.0f
 
 /* TODO: make C++ math classes and clean up code here later */
 
@@ -2516,7 +2516,7 @@ void OBSBasicPreview::DrawSpacingHelpers()
 	}
 
 	// Switch top/bottom or right/left if scale is negative
-	if (oti.scale.x < 0.0f) {
+	if (oti.scale.x < 0.0f && oti.bounds_type == OBS_BOUNDS_NONE) {
 		vec3 l = left;
 		vec3 r = right;
 
@@ -2524,7 +2524,7 @@ void OBSBasicPreview::DrawSpacingHelpers()
 		vec3_copy(&right, &l);
 	}
 
-	if (oti.scale.y < 0.0f) {
+	if (oti.scale.y < 0.0f && oti.bounds_type == OBS_BOUNDS_NONE) {
 		vec3 t = top;
 		vec3 b = bottom;
 
@@ -2532,8 +2532,8 @@ void OBSBasicPreview::DrawSpacingHelpers()
 		vec3_copy(&bottom, &t);
 	}
 
-	if (rot >= HELPER_ROT_BREAKPONT) {
-		for (float i = HELPER_ROT_BREAKPONT; i <= 360.0f; i += 90.0f) {
+	if (rot >= HELPER_ROT_BREAKPOINT) {
+		for (float i = HELPER_ROT_BREAKPOINT; i <= 360.0f; i += 90.0f) {
 			if (rot < i)
 				break;
 
@@ -2547,8 +2547,8 @@ void OBSBasicPreview::DrawSpacingHelpers()
 			vec3_copy(&bottom, &r);
 			vec3_copy(&left, &b);
 		}
-	} else if (rot <= -HELPER_ROT_BREAKPONT) {
-		for (float i = -HELPER_ROT_BREAKPONT; i >= -360.0f;
+	} else if (rot <= -HELPER_ROT_BREAKPOINT) {
+		for (float i = -HELPER_ROT_BREAKPOINT; i >= -360.0f;
 		     i -= 90.0f) {
 			if (rot > i)
 				break;

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -389,18 +389,19 @@ static bool FindHandleAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 
 	vec2 scale;
 	obs_sceneitem_get_scale(item, &scale);
+	obs_bounds_type boundsType = obs_sceneitem_get_bounds_type(item);
 	vec2 rotHandleOffset;
 	vec2_set(&rotHandleOffset, 0.0f,
 		 HANDLE_RADIUS * data.radius * 1.5 - data.radius);
-	float angle =
-		atan2(scale.x < 0.0f ? transform.x.y * -1.0f : transform.x.y,
-		      scale.x < 0.0f ? transform.x.x * -1.0f : transform.x.x);
+	bool invertx = scale.x < 0.0f && boundsType == OBS_BOUNDS_NONE;
+	float angle = atan2(invertx ? transform.x.y * -1.0f : transform.x.y,
+			    invertx ? transform.x.x * -1.0f : transform.x.x);
 	RotatePos(&rotHandleOffset, angle);
 	RotatePos(&rotHandleOffset, RAD(data.angleOffset));
 
-	bool invert = scale.y < 0.0f;
+	bool inverty = scale.y < 0.0f && boundsType == OBS_BOUNDS_NONE;
 	vec3 handlePos =
-		GetTransformedPos(0.5f, invert ? 1.0f : 0.0f, transform);
+		GetTransformedPos(0.5f, inverty ? 1.0f : 0.0f, transform);
 	vec3_transform(&handlePos, &handlePos, &data.parent_xform);
 	handlePos.x -= rotHandleOffset.x;
 	handlePos.y -= rotHandleOffset.y;
@@ -2120,7 +2121,8 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item,
 			prev->circleFill = gs_render_save();
 		}
 
-		bool invert = info.scale.y < 0.0f;
+		bool invert = info.scale.y < 0.0f &&
+			      info.bounds_type == OBS_BOUNDS_NONE;
 		DrawRotationHandle(prev->circleFill, info.rot + prev->groupRot,
 				   pixelRatio, invert);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This fixes a couple issues related to the handling of sceneitem flipping by the preview, and in particular when within a bounding box.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The issues in question are the following : 

Penwy/obs-studio@a2487fc2021765ae0ad655abe378658de4165685 fixes the rotation handle's mouse interaction being incorrectly positioned when an item has been flipped.
Steps to reproduce :
1. Horizontally flip a sceneitem
2. Rotate it (90° for most observable result)
3. Try to grab the rotate handle

Penwy/obs-studio@70a9343861eabb2842148ac89f7ea72d61e7f955 and Penwy/obs-studio@41f78c129f7d79fe99f0ab84fe83c56ea670fa86 fix the rotation handle and the pixel guides being drawn at the wrong position on a flipped sceneitem in a bounding box.
Steps to reproduce :
1. Set a sceneitem's bounding box type to anything other than "None"
2. Flip it (vertically to also see the effect on the rotation handle)
3. Notice the handle and the guides being drawn incorrectly

Penwy/obs-studio@8c6a3ad180afbea9e56ee6c115863a68e70e0540 fixes cropping by alt + dragging handles not working on flipped items inside bounding boxes.
Steps to reproduce : 
1. Set a sceneitem's bounding box type to anything other than "None"
2. Flip it
3. Attempt to crop by alt-dragging a handle in the direction it was flipped (top/bottom for flipped vertically, left/right for flipped horizontally)
4. Notice nothing happens

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 22.04
Tested by verifying said bugs do not happen anymore, in as much different situations I could think of.
Tested on sceneitems inside groups, didn't notice any more unexpected behaviour than usual.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
