### PR TITLE
build-aux: Add RNNoise Flatpak module

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -60,6 +60,7 @@
         "modules/50-libqrcodegencpp.json",
         "modules/50-ntv2.json",
         "modules/50-pipewire.json",
+        "modules/50-rnnoise.json",
         "modules/50-swig.json",
         "modules/50-v4l-utils.json",
         "modules/90-asio.json",

--- a/build-aux/modules/50-rnnoise.json
+++ b/build-aux/modules/50-rnnoise.json
@@ -1,0 +1,21 @@
+{
+    "name": "rnnoise",
+    "config-opts": [
+        "--enable-shared",
+        "-C",
+        "--disable-dependency-tracking",
+        "--disable-doc",
+        "--disable-examples"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/xiph/rnnoise.git",
+            "commit": "085d8f484af6141b1b88281a4043fb9215cead01"
+        }
+    ]
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Replace in-tree RNNoise with a module with the same version as macOS obs-deps

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Align with obs-deps and make Ubuntu the only reason that RNNoise in-tree exists.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Flatpak build (configure step does not have the message about using a bundled RNNoise) and the noise filter have the RNNoise option while running the Flatpak

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
