### PR TITLE
libobs: Fix back-to-back GPU encoder sessions breaking

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -668,7 +668,7 @@ void obs_encoder_shutdown(obs_encoder_t *encoder)
 		encoder->first_received = false;
 		encoder->offset_usec = 0;
 		encoder->start_ts = 0;
-		encoder->frame_rate_divisor_counter = 1;
+		encoder->frame_rate_divisor_counter = 0;
 		maybe_clear_encoder_core_video_mix(encoder);
 	}
 	obs_encoder_set_last_error(encoder, NULL);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Reset frame_rate_divisor_counter to 0 on encoder shutdown.

After starting and stopping a GPU encoder session, obs_encoder_shutdown would set frame_rate_divisor_counter to 1. When the next GPU encoder session was started, in libobs/obs-video-gpu-encode.c, gpu_encode_thread would set skip to this value (1), and increment frame_rate_divisor_counter to 2. This causes the next check to fail, as frame_rate_divisor is 1 by default (2 == 1 is false), so frame_rate_divisor_counter retains its value. Since skip is non-zero, the next check, if(skip), passes, and skip to the next loop iteration.

This will continue forever, because frame_rate_divisor_counter will continue to increment, so it will never hold the same value as frame_rate_divisor. This means that send_off_encoder_packet is never called, so the muxer never receives encoded packets.

To the end-user, this manifests as their second encoder session being impossible to stop. They then have to force quit OBS and the obs-ffmpeg-mux process. This change prevents that from occurring and allows multiple back-to-back GPU encoder sessions to be completed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want users to be able to perform multiple GPU encoder sessions in a row (multiple recordings, etc.).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
