### PR TITLE
cmake: Remove Qt 5 support

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -71,7 +71,6 @@
       "cacheVariables": {
         "ENABLE_WAYLAND": true,
         "ENABLE_VLC": true,
-        "QT_VERSION": "6",
         "CMAKE_BUILD_TYPE": "Debug"
       }
     },
@@ -108,7 +107,6 @@
       "cacheVariables": {
         "ENABLE_WAYLAND": true,
         "ENABLE_VLC": true,
-        "QT_VERSION": {"type": "STRING", "value": "6"},
         "CMAKE_BUILD_TYPE": {"type": "STRING", "value": "Debug"}
       }
     },

--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -82,7 +82,7 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms;forms/source-toolbar")
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(obs PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 
@@ -356,11 +356,6 @@ if(OS_WINDOWS)
             update/crypto-helpers-mbedtls.cpp
             update/crypto-helpers.hpp
             ${CMAKE_BINARY_DIR}/obs.rc)
-
-  if(_QT_VERSION EQUAL 5)
-    find_qt(COMPONENTS WinExtras)
-    target_link_libraries(obs PRIVATE Qt::WinExtras)
-  endif()
 
   find_package(MbedTLS)
   target_link_libraries(obs PRIVATE Mbedtls::Mbedtls OBS::blake2 Detours::Detours)

