### PR TITLE
Fix obs-webrtc CMake syntax

### DIFF
--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -4,7 +4,7 @@ legacy_check()
 
 option(ENABLE_WEBRTC "Enable WebRTC Output support" ON)
 if(NOT ENABLE_WEBRTC)
-  message(STATUS "OBS:  DISABLED   obs-webrtc")
+  target_disable(obs-webrtc)
   return()
 endif()
 

--- a/plugins/obs-webrtc/cmake/legacy.cmake
+++ b/plugins/obs-webrtc/cmake/legacy.cmake
@@ -2,7 +2,7 @@ project(obs-webrtc)
 
 option(ENABLE_WEBRTC "Enable WebRTC Output support" ON)
 if(NOT ENABLE_WEBRTC)
-  obs_status(DISABLED, "obs-webrtc")
+  obs_status(DISABLED "obs-webrtc")
   return()
 endif()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix legacy CMake obs_status call
An additional stray comma resulted in an incorrectly formatted status message in the CMake log.

Fix CMake 3.0 module disabled path
The CMake 3.0 path used the old syntax for logging if the module was disabled. Update this to use `target_disable` to match the syntax in other CMake 3.0 paths.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Was doing local test builds and noticed the CMake logging was incorrect.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
