### PR TITLE
CI: Switch service availability checks to macOS runners

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -34,7 +34,7 @@ jobs:
   services-validation:
     name: Check Services Configuration Files 🕵️
     if: github.repository_owner == 'obsproject' && inputs.job == 'services'
-    runs-on: ubuntu-22.04
+    runs-on: macos-13
     permissions:
       checks: write
     steps:

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
   services-availability:
     name: Check Service Availability 🛜
     if: github.repository_owner == 'obsproject'
-    runs-on: ubuntu-22.04
+    runs-on: macos-13
     permissions:
       checks: write
     steps:


### PR DESCRIPTION
### Description
Switches service availability checks to macOS runners on GitHub Actions. Affects only scheduled and dispatched workflow runs, as other invocations only check schema validity.

### Motivation and Context
Linux runners exhibit connectivity issues with some services that are not present with macOS runners. Switching to macOS thus reduces chances for false positives.

### How Has This Been Tested?
Requires testing on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
