### PR TITLE
UI: Fix transform shortcuts for audio only sources

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3328,9 +3328,24 @@ void OBSBasic::SourceToolBarActionsSetEnabled()
 	RefreshToolBarStyling(ui->sourcesToolbar);
 }
 
+void OBSBasic::UpdateTransformShortcuts()
+{
+	OBSSource source = obs_sceneitem_get_source(GetCurrentSceneItem());
+	uint32_t flags = obs_source_get_output_flags(source);
+	bool audioOnly = (flags & OBS_SOURCE_VIDEO) == 0;
+
+	ui->actionEditTransform->setEnabled(!audioOnly);
+	ui->actionCopyTransform->setEnabled(!audioOnly);
+	ui->actionPasteTransform->setEnabled(audioOnly ? false
+						       : hasCopiedTransform);
+
+	ui->actionResetTransform->setEnabled(!audioOnly);
+}
+
 void OBSBasic::UpdateContextBar(bool force)
 {
 	SourceToolBarActionsSetEnabled();
+	UpdateTransformShortcuts();
 
 	if (!ui->contextContainer->isVisible() && !force)
 		return;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -662,6 +662,8 @@ private:
 
 	bool restartingVCam = false;
 
+	void UpdateTransformShortcuts();
+
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();


### PR DESCRIPTION
### Description
The edit, copy, paste and reset transform shortcuts would still work for audio only sources, even though the menu was hidden for these.

### Motivation and Context
Fixes bug I found

### How Has This Been Tested?
Selected audio only source to make sure the shortcuts didn't fire

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
