### PR TITLE
UI, libobs: Add RAII wrappers for faders/volume meters

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -431,8 +431,6 @@ VolControl::~VolControl()
 				  "audio_monitoring",
 				  OBSMixersOrMonitoringChanged, this);
 
-	obs_fader_destroy(obs_fader);
-	obs_volmeter_destroy(obs_volmeter);
 	if (contextMenu)
 		contextMenu->close();
 }

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -290,8 +290,8 @@ private:
 	QPushButton *config = nullptr;
 	float levelTotal;
 	float levelCount;
-	obs_fader_t *obs_fader;
-	obs_volmeter_t *obs_volmeter;
+	OBSFader obs_fader;
+	OBSVolMeter obs_volmeter;
 	bool vertical;
 	QMenu *contextMenu;
 

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -310,6 +310,8 @@ public:
 
 using OBSDisplay = OBSPtr<obs_display_t *, obs_display_destroy>;
 using OBSView = OBSPtr<obs_view_t *, obs_view_destroy>;
+using OBSFader = OBSPtr<obs_fader_t *, obs_fader_destroy>;
+using OBSVolMeter = OBSPtr<obs_volmeter_t *, obs_volmeter_destroy>;
 
 /* signal handler connection */
 class OBSSignal {


### PR DESCRIPTION
### Description
They can now be automatically deleted.

### Motivation and Context
Split from #5873

### How Has This Been Tested?
Ran program, add/deleted volume meters to make sure nothing broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
