### PR TITLE
CI: Fix Qt XML validator attempting to validate non-XML files

### DIFF
--- a/.github/actions/qt-xml-validator/action.yaml
+++ b/.github/actions/qt-xml-validator/action.yaml
@@ -44,13 +44,14 @@ runs:
         : Validate XML 💯
         if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
         shopt -s extglob
+        shopt -s globstar
 
-        changes=($(git diff --name-only HEAD~1 HEAD -- UI/forms))
+        changes=($(git diff --name-only HEAD~1 HEAD -- UI/forms/**/*.ui))
         case "${GITHUB_EVENT_NAME}" in
-          pull_request) changes=($(git diff --name-only origin/"${GITHUB_BASE_REF}" HEAD -- UI/forms)) ;;
+          pull_request) changes=($(git diff --name-only origin/"${GITHUB_BASE_REF}" HEAD -- UI/forms/**/*.ui)) ;;
           push)
             if [[ "${GITHUB_EVENT_FORCED}" == false ]]; then
-              changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD -- UI/forms))
+              changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD -- UI/forms/**/*.ui))
             fi
             ;;
           *) ;;


### PR DESCRIPTION
### Description
Explicitly check only for changes `.ui` files in forms subdirectory and pass only changed files with that suffix to validator.

### Motivation and Context
Fix validator being triggered by any changes to files in the `forms` subdirectory, which will inevitably lead to such files not passing validation.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
