### PR TITLE
rtmp-services: Add MasterStream.iR to ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 231,
+    "version": 232,
     "files": [
         {
             "name": "services.json",
-            "version": 231
+            "version": 232
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2754,6 +2754,62 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "MasterStream.iR | مستراستریم | ری استریم و استریم همزمان",
+            "common": false,
+            "more_info_link": "https://masterstream.ir/webpage/page/docs",
+            "stream_key_link": "https://masterstream.ir/managestreams.php",
+            "servers": [
+                {
+                    "name": "Iran Server 1",
+                    "url": "rtmp://live1.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 2",
+                    "url": "rtmp://live2.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 3",
+                    "url": "rtmp://live3.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 4",
+                    "url": "rtmp://live4.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 5",
+                    "url": "rtmp://live5.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 6",
+                    "url": "rtmp://live6.masterstream.ir/live"
+                },
+                {
+                    "name": "Iran Server 7",
+                    "url": "rtmp://live7.masterstream.ir/live"
+                },
+                {
+                    "name": "Turkey Server 1",
+                    "url": "rtmp://tr-live1.masterstream.ir/live"
+                }
+            ],
+            "protocol": "RTMP",
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "852x480",
+                    "640x360"
+                ],
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2762,6 +2762,10 @@
             "stream_key_link": "https://masterstream.ir/managestreams.php",
             "servers": [
                 {
+                    "name": "Auto (Iran Servers)",
+                    "url": "rtmp://auto.masterstream.ir/live"
+                },
+                {
                     "name": "Iran Server 1",
                     "url": "rtmp://live1.masterstream.ir/live"
                 },


### PR DESCRIPTION

### Description
Adding MasterStream.iR to OBS-Studio's Ingest List

### Motivation and Context
This pull request adds the website of MasterStream.iR, which is the biggest restreaming platform in Iran with more than 3 years of availability and a user base of over 6,000 users, to OBS-Studio's ingest list. By adding this website to the ingest list, OBS-Studio users will be able to easily and conveniently use MasterStream.iR as a source for their live streams and content.

### How Has This Been Tested?

- JSON validation: Ensured that the JSON files are well-formed and adhered to the required format for OBS-Studio's ingest list.
- Copy JSON files to `%APPDATA%\obs-studio\plugin_config\rtmp-services`: Manually copied the JSON files to the appropriate location where OBS-Studio reads ingest settings.
- Checked settings: Verified that MasterStream.iR appears in the updated ingest list within OBS-Studio's settings.
- Connection testing: Attempted to connect to the servers provided by MasterStream.iR to ensure successful streaming functionality.
- According to [Service Submission Guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines) 


### Types of changes

- New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits are squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
