### PR TITLE
win-capture: Fix leaking framebuffers data

### DIFF
--- a/plugins/win-capture/graphics-hook-ver.h
+++ b/plugins/win-capture/graphics-hook-ver.h
@@ -13,7 +13,7 @@
 
 #define HOOK_VER_MAJOR 1
 #define HOOK_VER_MINOR 8
-#define HOOK_VER_PATCH 1
+#define HOOK_VER_PATCH 2
 
 #ifndef STRINGIFY
 #define STRINGIFY(s) #s

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -397,7 +397,7 @@ static void remove_free_framebuffer_data(struct vk_data *data,
 					 const VkAllocationCallbacks *ac)
 {
 	struct vk_swap_data *const framebuffer_data =
-		(struct vk_swap_data *)remove_obj_data(&data->swaps,
+		(struct vk_swap_data *)remove_obj_data(&data->framebuffers,
 						       (uint64_t)framebuffer);
 	vk_free(ac, framebuffer_data);
 }
@@ -2100,8 +2100,8 @@ OBS_CmdBeginRenderPass(VkCommandBuffer commandBuffer,
 {
 	struct vk_data *const data =
 		get_device_data_by_command_buffer(commandBuffer);
+	VkRenderPassBeginInfo alternateBegin;
 	if (data->valid) {
-		VkRenderPassBeginInfo alternateBegin;
 		pRenderPassBegin = process_render_pass_begin_info(
 			pRenderPassBegin, &alternateBegin, data);
 	}
@@ -2117,8 +2117,8 @@ OBS_CmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
 {
 	struct vk_data *const data =
 		get_device_data_by_command_buffer(commandBuffer);
+	VkRenderPassBeginInfo alternateBegin;
 	if (data->valid) {
-		VkRenderPassBeginInfo alternateBegin;
 		pRenderPassBegin = process_render_pass_begin_info(
 			pRenderPassBegin, &alternateBegin, data);
 	}
@@ -2134,8 +2134,8 @@ OBS_CmdBeginRenderPass2(VkCommandBuffer commandBuffer,
 {
 	struct vk_data *const data =
 		get_device_data_by_command_buffer(commandBuffer);
+	VkRenderPassBeginInfo alternateBegin;
 	if (data->valid) {
-		VkRenderPassBeginInfo alternateBegin;
 		pRenderPassBegin = process_render_pass_begin_info(
 			pRenderPassBegin, &alternateBegin, data);
 	}


### PR DESCRIPTION


### Description
The wrong linked list was used when removing framebuffer data. It generated memory leak, the linked list grew more and more involving performance degradation each time an application called the vkCmdBeginRenderPass.
Furthermore, few pointers referenced objects on the stack that were no more valid.


### Motivation and Context
It solves a memory leak and performance problems.

### How Has This Been Tested?
Tested on Windows 10.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
