### PR TITLE
Clang format update

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
-#AllowShortLambdasOnASingleLine: Inline  # requires clang-format 9
+AllowShortLambdasOnASingleLine: Inline
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None

--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
-#AllowAllArgumentsOnNextLine: false  # requires clang-format 9
+AllowAllArgumentsOnNextLine: false
 #AllowAllConstructorInitializersOnNextLine: false  # requires clang-format 9
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
 AllowAllArgumentsOnNextLine: false
-#AllowAllConstructorInitializersOnNextLine: false  # requires clang-format 9
+AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false

--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
-# please use clang-format version 8 or later
+# please use clang-format version 13 or later
 
-Standard: Cpp11
+Standard: c++17
 AccessModifierOffset: -8
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
@@ -66,7 +66,7 @@ IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: true
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-#ObjCBinPackProtocolList: Auto  # requires clang-format 7
+ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 8
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
@@ -84,13 +84,13 @@ ReflowComments: false
 SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false
-#SpaceAfterLogicalNot: false  # requires clang-format 9
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-#SpaceBeforeCtorInitializerColon: true  # requires clang-format 7
-#SpaceBeforeInheritanceColon: true  # requires clang-format 7
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
-#SpaceBeforeRangeBasedForLoopColon: true  # requires clang-format 7
+SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false
@@ -98,11 +98,11 @@ SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-#StatementMacros:  # requires clang-format 8
-#  - 'Q_OBJECT'
+StatementMacros:
+  - 'Q_OBJECT'
 TabWidth: 8
-#TypenameMacros:  # requires clang-format 9
-#  - 'DARRAY'
+TypenameMacros:
+  - 'DARRAY'
 UseTab: ForContinuationAndIndentation
 ---
 Language: ObjC

--- a/CI/check-format.sh
+++ b/CI/check-format.sh
@@ -47,7 +47,6 @@ find . -type d \( \
     -path ./cmake -o \
     -path ./plugins/decklink/\*/decklink-sdk -o \
     -path ./plugins/enc-amf -o \
-    -path ./plugins/mac-syphon/syphon-framework -o \
     -path ./plugins/obs-outputs/ftl-sdk -o \
     -path ./plugins/obs-websocket/deps \
 \) -prune -false -type f -o \

--- a/UI/audio-encoders.cpp
+++ b/UI/audio-encoders.cpp
@@ -58,7 +58,9 @@ static void HandleListProperty(obs_property_t *prop, const char *id,
 
 static void HandleSampleRate(obs_property_t *prop, const char *id)
 {
-	auto ReleaseData = [](obs_data_t *data) { obs_data_release(data); };
+	auto ReleaseData = [](obs_data_t *data) {
+		obs_data_release(data);
+	};
 	std::unique_ptr<obs_data_t, decltype(ReleaseData)> data{
 		obs_encoder_defaults(id), ReleaseData};
 

--- a/UI/auth-base.hpp
+++ b/UI/auth-base.hpp
@@ -18,7 +18,8 @@ protected:
 		std::string error;
 
 		ErrorInfo(std::string message_, std::string error_)
-			: message(message_), error(error_)
+			: message(message_),
+			  error(error_)
 		{
 		}
 	};

--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -27,7 +27,8 @@ extern QCefCookieManager *panel_cookies;
 /* ------------------------------------------------------------------------- */
 
 OAuthLogin::OAuthLogin(QWidget *parent, const std::string &url, bool token)
-	: QDialog(parent), get_token(token)
+	: QDialog(parent),
+	  get_token(token)
 {
 #ifdef BROWSER_AVAILABLE
 	if (!cef) {

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -302,7 +302,9 @@ std::shared_ptr<Auth> YoutubeAuth::Login(QWidget *owner,
 		dlg.reject();
 	});
 
-	auto open_external_browser = [url]() { OpenBrowser(url); };
+	auto open_external_browser = [url]() {
+		OpenBrowser(url);
+	};
 	QScopedPointer<QThread> thread(CreateQThread(open_external_browser));
 	thread->start();
 

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -69,7 +69,8 @@ void RegisterYoutubeAuth()
 }
 
 YoutubeAuth::YoutubeAuth(const Def &d)
-	: OAuthStreamKey(d), section(SECTION_NAME)
+	: OAuthStreamKey(d),
+	  section(SECTION_NAME)
 {
 }
 

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -92,7 +92,8 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 /* ========================================================================= */
 
 BrowserToolbar::BrowserToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_BrowserSourceToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_BrowserSourceToolbar)
 {
 	ui->setupUi(this);
 }
@@ -113,7 +114,8 @@ void BrowserToolbar::on_refresh_clicked()
 /* ========================================================================= */
 
 ComboSelectToolbar::ComboSelectToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_DeviceSelectToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_DeviceSelectToolbar)
 {
 	ui->setupUi(this);
 }
