### PR TITLE
Remove outdated TODO comments

### DIFF
--- a/libobs/util/cf-lexer.h
+++ b/libobs/util/cf-lexer.h
@@ -165,7 +165,6 @@ static inline void cf_def_free(struct cf_def *cfd)
  *     features for certain language implementations
  *   + macro parameter string operator #
  *   + macro parameter token concatenation operator ##
- *   + predefined macros
  *   + restricted macros
  */
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -133,8 +133,6 @@ bool active(struct ffmpeg_muxer *stream)
 	return os_atomic_load_bool(&stream->active);
 }
 
-/* TODO: allow codecs other than h264 whenever we start using them */
-
 static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 				     struct dstr *cmd, obs_encoder_t *vencoder)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR removes outdated TODO comments.

- libobs/util/cf-lexer.h: Left to implement predefined macros
- plugins/obs-ffmpeg/obs-ffmpeg-mux.c: Allow codecs other than h264
  Now we support other codecs such as HEVC and obs-ffmpeg-mux can handle other codecs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Less number of TODO is better.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Reviewed modification so that this PR does not change any behavior itself.
- Checked predefined macro `_OPENGL` defined in `ep_parse` can enable the preprocess result of `#ifdef _OPENGL`.
- Checked HEVC can be saved using VA-API on Linux.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
