### PR TITLE
obs-outputs: Enable HDR for HEVC over RTMP

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1342,8 +1342,9 @@ static void *connect_thread(void *data)
 		return NULL;
 	}
 
-	// HDR streaming disabled for AV1 and HEVC
-	if (stream->video_codec != CODEC_H264) {
+	// HDR streaming disabled for AV1
+	if (stream->video_codec != CODEC_H264 &&
+	    stream->video_codec != CODEC_HEVC) {
 		video_t *video = obs_get_video();
 		const struct video_output_info *info =
 			video_output_get_info(video);


### PR DESCRIPTION
Removes flag guard to enable HDR streaming for HEVC over Enhanced RTMP. This functionality is currently only supported by YouTube. See [github.com/veovera/enhanced-rtmp](http://github.com/veovera/enhanced-rtmp) for the Enhanced RTMP spec.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
HDR support for RTMP was previously added in https://github.com/obsproject/obs-studio/pull/8522, according to the Enhanced RTMP spec at [github.com/veovera/enhanced-rtmp](http://github.com/veovera/enhanced-rtmp). This change partially removes the flag guard, to enable streaming HDR with HEVC over RTMP.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Enables streaming HDR with HEVC over RTMP to YouTube, which now supports this functionality.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested against YouTube with Nvidia RTX 4090, Intel Arc A750, AMD RX 7900 XTX.

Known issues: HDR not correctly detected by YouTube on AMD encoder. Debugging in progress. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.