### PR TITLE
CI: Enforce the use of Ubuntu's CMake

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,11 @@ indent_size = 4
 [*.py]
 indent_style = space
 indent_size = 4
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+[{*.zsh,.*.zsh,build-aux/.functions/*,.github/scripts/utils.zsh/*}]
+indent_style = space
+indent_size = 2

--- a/.github/scripts/.Aptfile
+++ b/.github/scripts/.Aptfile
@@ -1,5 +1,5 @@
 package 'ccache'
-package 'cmake'
+package 'cmake', bin: '/usr/bin/cmake'
 package 'curl'
 package 'git'
 package 'jq'

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -185,6 +185,7 @@ build() {
       popd
       ;;
     linux-*)
+      local cmake_bin='/usr/bin/cmake'
       cmake_args+=(
         -S ${PWD} -B build_${target##*-}
         -G Ninja
@@ -199,15 +200,15 @@ build() {
       cmake_install_args+=(build_${target##*-} --prefix ${project_root}/build_${target##*-}/install/${config})
 
       log_group "Configuring ${product_name}..."
-      cmake -S ${project_root} ${cmake_args}
+      ${cmake_bin} -S ${project_root} ${cmake_args}
 
       log_group "Building ${product_name}..."
       if (( debug )) cmake_build_args+=(--verbose)
-      cmake ${cmake_build_args}
+      ${cmake_bin} ${cmake_build_args}
 
       log_group "Installing ${product_name}..."
       if (( debug )) cmake_install_args+=(--verbose)
-      cmake ${cmake_install_args}
+      ${cmake_bin} ${cmake_install_args}
       ;;
   }
   popd

--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -209,13 +209,14 @@ package() {
     log_group
 
   } elif [[ ${host_os} == linux ]] {
+    local cmake_bin='/usr/bin/cmake'
     local -a cmake_args=()
     if (( debug )) cmake_args+=(--verbose)
 
     if (( package )) {
       log_group "Packaging obs-studio..."
       pushd ${project_root}
-      cmake --build build_${target##*-} --config ${config} -t package ${cmake_args}
+      ${cmake_bin} --build build_${target##*-} --config ${config} -t package ${cmake_args}
       output_name="${output_name}-${target##*-}-linux-gnu"
 
       pushd ${project_root}/build_${target##*-}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Requires:
 - #9304

Use Ubuntu CMake package.

If it worked CI should fail while configuring obs-qsv until #9304 is merged.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Github enforce an updated version of CMake, while we need to rely on what the distribution actually provides.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

If it worked CI should fail while configuring obs-qsv until #9304 is merged.

The right CMake is indeed use since configure has failed on obs-qsv.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
