### PR TITLE
mac-capture: Remove internal display settings from SCK Audio Capture

### DIFF
--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -175,23 +175,6 @@ static bool init_audio_screen_stream(struct screen_capture *sc)
 
 static void sck_audio_capture_defaults(obs_data_t *settings)
 {
-    CGDirectDisplayID initial_display = 0;
-    {
-        NSScreen *mainScreen = [NSScreen mainScreen];
-        if (mainScreen) {
-            NSNumber *screen_num = mainScreen.deviceDescription[@"NSScreenNumber"];
-            if (screen_num) {
-                initial_display = (CGDirectDisplayID) (uintptr_t) screen_num.pointerValue;
-            }
-        }
-    }
-
-    CFUUIDRef display_uuid = CGDisplayCreateUUIDFromDisplayID(initial_display);
-    CFStringRef uuid_string = CFUUIDCreateString(kCFAllocatorDefault, display_uuid);
-    obs_data_set_default_string(settings, "display_uuid", CFStringGetCStringPtr(uuid_string, kCFStringEncodingUTF8));
-    CFRelease(uuid_string);
-    CFRelease(display_uuid);
-
     obs_data_set_default_obj(settings, "application", NULL);
     obs_data_set_default_int(settings, "type", ScreenCaptureAudioDesktopStream);
 }
@@ -210,16 +193,7 @@ static void *sck_audio_capture_create(obs_data_t *settings, obs_source_t *source
     sc->capture_delegate = [[ScreenCaptureDelegate alloc] init];
     sc->capture_delegate.sc = sc;
 
-    const char *display_uuid = obs_data_get_string(settings, "display_uuid");
-    if (display_uuid) {
-        CFStringRef uuid_string = CFStringCreateWithCString(kCFAllocatorDefault, display_uuid, kCFStringEncodingUTF8);
-        CFUUIDRef uuid_ref = CFUUIDCreateFromString(kCFAllocatorDefault, uuid_string);
-        sc->display = CGDisplayGetDisplayIDFromUUID(uuid_ref);
-        CFRelease(uuid_string);
-        CFRelease(uuid_ref);
-    } else {
-        sc->display = CGMainDisplayID();
-    }
+    sc->display = CGMainDisplayID();
 
     sc->application_id = [[NSString alloc] initWithUTF8String:obs_data_get_string(settings, "application")];
     pthread_mutex_init(&sc->mutex, NULL);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the internal display settings from SCK Audio Capture.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When capturing desktop audio via ScreenCaptureKit, this always includes the entire audio, independent of which display an application might be running on. As such we don't currently expose a setting to change the display, and don't need any code handling a display setting (as we can always simply use the primary display because it doesn't matter).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14 23A5286g
Checked that SCK Audio Capture still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
