### PR TITLE
UI: Migrate WhatsNew, update branches, and Windows update check to nlohmann JSON

### DIFF
--- a/UI/cmake/feature-macos-update.cmake
+++ b/UI/cmake/feature-macos-update.cmake
@@ -1,10 +1,20 @@
 include_guard(DIRECTORY)
 
+find_package(nlohmann_json REQUIRED)
+
 if(NOT TARGET OBS::blake2)
   add_subdirectory("${CMAKE_SOURCE_DIR}/deps/blake2" "${CMAKE_BINARY_DIR}/deps/blake2")
 endif()
 
-target_sources(obs-studio PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mac.mm update/shared-update.cpp
-                                  update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
+target_sources(
+  obs-studio
+  PRIVATE update/crypto-helpers.hpp
+          update/crypto-helpers-mac.mm
+          update/shared-update.cpp
+          update/shared-update.hpp
+          update/update-helpers.cpp
+          update/update-helpers.hpp
+          update/models/branches.hpp)
 
-target_link_libraries(obs-studio PRIVATE "$<LINK_LIBRARY:FRAMEWORK,Security.framework>" OBS::blake2)
+target_link_libraries(obs-studio PRIVATE "$<LINK_LIBRARY:FRAMEWORK,Security.framework>" nlohmann_json::nlohmann_json
+                                         OBS::blake2)

--- a/UI/cmake/feature-macos-update.cmake
+++ b/UI/cmake/feature-macos-update.cmake
@@ -14,7 +14,8 @@ target_sources(
           update/shared-update.hpp
           update/update-helpers.cpp
           update/update-helpers.hpp
-          update/models/branches.hpp)
+          update/models/branches.hpp
+          update/models/whatsnew.hpp)
 
 target_link_libraries(obs-studio PRIVATE "$<LINK_LIBRARY:FRAMEWORK,Security.framework>" nlohmann_json::nlohmann_json
                                          OBS::blake2)

--- a/UI/cmake/feature-whatsnew.cmake
+++ b/UI/cmake/feature-whatsnew.cmake
@@ -5,11 +5,18 @@ if(ENABLE_WHATSNEW AND TARGET OBS::browser-panels)
     include(cmake/feature-macos-update.cmake)
   elseif(OS_LINUX)
     find_package(MbedTLS REQUIRED)
-    target_link_libraries(obs-studio PRIVATE MbedTLS::MbedTLS OBS::blake2)
+    find_package(nlohmann_json REQUIRED)
+    target_link_libraries(obs-studio PRIVATE MbedTLS::MbedTLS nlohmann_json::nlohmann_json OBS::blake2)
 
     target_sources(
-      obs-studio PRIVATE update/crypto-helpers-mbedtls.cpp update/crypto-helpers.hpp update/shared-update.cpp
-                         update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
+      obs-studio
+      PRIVATE update/crypto-helpers-mbedtls.cpp
+              update/crypto-helpers.hpp
+              update/shared-update.cpp
+              update/shared-update.hpp
+              update/update-helpers.cpp
+              update/update-helpers.hpp
+              update/models/whatsnew.hpp)
   endif()
 
   target_enable_feature(obs-studio "What's New panel" WHATSNEW_ENABLED)

--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -357,6 +357,7 @@ if(OS_WINDOWS)
             update/update-helpers.hpp
             update/crypto-helpers-mbedtls.cpp
             update/crypto-helpers.hpp
+            update/models/branches.hpp
             win-update/updater/manifest.hpp
             ${CMAKE_BINARY_DIR}/obs.rc)
 
@@ -425,17 +426,26 @@ elseif(OS_MACOS)
 
   if(ENABLE_WHATSNEW)
     find_library(SECURITY Security)
+    find_package(nlohmann_json REQUIRED)
     mark_as_advanced(SECURITY)
-    target_link_libraries(obs PRIVATE ${SECURITY} OBS::blake2)
 
-    target_sources(obs PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mac.mm update/shared-update.cpp
-                               update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
+    target_link_libraries(obs PRIVATE ${SECURITY} OBS::blake2 nlohmann_json::nlohmann_json)
+
+    target_sources(
+      obs
+      PRIVATE update/crypto-helpers.hpp
+              update/crypto-helpers-mac.mm
+              update/shared-update.cpp
+              update/shared-update.hpp
+              update/update-helpers.cpp
+              update/update-helpers.hpp)
 
     if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
       find_library(SPARKLE Sparkle)
       mark_as_advanced(SPARKLE)
 
-      target_sources(obs PRIVATE update/mac-update.cpp update/mac-update.hpp update/sparkle-updater.mm)
+      target_sources(obs PRIVATE update/mac-update.cpp update/mac-update.hpp update/sparkle-updater.mm
+                                 update/models/branches.hpp)
       target_compile_definitions(obs PRIVATE ENABLE_SPARKLE_UPDATER)
       target_link_libraries(obs PRIVATE ${SPARKLE})
       # Enable Automatic Reference Counting for Sparkle wrapper

--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -358,6 +358,7 @@ if(OS_WINDOWS)
             update/crypto-helpers-mbedtls.cpp
             update/crypto-helpers.hpp
             update/models/branches.hpp
+            update/models/whatsnew.hpp
             win-update/updater/manifest.hpp
             ${CMAKE_BINARY_DIR}/obs.rc)
 
