### PR TITLE
libobs: Enable fast clear on Windows with driver check

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -3593,3 +3593,8 @@ uint32_t gs_get_adapter_count(void)
 
 	return count;
 }
+
+extern "C" EXPORT bool device_can_adapter_fast_clear(gs_device_t *device)
+{
+	return device->fastClearSupported;
+}

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1022,6 +1022,7 @@ struct gs_device {
 	uint32_t adpIdx = 0;
 	bool nv12Supported = false;
 	bool p010Supported = false;
+	bool fastClearSupported = false;
 
 	gs_texture_2d *curRenderTarget = nullptr;
 	gs_zstencil_buffer *curZStencilBuffer = nullptr;

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -221,6 +221,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module,
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_color_space);
 	GRAPHICS_IMPORT_OPTIONAL(gs_duplicator_get_sdr_white_level);
 	GRAPHICS_IMPORT_OPTIONAL(gs_get_adapter_count);
+	GRAPHICS_IMPORT_OPTIONAL(device_can_adapter_fast_clear);
 	GRAPHICS_IMPORT_OPTIONAL(device_texture_create_gdi);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_get_dc);
 	GRAPHICS_IMPORT_OPTIONAL(gs_texture_release_dc);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -312,6 +312,7 @@ struct gs_exports {
 	float (*gs_duplicator_get_sdr_white_level)(gs_duplicator_t *duplicator);
 
 	uint32_t (*gs_get_adapter_count)(void);
+	bool (*device_can_adapter_fast_clear)(gs_device_t *device);
 
 	gs_texture_t *(*device_texture_create_gdi)(gs_device_t *device,
 						   uint32_t width,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -3040,6 +3040,17 @@ uint32_t gs_get_adapter_count(void)
 	return thread_graphics->exports.gs_get_adapter_count();
 }
 
+bool gs_can_adapter_fast_clear(void)
+{
+	if (!gs_valid("gs_can_adapter_fast_clear"))
+		return false;
+	if (!thread_graphics->exports.device_can_adapter_fast_clear)
+		return false;
+
+	return thread_graphics->exports.device_can_adapter_fast_clear(
+		thread_graphics->device);
+}
+
 gs_texture_t *gs_duplicator_get_texture(gs_duplicator_t *duplicator)
 {
 	if (!gs_valid_p("gs_duplicator_get_texture", duplicator))

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -924,6 +924,7 @@ gs_duplicator_get_color_space(gs_duplicator_t *duplicator);
 EXPORT float gs_duplicator_get_sdr_white_level(gs_duplicator_t *duplicator);
 
 EXPORT uint32_t gs_get_adapter_count(void);
+EXPORT bool gs_can_adapter_fast_clear(void);
 
 /** creates a windows GDI-lockable texture */
 EXPORT gs_texture_t *gs_texture_create_gdi(uint32_t width, uint32_t height);

--- a/libobs/obs-display.c
+++ b/libobs/obs-display.c
@@ -27,7 +27,8 @@ bool obs_display_init(struct obs_display *display,
 
 #if defined(_WIN32)
 	/* Conservative test for NVIDIA flickering in multi-GPU setups */
-	display->use_clear_workaround = gs_get_adapter_count() > 1;
+	display->use_clear_workaround = gs_get_adapter_count() > 1 &&
+					!gs_can_adapter_fast_clear();
 #elif defined(__APPLE__)
 	/* Apple Silicon GL driver doesn't seem to track SRGB clears correctly */
 	display->use_clear_workaround = true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
On multi-adapter systems where at least one GPU is an NVIDIA GPU, using fast clear can cause the Properties window's preview pane to flicker rapidly if the NVIDIA driver is older than 527.37. This series of changes enables us to run a one-time check for if the graphics adapter can perform a fast clear, and if so, then always use that. The check is performed once and the result is stored for future use. If the adapter is determined to not be able to safely fast clear, continue to use the clear workaround.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want fast clear when possible. Don't want to try fast clear when it's not safe.

Follow-up to:
* #7601
* #7214
* #7177
* #7175

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested OBS Studio 28.0.0-rc1 (a version where fast clear was universally enabled) on my Intel+NVIDIA laptop (Windows 10) with NVIDIA driver versions 522-528 to determine exactly which driver version fixes the issue. That testing determined that NVIDIA driver version 527.37 is the first driver version that is fixed (526.98 still flickers). I tested both driver versions while debugging in Visual Studio to confirm that `use_clear_workaround` remains `true` on driver version 526.98 and that it becomes `false` on driver version 527.37+.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
