### PR TITLE
aja: Ignore return value from aja-common functions

### DIFF
--- a/plugins/aja/aja-routing.cpp
+++ b/plugins/aja/aja-routing.cpp
@@ -23,9 +23,9 @@ bool Routing::ParseRouteString(const std::string &route,
 	blog(LOG_DEBUG, "aja::Routing::ParseRouteString: Input string: %s",
 	     route.c_str());
 
-	std::string route_lower(route);
-	route_lower = aja::lower(route_lower);
-	const std::string &route_strip = aja::replace(route_lower, " ", "");
+	std::string route_strip(route);
+	aja::lower(route_strip);
+	aja::replace(route_strip, " ", "");
 
 	if (route_strip.empty()) {
 		blog(LOG_DEBUG,
@@ -274,7 +274,7 @@ bool Routing::ConfigureSourceRoute(const SourceProps &props, NTV2Mode mode,
 		for (const auto &name : fs_associated) {
 			std::string placeholder = std::string(
 				name + "[{ch" + aja::to_string(c + 1) + "}]");
-			route_string = aja::replace(
+			aja::replace(
 				route_string, placeholder,
 				name + "[" +
 					aja::to_string(start_framestore_index) +
@@ -288,9 +288,8 @@ bool Routing::ConfigureSourceRoute(const SourceProps &props, NTV2Mode mode,
 	for (ULWord c = 0; c < NTV2_MAX_NUM_CHANNELS; c++) {
 		std::string channel_placeholder =
 			std::string("{ch" + aja::to_string(c + 1) + "}");
-		route_string =
-			aja::replace(route_string, channel_placeholder,
-				     aja::to_string(start_channel_index++));
+		aja::replace(route_string, channel_placeholder,
+			     aja::to_string(start_channel_index++));
 	}
 
 	if (!ParseRouteString(route_string, cnx))
@@ -421,7 +420,7 @@ bool Routing::ConfigureOutputRoute(const OutputProps &props, NTV2Mode mode,
 		for (const auto &name : fs_associated) {
 			std::string placeholder = std::string(
 				name + "[{ch" + aja::to_string(c + 1) + "}]");
-			route_string = aja::replace(
+			aja::replace(
 				route_string, placeholder,
 				name + "[" +
 					aja::to_string(start_framestore_index) +
@@ -435,9 +434,8 @@ bool Routing::ConfigureOutputRoute(const OutputProps &props, NTV2Mode mode,
 	for (ULWord c = 0; c < NTV2_MAX_NUM_CHANNELS; c++) {
 		std::string channel_placeholder =
 			std::string("{ch" + aja::to_string(c + 1) + "}");
-		route_string =
-			aja::replace(route_string, channel_placeholder,
-				     aja::to_string(start_channel_index++));
+		aja::replace(route_string, channel_placeholder,
+			     aja::to_string(start_channel_index++));
 	}
 
 	if (!ParseRouteString(route_string, cnx))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR will replace another PR #9294.

Ignore return values from the functions `aja::lower` and `aja::replace`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The functions `aja::lower` and `aja::replace` overwrite the 1st argument and just return the reference to the 1st argument. It is not necessary to use the return value.

- `aja::lower`: https://github.com/aja-video/ntv2/blob/3a1e91f740e36e43a1ec74ff446a097330e87220/ajalibraries/ajabase/common/common.cpp#L343-L347
- `aja::replace`: https://github.com/aja-video/ntv2/blob/3a1e91f740e36e43a1ec74ff446a097330e87220/ajalibraries/ajabase/common/common.cpp#L60-L70

According to the other PR #9294, GCC 13's warning `-Wdangling-reference` reported a warning on the line below.
https://github.com/obsproject/obs-studio/blob/edf2c8210ca45d4d25c96ac1b9afc122caadb529/plugins/aja/aja-routing.cpp#L28

This PR should silent the warning.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: CentOS Stream 9

Built with 11.3 with coverage option. Checked all the modified lines are hit.
Also checked the string before and after `aja::replace` by printing the string to a log file.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