@@ -438,7 +439,8 @@ elseif(OS_MACOS)
               update/shared-update.cpp
               update/shared-update.hpp
               update/update-helpers.cpp
-              update/update-helpers.hpp)
+              update/update-helpers.hpp
+              update/models/whatsnew.hpp)
 
     if(SPARKLE_APPCAST_URL AND SPARKLE_PUBLIC_KEY)
       find_library(SPARKLE Sparkle)
@@ -477,13 +479,14 @@ elseif(OS_POSIX)
 
   if(OS_LINUX AND ENABLE_WHATSNEW)
     find_package(MbedTLS)
+    find_package(nlohmann_json REQUIRED)
     if(NOT MBEDTLS_FOUND)
       obs_status(FATAL_ERROR "mbedTLS not found, but required for WhatsNew support on Linux")
     endif()
 
     target_sources(obs PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mbedtls.cpp update/shared-update.cpp
                                update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
-    target_link_libraries(obs PRIVATE Mbedtls::Mbedtls OBS::blake2)
+    target_link_libraries(obs PRIVATE Mbedtls::Mbedtls nlohmann_json::nlohmann_json OBS::blake2)
   endif()
 endif()
 

--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -340,6 +340,7 @@ if(OS_WINDOWS)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/obs.rc.in ${CMAKE_BINARY_DIR}/obs.rc)
 
   find_package(Detours REQUIRED)
+  find_package(nlohmann_json REQUIRED)
 
   target_sources(
     obs
@@ -356,10 +357,11 @@ if(OS_WINDOWS)
             update/update-helpers.hpp
             update/crypto-helpers-mbedtls.cpp
             update/crypto-helpers.hpp
+            win-update/updater/manifest.hpp
             ${CMAKE_BINARY_DIR}/obs.rc)
 
   find_package(MbedTLS)
-  target_link_libraries(obs PRIVATE Mbedtls::Mbedtls OBS::blake2 Detours::Detours)
+  target_link_libraries(obs PRIVATE Mbedtls::Mbedtls nlohmann_json::nlohmann_json OBS::blake2 Detours::Detours)
 
   target_compile_features(obs PRIVATE cxx_std_17)
 

