### PR TITLE
UI: Fix remaining status bar nits

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -235,19 +235,12 @@ void OBSBasicStatusBar::UpdateCPUUsage()
 
 void OBSBasicStatusBar::UpdateCurrentFPS()
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
-	if (!main)
-		return;
-
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
 	float targetFPS = (float)ovi.fps_num / (float)ovi.fps_den;
 
-	QString text;
-	text += QString::number(obs_get_active_fps(), 'f', 2);
-	text += QString(" / ");
-	text += QString::number(targetFPS, 'f', 2);
-	text += QString(" FPS");
+	QString text = QString::asprintf("%.2f / %.2f FPS",
+					 obs_get_active_fps(), targetFPS);
 
 	statusWidget->ui->fpsCurrent->setText(text);
 	statusWidget->ui->fpsCurrent->setMinimumWidth(


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Amends 1c8407183 to address the remaining points brought up on the Pull Request that were not changed before merging.
Removes the unused `main` pointer and changes the string concatenation into a single `asprintf` call.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Commented about this on the PR, but it was agreed to merge the PR first and fix this up later.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.
Status bar FPS still show up the same way as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
