### PR TITLE
obs-qsv11: Fix missing ENABLE_HEVC definition for test executable

### DIFF
--- a/plugins/obs-qsv11/obs-qsv-test/CMakeLists.txt
+++ b/plugins/obs-qsv11/obs-qsv-test/CMakeLists.txt
@@ -5,6 +5,7 @@ legacy_check()
 add_executable(obs-qsv-test)
 
 target_sources(obs-qsv-test PRIVATE obs-qsv-test.cpp)
+target_compile_definitions(obs-qsv-test PRIVATE "$<$<BOOL:${ENABLE_HEVC}>:ENABLE_HEVC>")
 target_link_libraries(obs-qsv-test d3d11 dxgi dxguid OBS::libmfx OBS::COMutils)
 
 # cmake-format: off


### PR DESCRIPTION
### Description
Adds the `ENABLE_HEVC` preprocessor definition to the `obs-qsv11` test executable, as the define is usually inherited from `libobs`, but the test executable is standalone and thus the configuration option isn't propagated to the target otherwise.

### Motivation and Context
Make `obs-qsv-test` check for HEVC encoding capabilities again.

### How Has This Been Tested?
Needs to be tested by another maintainer with access to Intel hardware.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
