### PR TITLE
libobs-d3d11,UI: Move shader cache folder creation

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -567,12 +567,6 @@ static bool MakeUserDirs()
 		return false;
 	if (!do_mkdir(path))
 		return false;
-
-	if (GetProgramDataPath(path, sizeof(path), "obs-studio/shader-cache") <=
-	    0)
-		return false;
-	if (!do_mkdir(path))
-		return false;
 #endif
 
 #ifdef WHATSNEW_ENABLED

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1494,6 +1494,17 @@ static inline void LogD3DAdapters()
 	}
 }
 
+static void CreateShaderCacheDirectory()
+{
+	BPtr cachePath =
+		os_get_program_data_path_ptr("obs-studio/shader-cache");
+
+	if (os_mkdirs(cachePath) == MKDIR_ERROR) {
+		blog(LOG_WARNING, "Failed to create shader cache directory, "
+				  "cache may not be available.");
+	}
+}
+
 int device_create(gs_device_t **p_device, uint32_t adapter)
 {
 	gs_device *device = NULL;
@@ -1503,6 +1514,7 @@ int device_create(gs_device_t **p_device, uint32_t adapter)
 		blog(LOG_INFO, "---------------------------------");
 		blog(LOG_INFO, "Initializing D3D11...");
 		LogD3DAdapters();
+		CreateShaderCacheDirectory();
 
 		device = new gs_device(adapter);
 


### PR DESCRIPTION
### Description

Moves creation of the shader cache folder from the UI to libobs-d3d11

### Motivation and Context

Kinda maybe better practice?

### How Has This Been Tested?

Verified folder is still created before anything is written to it.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
