### PR TITLE
win-dshow, linux-v4l2: Add support for grayscale MJPEG decoding

### DIFF
--- a/plugins/linux-v4l2/v4l2-decoder.c
+++ b/plugins/linux-v4l2/v4l2-decoder.c
@@ -104,6 +104,9 @@ int v4l2_decode_frame(struct obs_source_frame *out, uint8_t *data,
 	}
 
 	switch (decoder->context->pix_fmt) {
+	case AV_PIX_FMT_GRAY8:
+		out->format = VIDEO_FORMAT_Y800;
+		break;
 	case AV_PIX_FMT_YUVJ422P:
 	case AV_PIX_FMT_YUV422P:
 		out->format = VIDEO_FORMAT_I422;

--- a/plugins/win-dshow/ffmpeg-decode.c
+++ b/plugins/win-dshow/ffmpeg-decode.c
@@ -138,6 +138,8 @@ static inline enum video_format convert_pixel_format(int f)
 	switch (f) {
 	case AV_PIX_FMT_NONE:
 		return VIDEO_FORMAT_NONE;
+	case AV_PIX_FMT_GRAY8:
+		return VIDEO_FORMAT_Y800;
 	case AV_PIX_FMT_YUV420P:
 	case AV_PIX_FMT_YUVJ420P:
 		return VIDEO_FORMAT_I420;


### PR DESCRIPTION
### Description
Add pixel format mappings to support decoding grayscale MJPEG streams in the Windows DShow plugin as well as Linux V4L2 plugin. (Already working fine without any changes when tested on MacOS.)

### Motivation and Context
I am the author of the [GB Interceptor](https://github.com/Staacks/gbinterceptor), a device that analyses the data on a Game Boy's memory bus to recreate the image seen on screen. It acts as a USB Video Class device, so a video stream of the Game Boy can be used for recording or streaming. Unfortunately, since it is only a USB 1.1 device with limited processing power, I can only squeeze the full 60fps of the Game Boy through the USB bus by encoding it as grayscale MJPEG, i.e. without chroma channels which would be filled with zeros for the grayscale Game Boy anyway.

While UVC 1.5 clearly requires MJPEG streams to be YCbCr in 422 subsampling, OBS already supports other pixel formats and even supports single channel grayscale on MacOS. Adding support for grayscale for Windows and Linux turned out to be as trivial as adding a missing mapping for the format and while I don't think that there will be many other devices with that format out there, it still extends compatibility for a reasonable format as a sequence of valid JPEG frames.

### How Has This Been Tested?
Tested compatibility with the latest [beta firmware for the GB Interceptor](https://github.com/Staacks/gbinterceptor/releases/tag/v1.2.0-beta3) with a fresh build of OBS with and without my patch on a Dell XPS 12 running Windows 10 and on a Dell XPS 13 running Linux Mint with a 5.19.0 kernel. Windows version refused to decode the grayscale stream entirely while the Linux version tends to flicker to some green colors (probably filling in chroma channels with garbage). After my changes both worked as expected.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation. (I am not aware of this detail being documented)
