### PR TITLE
aja,aja-output-ui: Enforce -Wdangling-reference to never turn into an error

### DIFF
--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -81,7 +81,18 @@ elseif(OS_LINUX OR OS_FREEBSD)
   find_package(X11 REQUIRED)
   target_link_libraries(aja-output-ui PRIVATE X11::X11 Qt::GuiPrivate)
 
-  target_compile_options(aja-output-ui PRIVATE -Wno-error=deprecated-declarations)
+  #[[
+    Note about -Wdangling-reference on GCC, this warning seems to be subject of false positives. This warning is set to not turn into an error.
+
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532
+    - Example close to ours: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532#c20
+  ]]
+  target_compile_options(
+    aja-output-ui
+    PRIVATE
+      -Wno-error=deprecated-declarations
+      "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,13>>:-Wno-error=dangling-reference>"
+  )
 endif()
 
 set_target_properties_obs(

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -80,6 +80,8 @@ elseif(OS_MACOS)
 elseif(OS_LINUX OR OS_FREEBSD)
   find_package(X11 REQUIRED)
   target_link_libraries(aja-output-ui PRIVATE X11::X11 Qt::GuiPrivate)
+
+  target_compile_options(aja-output-ui PRIVATE -Wno-error=deprecated-declarations)
 endif()
 
 set_target_properties_obs(

--- a/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
+++ b/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
@@ -84,7 +84,18 @@ else()
 endif()
 
 if(NOT MSVC)
-  target_compile_options(aja-output-ui PRIVATE -Wno-error=deprecated-declarations)
+  #[[
+    Note about -Wdangling-reference on GCC, this warning seems to be subject of false positives. This warning is set to not turn into an error.
+
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532
+    - Example close to ours: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532#c20
+  ]]
+  target_compile_options(
+    aja-output-ui
+    PRIVATE
+      -Wno-error=deprecated-declarations
+      "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,13>>:-Wno-error=dangling-reference>"
+  )
 endif()
 
 set_target_properties(aja-output-ui PROPERTIES FOLDER "frontend" PREFIX "")

--- a/plugins/aja/CMakeLists.txt
+++ b/plugins/aja/CMakeLists.txt
@@ -60,7 +60,18 @@ elseif(OS_MACOS)
   target_link_libraries(aja PRIVATE ${IOKIT} ${COREFOUNDATION} ${APPKIT})
   target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations)
 elseif(OS_LINUX OR OS_FREEBSD)
-  target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations)
+  #[[
+    Note about -Wdangling-reference on GCC, this warning seems to be subject of false positives. This warning is set to not turn into an error.
+
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532
+    - Example close to ours: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532#c20
+  ]]
+  target_compile_options(
+    aja
+    PRIVATE
+      -Wno-error=deprecated-declarations
+      "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,13>>:-Wno-error=dangling-reference>"
+  )
 endif()
 
 set_target_properties_obs(aja PROPERTIES FOLDER plugins PREFIX "")

--- a/plugins/aja/cmake/legacy.cmake
+++ b/plugins/aja/cmake/legacy.cmake
@@ -66,7 +66,18 @@ elseif(OS_WINDOWS)
 endif()
 
 if(NOT MSVC)
-  target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations)
+  #[[
+    Note about -Wdangling-reference on GCC, this warning seems to be subject of false positives. This warning is set to not turn into an error.
+
+    - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532
+    - Example close to ours: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107532#c20
+  ]]
+  target_compile_options(
+    aja
+    PRIVATE
+      -Wno-error=deprecated-declarations
+      "$<$<AND:$<COMPILE_LANG_AND_ID:CXX,GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,13>>:-Wno-error=dangling-reference>"
+  )
 endif()
 
 set_target_properties(aja PROPERTIES FOLDER "plugins/aja" PREFIX "")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

With how GCC 13.1 progress, `-Wdangling-reference` is victim of false positive, avoid letting it turn into an error on AJA plugins since those are the only one having this warning.

`" "` and `""` are temporaries considered bound to the returned reference but this is not the case.
```
[build] obs-studio/plugins/aja/aja-routing.cpp: In static member function ‘static bool aja::Routing::ParseRouteString(const std::string&, NTV2XptConnections&)’:
[build] /home/tytan652/Programming/OBS/obs-studio/plugins/aja/aja-routing.cpp:28:28: error: possibly dangling reference to a temporary [-Werror=dangling-reference]
[build]    28 |         const std::string &route_strip = aja::replace(route_lower, " ", "");
[build]       |                            ^~~~~~~~~~~
[build] obs-studio/plugins/aja/aja-routing.cpp:28:54: note: the temporary was destroyed at the end of the full expression ‘aja::replace(route_lower, std::__cxx11::basic_string<char>(((const char*)" "), std::allocator<char>()), std::__cxx11::basic_string<char>(((const char*)""), std::allocator<char>()))’
[build]    28 |         const std::string &route_strip = aja::replace(route_lower, " ", "");
[build]       |                                          ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Reduction of false positive is not planned until GCC 14.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Build with ArchLinux GCC 13 package and no errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- GCC false positive bypass

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
