### PR TITLE
CI: Fix broken Flatpak cache generation on CI

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -278,11 +278,12 @@ jobs:
             "$(gh actions-cache list -B ${cache_ref} --key "${cache_key}-x86_64" | head -1)"
 
           if [[ "${key}" ]]; then
-            echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
             echo "cacheHit=true" >> $GITHUB_OUTPUT
           else
             echo "cacheHit=false" >> $GITHUB_OUTPUT
           fi
+
+          echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest 🧾
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -82,12 +82,12 @@ jobs:
             "$(gh actions-cache list -B ${cache_ref} --key "${cache_key}-x86_64" | head -1)"
 
           if [[ "${key}" ]]; then
-            echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
             echo "cacheHit=true" >> $GITHUB_OUTPUT
           else
             echo "cacheHit=false" >> $GITHUB_OUTPUT
           fi
 
+          echo "cacheKey=${cache_key}" >> $GITHUB_OUTPUT
           echo "commitHash=$(git rev-parse --short=9 HEAD)" >> $GITHUB_OUTPUT
 
       - name: Build Flatpak Manifest


### PR DESCRIPTION
### Description
Fixes Flatpak build runs on master branch not generating a new cache entry after manifest changes.

### Motivation and Context
Cache key needs to provided regardless of whether a cache hit occurs, the key is not automatically generated by the action.

### How Has This Been Tested?
Tested on local fork with direct pushes to master branch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