--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -28,6 +28,7 @@ target_sources(
           update/update-window.hpp
           update/win-update.cpp
           update/win-update.hpp
+          update/models/branches.hpp
           win-update/updater/manifest.hpp)
 
 target_link_libraries(obs-studio PRIVATE crypt32 OBS::blake2 OBS::w32-pthreads MbedTLS::MbedTLS

--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -8,6 +8,7 @@ endif()
 
 find_package(MbedTLS)
 find_package(Detours REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
 configure_file(cmake/windows/obs.rc.in obs.rc)
 
@@ -26,9 +27,11 @@ target_sources(
           update/update-window.cpp
           update/update-window.hpp
           update/win-update.cpp
-          update/win-update.hpp)
+          update/win-update.hpp
+          win-update/updater/manifest.hpp)
 
-target_link_libraries(obs-studio PRIVATE crypt32 OBS::blake2 OBS::w32-pthreads MbedTLS::MbedTLS Detours::Detours)
+target_link_libraries(obs-studio PRIVATE crypt32 OBS::blake2 OBS::w32-pthreads MbedTLS::MbedTLS
+                                         nlohmann_json::nlohmann_json Detours::Detours)
 target_compile_definitions(obs-studio PRIVATE PSAPI_VERSION=2)
 target_link_options(obs-studio PRIVATE /IGNORE:4098 /IGNORE:4099)
 

--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -29,6 +29,7 @@ target_sources(
           update/win-update.cpp
           update/win-update.hpp
           update/models/branches.hpp
+          update/models/whatsnew.hpp
           win-update/updater/manifest.hpp)
 
 target_link_libraries(obs-studio PRIVATE crypt32 OBS::blake2 OBS::w32-pthreads MbedTLS::MbedTLS

--- a/UI/update/models/branches.hpp
+++ b/UI/update/models/branches.hpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+struct JsonBranch {
+	/* Internal name / ID of the branch (used in updater) */
+	std::string name;
+	/* Human readable name */
+	std::string display_name;
+	/* Description */
+	std::string description;
+	/* Whether updating should use the branch if selected or fall back to stable */
+	bool enabled = false;
+	/* Whether the branch should be displayed in the UI */
+	bool visible = false;
+	/* OS compatibility */
+	bool windows = false;
+	bool macos = false;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(JsonBranch, name,
+						    display_name, description,
+						    enabled, visible, windows,
+						    macos)
+};
+
+using JsonBranches = std::vector<JsonBranch>;

--- a/UI/update/models/whatsnew.hpp
+++ b/UI/update/models/whatsnew.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <string>
+#include <optional>
+
+#include <nlohmann/json.hpp>
+
+/* Ubuntu 22.04 be damned. */
+#ifndef NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT
+#define NLOHMANN_JSON_FROM_WITH_DEFAULT(v1) \
+	nlohmann_json_t.v1 =                \
+		nlohmann_json_j.value(#v1, nlohmann_json_default_obj.v1);
+
+#define NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(Type, ...)              \
+	friend void to_json(nlohmann::json &nlohmann_json_j,                \
+			    const Type &nlohmann_json_t)                    \
+	{                                                                   \
+		NLOHMANN_JSON_EXPAND(                                       \
+			NLOHMANN_JSON_PASTE(NLOHMANN_JSON_TO, __VA_ARGS__)) \
+	}                                                                   \
+	friend void from_json(const nlohmann::json &nlohmann_json_j,        \
+			      Type &nlohmann_json_t)                        \
+	{                                                                   \
+		Type nlohmann_json_default_obj;                             \
+		NLOHMANN_JSON_EXPAND(NLOHMANN_JSON_PASTE(                   \
+			NLOHMANN_JSON_FROM_WITH_DEFAULT, __VA_ARGS__))      \
+	}
+
+#endif
+
+/*
+ * Support for (de-)serialising std::optional
+ * Adapted from https://github.com/nlohmann/json/issues/1749#issuecomment-1555093802
+ */
+template<typename T> struct nlohmann::adl_serializer<std::optional<T>> {
+	static std::optional<T> from_json(const json &json)
+	{
+		return json.is_null() ? std::nullopt
+				      : std::optional{json.get<T>()};
+	}
+
+	static void to_json(json &json, std::optional<T> t)
+	{
+		if (t)
+			json = *t;
+		else
+			json = nullptr;
+	}
+};
+
+struct WhatsNewPlatforms {
+	bool windows = false;
+	bool macos = false;
+	bool linux = false;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(WhatsNewPlatforms, windows,
+						    macos, linux)
+};
+
+struct WhatsNewItem {
+	/* Target OBS version (patch is ignored) */
+	std::string version;
+	/* Beta/RC release to target */
+	int Beta = 0;
+	int RC = 0;
+	/* URL of webpage to be displayed */
+	std::string url;
+	/* Increment for this version's item */
+	int increment = 0;
+	/* Optional OS filter */
+	std::optional<WhatsNewPlatforms> os = std::nullopt;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(WhatsNewItem, version, Beta,
+						    RC, url, increment, os)
+};
+
+using WhatsNewList = std::vector<WhatsNewItem>;

--- a/UI/win-update/updater/manifest.hpp
+++ b/UI/win-update/updater/manifest.hpp
@@ -53,17 +53,17 @@ struct Manifest {
 	uint8_t version_patch = 0;
 	uint8_t beta = 0;
 	uint8_t rc = 0;
+	std::string commit;
 
 	/* Hash of VC redist file */
 	std::string vc2019_redist_x64;
 
-	/* Unused until UI is migrated to nlohmann_json */
-	// std::string commit;
-	// std::string notes;
+	/* Release notes in HTML format */
+	std::string notes;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Manifest, packages, version_major,
 				       version_minor, version_patch, beta, rc,
-				       vc2019_redist_x64)
+				       commit, vc2019_redist_x64, notes)
 };
 
 struct PatchRequest {


### PR DESCRIPTION
### Description

This PR does three things:
- Migrate Windows update check to use nlohmann JSON for manifest deserialisation
- Migrate macOS/Windows update branch deserialisation to use nlohmann JSON
- Migrate WhatsNew deserialisation to use nlohmann JSON

### Motivation and Context

json11 is dead/abandoned, and nlohmann allows us to more prettily deserialise things into a struct.

### How Has This Been Tested?

- Verified manifest is parsed correctly and version check works
- Verified branches are parsed correctly
- Tested WhatsNew on Windows with some mock data including the optional `os` filter.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
