### PR TITLE
UI: Don't call activateWindow() when hidden

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2295,7 +2295,8 @@ void OBSBasic::OBSInit()
 	UpdatePreviewProgramIndicators();
 	OnFirstLoad();
 
-	activateWindow();
+	if (!hideWindowOnStart)
+		activateWindow();
 
 	/* ------------------------------------------- */
 	/* display warning message for failed modules  */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

During initialization, if the window is supposed to be hidden, don't call `activateWindow()`. This is determined through `hideWindowOnStart`, which is the same variable that determines whether to call `show()`. This change prevents the window from stealing focus and becoming the active window.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Users may choose to launch OBS Studio based on the current active window. If launching OBS to the system tray changes the active window, this could result in undesired behaviour if the user is not expecting the active window to change. Additionally, I would argue that setting the window to active when not showing it is not correct, but that is probably subjective, and in any case, the first point applies.

[Forum post describing the issue](https://obsproject.com/forum/threads/obs-steals-focus-on-start-even-with-minimize-to-tray-windows-10.159656/)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10, Intel i7-12700k, Nvidia RTX 3070 Ti.

Before change:

Navigate to the directory containing the binary and run `.\obs64.exe --minimize-to-tray`. The terminal window grays out because the OBS Studio window, although hidden, is set as the active window. This can also be confirmed through the `user32` function `GetForegroundWindow()`.

After change:

Navigate to the directory containing the binary and run `.\obs64.exe --minimize-to-tray`. The terminal window remains the active window, and no change in focus or colour is observed. `GetForegroundWindow()` still reports the terminal as the foreground window.

Additional tests:

- window still opens when clicking the system tray icon
- obs-websocket works nominally
- recording and replay buffer work nominally, both before and after the window is shown
- window is properly focused when run with no flag

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
