### PR TITLE
CI: Fix broken download of nightly build artifacts for Steam uploads

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -68,6 +68,11 @@ runs:
         print "::error:steam-upload action can only be used with 'release', 'workflow-dispatch', or 'schedule' events."
         exit 2
 
+    - name: Download Nightly Assets 🌙
+      id: asset-info-nightly
+      uses: actions/download-artifact@v3
+      if: github.event_name == 'schedule'
+
     - name: Download Assets 📥
       id: asset-info
       shell: zsh --no-rcs --errexit --pipefail {0}
@@ -140,16 +145,12 @@ runs:
             }
             ;;
           schedule)
-            gh run download ${GITHUB_RUN_ID} \
-              --pattern '*macos*' \
-              --pattern '*windows*'
-
             local short_hash="${GITHUB_SHA:0:9}"
             mv obs-studio-windows-x64-${short_hash}/obs-studio-*-windows-x64.zip \
               ${root_dir}
             mv obs-studio-macos-arm64-${short_hash}/obs-studio-*-macos-apple.dmg \
               ${root_dir}
-            mv obs-studio-macos-intel-${short_hash}/obs-studio-*-macos-intel.dmg \
+            mv obs-studio-macos-x86_64-${short_hash}/obs-studio-*-macos-intel.dmg \
               ${root_dir}
 
             description="g${GITHUB_SHA}"


### PR DESCRIPTION
### Description
Fix nightly runs of steam-upload action not being able to download generated build artefacts.

### Motivation and Context
GitHub's CLI utility is not capable of downloading artifacts generated by the workflow job it is being run in itself. Thus the official repository action is needed.

### How Has This Been Tested?
Tested with scheduled runs on fork of `obs-studio`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
