### PR TITLE
CI: Fix Python 3.11 installation on macOS 13 runners

### DIFF
--- a/.github/actions/services-validator/action.yaml
+++ b/.github/actions/services-validator/action.yaml
@@ -46,7 +46,7 @@ runs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         fi
-        brew install --quiet python3
+        brew install --overwrite --quiet python3
         python3 -m pip install jsonschema json_source_map requests
         echo ::endgroup::
 


### PR DESCRIPTION
### Description
Enforce installation of Python 3.11 via Homebrew for scheduled service checks.

### Motivation and Context
Once again GitHub Action runners have a minor Python 3 version preinstalled that we want to upgrade, which will fail because that versions does not seem to be Homebrew-based.

Enforcing an upgrade will fix the issue as Homebrew can overwrite the files.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
