### PR TITLE
CI: Fix scheduled Steam builds

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -103,7 +103,7 @@ jobs:
           : Check Nightly Runs ☑️
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          local last_nightly=$(gh run list --workflow scheduled.yaml --limit 1 --json headSha --jq '.[0].headSha')
+          local last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
 
           if [[ "${GITHUB_SHA}" == "${last_nightly}" ]] {
             print "passed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Description
Change the workflow to fetch at most 2 runs of the scheduled workflow runs to compare the last run's commit hash with the current one.

### Motivation and Context
Apparently the workflow run list will also yield the _current_ workflow run, so we have to fetch at least 2 runs to also get the prior one.

### How Has This Been Tested?
Needs to bested on master branch with a scheduled run.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
