### PR TITLE
Fix defer encoder updates and NVENC VBR maxBitRate

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -264,9 +264,14 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	/* Only support reconfiguration of CBR bitrate */
 	if (enc->can_change_bitrate) {
 		int bitrate = (int)obs_data_get_int(settings, "bitrate");
+		int max_bitrate =
+			(int)obs_data_get_int(settings, "max_bitrate");
+		bool vbr = (enc->config.rcParams.rateControlMode ==
+			    NV_ENC_PARAMS_RC_VBR);
 
 		enc->config.rcParams.averageBitRate = bitrate * 1000;
-		enc->config.rcParams.maxBitRate = bitrate * 1000;
+		enc->config.rcParams.maxBitRate = vbr ? max_bitrate * 1000
+						      : bitrate * 1000;
 
 		NV_ENC_RECONFIGURE_PARAMS params = {0};
 		params.version = NV_ENC_RECONFIGURE_PARAMS_VER;


### PR DESCRIPTION
### Description
MaxBitrate gets correctly set during encoder init. https://github.com/obsproject/obs-studio/blob/578dc46a797db8860e90789741bae40441d18575/plugins/obs-ffmpeg/obs-nvenc.c#L672

Gets promptly overwritten by nvenc_update, which set max = (avg)bitrate.

### Motivation and Context
I wish for the max bitrate value in the UI to be respect. There were at least 2 complaints.

### How Has This Been Tested?
Built on win10 22h2, it compiles. Using breakpoints in the debugger, I confirmed the contents of `maxBitRate` when running VBR and CBR. I checked the recordings pre and post this change, and confirmed the encoder now allows the bitrate to spike higher (I used 2500kbps bitrate, 10 000kbps max).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
