### PR TITLE
updater: Migrate to nlohmann JSON

### DIFF
--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -3,10 +3,7 @@ cmake_minimum_required(VERSION 3.24...3.25)
 legacy_check()
 
 find_package(zstd)
-
-if(NOT TARGET OBS::json11)
-  add_subdirectory("${CMAKE_SOURCE_DIR}/deps/json11" "${CMAKE_BINARY_DIR}/deps/json11")
-endif()
+find_package(nlohmann_json 3 REQUIRED)
 
 add_executable(updater WIN32)
 
@@ -17,6 +14,7 @@ target_sources(
           helpers.hpp
           http.cpp
           init-hook-files.c
+          manifest.hpp
           patch.cpp
           resource.h
           updater.cpp
@@ -29,7 +27,8 @@ target_compile_definitions(updater PRIVATE NOMINMAX "PSAPI_VERSION=2")
 
 target_include_directories(updater PRIVATE "${CMAKE_SOURCE_DIR}/libobs" "${CMAKE_SOURCE_DIR}/UI/win-update")
 
-target_link_libraries(updater PRIVATE OBS::blake2 OBS::json11 zstd::libzstd_static comctl32 shell32 winhttp)
+target_link_libraries(updater PRIVATE OBS::blake2 nlohmann_json::nlohmann_json zstd::libzstd_static comctl32 shell32
+                                      winhttp)
 target_link_options(updater PRIVATE /IGNORE:4098)
 
 set_target_properties(updater PROPERTIES FOLDER frontend OUTPUT_NAME updater)

--- a/UI/win-update/updater/cmake/legacy.cmake
+++ b/UI/win-update/updater/cmake/legacy.cmake
@@ -8,6 +8,7 @@ if(NOT ENABLE_UPDATER)
 endif()
 
 find_package(zstd)
+find_package(nlohmann_json 3 REQUIRED)
 
 add_executable(updater WIN32)
 
@@ -23,11 +24,9 @@ target_sources(
           init-hook-files.c
           updater.manifest
           helpers.cpp
-          helpers.hpp
-          ${CMAKE_SOURCE_DIR}/deps/json11/json11.hpp
-          ${CMAKE_SOURCE_DIR}/deps/json11/json11.cpp)
+          helpers.hpp)
 
-target_include_directories(updater PRIVATE ${CMAKE_SOURCE_DIR}/libobs ${CMAKE_SOURCE_DIR}/deps/json11)
+target_include_directories(updater PRIVATE ${CMAKE_SOURCE_DIR}/libobs)
 
 target_compile_definitions(updater PRIVATE NOMINMAX "PSAPI_VERSION=2")
 
@@ -37,6 +36,7 @@ if(MSVC)
   target_link_options(updater PRIVATE "LINKER:/IGNORE:4098")
 endif()
 
-target_link_libraries(updater PRIVATE OBS::blake2 zstd::libzstd_static comctl32 shell32 winhttp)
+target_link_libraries(updater PRIVATE OBS::blake2 nlohmann_json::nlohmann_json zstd::libzstd_static comctl32 shell32
+                                      winhttp)
 
 set_target_properties(updater PROPERTIES FOLDER "frontend")

--- a/UI/win-update/updater/manifest.hpp
+++ b/UI/win-update/updater/manifest.hpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace updater {
+struct File {
+	/* 160-bit blake2b hashes of zstd compressed and raw file (hex string) */
+	std::string compressed_hash;
+	std::string hash;
+	/* Relative path */
+	std::string name;
+	/* Uncompressed size in bytes */
+	size_t size = 0;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(File, compressed_hash, hash, name, size)
+};
+
+struct Package {
+	std::string name;
+	std::vector<File> files = {};
+	/* Relative paths of files to remove */
+	std::vector<std::string> removed_files = {};
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Package, name, files, removed_files)
+};
+
+struct Manifest {
+	/* Update packages */
+	std::vector<Package> packages = {};
+
+	/* Version information */
+	uint8_t version_major = 0;
+	uint8_t version_minor = 0;
+	uint8_t version_patch = 0;
+	uint8_t beta = 0;
+	uint8_t rc = 0;
+
+	/* Hash of VC redist file */
+	std::string vc2019_redist_x64;
+
+	/* Unused until UI is migrated to nlohmann_json */
+	// std::string commit;
+	// std::string notes;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Manifest, packages, version_major,
+				       version_minor, version_patch, beta, rc,
+				       vc2019_redist_x64)
+};
+
+struct PatchRequest {
+	/* Relative path of file */
+	std::string name;
+	/* 160-bit blake2b hash of existing file */
+	std::string hash;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(PatchRequest, name, hash)
+};
+
+using PatchesRequest = std::vector<PatchRequest>;
+
+struct PatchResponse {
+	/* Relative path of file */
+	std::string name;
+	/* 160-bit blake2b hash of patch file */
+	std::string hash;
+	/* Download URL for patch file */
+	std::string source;
+	/* Size of patch file */
+	size_t size = 0;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(PatchResponse, name, hash, size, source)
+};
+
+using PatchesResponse = std::vector<PatchResponse>;
+}

--- a/UI/win-update/updater/updater.hpp
+++ b/UI/win-update/updater/updater.hpp
@@ -76,7 +76,6 @@ using B2Hash = std::array<std::byte, kBlake2HashLength>;
 #endif
 
 #include <util/windows/WinHandle.hpp>
-#include <json11.hpp>
 #include "resource.h"
 
 bool HTTPGetFile(HINTERNET hConnect, const wchar_t *url,
@@ -99,8 +98,8 @@ int ApplyPatch(ZSTD_DCtx *zstdCtx, std::byte *patch_data,
 
 extern HWND hwndMain;
 extern HCRYPTPROV hProvider;
-extern int totalFileSize;
-extern int completedFileSize;
+extern size_t totalFileSize;
+extern size_t completedFileSize;
 extern HANDLE cancelRequested;
 
 #pragma pack(push, r1, 1)


### PR DESCRIPTION
### Description

Migrate the updater from defunct Json11 to nlohmann JSON as we use in websockets/browser and potentially the UI as well in the future.

Includes #9291

### Motivation and Context

json11 is unmaintained/abandoned and nlohmann allows us to have nicer struct based (de)serialisation.

### How Has This Been Tested?

Updated OBS.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
