### PR TITLE
updater: Fix updating without patch files

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1120,8 +1120,9 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 				}
 			}
 		} else {
-			QuickWriteFile(file.outputPath.c_str(),
-				       patch_data.data(), patch_data.size());
+			installed_ok = QuickWriteFile(file.outputPath.c_str(),
+						      patch_data.data(),
+						      patch_data.size());
 			error_code = GetLastError();
 		}
 


### PR DESCRIPTION
### Description

#8952 refactored parts of the updater but forgot to set the `installed_ok` result in the non-patch path.

### Motivation and Context

Don't want this to be broken.

### How Has This Been Tested?

Tested updater with and without deltas.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- 
### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
