### PR TITLE
libobs: Fix GPU scaled video encoder media not being cleared

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -25,6 +25,8 @@
 
 #define get_weak(encoder) ((obs_weak_encoder_t *)encoder->context.control)
 
+static void encoder_set_video(obs_encoder_t *encoder, video_t *video);
+
 struct obs_encoder_info *find_encoder(const char *id)
 {
 	for (size_t i = 0; i < obs->encoder_types.num; i++) {
@@ -660,7 +662,7 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 		if (!mix->encoder_only_mix)
 			break;
 
-		obs_encoder_set_video(encoder, obs_get_video());
+		encoder_set_video(encoder, obs_get_video());
 		mix->encoder_refs -= 1;
 		if (mix->encoder_refs == 0) {
 			da_erase(obs->video.mixes, i);
@@ -1066,7 +1068,6 @@ size_t obs_encoder_get_frame_size(const obs_encoder_t *encoder)
 
 void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 {
-	const struct video_output_info *voi;
 
 	if (!obs_encoder_valid(encoder, "obs_encoder_set_video"))
 		return;
@@ -1084,6 +1085,13 @@ void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 		     obs_encoder_get_name(encoder));
 		return;
 	}
+
+	encoder_set_video(encoder, video);
+}
+
+static void encoder_set_video(obs_encoder_t *encoder, video_t *video)
+{
+	const struct video_output_info *voi;
 
 	if (encoder->fps_override) {
 		video_output_free_frame_rate_divisor(encoder->fps_override);


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
During encoder shutdown `maybe_clear_encoder_core_video_mix` is called to clear created mixes that are no longer needed; at that time `obs_encoder_set_video` rejects changes to `media` since the encoder is still active, so we bypass those checks

This is an issue e.g. when a rtmp stream disconnects (and thus all encoders are cleared) and subsequently reconnects

The call to `set_encoder_active(encoder, false)` happens right after the call to `obs_encoder_shutdown` in this case, but I'm not entirely sure whether it's safer to reorder those calls rather than bypassing the check for `obs_encoder_set_video`

### Motivation and Context
OBS crashes when GPU scaling is used through additional core video mixes and those encoders are recreated due to e.g. rtmp disconnects

### How Has This Been Tested?
Disconnect an rtmp stream while having an encoder attached through a GPU scaled additional core video mix. Without this change this crashes inside `copy_rgbx_frame`

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
