### PR TITLE
obs-ffmpeg: Fix media source always STATE_ENDED

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -316,8 +316,10 @@ static void media_stopped(void *opaque)
 	if ((s->close_when_inactive || !s->is_local_file) && s->media)
 		s->destroy_media = true;
 
-	set_media_state(s, OBS_MEDIA_STATE_ENDED);
-	obs_source_media_ended(s->source);
+	if (s->state != OBS_MEDIA_STATE_STOPPED) {
+		set_media_state(s, OBS_MEDIA_STATE_ENDED);
+		obs_source_media_ended(s->source);
+	}
 }
 
 static void ffmpeg_source_open(struct ffmpeg_source *s)


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously would always end up with OBS_MEDIA_STATE_ENDED whether the
video reaches the end or the user stops the source (state is set to
STOPPED, but becomes ENDED right after). This fixes it so that if the
user stops the source, it will remain stopped.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Found this bug after https://github.com/obsproject/obs-studio/pull/9137 got merged. Even Advanced Scene Switcher users are affected by this weirdness. My interpretation of the two states is that ENDED is when the video naturally ends, and STOPPED when the user stops the video manually.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I put a breakpoint in update function to watch the state.
- If video ended, state is `OBS_MEDIA_STATE_ENDED`
- If video stopped, state is `OBS_MEDIA_STATE_STOPPED`

This also made the referenced PR do what was intended; to only restart the media if the state is `OBS_MEDIA_STATE_ENDED`

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
