### PR TITLE
UI: Avoid auto config selecting QSV on linux

### DIFF
--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -947,6 +947,16 @@ void AutoConfigTestPage::TestStreamEncoderThread()
 		wiz->streamingEncoder = AutoConfig::Encoder::x264;
 	}
 
+#ifdef __linux__
+	// On linux CBR rate control is not guaranteed so fallback to x264.
+	if (wiz->streamingEncoder == AutoConfig::Encoder::QSV) {
+		wiz->streamingEncoder = AutoConfig::Encoder::x264;
+		if (!TestSoftwareEncoding()) {
+			return;
+		}
+	}
+#endif
+
 	if (preferHardware && !softwareTested && wiz->hardwareEncodingAvailable)
 		FindIdealHardwareResolution();
 

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -839,12 +839,10 @@ void OBSBasic::CheckForSimpleModeX264Fallback()
 	while (obs_enum_encoder_types(idx++, &id)) {
 		if (strcmp(id, "amd_amf_h264") == 0)
 			amd_supported = true;
-#ifdef _WIN32
 		else if (strcmp(id, "obs_qsv11") == 0)
 			qsv_supported = true;
 		else if (strcmp(id, "obs_qsv11_av1") == 0)
 			qsv_av1_supported = true;
-#endif
 		else if (strcmp(id, "ffmpeg_nvenc") == 0)
 			nve_supported = true;
 #ifdef ENABLE_HEVC


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously we left the QSV -> x264 in the fallback function to deal with the autoconfig wizard possibly selecting QSV outside of the UI. But this actually runs for both recording and streaming every time obs starts, reseting user's config if they selected QSV for recording.

Instead avoid QSV from being selected in the UI and by the auto-config wizard, and revert changes to the fallback function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Reseting user's config does not make users happy.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Autoconfig wizard with "Prefer Hardware Encoding" still selects x264.

I can restart obs after selecting QSV in simple mode and it isnt reset.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
