### PR TITLE
CI: Remove label triggers from pull request workflow

### DIFF
--- a/.github/workflows/pr-pull.yaml
+++ b/.github/workflows/pr-pull.yaml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
     branches: [master]
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+    types: [ opened, synchronize, reopened ]
 permissions:
   contents: read
 concurrency:


### PR DESCRIPTION
### Description
Removes label triggers from pull request workflow.

### Motivation and Context
Having the main pull request workflow run for labeling events has the unintended side-effect of an automatically canceled run when a pull request is opened with labels attached to it.

As GitHub's user interface allows interactive restarts of CI jobs, maintainers can add the label and re-trigger builds directly.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