@@ -384,7 +386,8 @@ void DeviceCaptureToolbar::on_activateButton_clicked()
 /* ========================================================================= */
 
 GameCaptureToolbar::GameCaptureToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_GameCaptureToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_GameCaptureToolbar)
 {
 	obs_property_t *p;
 	int cur_idx;
@@ -469,7 +472,8 @@ void GameCaptureToolbar::on_window_currentIndexChanged(int idx)
 /* ========================================================================= */
 
 ImageSourceToolbar::ImageSourceToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_ImageSourceToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_ImageSourceToolbar)
 {
 	ui->setupUi(this);
 
@@ -529,7 +533,8 @@ static inline long long color_to_int(QColor color)
 }
 
 ColorSourceToolbar::ColorSourceToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_ColorSourceToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_ColorSourceToolbar)
 {
 	ui->setupUi(this);
 
@@ -598,7 +603,8 @@ void ColorSourceToolbar::on_choose_clicked()
 extern void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false);
 
 TextSourceToolbar::TextSourceToolbar(QWidget *parent, OBSSource source)
-	: SourceToolbar(parent, source), ui(new Ui_TextSourceToolbar)
+	: SourceToolbar(parent, source),
+	  ui(new Ui_TextSourceToolbar)
 {
 	ui->setupUi(this);
 

--- a/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
+++ b/UI/frontend-plugins/aja-output-ui/aja-ui-main.cpp
@@ -412,7 +412,9 @@ void addOutputUI(void)
 	ajaOutputUI = new AJAOutputUI(window);
 	obs_frontend_pop_ui_translation();
 
-	auto cb = []() { ajaOutputUI->ShowHideDialog(); };
+	auto cb = []() {
+		ajaOutputUI->ShowHideDialog();
+	};
 
 	action->connect(action, &QAction::triggered, cb);
 }

--- a/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
+++ b/UI/frontend-plugins/decklink-captions/decklink-captions.cpp
@@ -23,7 +23,8 @@ obs_captions::obs_captions() {}
 static obs_captions *captions = nullptr;
 
 DecklinkCaptionsUI::DecklinkCaptionsUI(QWidget *parent)
