### PR TITLE
build-aux: Add shader cache cleanup to steam uninstall script

### DIFF
--- a/build-aux/steam/scripts_windows/uninstall.bat
+++ b/build-aux/steam/scripts_windows/uninstall.bat
@@ -20,6 +20,7 @@ goto checkAdmin
 
 :deleteProgramDataFolder
 	RMDIR /S /Q "%PROGRAMDATA%\obs-studio-hook"
+	RMDIR /S /Q "%PROGRAMDATA%\obs-studio\shader-cache"
 
 :uninstallDLLs
 	regsvr32.exe /u /s %1\data\obs-plugins\win-dshow\obs-virtualcam-module32.dll


### PR DESCRIPTION
### Description

Cleanup shader cache directory created by #9249 when uninstalling OBS via Steam.

### Motivation and Context

Cleanup files that are no longer needed.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
