### PR TITLE
libobs: Profile graphics initialisation and shader compilation

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -540,6 +540,8 @@ gs_effect_t *obs_load_effect(gs_effect_t **effect, const char *file)
 	return *effect;
 }
 
+static const char *shader_comp_name = "shader compilation";
+static const char *obs_init_graphics_name = "obs_init_graphics";
 static int obs_init_graphics(struct obs_video_info *ovi)
 {
 	struct obs_core_video *video = &obs->video;
@@ -549,9 +551,13 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 	bool success = true;
 	int errorcode;
 
+	profile_start(obs_init_graphics_name);
+
 	errorcode =
 		gs_create(&video->graphics, ovi->graphics_module, ovi->adapter);
 	if (errorcode != GS_SUCCESS) {
+		profile_end(obs_init_graphics_name);
+
 		switch (errorcode) {
 		case GS_ERROR_MODULE_NOT_FOUND:
 			return OBS_VIDEO_MODULE_NOT_FOUND;
@@ -562,6 +568,7 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 		}
 	}
 
+	profile_start(shader_comp_name);
 	gs_enter_context(video->graphics);
 
 	char *filename = obs_find_data_file("default.effect");
@@ -639,6 +646,9 @@ static int obs_init_graphics(struct obs_video_info *ovi)
 		success = false;
 
 	gs_leave_context();
+	profile_end(shader_comp_name);
+	profile_end(obs_init_graphics_name);
+
 	return success ? OBS_VIDEO_SUCCESS : OBS_VIDEO_FAIL;
 }
 


### PR DESCRIPTION
### Description

Adds profiling to `obs_init_graphics()` and the shader compilation contained within.

Note: Typically we keep profiling to a function level, if we want to keep that pattern the default shader compilation could be moved to a separate function like so: https://github.com/derrod/obs-studio/commit/f17eeea15189d5cb2096c58197725449b57366a4

### Motivation and Context

Wanted to evaluate user-provided logs to measure impact of shader compilation on macOS/Linux startup time to see if we'd want to also add a shader cache to the OpenGL graphics backend.

Without cache:
```
11:18:42.521:      ┣OBSBasic::ResetVideo: 896.154 ms
11:18:42.521:      ┃ ┗obs_init_graphics: 894.978 ms
11:18:42.521:      ┃   ┗obs_init_default_shaders: 808.217 ms
```
With cache:
```
11:18:46.936:      ┣OBSBasic::ResetVideo: 127.955 ms
11:18:46.936:      ┃ ┗obs_init_graphics: 126.718 ms
11:18:46.936:      ┃   ┗obs_init_default_shaders: 47.855 ms
```

### How Has This Been Tested?

Ran OBS.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
