### PR TITLE
rtmp-services: Add "VStream" RTMP service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v4",
-    "version": 229,
+    "version": 230,
     "files": [
         {
             "name": "services.json",
-            "version": 229
+            "version": 230
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2694,6 +2694,66 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "VStream",
+            "common": false,
+            "stream_key_link": "https://vstream.com/dashboard/livestreams",
+            "more_info_link": "https://vstream.com/help/streaming-with-obs",
+            "servers": [
+                {
+                    "name": "Global (RTMP)",
+                    "url": "rtmp://live.vstream.com"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "x264opts": "scenecut=0",
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "852x480"
+                ],
+                "bitrate matrix": [
+                    {
+                        "res": "1920x1080",
+                        "fps": 60,
+                        "max bitrate": 8000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 30,
+                        "max bitrate": 6000
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 60,
+                        "max bitrate": 6000
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 30,
+                        "max bitrate": 4000
+                    },
+                    {
+                        "res": "852x480",
+                        "fps": 60,
+                        "max bitrate": 3000
+                    },
+                    {
+                        "res": "852x480",
+                        "fps": 30,
+                        "max bitrate": 2000
+                    }
+                ],
+                "max fps": 60,
+                "max video bitrate": 8000,
+                "max audio bitrate": 320
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
[VStream](https://vstream.com/) is a live streaming and video hosting platform for [VTubers](https://en.wikipedia.org/wiki/VTuber). 

### Motivation and Context
As a livestreaming platform we would love it so that our creators could more easily start streaming to VStream using OBS. While we have [existing docs](https://vstream.com/help/streaming-with-obs) on how to stream to OBS, users who are coming from platforms like Twitch or Youtube are often confused by them and forget to set important settings like their keyframe interval. By adding VStream an support rtmp-service this would make life much easier for our users and us.

### How Has This Been Tested?
We've been in private-beta for the past 3 months and our beta users have been very successfully streaming using these settings and OBS. We'll be entering our open-beta stage [very soon now](https://twitter.com/vstream_en/status/1680985714454937604) where anyone can start streaming with us.

### Types of changes
* New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
