### PR TITLE
UI: Don't clear lastService immediately after setting it

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -185,7 +185,6 @@ void OBSBasicSettings::LoadStream1Settings()
 	else
 		ui->key->setText(key);
 
-	lastService.clear();
 	ServiceChanged();
 
 	UpdateKeyLink();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the `lastService.clear()` in `LoadStream1Settings`.
Here is why I *think* this is safe:

`lastService` only gets set in `UpdateServerList`. There are 2 times where `UpdateServerList` is called:
- In `on_service_currentIndexChanged`: This means that after switching service once, and *then* click "Show more", the service is remembered.
- In `LoadStream1Settings`, where it is currently cleared immediately after.

`lastService` is only used in two places:
- In `LoadServices` to set the server in the list after creating the list, where it currently is mostly useless.
- In `ServiceChanged` to make sure that the code reloading service specific properties is not called multiple times - which on load it *also* fails to do, because the service gets reset immediately before.

I'll be honest, I can't quite figure out why the line is there in the first place. My assumption is that during one of many refactors it got obsolete.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes a bug where when you clicked "Show more..." in the service settings combobox, the currently selected service would be changed to the first service in the list.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tried many combinations of selecting services, showing all, saving, reopening settings, and repeat. All behaved as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
