### PR TITLE
libobs, win-wasapi: Fix PROPVARIANT variable has not be freed

### DIFF
--- a/libobs/audio-monitoring/win32/wasapi-enum-devices.c
+++ b/libobs/audio-monitoring/win32/wasapi-enum-devices.c
@@ -71,6 +71,7 @@ static bool get_device_info(obs_enum_audio_device_cb cb, void *data,
 	os_wcs_to_utf8(name_var.pwszVal, 0, utf8_name, 512);
 
 	cont = cb(data, utf8_name, utf8_id);
+	PropVariantClear(&name_var);
 
 fail:
 	safe_release(store);

--- a/plugins/win-wasapi/enum-wasapi.cpp
+++ b/plugins/win-wasapi/enum-wasapi.cpp
@@ -30,6 +30,7 @@ string GetDeviceName(IMMDevice *device)
 			device_name.resize(size);
 			os_wcs_to_utf8(nameVar.pwszVal, len, &device_name[0],
 				       size);
+			PropVariantClear(&nameVar);
 		}
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
```
        PROPVARIANT name_var;
	PropVariantInit(&name_var);
	hr = store->lpVtbl->GetValue(store, &PKEY_Device_FriendlyName,
				     &name_var);
	if (FAILED(hr)) {
		goto fail;
	}
	PropVariantClear(&name_var);
```
Free `name_var` by PropVariantClear when its value has been given.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Avoid memory leak. 
Reference: https://learn.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-propvariantclear
https://learn.microsoft.com/en-us/windows/win32/coreaudio/device-properties

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This commit has been tested on my computer, win10.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
