### PR TITLE
UI: Remove signal disconnect calls

### DIFF
--- a/UI/source-label.cpp
+++ b/UI/source-label.cpp
@@ -37,8 +37,4 @@ void OBSSourceLabel::SourceDestroyed(void *data, calldata_t *)
 {
 	auto &label = *static_cast<OBSSourceLabel *>(data);
 	emit label.Destroyed();
-
-	label.destroyedSignal.Disconnect();
-	label.removedSignal.Disconnect();
-	label.renamedSignal.Disconnect();
 }

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -180,24 +180,8 @@ void SourceTreeItem::paintEvent(QPaintEvent *event)
 	QWidget::paintEvent(event);
 }
 
-void SourceTreeItem::DisconnectSignals()
-{
-	sceneRemoveSignal.Disconnect();
-	itemRemoveSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	visibleSignal.Disconnect();
-	lockedSignal.Disconnect();
-	renameSignal.Disconnect();
-	removeSignal.Disconnect();
-
-	if (obs_sceneitem_is_group(sceneitem))
-		groupReorderSignal.Disconnect();
-}
-
 void SourceTreeItem::Clear()
 {
-	DisconnectSignals();
 	sceneitem = nullptr;
 }
 
@@ -205,8 +189,6 @@ void SourceTreeItem::ReconnectSignals()
 {
 	if (!sceneitem)
 		return;
-
-	DisconnectSignals();
 
 	/* --------------------------------------------------------- */
 
@@ -308,7 +290,6 @@ void SourceTreeItem::ReconnectSignals()
 	auto removeSource = [](void *data, calldata_t *) {
 		SourceTreeItem *this_ =
 			reinterpret_cast<SourceTreeItem *>(data);
-		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
 		QMetaObject::invokeMethod(this_->tree, "RefreshItems");
 	};

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -51,7 +51,6 @@ class SourceTreeItem : public QFrame {
 		SubItem,
 	};
 
-	void DisconnectSignals();
 	void ReconnectSignals();
 
 	Type type = Type::Unknown;

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -142,9 +142,6 @@ void OBSBasicAdvAudio::SetShowInactive(bool show)
 
 	showInactive = show;
 
-	sourceAddedSignal.Disconnect();
-	sourceRemovedSignal.Disconnect();
-
 	if (showInactive) {
 		sourceAddedSignal.Connect(obs_get_signal_handler(),
 					  "source_create", OBSSourceAdded,

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -249,7 +249,6 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 	}
 
 	if (view) {
-		updatePropertiesSignal.Disconnect();
 		ui->propertiesFrame->setVisible(false);
 		/* Deleting a filter will trigger a visibility change, which will also
 		 * trigger a focus change if the focus has not been on the list itself

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1103,11 +1103,6 @@ bool SimpleOutput::SetupStreaming(obs_service_t *service)
 
 	/* XXX: this is messy and disgusting and should be refactored */
 	if (outputType != type) {
-		streamDelayStarting.Disconnect();
-		streamStopping.Disconnect();
-		startStreaming.Disconnect();
-		stopStreaming.Disconnect();
-
 		streamOutput = obs_output_create(type, "simple_stream", nullptr,
 						 nullptr);
 		if (!streamOutput) {
@@ -2096,11 +2091,6 @@ bool AdvancedOutput::SetupStreaming(obs_service_t *service)
 
 	/* XXX: this is messy and disgusting and should be refactored */
 	if (outputType != type) {
-		streamDelayStarting.Disconnect();
-		streamStopping.Disconnect();
-		startStreaming.Disconnect();
-		stopStreaming.Disconnect();
-
 		streamOutput =
 			obs_output_create(type, "adv_stream", nullptr, nullptr);
 		if (!streamOutput) {

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -111,11 +111,6 @@ OBSBasicTransform::~OBSBasicTransform()
 
 void OBSBasicTransform::SetScene(OBSScene scene)
 {
-	transformSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	removeSignal.Disconnect();
-
 	if (scene) {
 		OBSSource source = obs_scene_get_source(scene);
 		signal_handler_t *signal =


### PR DESCRIPTION
### Description
The signals are wrapped in OBSSignal, so they are already automatically disconnected.

### Motivation and Context
Split from #5873

### How Has This Been Tested?
Ran program to make sure nothing broke

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
