### PR TITLE
cmake: Fix missing libobs subdirectories in MSVC code navigator

### DIFF
--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -161,6 +161,30 @@ function(set_target_properties_obs target)
 
   target_link_options(${target} PRIVATE "/PDBALTPATH:$<TARGET_PDB_FILE_NAME:${target}>")
   target_install_resources(${target})
+
+  get_target_property(target_sources ${target} SOURCES)
+  set(target_ui_files ${target_sources})
+  list(FILTER target_ui_files INCLUDE REGEX ".+\\.(ui|qrc)")
+  source_group(
+    TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+    PREFIX "UI Files"
+    FILES ${target_ui_files})
+
+  if(${target} STREQUAL libobs)
+    set(target_source_files ${target_sources})
+    set(target_header_files ${target_sources})
+    list(FILTER target_source_files INCLUDE REGEX ".+\\.(m|c[cp]?p?|swift)")
+    list(FILTER target_header_files INCLUDE REGEX ".+\\.h(pp)?")
+
+    source_group(
+      TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+      PREFIX "Source Files"
+      FILES ${target_source_files})
+    source_group(
+      TREE "${CMAKE_CURRENT_SOURCE_DIR}"
+      PREFIX "Header Files"
+      FILES ${target_header_files})
+  endif()
 endfunction()
 
 # _target_install_obs: Helper function to install build artifacts to rundir and install location


### PR DESCRIPTION
### Description
Adds missing code to Windows CMake files to sort `libobs` sort files into respective subdirectories in MSVC's code navigator.

### Motivation and Context
Code was implemented for macOS and Xcode, but missed for Windows.

### How Has This Been Tested?
Tested with MSVC 17 2022 on Windows 11.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
