### PR TITLE
libobs: Add obs_source_info.filter_add

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -410,6 +410,15 @@ Source Definition Structure (obs_source_info)
    :param event:       Key event properties
    :param focus:       Key event type (true if mouse-up)
 
+.. member:: void (*obs_source_info.filter_add)(void *data, obs_source_t *source)
+
+   Called when the filter is added to a source.
+
+   (Optional)
+
+   :param  data:   Filter data
+   :param  source: Source that the filter is being added to
+
 .. member:: void (*obs_source_info.filter_remove)(void *data, obs_source_t *source)
 
    Called when the filter is removed from a source.
@@ -1547,7 +1556,7 @@ Filters
    reference.
 
    Only guaranteed to be valid inside of the video_render, filter_audio,
-   filter_video, and filter_remove callbacks.
+   filter_video, filter_add, and filter_remove callbacks.
 
 ---------------------
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3132,6 +3132,10 @@ void obs_source_filter_add(obs_source_t *source, obs_source_t *filter)
 
 	blog(LOG_DEBUG, "- filter '%s' (%s) added to source '%s'",
 	     filter->context.name, filter->info.id, source->context.name);
+
+	if (filter->info.filter_add)
+		filter->info.filter_add(filter->context.data,
+					filter->filter_parent);
 }
 
 static bool obs_source_filter_remove_refless(obs_source_t *source,

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -552,6 +552,14 @@ struct obs_source_info {
 	enum gs_color_space (*video_get_color_space)(
 		void *data, size_t count,
 		const enum gs_color_space *preferred_spaces);
+
+	/**
+	 * Called when the filter is added to a source
+	 *
+	 * @param  data    Filter data
+	 * @param  source  Source that the filter is being added to
+	 */
+	void (*filter_add)(void *data, obs_source_t *source);
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info,


### PR DESCRIPTION
If there is filter_remove, it is reasonable to expect that there is also filter_add. filter_add also enables filters to attach signal handlers on the parent, and disconnect them in filter_remove.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add obs_source_info.filter_add, counterpart of filter_remove

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I've had two plugins where I needed to reference the parent outside of the valid functions. One is my Source Defaults that creates a custom filter which uses the global "source_create" signal to copy settings of the parent source to the new source (same source type). Adding a `filter_video` that does nothing except get a reference to the parent does not seem optimal to me.

In the other, I wrote a custom filter that generates subtitles. I wanted to attach to the signal handler of the parent source, but the parent source is not available in `obs_source_info.source_create`. I needed these signal handlers as I wanted to clear the displayed subtitles when the parent media source has ended or stopped. I ended up getting the parent in `filter_audio` every time, and checking if the previous parent is the same ([code](https://github.com/CodeYan01/media-playlist-source/blob/81ddc3c051a66f22114dbd2848b8e378bb119456/src/vosk-filter.c#L510-L522)). If `filter_add` existed, the code would be much cleaner as I would simply connect the signal handlers in `filter_add` once, without having to check and reconnect.
[Extra convo](https://discord.com/channels/348973006581923840/374636084883095554/1123622304539234304)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Not yet, but will try to modify my plugin with this change to test on Windows. Changed code looks straightforward tho

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