-	: QDialog(parent), ui(new Ui_CaptionsDialog)
+	: QDialog(parent),
+	  ui(new Ui_CaptionsDialog)
 {
 	ui->setupUi(this);
 

--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.cpp
@@ -5,7 +5,8 @@
 #include "decklink-ui-main.h"
 
 DecklinkOutputUI::DecklinkOutputUI(QWidget *parent)
-	: QDialog(parent), ui(new Ui_Output)
+	: QDialog(parent),
+	  ui(new Ui_Output)
 {
 	ui->setupUi(this);
 

--- a/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
+++ b/UI/frontend-plugins/decklink-output-ui/decklink-ui-main.cpp
@@ -449,7 +449,9 @@ void addOutputUI(void)
 	doUI = new DecklinkOutputUI(window);
 	obs_frontend_pop_ui_translation();
 
-	auto cb = []() { doUI->ShowHideDialog(); };
+	auto cb = []() {
+		doUI->ShowHideDialog();
+	};
 
 	action->connect(action, &QAction::triggered, cb);
 }

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
@@ -26,7 +26,9 @@ struct SceneSwitch {
 	regex re;
 
 	inline SceneSwitch(OBSWeakSource scene_, const char *window_)
-		: scene(scene_), window(window_), re(window_)
+		: scene(scene_),
+		  window(window_),
+		  re(window_)
 	{
 	}
 };
@@ -79,7 +81,8 @@ static inline QString MakeSwitchName(const QString &scene,
 }
 
 SceneSwitcher::SceneSwitcher(QWidget *parent)
-	: QDialog(parent), ui(new Ui_SceneSwitcher)
+	: QDialog(parent),
+	  ui(new Ui_SceneSwitcher)
 {
 	ui->setupUi(this);
 

--- a/UI/frontend-plugins/frontend-tools/captions.cpp
+++ b/UI/frontend-plugins/frontend-tools/captions.cpp
@@ -74,7 +74,8 @@ struct locale_info {
 	inline locale_info() {}
 	inline locale_info(const locale_info &) = delete;
 	inline locale_info(locale_info &&li)
-		: name(std::move(li.name)), id(li.id)
+		: name(std::move(li.name)),
+		  id(li.id)
 	{
 	}
 };
@@ -85,7 +86,8 @@ static bool valid_lang(LANGID id);
 /* ------------------------------------------------------------------------- */
 
 CaptionsDialog::CaptionsDialog(QWidget *parent)
-	: QDialog(parent), ui(new Ui_CaptionsDialog)
+	: QDialog(parent),
+	  ui(new Ui_CaptionsDialog)
 {
 	ui->setupUi(this);
 

--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -340,7 +340,9 @@ extern "C" void InitOutputTimer()
 
 	ot = new OutputTimer(window);
 
-	auto cb = []() { ot->ShowHideDialog(); };
+	auto cb = []() {
+		ot->ShowHideDialog();
+	};
 
 	obs_frontend_pop_ui_translation();
 

--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -13,7 +13,8 @@ using namespace std;
 OutputTimer *ot;
 
 OutputTimer::OutputTimer(QWidget *parent)
-	: QDialog(parent), ui(new Ui_OutputTimer)
+	: QDialog(parent),
+	  ui(new Ui_OutputTimer)
 {
 	ui->setupUi(this);
 

--- a/UI/hotkey-edit.hpp
+++ b/UI/hotkey-edit.hpp
@@ -60,7 +60,9 @@ class OBSHotkeyEdit : public QLineEdit {
 public:
 	OBSHotkeyEdit(QWidget *parent, obs_key_combination_t original,
 		      OBSBasicSettings *settings)
-		: QLineEdit(parent), original(original), settings(settings)
+		: QLineEdit(parent),
+		  original(original),
+		  settings(settings)
 	{
 #ifdef __APPLE__
 		// disable the input cursor on OSX, focus should be clear
@@ -73,7 +75,9 @@ public:
 		ResetKey();
 	}
 	OBSHotkeyEdit(QWidget *parent = nullptr)
-		: QLineEdit(parent), original({}), settings(nullptr)
+		: QLineEdit(parent),
+		  original({}),
+		  settings(nullptr)
 	{
 #ifdef __APPLE__
 		// disable the input cursor on OSX, focus should be clear

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -13,7 +13,8 @@
 #include "qt-wrappers.hpp"
 
 OBSLogViewer::OBSLogViewer(QWidget *parent)
-	: QDialog(parent), ui(new Ui::OBSLogViewer)
+	: QDialog(parent),
+	  ui(new Ui::OBSLogViewer)
 {
 	setWindowFlags(windowFlags() & Qt::WindowMaximizeButtonHint &
 		       ~Qt::WindowContextHelpButtonHint);

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -44,7 +44,8 @@ void MediaControls::OBSMediaPrevious(void *data, calldata_t *)
 }
 
 MediaControls::MediaControls(QWidget *parent)
-	: QWidget(parent), ui(new Ui::MediaControls)
+	: QWidget(parent),
+	  ui(new Ui::MediaControls)
 {
 	ui->setupUi(this);
 	ui->playPauseButton->setProperty("themeID", "playIcon");

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1390,7 +1390,8 @@ std::vector<UpdateBranch> OBSApp::GetBranches()
 }
 
 OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
-	: QApplication(argc, argv), profilerNameStore(store)
+	: QApplication(argc, argv),
+	  profilerNameStore(store)
 {
 	/* fix float handling */
 #if defined(Q_OS_UNIX)

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1718,7 +1718,9 @@ static bool FrameRateChanged(QWidget *widget, const char *name,
 	if (!variant.canConvert<frame_rate_tag>())
 		return false;
 
-	auto StopUpdating = [&](void *) { w->updating = false; };
+	auto StopUpdating = [&](void *) {
+		w->updating = false;
+	};
 	unique_ptr<void, decltype(StopUpdating)> signalGuard(
 		static_cast<void *>(w), StopUpdating);
 	w->updating = true;

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -51,7 +51,9 @@ private:
 public:
 	inline WidgetInfo(OBSPropertiesView *view_, obs_property_t *prop,
 			  QWidget *widget_)
-		: view(view_), property(prop), widget(widget_)
+		: view(view_),
+		  property(prop),
+		  widget(widget_)
 	{
 	}
 

--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -22,7 +22,9 @@
 
 using namespace std;
 
-static auto curl_deleter = [](CURL *curl) { curl_easy_cleanup(curl); };
+static auto curl_deleter = [](CURL *curl) {
+	curl_easy_cleanup(curl);
+};
 using Curl = unique_ptr<CURL, decltype(curl_deleter)>;
 
 static size_t string_write(char *ptr, size_t size, size_t nmemb, string &str)

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -33,7 +33,8 @@ static inline OBSScene GetCurrentScene()
 /* ========================================================================= */
 
 SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
-	: tree(tree_), sceneitem(sceneitem_)
+	: tree(tree_),
+	  sceneitem(sceneitem_)
 {
 	setAttribute(Qt::WA_TranslucentBackground);
 	setMouseTracking(true);
@@ -853,7 +854,8 @@ OBSSceneItem SourceTreeModel::Get(int idx)
 }
 
 SourceTreeModel::SourceTreeModel(SourceTree *st_)
-	: QAbstractListModel(st_), st(st_)
+	: QAbstractListModel(st_),
+	  st(st_)
 {
 	obs_frontend_add_event_callback(OBSFrontendEvent, this);
 }

--- a/UI/update/win-update.hpp
+++ b/UI/update/win-update.hpp
@@ -23,7 +23,8 @@ private slots:
 
 public:
 	AutoUpdateThread(bool manualUpdate_, bool repairMode_ = false)
-		: manualUpdate(manualUpdate_), repairMode(repairMode_)
+		: manualUpdate(manualUpdate_),
+		  repairMode(repairMode_)
 	{
 	}
 };

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -828,7 +828,9 @@ void VolumeMeter::wheelEvent(QWheelEvent *event)
 
 VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 			 bool vertical)
-	: QWidget(parent), obs_volmeter(obs_volmeter), vertical(vertical)
+	: QWidget(parent),
+	  obs_volmeter(obs_volmeter),
+	  vertical(vertical)
 {
 	setAttribute(Qt::WA_OpaquePaintEvent, true);
 

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -534,7 +534,10 @@ struct Result {
 	int fps_den;
 
 	inline Result(int cx_, int cy_, int fps_num_, int fps_den_)
-		: cx(cx_), cy(cy_), fps_num(fps_num_), fps_den(fps_den_)
+		: cx(cx_),
+		  cy(cy_),
+		  fps_num(fps_num_),
+		  fps_den(fps_den_)
 	{
 	}
 };
@@ -1217,7 +1220,8 @@ void AutoConfigTestPage::Progress(int percentage)
 }
 
 AutoConfigTestPage::AutoConfigTestPage(QWidget *parent)
-	: QWizardPage(parent), ui(new Ui_AutoConfigTestPage)
+	: QWizardPage(parent),
+	  ui(new Ui_AutoConfigTestPage)
 {
 	ui->setupUi(this);
 	setTitle(QTStr("Basic.AutoConfig.TestPage"));

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -67,7 +67,8 @@ static void GetServiceInfo(std::string &type, std::string &service,
 /* ------------------------------------------------------------------------- */
 
 AutoConfigStartPage::AutoConfigStartPage(QWidget *parent)
-	: QWizardPage(parent), ui(new Ui_AutoConfigStartPage)
+	: QWizardPage(parent),
+	  ui(new Ui_AutoConfigStartPage)
 {
 	ui->setupUi(this);
 	setTitle(QTStr("Basic.AutoConfig.StartPage"));
@@ -120,7 +121,8 @@ void AutoConfigStartPage::PrioritizeVCam()
 #define FPS_PREFER_HIGH_RES RES_TEXT("FPS.PreferHighRes")
 
 AutoConfigVideoPage::AutoConfigVideoPage(QWidget *parent)
-	: QWizardPage(parent), ui(new Ui_AutoConfigVideoPage)
+	: QWizardPage(parent),
+	  ui(new Ui_AutoConfigVideoPage)
 {
 	ui->setupUi(this);
 
@@ -250,7 +252,8 @@ enum class ListOpt : int {
 };
 
 AutoConfigStreamPage::AutoConfigStreamPage(QWidget *parent)
-	: QWizardPage(parent), ui(new Ui_AutoConfigStreamPage)
+	: QWizardPage(parent),
+	  ui(new Ui_AutoConfigStreamPage)
 {
 	ui->setupUi(this);
 	ui->bitrateLabel->setVisible(false);

--- a/UI/window-basic-auto-config.hpp
+++ b/UI/window-basic-auto-config.hpp
@@ -251,7 +251,8 @@ class AutoConfigTestPage : public QWizardPage {
 		inline ServerInfo() {}
 
 		inline ServerInfo(const char *name_, const char *address_)
-			: name(name_), address(address_)
+			: name(name_),
+			  address(address_)
 		{
 		}
 	};

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -502,7 +502,8 @@ QMenu *OBSBasicFilters::CreateAddFilterPopupMenu(bool async)
 		string name;
 
 		inline FilterInfo(const char *type_, const char *name_)
-			: type(type_), name(name_)
+			: type(type_),
+			  name(name_)
 		{
 		}
 

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -632,7 +632,9 @@ void OBSBasic::on_transitionProps_clicked()
 	if (!obs_source_configurable(source))
 		return;
 
-	auto properties = [&]() { CreatePropertiesWindow(source); };
+	auto properties = [&]() {
+		CreatePropertiesWindow(source);
+	};
 
 	QMenu menu(this);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -281,7 +281,9 @@ extern void RegisterYoutubeAuth();
 #endif
 
 OBSBasic::OBSBasic(QWidget *parent)
-	: OBSMainWindow(parent), undo_s(ui), ui(new Ui::OBSBasic)
+	: OBSMainWindow(parent),
+	  undo_s(ui),
+	  ui(new Ui::OBSBasic)
 {
 	setAttribute(Qt::WA_NativeWindow);
 
@@ -5829,7 +5831,8 @@ QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu,
 }
 
 ColorSelect::ColorSelect(QWidget *parent)
-	: QWidget(parent), ui(new Ui::ColorSelect)
+	: QWidget(parent),
+	  ui(new Ui::ColorSelect)
 {
 	ui->setupUi(this);
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3546,7 +3546,9 @@ void OBSBasic::UnhideAllAudioControls()
 	using UnhideAudioMixer_t = decltype(UnhideAudioMixer);
 
 	auto PreEnum = [](void *data, obs_source_t *source) -> bool /* -- */
-	{ return (*reinterpret_cast<UnhideAudioMixer_t *>(data))(source); };
+	{
+		return (*reinterpret_cast<UnhideAudioMixer_t *>(data))(source);
+	};
 
 	obs_enum_sources(PreEnum, &UnhideAudioMixer);
 }

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -77,7 +77,8 @@ struct SceneFindData {
 	SceneFindData &operator=(SceneFindData &&) = delete;
 
 	inline SceneFindData(const vec2 &pos_, bool selectBelow_)
-		: pos(pos_), selectBelow(selectBelow_)
+		: pos(pos_),
+		  selectBelow(selectBelow_)
 	{
 	}
 };
@@ -93,7 +94,8 @@ struct SceneFindBoxData {
 	SceneFindBoxData &operator=(SceneFindData &&) = delete;
 
 	inline SceneFindBoxData(const vec2 &startPos_, const vec2 &pos_)
-		: startPos(startPos_), pos(pos_)
+		: startPos(startPos_),
+		  pos(pos_)
 	{
 	}
 };
@@ -314,7 +316,8 @@ struct HandleFindData {
 	HandleFindData &operator=(HandleFindData &&) = delete;
 
 	inline HandleFindData(const vec2 &pos_, float scale)
-		: pos(pos_), radius(HANDLE_SEL_RADIUS / scale)
+		: pos(pos_),
+		  radius(HANDLE_SEL_RADIUS / scale)
 	{
 		matrix4_identity(&parent_xform);
 	}

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -97,7 +97,9 @@ struct FormatDesc {
 	inline FormatDesc() = default;
 	inline FormatDesc(const char *name, const char *mimeType,
 			  const ff_format_desc *desc = nullptr)
-		: name(name), mimeType(mimeType), desc(desc)
+		: name(name),
+		  mimeType(mimeType),
+		  desc(desc)
 	{
 	}
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5140,7 +5140,9 @@ static void ResetInvalidSelection(QComboBox *cbox)
 
 void OBSBasicSettings::AdvOutRecCheckWarnings()
 {
-	auto Checked = [](QCheckBox *box) { return box->isChecked() ? 1 : 0; };
+	auto Checked = [](QCheckBox *box) {
+		return box->isChecked() ? 1 : 0;
+	};
 
 	QString errorMsg;
 	QString warningMsg;

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -41,7 +41,9 @@ void OBSBasicTransform::HookWidget(QWidget *widget, const char *signal,
 #define DSCROLL_CHANGED SIGNAL(valueChanged(double))
 
 OBSBasicTransform::OBSBasicTransform(OBSSceneItem item, OBSBasic *parent)
-	: QDialog(parent), ui(new Ui::OBSBasicTransform), main(parent)
+	: QDialog(parent),
+	  ui(new Ui::OBSBasicTransform),
+	  main(parent)
 {
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -123,7 +123,8 @@ public:
 class EditWidget : public QLineEdit {
 public:
 	inline EditWidget(QWidget *parent, QModelIndex index_)
-		: QLineEdit(parent), index(index_)
+		: QLineEdit(parent),
+		  index(index_)
 	{
 	}
 
@@ -420,7 +421,8 @@ bool ExtraBrowsersDelegate::UpdateText(QLineEdit *edit_)
 /* ------------------------------------------------------------------------- */
 
 OBSExtraBrowsers::OBSExtraBrowsers(QWidget *parent)
-	: QDialog(parent), ui(new Ui::OBSExtraBrowsers)
+	: QDialog(parent),
+	  ui(new Ui::OBSExtraBrowsers)
 {
 	ui->setupUi(this);
 

--- a/UI/window-extra-browsers.hpp
+++ b/UI/window-extra-browsers.hpp
@@ -76,7 +76,8 @@ class ExtraBrowsersDelegate : public QStyledItemDelegate {
 
 public:
 	inline ExtraBrowsersDelegate(ExtraBrowsersModel *model_)
-		: QStyledItemDelegate(nullptr), model(model_)
+		: QStyledItemDelegate(nullptr),
+		  model(model_)
 	{
 	}
 

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -23,7 +23,8 @@
 #include "obs-app.hpp"
 
 OBSLogReply::OBSLogReply(QWidget *parent, const QString &url, const bool crash)
-	: QDialog(parent), ui(new Ui::OBSLogReply)
+	: QDialog(parent),
+	  ui(new Ui::OBSLogReply)
 {
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->setupUi(this);

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -43,7 +43,9 @@ enum MissingFilesRole { EntryStateRole = Qt::UserRole, NewPathsToProcessRole };
 
 MissingFilesPathItemDelegate::MissingFilesPathItemDelegate(
 	bool isOutput, const QString &defaultPath)
-	: QStyledItemDelegate(), isOutput(isOutput), defaultPath(defaultPath)
+	: QStyledItemDelegate(),
+	  isOutput(isOutput),
+	  defaultPath(defaultPath)
 {
 }
 

--- a/UI/window-permissions.cpp
+++ b/UI/window-permissions.cpp
@@ -23,7 +23,8 @@ OBSPermissions::OBSPermissions(QWidget *parent, MacPermissionStatus capture,
 			       MacPermissionStatus video,
 			       MacPermissionStatus audio,
 			       MacPermissionStatus accessibility)
-	: QDialog(parent), ui(new Ui::OBSPermissions)
+	: QDialog(parent),
+	  ui(new Ui::OBSPermissions)
 {
 	ui->setupUi(this);
 	SetStatus(ui->capturePermissionButton, capture,

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -16,7 +16,8 @@ static bool updatingMultiview = false, mouseSwitching, transitionOnDoubleClick;
 
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 			   ProjectorType type_)
-	: OBSQTDisplay(widget, Qt::Window), weakSource(OBSGetWeakRef(source_))
+	: OBSQTDisplay(widget, Qt::Window),
+	  weakSource(OBSGetWeakRef(source_))
 {
 	OBSSource source = GetSource();
 	if (source) {

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -56,7 +56,9 @@ enum RemuxEntryRole { EntryStateRole = Qt::UserRole, NewPathsToProcessRole };
 
 RemuxEntryPathItemDelegate::RemuxEntryPathItemDelegate(
 	bool isOutput, const QString &defaultPath)
-	: QStyledItemDelegate(), isOutput(isOutput), defaultPath(defaultPath)
+	: QStyledItemDelegate(),
+	  isOutput(isOutput),
+	  defaultPath(defaultPath)
 {
 }
 

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -96,7 +96,8 @@ class RemuxQueueModel : public QAbstractTableModel {
 
 public:
 	RemuxQueueModel(QObject *parent = 0)
-		: QAbstractTableModel(parent), isProcessing(false)
+		: QAbstractTableModel(parent),
+		  isProcessing(false)
 	{
 	}
 

--- a/libobs-d3d11/d3d11-samplerstate.cpp
+++ b/libobs-d3d11/d3d11-samplerstate.cpp
@@ -67,7 +67,8 @@ static inline D3D11_FILTER ConvertGSFilter(gs_sample_filter filter)
 
 gs_sampler_state::gs_sampler_state(gs_device_t *device,
 				   const gs_sampler_info *info)
-	: gs_obj(device, gs_type::gs_sampler_state), info(*info)
+	: gs_obj(device, gs_type::gs_sampler_state),
+	  info(*info)
 {
 	HRESULT hr;
 	vec4 v4;

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -52,7 +52,8 @@ static inline void LogD3D11ErrorDetails(HRError error, gs_device_t *device)
 }
 
 gs_obj::gs_obj(gs_device_t *device_, gs_type type)
-	: device(device_), obj_type(type)
+	: device(device_),
+	  obj_type(type)
 {
 	prev_next = &device->first_obj;
 	next = device->first_obj;

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -476,13 +476,16 @@ struct gs_texture : gs_obj {
 
 	inline gs_texture(gs_texture_type type, uint32_t levels,
 			  gs_color_format format)
-		: type(type), levels(levels), format(format)
+		: type(type),
+		  levels(levels),
+		  format(format)
 	{
 	}
 
 	inline gs_texture(gs_device *device, gs_type obj_type,
 			  gs_texture_type type)
-		: gs_obj(device, obj_type), type(type)
+		: gs_obj(device, obj_type),
+		  type(type)
 	{
 	}
 
@@ -632,7 +635,9 @@ struct gs_zstencil_buffer : gs_obj {
 	}
 
 	inline gs_zstencil_buffer()
-		: width(0), height(0), dxgiFormat(DXGI_FORMAT_UNKNOWN)
+		: width(0),
+		  height(0),
+		  dxgiFormat(DXGI_FORMAT_UNKNOWN)
 	{
 	}
 
@@ -693,7 +698,8 @@ struct ShaderError {
 	HRESULT hr;
 
 	inline ShaderError(const ComPtr<ID3D10Blob> &errors, HRESULT hr)
-		: errors(errors), hr(hr)
+		: errors(errors),
+		  hr(hr)
 	{
 	}
 };
@@ -717,7 +723,9 @@ struct gs_shader : gs_obj {
 
 	inline gs_shader(gs_device_t *device, gs_type obj_type,
 			 gs_shader_type type)
-		: gs_obj(device, obj_type), type(type), constantSize(0)
+		: gs_obj(device, obj_type),
+		  type(type),
+		  constantSize(0)
 	{
 	}
 
@@ -730,7 +738,8 @@ struct ShaderSampler {
 
 	inline ShaderSampler(const char *name, gs_device_t *device,
 			     gs_sampler_info *info)
-		: name(name), sampler(device, info)
+		: name(name),
+		  sampler(device, info)
 	{
 	}
 };
@@ -894,7 +903,8 @@ struct SavedBlendState : BlendState {
 	inline void Release() { state.Release(); }
 
 	inline SavedBlendState(const BlendState &val, D3D11_BLEND_DESC &desc)
-		: BlendState(val), bd(desc)
+		: BlendState(val),
+		  bd(desc)
 	{
 	}
 };
@@ -906,7 +916,10 @@ struct StencilSide {
 	gs_stencil_op_type zpass;
 
 	inline StencilSide()
-		: test(GS_ALWAYS), fail(GS_KEEP), zfail(GS_KEEP), zpass(GS_KEEP)
+		: test(GS_ALWAYS),
+		  fail(GS_KEEP),
+		  zfail(GS_KEEP),
+		  zpass(GS_KEEP)
 	{
 	}
 };
@@ -946,7 +959,8 @@ struct SavedZStencilState : ZStencilState {
 
 	inline SavedZStencilState(const ZStencilState &val,
 				  D3D11_DEPTH_STENCIL_DESC desc)
-		: ZStencilState(val), dsd(desc)
+		: ZStencilState(val),
+		  dsd(desc)
 	{
 	}
 };
@@ -973,7 +987,8 @@ struct SavedRasterState : RasterState {
 
 	inline SavedRasterState(const RasterState &val,
 				D3D11_RASTERIZER_DESC &desc)
-		: RasterState(val), rd(desc)
+		: RasterState(val),
+		  rd(desc)
 	{
 	}
 };

--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -8,8 +8,8 @@
 #include "wasapi-output.h"
 
 #define ACTUALLY_DEFINE_GUID(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
-	EXTERN_C const GUID DECLSPEC_SELECTANY name = {                       \
-		l, w1, w2, {b1, b2, b3, b4, b5, b6, b7, b8}}
+	EXTERN_C const GUID DECLSPEC_SELECTANY                                \
+		name = {l, w1, w2, {b1, b2, b3, b4, b5, b6, b7, b8}}
 
 #define do_log(level, format, ...)                      \
 	blog(level, "[audio monitoring: '%s'] " format, \

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -188,8 +188,9 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 
 		uint32_t handle = gs_texture_get_shared_handle(tex);
 
-		struct obs_tex_frame frame = {
-			.tex = tex, .tex_uv = tex_uv, .handle = handle};
+		struct obs_tex_frame frame = {.tex = tex,
+					      .tex_uv = tex_uv,
+					      .handle = handle};
 
 		circlebuf_push_back(&video->gpu_encoder_avail_queue, &frame,
 				    sizeof(frame));

--- a/libobs/util/profiler.hpp
+++ b/libobs/util/profiler.hpp
@@ -12,7 +12,8 @@ struct ScopeProfiler {
 
 	ScopeProfiler(const ScopeProfiler &) = delete;
 	ScopeProfiler(ScopeProfiler &&other)
-		: name(other.name), enabled(other.enabled)
+		: name(other.name),
+		  enabled(other.enabled)
 	{
 		other.enabled = false;
 	}

--- a/plugins/decklink/DecklinkInput.cpp
+++ b/plugins/decklink/DecklinkInput.cpp
@@ -4,7 +4,8 @@
 
 DeckLinkInput::DeckLinkInput(obs_source_t *source,
 			     DeckLinkDeviceDiscovery *discovery_)
-	: DecklinkBase(discovery_), source(source)
+	: DecklinkBase(discovery_),
+	  source(source)
 {
 	discovery->AddCallback(DeckLinkInput::DevicesChanged, this);
 }

--- a/plugins/decklink/DecklinkOutput.cpp
+++ b/plugins/decklink/DecklinkOutput.cpp
@@ -4,7 +4,8 @@
 
 DeckLinkOutput::DeckLinkOutput(obs_output_t *output,
 			       DeckLinkDeviceDiscovery *discovery_)
-	: DecklinkBase(discovery_), output(output)
+	: DecklinkBase(discovery_),
+	  output(output)
 {
 	discovery->AddCallback(DeckLinkOutput::DevicesChanged, this);
 }

--- a/plugins/decklink/decklink-device-mode.cpp
+++ b/plugins/decklink/decklink-device-mode.cpp
@@ -1,7 +1,8 @@
 #include "decklink-device-mode.hpp"
 
 DeckLinkDeviceMode::DeckLinkDeviceMode(IDeckLinkDisplayMode *mode, long long id)
-	: id(id), mode(mode)
+	: id(id),
+	  mode(mode)
 {
 	if (mode == nullptr)
 		return;
@@ -12,7 +13,9 @@ DeckLinkDeviceMode::DeckLinkDeviceMode(IDeckLinkDisplayMode *mode, long long id)
 }
 
 DeckLinkDeviceMode::DeckLinkDeviceMode(const std::string &name, long long id)
-	: id(id), mode(nullptr), name(name)
+	: id(id),
+	  mode(nullptr),
+	  name(name)
 {
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -107,8 +107,9 @@ static bool get_audio_headers(struct ffmpeg_output *stream,
 	AVCodecParameters *par = data->audio_infos[idx].stream->codecpar;
 	obs_encoder_t *aencoder =
 		obs_output_get_audio_encoder(stream->output, idx);
-	struct encoder_packet packet = {
-		.type = OBS_ENCODER_AUDIO, .timebase_den = 1, .track_idx = idx};
+	struct encoder_packet packet = {.type = OBS_ENCODER_AUDIO,
+					.timebase_den = 1,
+					.track_idx = idx};
 
 	if (obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size)) {
 		par->extradata = av_memdup(packet.data, packet.size);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -685,8 +685,9 @@ bool write_packet(struct ffmpeg_muxer *stream, struct encoder_packet *packet)
 static bool send_audio_headers(struct ffmpeg_muxer *stream,
 			       obs_encoder_t *aencoder, size_t idx)
 {
-	struct encoder_packet packet = {
-		.type = OBS_ENCODER_AUDIO, .timebase_den = 1, .track_idx = idx};
+	struct encoder_packet packet = {.type = OBS_ENCODER_AUDIO,
+					.timebase_den = 1,
+					.track_idx = idx};
 
 	if (!obs_encoder_get_extra_data(aencoder, &packet.data, &packet.size))
 		return false;

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -131,8 +131,9 @@ static void write_video_header(struct flv_output *stream)
 	uint8_t *header;
 	size_t size;
 
-	struct encoder_packet packet = {
-		.type = OBS_ENCODER_VIDEO, .timebase_den = 1, .keyframe = true};
+	struct encoder_packet packet = {.type = OBS_ENCODER_VIDEO,
+					.timebase_den = 1,
+					.keyframe = true};
 
 	if (!obs_encoder_get_extra_data(vencoder, &header, &size))
 		return;

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -795,8 +795,9 @@ static bool send_video_header(struct rtmp_stream *stream)
 	uint8_t *header;
 	size_t size;
 
-	struct encoder_packet packet = {
-		.type = OBS_ENCODER_VIDEO, .timebase_den = 1, .keyframe = true};
+	struct encoder_packet packet = {.type = OBS_ENCODER_VIDEO,
+					.timebase_den = 1,
+					.keyframe = true};
 
 	if (!obs_encoder_get_extra_data(vencoder, &header, &size))
 		return false;

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -1113,7 +1113,9 @@ bool obs_module_load(void)
 	si.get_properties = get_properties;
 	si.icon_type = OBS_ICON_TYPE_TEXT;
 
-	si.get_name = [](void *) { return obs_module_text("TextGDIPlus"); };
+	si.get_name = [](void *) {
+		return obs_module_text("TextGDIPlus");
+	};
 	si.create = [](obs_data_t *settings, obs_source_t *source) {
 		return (void *)new TextSource(source, settings);
 	};
@@ -1126,7 +1128,9 @@ bool obs_module_load(void)
 	si.get_height = [](void *data) {
 		return reinterpret_cast<TextSource *>(data)->cy;
 	};
-	si.get_defaults = [](obs_data_t *settings) { defaults(settings, 1); };
+	si.get_defaults = [](obs_data_t *settings) {
+		defaults(settings, 1);
+	};
 	si.update = [](void *data, obs_data_t *settings) {
 		reinterpret_cast<TextSource *>(data)->Update(settings);
 	};

--- a/plugins/obs-vst/EditorWidget.cpp
+++ b/plugins/obs-vst/EditorWidget.cpp
@@ -20,7 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QCloseEvent>
 
 EditorWidget::EditorWidget(QWidget *parent, VSTPlugin *plugin)
-	: QWidget(parent), plugin(plugin)
+	: QWidget(parent),
+	  plugin(plugin)
 {
 	setWindowFlags(this->windowFlags() |= Qt::MSWindowsFixedSizeDialogHint);
 }

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -468,7 +468,8 @@ void register_whip_output()
 				 struct encoder_packet *packet) {
 		static_cast<WHIPOutput *>(priv_data)->Data(packet);
 	};
-	info.get_defaults = [](obs_data_t *) {};
+	info.get_defaults = [](obs_data_t *) {
+	};
 	info.get_properties = [](void *) -> obs_properties_t * {
 		return obs_properties_create();
 	};

--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -76,7 +76,9 @@ void register_whip_service()
 	info.get_properties = [](void *) -> obs_properties_t * {
 		return WHIPService::Properties();
 	};
-	info.get_protocol = [](void *) -> const char * { return "WHIP"; };
+	info.get_protocol = [](void *) -> const char * {
+		return "WHIP";
+	};
 	info.get_url = [](void *priv_data) -> const char * {
 		return static_cast<WHIPService *>(priv_data)->server.c_str();
 	};

--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -4,7 +4,8 @@ const char *audio_codecs[MAX_CODECS] = {"opus"};
 const char *video_codecs[MAX_CODECS] = {"h264"};
 
 WHIPService::WHIPService(obs_data_t *settings, obs_service_t *)
-	: server(), bearer_token()
+	: server(),
+	  bearer_token()
 {
 	Update(settings);
 }

--- a/plugins/win-capture/plugin-main.c
+++ b/plugins/win-capture/plugin-main.c
@@ -116,8 +116,10 @@ bool obs_module_load(void)
 	snprintf(update_url, sizeof(update_url), "%s/v%d", COMPAT_URL,
 		 COMPAT_FORMAT_VERSION);
 
-	struct win_version_info win1903 = {
-		.major = 10, .minor = 0, .build = 18362, .revis = 0};
+	struct win_version_info win1903 = {.major = 10,
+					   .minor = 0,
+					   .build = 18362,
+					   .revis = 0};
 
 	local_dir = obs_module_file(NULL);
 	config_dir = obs_module_config_path(NULL);

--- a/plugins/win-dshow/win-dshow-encoder.cpp
+++ b/plugins/win-dshow/win-dshow-encoder.cpp
@@ -22,7 +22,8 @@ struct DShowEncoder {
 	DARRAY(uint8_t) header;
 
 	inline DShowEncoder(obs_encoder_t *context_, const wchar_t *device_)
-		: context(context_), device(device_)
+		: context(context_),
+		  device(device_)
 	{
 		da_init(firstPacket);
 		da_init(header);

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -228,7 +228,8 @@ struct DShowInput {
 	}
 
 	inline DShowInput(obs_source_t *source_, obs_data_t *settings)
-		: source(source_), device(InitGraph::False)
+		: source(source_),
+		  device(InitGraph::False)
 	{
 		memset(&audio, 0, sizeof(audio));
 		memset(&frame, 0, sizeof(frame));


### PR DESCRIPTION

### Description

Updates the clang format file and affected file by uncommenting options that were previously commented out due to not being supported in the clang-format version used when the file was originally written. As we are now using clang-format 13 we can enable them.

Each option is its own commit to make it easier to review and decide which ones we might want.

Some options did not result in any changes at all since they were the default anyway, but perhaps we want to keep those for forwards-compatibility should clang defaults change.

### Motivation and Context

Cleanup.

### How Has This Been Tested?

Ran the formatting locally using `CI/check-format.sh`.

### Types of changes

 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
