### PR TITLE
obs-webrtc: Fix WHIP request not following redirects

### DIFF
--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -45,7 +45,7 @@ static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
 static size_t curl_header_location_function(char *data, size_t size,
 					    size_t nmemb, void *priv_data)
 {
-	auto header_buffer = static_cast<std::string *>(priv_data);
+	auto header_buffer = static_cast<std::vector<std::string> *>(priv_data);
 
 	size_t real_size = size * nmemb;
 
@@ -54,8 +54,11 @@ static size_t curl_header_location_function(char *data, size_t size,
 
 	if (!astrcmpi_n(data, "location: ", LOCATION_HEADER_LENGTH)) {
 		char *val = data + LOCATION_HEADER_LENGTH;
-		header_buffer->append(val, real_size - LOCATION_HEADER_LENGTH);
-		*header_buffer = trim_string(*header_buffer);
+		auto header_temp =
+			std::string(val, real_size - LOCATION_HEADER_LENGTH);
+
+		header_temp = trim_string(header_temp);
+		header_buffer->push_back(header_temp);
 	}
 
 	return real_size;


### PR DESCRIPTION
### Description

Fix issues that WHIP request did not follow 307 redirect.

Reference to [WHIP Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-wish-whip-08#section-4.3)

> WHIP endpoints and Media Servers might not be colocated on the same server, so it is possible to load balance incoming requests to different Media Servers. WHIP clients SHALL support HTTP redirection via the "307 Temporary Redirect" response as described in [[RFC9110](https://www.rfc-editor.org/rfc/rfc9110)] section 6.4.7. The WHIP resource URL MUST be a final one, and redirections are not required to be supported for the PATCH and DELETE requests sent to it.

And libcurl documents [https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html](https://curl.se/libcurl/c/CURLOPT_FOLLOWLOCATION.html) . CURLOPT_FOLLOWLOCATION should be set 1L to allow curl_easy_perform follow the redirection response.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

Tested on separate branch as far as possible.

### Types of changes

Add a curl option to curl_sasy_perform.

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
