### PR TITLE
libobs-d3d11: Implement shader cache

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -562,6 +562,12 @@ static bool MakeUserDirs()
 		return false;
 	if (!do_mkdir(path))
 		return false;
+
+	if (GetProgramDataPath(path, sizeof(path), "obs-studio/shader-cache") <=
+	    0)
+		return false;
+	if (!do_mkdir(path))
+		return false;
 #endif
 
 #ifdef WHATSNEW_ENABLED

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -294,12 +294,14 @@ void gs_device::InitCompiler()
 		if (module) {
 			d3dCompile = (pD3DCompile)GetProcAddress(module,
 								 "D3DCompile");
+			d3dCreateBlob = (pD3DCreateBlob)GetProcAddress(
+				module, "D3DCreateBlob");
 
 #ifdef DISASSEMBLE_SHADERS
 			d3dDisassemble = (pD3DDisassemble)GetProcAddress(
 				module, "D3DDisassemble");
 #endif
-			if (d3dCompile) {
+			if (d3dCompile && d3dCreateBlob) {
 				return;
 			}
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -38,6 +38,9 @@
 
 // #define DISASSEMBLE_SHADERS
 
+typedef HRESULT(WINAPI *pD3DCreateBlob)(_In_ SIZE_T Size,
+					_Out_ ID3DBlob **ppBlob);
+
 struct shader_var;
 struct shader_sampler;
 struct gs_vertex_shader;
@@ -1052,6 +1055,7 @@ struct gs_device {
 	D3D11_PRIMITIVE_TOPOLOGY curToplogy;
 
 	pD3DCompile d3dCompile = nullptr;
+	pD3DCreateBlob d3dCreateBlob = nullptr;
 #ifdef DISASSEMBLE_SHADERS
 	pD3DDisassemble d3dDisassemble = nullptr;
 #endif


### PR DESCRIPTION
### Description
Implements a D3D shader cache. The shader script itself is hashed (using fnv1a for now as a quick hash) and if a file exists with a matching hash the compiled program is read from that instead of calling `D3DCompile` which is slow.

### Motivation and Context
A lot of time on OBS startup on Windows is spent compiling the same static shaders.

### How Has This Been Tested?
Ran OBS a bit and it worked. More testing across different drivers / vendors would be nice. We had a similar implementation of a shader cache in OBS Classic that seemed to always break things, but I have no idea why. Microsoft recommend precompiling and shipping compiled shaders as D3D compiles to [DXIL](https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/DXIL.rst) which is then further consumed by the GPU driver and compiled to native GPU code. So the D3D compiled shaders _should_ be entirely deterministic.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
