### PR TITLE
CI: Fix random password generation for macOS codesigning

### DIFF
--- a/.github/actions/setup-macos-codesigning/action.yaml
+++ b/.github/actions/setup-macos-codesigning/action.yaml
@@ -68,7 +68,7 @@ runs:
 
           print -n "${MACOS_SIGNING_CERT}" | base64 --decode --output=${certificate_path}
 
-          : "${MACOS_KEYCHAIN_PASSWORD:="$(print ${RANDOM} | sha1sum | head -c 32)"}"
+          : "${MACOS_KEYCHAIN_PASSWORD:="$(print ${RANDOM} | shasum | head -c 32)"}"
 
           print '::group::Keychain setup'
           security create-keychain -p "${MACOS_KEYCHAIN_PASSWORD}" ${keychain_path}


### PR DESCRIPTION
### Description
Fix error when generating random password if no keychain password is set for macOS codesigning credentials

### Motivation and Context
`sha1sum` is part of Homebrew's coreutils, but macOS ships with `shasum` by default, which supports many variants and defaults to SHA-1 by default.

### How Has This Been Tested?
Tested on local fork without a keychain password set in repository secrets.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
