### PR TITLE
UI: Fix preprocessor directives for streaming platform integrations

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -19,7 +19,7 @@
 
 #include "auth-oauth.hpp"
 #include "ui-config.h"
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 #include "youtube-api-wrappers.hpp"
 #endif
 
@@ -355,7 +355,7 @@ bool AutoConfigStreamPage::validatePage()
 	} else {
 		/* Default test target is 10 Mbps */
 		bitrate = 10000;
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		if (IsYouTubeService(wiz->serviceName)) {
 			/* Adjust upper bound to YouTube limits
 			 * for resolutions above 1080p */
@@ -394,7 +394,7 @@ bool AutoConfigStreamPage::validatePage()
 	if (!wiz->customServer) {
 		if (wiz->serviceName == "Twitch")
 			wiz->service = AutoConfig::Service::Twitch;
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		else if (IsYouTubeService(wiz->serviceName))
 			wiz->service = AutoConfig::Service::YouTube;
 #endif
@@ -450,7 +450,7 @@ void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 		ui->connectedAccountLabel->setVisible(false);
 		ui->connectedAccountText->setVisible(false);
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		if (IsYouTubeService(a->service())) {
 			ui->key->clear();
 
@@ -567,7 +567,7 @@ static inline bool is_external_oauth(const std::string &service)
 
 void AutoConfigStreamPage::reset_service_ui_fields(std::string &service)
 {
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	// when account is already connected:
 	OAuthStreamKey *a = reinterpret_cast<OAuthStreamKey *>(auth.get());
 	if (a && service == a->service() && IsYouTubeService(a->service())) {
@@ -660,7 +660,7 @@ void AutoConfigStreamPage::ServiceChanged()
 		auto system_auth_service = main->auth->service();
 		bool service_check = service.find(system_auth_service) !=
 				     std::string::npos;
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		service_check =
 			service_check ? service_check
 				      : IsYouTubeService(system_auth_service) &&
@@ -1083,7 +1083,7 @@ void AutoConfig::SaveStreamSettings()
 	if (!customServer)
 		obs_data_set_string(settings, "service", serviceName.c_str());
 	obs_data_set_string(settings, "server", server.c_str());
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	if (!IsYouTubeService(serviceName))
 		obs_data_set_string(settings, "key", key.c_str());
 #else

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -60,7 +60,7 @@
 #endif
 #include "window-projector.hpp"
 #include "window-remux.hpp"
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 #include "auth-youtube.hpp"
 #include "window-youtube-actions.hpp"
 #include "youtube-api-wrappers.hpp"
@@ -280,7 +280,7 @@ void setupDockAction(QDockWidget *dock)
 
 extern void RegisterTwitchAuth();
 extern void RegisterRestreamAuth();
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 extern void RegisterYoutubeAuth();
 #endif
 
@@ -294,13 +294,13 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	setAttribute(Qt::WA_NativeWindow);
 
-#if TWITCH_ENABLED
+#ifdef TWITCH_ENABLED
 	RegisterTwitchAuth();
 #endif
-#if RESTREAM_ENABLED
+#ifdef RESTREAM_ENABLED
 	RegisterRestreamAuth();
 #endif
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	RegisterYoutubeAuth();
 #endif
 
@@ -4993,7 +4993,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 		return;
 	}
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	/* Also don't close the window if the youtube stream check is active */
 	if (youtubeStreamCheckThread) {
 		QTimer::singleShot(1000, this, SLOT(close()));
@@ -6748,7 +6748,7 @@ void OBSBasic::DisplayStreamStartError()
 	QMessageBox::critical(this, QTStr("Output.StartStreamFailed"), message);
 }
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 void OBSBasic::YouTubeActionDialogOk(const QString &id, const QString &key,
 				     bool autostart, bool autostop,
 				     bool start_now)
@@ -6944,7 +6944,7 @@ void OBSBasic::StartStreaming()
 	if (replayBufferWhileStreaming)
 		StartReplayBuffer();
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	if (!autoStartBroadcast)
 		OBSBasic::ShowYouTubeAutoStartWarning();
 #endif
@@ -6961,7 +6961,7 @@ void OBSBasic::BroadcastButtonClicked()
 	}
 
 	if (!autoStartBroadcast) {
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		std::shared_ptr<YoutubeApiWrappers> ytAuth =
 			dynamic_pointer_cast<YoutubeApiWrappers>(auth);
 		if (ytAuth.get()) {
@@ -7001,7 +7001,7 @@ void OBSBasic::BroadcastButtonClicked()
 		ui->broadcastButton->style()->unpolish(ui->broadcastButton);
 		ui->broadcastButton->style()->polish(ui->broadcastButton);
 	} else if (!autoStopBroadcast) {
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					       "WarnBeforeStoppingStream");
 		if (confirm && isVisible()) {
@@ -7060,7 +7060,7 @@ void OBSBasic::SetBroadcastFlowEnabled(bool enabled)
 
 void OBSBasic::SetupBroadcast()
 {
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	Auth *const auth = GetAuth();
 	if (IsYouTubeService(auth->service())) {
 		OBSYoutubeActions dialog(this, auth, broadcastReady);
@@ -7323,7 +7323,7 @@ void OBSBasic::StreamingStart()
 		sysTrayStream->setEnabled(true);
 	}
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	if (!autoStartBroadcast) {
 		// get a current stream key
 		obs_service_t *service_obj = GetService();
@@ -7975,7 +7975,7 @@ void OBSBasic::on_streamButton_clicked()
 		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
 					       "WarnBeforeStoppingStream");
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		if (isVisible() && auth && IsYouTubeService(auth->service()) &&
 		    autoStopBroadcast) {
 			QMessageBox::StandardButton button = OBSMessageBox::question(

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -626,7 +626,7 @@ private:
 	bool broadcastActive = false;
 	bool broadcastReady = false;
 	QPointer<QThread> youtubeStreamCheckThread;
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	void YoutubeStreamCheck(const std::string &key);
 	void ShowYouTubeAutoStartWarning();
 	void YouTubeActionDialogOk(const QString &id, const QString &key,

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -16,7 +16,7 @@
 
 #include "ui-config.h"
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 #include "youtube-api-wrappers.hpp"
 #endif
 
@@ -458,7 +458,7 @@ static void reset_service_ui_fields(Ui::OBSBasicSettings *ui,
 	ui->disconnectAccount->setVisible(false);
 }
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 static void get_yt_ch_title(Ui::OBSBasicSettings *ui)
 {
 	const char *name = config_get_string(OBSBasic::Get()->Config(),
@@ -560,7 +560,7 @@ void OBSBasicSettings::ServiceChanged()
 	auto system_auth_service = main->auth->service();
 	bool service_check = service.find(system_auth_service) !=
 			     std::string::npos;
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	service_check = service_check ? service_check
 				      : IsYouTubeService(system_auth_service) &&
 						IsYouTubeService(service);
@@ -728,7 +728,7 @@ void OBSBasicSettings::OnOAuthStreamKeyConnected()
 		} else {
 			ui->bandwidthTestEnable->setChecked(false);
 		}
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 		if (IsYouTubeService(a->service())) {
 			ui->key->clear();
 
@@ -983,7 +983,7 @@ void OBSBasicSettings::UpdateServiceRecommendations()
 	}
 #undef ENFORCE_TEXT
 
-#if YOUTUBE_ENABLED
+#ifdef YOUTUBE_ENABLED
 	if (IsYouTubeService(QT_TO_UTF8(ui->service->currentText()))) {
 		if (!text.isEmpty())
 			text += "<br><br>";


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR replaces `#if` with `#ifdef` for the lines of `#if YOUTUBE_ENABLED`, `#if RESTREAM_ENABLED`, `#if TWITCH_ENABLED`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

https://github.com/obsproject/obs-studio/pull/9031#discussion_r1261203925

`#if TWITCH_ENABLED` was implemented by a88b440. At that time, the macro was defined to `0` or `1` as below.
https://github.com/obsproject/obs-studio/blob/a88b440290372cc6699734c1df89027333436158/UI/ui-config.h.in#L19

Later commit 349372b removes the macros `TWITCH_ENABLED`, `RESTREAM_ENABLED`, and `YOUTUBE_ENABLED`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Linux (Fedora)

- Built with `YOUTUBE_CLIENTID`, `YOUTUBE_CLIENTID_HASH`, `YOUTUBE_SECRET`, `YOUTUBE_SECRET_HASH`. Checked the YouTube integration button appears on the settings.
- Built without `YOUTUBE_CLIENTID`, `YOUTUBE_CLIENTID_HASH`, `YOUTUBE_SECRET`, `YOUTUBE_SECRET_HASH`. Checked the YouTube integration button does not appear on the settings.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