--- a/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
+++ b/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
@@ -18,7 +18,7 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(aja-output-ui PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 

--- a/UI/frontend-plugins/decklink-captions/cmake/legacy.cmake
+++ b/UI/frontend-plugins/decklink-captions/cmake/legacy.cmake
@@ -18,7 +18,7 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(decklink-captions PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 

--- a/UI/frontend-plugins/decklink-output-ui/cmake/legacy.cmake
+++ b/UI/frontend-plugins/decklink-output-ui/cmake/legacy.cmake
@@ -16,7 +16,7 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(decklink-output-ui PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 

--- a/UI/frontend-plugins/frontend-tools/cmake/legacy.cmake
+++ b/UI/frontend-plugins/frontend-tools/cmake/legacy.cmake
@@ -12,7 +12,7 @@ set_target_properties(
              AUTORCC ON
              AUTOUIC_SEARCH_PATHS "forms")
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(frontend-tools PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2338,14 +2338,12 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 	setenv("QT_STYLE_OVERRIDE", "Fusion", false);
 
-#if OBS_QT_VERSION == 6
 	/* NOTE: Users blindly set this, but this theme is incompatble with Qt6 and
 	 * crashes loading saved geometry. Just turn off this theme and let users complain OBS
 	 * looks ugly instead of crashing. */
 	const char *platform_theme = getenv("QT_QPA_PLATFORMTHEME");
 	if (platform_theme && strcmp(platform_theme, "qt5ct") == 0)
 		unsetenv("QT_QPA_PLATFORMTHEME");
-#endif
 
 #if defined(ENABLE_WAYLAND) && defined(USE_XDG)
 	/* NOTE: Qt doesn't use the Wayland platform on GNOME, so we have to

--- a/cmake/Modules/CopyMSVCBins.cmake
+++ b/cmake/Modules/CopyMSVCBins.cmake
@@ -166,7 +166,7 @@ endif()
 file(GLOB RNNOISE_BIN_FILES "${RNNOISE_INCLUDE_DIR}/../bin${_bin_suffix}/rnnoise*.dll"
      "${RNNOISE_INCLUDE_DIR}/../bin/rnnoise*.dll")
 
-set(QtCore_DIR "${Qt${_QT_VERSION}Core_DIR}")
+set(QtCore_DIR "${Qt6Core_DIR}")
 cmake_path(SET QtCore_DIR_NORM NORMALIZE "${QtCore_DIR}/../../..")
 set(QtCore_BIN_DIR "${QtCore_DIR_NORM}bin")
 set(QtCore_PLUGIN_DIR "${QtCore_DIR_NORM}plugins")
@@ -176,13 +176,12 @@ obs_status(STATUS "QtCore_PLUGIN_DIR: ${QtCore_PLUGIN_DIR}")
 file(
   GLOB
   QT_DEBUG_BIN_FILES
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Cored.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Guid.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Widgetsd.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}WinExtrasd.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Svgd.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Xmld.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Networkd.dll"
+  "${QtCore_BIN_DIR}/Qt6Cored.dll"
+  "${QtCore_BIN_DIR}/Qt6Guid.dll"
+  "${QtCore_BIN_DIR}/Qt6Widgetsd.dll"
+  "${QtCore_BIN_DIR}/Qt6Svgd.dll"
+  "${QtCore_BIN_DIR}/Qt6Xmld.dll"
+  "${QtCore_BIN_DIR}/Qt6Networkd.dll"
   "${QtCore_BIN_DIR}/libGLESv2d.dll"
   "${QtCore_BIN_DIR}/libEGLd.dll")
 file(GLOB QT_DEBUG_PLAT_BIN_FILES "${QtCore_PLUGIN_DIR}/platforms/qwindowsd.dll")
@@ -194,13 +193,12 @@ file(GLOB QT_DEBUG_IMAGEFORMATS_BIN_FILES "${QtCore_PLUGIN_DIR}/imageformats/qsv
 file(
   GLOB
   QT_BIN_FILES
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Core.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Gui.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Widgets.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}WinExtras.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Svg.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Xml.dll"
-  "${QtCore_BIN_DIR}/Qt${_QT_VERSION}Network.dll"
+  "${QtCore_BIN_DIR}/Qt6Core.dll"
+  "${QtCore_BIN_DIR}/Qt6Gui.dll"
+  "${QtCore_BIN_DIR}/Qt6Widgets.dll"
+  "${QtCore_BIN_DIR}/Qt6Svg.dll"
+  "${QtCore_BIN_DIR}/Qt6Xml.dll"
+  "${QtCore_BIN_DIR}/Qt6Network.dll"
   "${QtCore_BIN_DIR}/libGLESv2.dll"
   "${QtCore_BIN_DIR}/libEGL.dll")
 file(GLOB QT_PLAT_BIN_FILES "${QtCore_PLUGIN_DIR}/platforms/qwindows.dll")

--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -309,78 +309,29 @@ function(define_graphic_modules target)
   endforeach()
 endfunction()
 
-if(NOT QT_VERSION)
-  set(QT_VERSION
-      AUTO
-      CACHE STRING "OBS Qt version [AUTO, 5, 6]" FORCE)
-  set_property(CACHE QT_VERSION PROPERTY STRINGS AUTO 5 6)
-endif()
-
 macro(find_qt)
   set(multiValueArgs COMPONENTS COMPONENTS_WIN COMPONENTS_MAC COMPONENTS_LINUX)
   cmake_parse_arguments(FIND_QT "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
   set(QT_NO_CREATE_VERSIONLESS_TARGETS ON)
   find_package(
-    Qt5
-    COMPONENTS Core
-    QUIET)
-  find_package(
     Qt6
     COMPONENTS Core
-    QUIET)
-
-  if(NOT _QT_VERSION AND QT_VERSION STREQUAL AUTO)
-    if(TARGET Qt6::Core)
-      set(_QT_VERSION
-          6
-          CACHE INTERNAL "")
-    elseif(TARGET Qt5::Core)
-      set(_QT_VERSION
-          5
-          CACHE INTERNAL "")
-    endif()
-    obs_status(STATUS "Qt version: ${_QT_VERSION}")
-  elseif(NOT _QT_VERSION)
-    if(TARGET Qt${QT_VERSION}::Core)
-      set(_QT_VERSION
-          ${QT_VERSION}
-          CACHE INTERNAL "")
-    else()
-      if(QT_VERSION EQUAL 6)
-        set(FALLBACK_QT_VERSION 5)
-      else()
-        set(FALLBACK_QT_VERSION 6)
-      endif()
-      message(WARNING "Qt${QT_VERSION} was not found, falling back to Qt${FALLBACK_QT_VERSION}")
-
-      if(TARGET Qt${FALLBACK_QT_VERSION}::Core)
-        set(_QT_VERSION
-            ${FALLBACK_QT_VERSION}
-            CACHE INTERNAL "")
-      endif()
-    endif()
-    obs_status(STATUS "Qt version: ${_QT_VERSION}")
-  endif()
-
+    REQUIRED)
   set(QT_NO_CREATE_VERSIONLESS_TARGETS OFF)
-
-  if(NOT _QT_VERSION)
-    message(FATAL_ERROR "Neither Qt5 or Qt6 were found")
-  endif()
 
   if(OS_WINDOWS)
     find_package(
-      Qt${_QT_VERSION}
+      Qt6
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_WIN}
       REQUIRED)
   elseif(OS_MACOS)
     find_package(
-      Qt${_QT_VERSION}
+      Qt6
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_MAC}
       REQUIRED)
   else()
     find_package(
-      Qt${_QT_VERSION}
+      Qt6
       COMPONENTS ${FIND_QT_COMPONENTS} ${FIND_QT_COMPONENTS_LINUX}
       REQUIRED)
   endif()
@@ -392,10 +343,10 @@ macro(find_qt)
   endif()
 
   foreach(_COMPONENT IN LISTS FIND_QT_COMPONENTS FIND_QT_COMPONENTS_WIN FIND_QT_COMPONENTS_MAC FIND_QT_COMPONENTS_LINUX)
-    if(NOT TARGET Qt::${_COMPONENT} AND TARGET Qt${_QT_VERSION}::${_COMPONENT})
+    if(NOT TARGET Qt::${_COMPONENT} AND TARGET Qt6::${_COMPONENT})
 
       add_library(Qt::${_COMPONENT} INTERFACE IMPORTED)
-      set_target_properties(Qt::${_COMPONENT} PROPERTIES INTERFACE_LINK_LIBRARIES "Qt${_QT_VERSION}::${_COMPONENT}")
+      set_target_properties(Qt::${_COMPONENT} PROPERTIES INTERFACE_LINK_LIBRARIES "Qt6::${_COMPONENT}")
     endif()
   endforeach()
 endmacro()

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -20,12 +20,6 @@ find_package(
   OPTIONAL_COMPONENTS avcodec)
 find_package(ZLIB REQUIRED)
 
-if(ENABLE_UI)
-  find_qt(COMPONENTS Core)
-else()
-  set(_QT_VERSION 0)
-endif()
-
 add_library(libobs SHARED)
 add_library(OBS::libobs ALIAS libobs)
 
@@ -474,8 +468,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/obsconfig.h.in ${CMAKE_BINARY_DIR}/co
 target_compile_definitions(
   libobs
   PUBLIC HAVE_OBSCONFIG_H
-  PRIVATE "OBS_INSTALL_PREFIX=\"${OBS_INSTALL_PREFIX}\"" "OBS_QT_VERSION=${_QT_VERSION}"
-          "$<$<BOOL:${LINUX_PORTABLE}>:LINUX_PORTABLE>")
+  PRIVATE "OBS_INSTALL_PREFIX=\"${OBS_INSTALL_PREFIX}\"" "$<$<BOOL:${LINUX_PORTABLE}>:LINUX_PORTABLE>")
 
 if(ENABLE_FFMPEG_MUX_DEBUG)
   target_compile_definitions(libobs PRIVATE SHOW_SUBPROCESSES)

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -16,7 +16,7 @@
 
 #include "obsconfig.h"
 
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
+#if !defined(__APPLE__)
 #define _GNU_SOURCE
 #include <link.h>
 #include <stdlib.h>
@@ -106,7 +106,7 @@ void os_dlclose(void *module)
 		dlclose(module);
 }
 
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
+#if !defined(__APPLE__)
 int module_has_qt5_check(const char *path)
 {
 	void *mod = os_dlopen(path);
@@ -147,7 +147,7 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 {
 	*is_obs_plugin = true;
 	*can_load = true;
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
+#if !defined(__APPLE__)
 	*can_load = !has_qt5_dependency(path);
 #endif
 	UNUSED_PARAMETER(path);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -138,7 +138,6 @@ void os_dlclose(void *module)
 	FreeLibrary(module);
 }
 
-#if OBS_QT_VERSION == 6
 static bool has_qt5_import(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 {
 	__try {
@@ -201,7 +200,6 @@ static bool has_qt5_import(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 
 	return false;
 }
-#endif
 
 static bool has_obs_export(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 {
@@ -335,13 +333,9 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 
 		*is_obs_plugin = has_obs_export(base, nt_headers);
 
-#if OBS_QT_VERSION == 6
 		if (*is_obs_plugin) {
 			*can_load = !has_qt5_import(base, nt_headers);
 		}
-#else
-		*can_load = true;
-#endif
 
 	} __except (EXCEPTION_EXECUTE_HANDLER) {
 		/* we failed somehow, for compatibility let's assume it

--- a/plugins/obs-vst/cmake/legacy.cmake
+++ b/plugins/obs-vst/cmake/legacy.cmake
@@ -21,7 +21,7 @@ set_target_properties(
              AUTOUIC ON
              AUTORCC ON)
 
-if(_QT_VERSION EQUAL 6 AND OS_WINDOWS)
+if(OS_WINDOWS)
   set_target_properties(obs-vst PROPERTIES AUTORCC_OPTIONS "--format-version;1")
 endif()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes cmake code to support Qt version selection, and Qt 5 in general.
Removes libobs ifdefs for the Qt 5 plugin check, as well as a remaining UI ifdef that used `OBS_QT_VERSION` instead of `QT_VERSION_CHECK`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Our code requires Qt 6 now, so having cmake for finding Qt 5 does not make a lot of sense, and can be confusing for people who only have Qt 5 and then run into issues when compiling time vs when cmake is generating.
Fixes https://github.com/obsproject/obs-studio/issues/9262.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14, generated and compiled with Qt 6.
Had CI build successfully on all supported platforms (see [here](https://github.com/gxalpha/obs-studio/actions/runs/5568706718)). Re-added Ubuntu 20.04 and saw it fail to find Qt 6 (see [here](https://github.com/gxalpha/obs-studio/actions/runs/5569042122/jobs/10172205492)).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
