### PR TITLE
UI: Make simple mode settings warnings float at bottom of page

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2256,22 +2256,6 @@
                      </widget>
                     </item>
                     <item>
-                     <layout class="QVBoxLayout" name="simpleOutInfoLayout">
-                      <property name="leftMargin">
-                       <number>10</number>
-                      </property>
-                      <property name="topMargin">
-                       <number>10</number>
-                      </property>
-                      <property name="rightMargin">
-                       <number>10</number>
-                      </property>
-                      <property name="bottomMargin">
-                       <number>10</number>
-                      </property>
-                     </layout>
-                    </item>
-                    <item>
                      <widget class="QFrame" name="simpleOutputContainer">
                       <property name="minimumSize">
                        <size>
@@ -2311,6 +2295,22 @@
                    </layout>
                   </widget>
                  </widget>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="simpleOutInfoLayout">
+                  <property name="leftMargin">
+                   <number>10</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>10</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>10</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>10</number>
+                  </property>
+                 </layout>
                 </item>
                </layout>
               </widget>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the warning box in the Simple Mode settings to be floating at the bottom of the visible page, instead of being at the bottom of the scroll area.

Before/After:
<p>
<img width="400" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/44a28fc0-1ff5-4dcf-bd15-31a14007ca09">
<img width="400" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/8b979978-beee-4edd-bccc-a7a9217731a7">
</p>




### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Warnings should be visible.
Prerequisite to #6700, this really does not require a huge refactor like the one proposed in #7709.

For reference, off-thread discussion a while back regarding #6700 yielded that this was the desired layout (see https://github.com/obsproject/obs-studio/pull/6700#issuecomment-1187632936):
<img width="400" alt="image" src="https://user-images.githubusercontent.com/59806498/179544127-05abd081-e12c-4c34-82eb-46d23fa516c9.png">


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14 Beta 3
Tested with and without warnings being shown, and they're now always visible on the bottom.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
