### PR TITLE
Contain simde diagnostic pragmas and replace variable-length arrays

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -462,7 +462,7 @@ static bool code_to_str(int code, struct dstr *str)
 void obs_key_to_str(obs_key_t key, struct dstr *str)
 {
     const UniCharCount max_length = 16;
-    UniChar buffer[max_length];
+    UniChar buffer[16];
 
     if (localized_key_to_str(key, str))
         return;

--- a/libobs/util/sse-intrin.h
+++ b/libobs/util/sse-intrin.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "c99defs.h"
+
 #if (defined(_MSC_VER) || defined(__MINGW32__)) && \
 	((defined(_M_X64) && !defined(_M_ARM64EC)) || defined(_M_IX86))
 #include <emmintrin.h>
@@ -25,5 +27,7 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #define SIMDE_ENABLE_NATIVE_ALIASES
+PRAGMA_WARN_PUSH
 #include "simde/x86/sse2.h"
+PRAGMA_WARN_POP
 #endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #9160

- Replace linux-pipewire variable-length arrays with dynamic arrays, those were not generating errors because of our in-tree simde that makes some warning ignored.
- Contain simde diagnostic pragmas

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I was trying to use my system simde rather than the in-tree and discover how to reproduce #9160.

So I tried to fix the vla issue and the pragma contamination.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Pipewire captures seems to work fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested on Linux.
- [ ] The code has been tested on macOS.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
