### PR TITLE
obs-webrtc: Add AV1 Support

### DIFF
--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -43,6 +43,7 @@ private:
 		  std::shared_ptr<rtc::RtcpSrReporter> rtcp_sr_reporter);
 
 	obs_output_t *output;
+	bool is_av1;
 
 	std::string endpoint_url;
 	std::string bearer_token;

--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -1,7 +1,7 @@
 #include "whip-service.h"
 
 const char *audio_codecs[MAX_CODECS] = {"opus"};
-const char *video_codecs[MAX_CODECS] = {"h264"};
+const char *video_codecs[MAX_CODECS] = {"h264", "av1"};
 
 WHIPService::WHIPService(obs_data_t *settings, obs_service_t *)
 	: server(),


### PR DESCRIPTION
### Description
This adds AV1 support to obs-webrtc

### Motivation and Context
Users wish to use AV1

### How Has This Been Tested?
Tested against Broadcast Box

### Types of changes
 - New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
