### PR TITLE
CI: Fix steamcmd being unable to find generated build file

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -245,7 +245,7 @@ runs:
 
         steamcmd \
           +login '${{ inputs.steamUser }}' '${{ inputs.steamPassword }}' '${{ steps.steam-totp.outputs.code }}' \
-          +run_app_build ${preview:+-preview} ${build_file} \
+          +run_app_build ${preview:+-preview} ${build_file:a} \
           +quit
         print '::endgroup'
         popd
@@ -275,7 +275,7 @@ runs:
 
         steamcmd \
           +login '${{ inputs.steamUser }}' '${{ inputs.steamPassword }}' '${{ steps.steam-totp.outputs.code }}' \
-          +run_app_build ${preview} ${build_file} \
+          +run_app_build ${preview} ${build_file:a} \
           +quit
         print '::endgroup'
         popd


### PR DESCRIPTION
### Description
Changes `steamcmd` invocation to pass absolute path to generated build file.

### Motivation and Context
steamcmd seems to have a quirk where it cannot find a file in the current working directory on macOS, but requires the absolute path to the file instead - using the `:a` Zsh modifier yields the absolute path of a valid filename in the current directory scope.

### How Has This Been Tested?
Needs to be tested via CI run.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
