### PR TITLE
obs-webrtc: Move libdatachannel code to C++ from C

### DIFF
--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -11,7 +11,7 @@
 #include <mutex>
 #include <thread>
 
-#include <rtc/rtc.h>
+#include <rtc/rtc.hpp>
 
 class WHIPOutput {
 public:
@@ -38,7 +38,9 @@ private:
 	void SendDelete();
 	void StopThread(bool signal);
 
-	void Send(void *data, uintptr_t size, uint64_t duration, int track);
+	void Send(void *data, uintptr_t size, uint64_t duration,
+		  std::shared_ptr<rtc::Track> track,
+		  std::shared_ptr<rtc::RtcpSrReporter> rtcp_sr_reporter);
 
 	obs_output_t *output;
 
@@ -52,9 +54,11 @@ private:
 	std::thread start_stop_thread;
 
 	uint32_t base_ssrc;
-	int peer_connection;
-	int audio_track;
-	int video_track;
+	std::shared_ptr<rtc::PeerConnection> peer_connection;
+	std::shared_ptr<rtc::Track> audio_track;
+	std::shared_ptr<rtc::Track> video_track;
+	std::shared_ptr<rtc::RtcpSrReporter> audio_sr_reporter;
+	std::shared_ptr<rtc::RtcpSrReporter> video_sr_reporter;
 
 	std::atomic<size_t> total_bytes_sent;
 	std::atomic<int> connect_time_ms;

--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -9,9 +9,6 @@
 #define do_log(level, format, ...)                              \
 	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
 	     obs_output_get_name(output), ##__VA_ARGS__)
-#define do_log_s(level, format, ...)                            \
-	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, \
-	     obs_output_get_name(whipOutput->output), ##__VA_ARGS__)
 
 static uint32_t generate_random_u32()
 {


### PR DESCRIPTION
### Motivation and Context
libdatachannel is now built with MSVC instead of MinGW so we are able to
use C++ API instead.

The C++ is preferred by upstream and what the project is written in. The
C API provides a subset of features and has a performance penalty.

### How Has This Been Tested?
I have used it locally on NixOS + macOS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
