### PR TITLE
UI: FFmpeg utils cleanup/fixes

### DIFF
--- a/UI/ffmpeg-utils.cpp
+++ b/UI/ffmpeg-utils.cpp
@@ -49,10 +49,10 @@ vector<FFmpegCodec> GetFormatCodecs(const FFmpegFormat &format,
 	return codecs;
 }
 
-static inline bool is_output_device(const AVClass *avclass)
+static bool is_output_device(const AVClass *avclass)
 {
 	if (!avclass)
-		return 0;
+		return false;
 
 	switch (avclass->category) {
 	case AV_CLASS_CATEGORY_DEVICE_VIDEO_OUTPUT:
@@ -115,7 +115,7 @@ bool FFCodecAndFormatCompatible(const char *codec, const char *format)
 #else
 	const AVOutputFormat *output_format;
 #endif
-	output_format = av_guess_format(format, NULL, NULL);
+	output_format = av_guess_format(format, nullptr, nullptr);
 	if (!output_format)
 		return false;
 

--- a/UI/ffmpeg-utils.hpp
+++ b/UI/ffmpeg-utils.hpp
@@ -47,6 +47,8 @@ static bool strequal(const char *a, const char *b)
 	return strcmp(a, b) == 0;
 }
 
+struct FFmpegCodec;
+
 struct FFmpegFormat {
 	const char *name;
 	const char *long_name;
@@ -60,7 +62,12 @@ struct FFmpegFormat {
 
 	FFmpegFormat(const char *name, const char *mime_type)
 		: name(name),
-		  mime_type(mime_type)
+		  long_name(nullptr),
+		  mime_type(mime_type),
+		  extensions(nullptr),
+		  audio_codec(AV_CODEC_ID_NONE),
+		  video_codec(AV_CODEC_ID_NONE),
+		  codec_tags(nullptr)
 	{
 	}
 
@@ -75,7 +82,7 @@ struct FFmpegFormat {
 	{
 	}
 
-	const char *GetDefaultName(FFmpegCodecType codec_type) const;
+	FFmpegCodec GetDefaultEncoder(FFmpegCodecType codec_type) const;
 
 	bool HasAudio() const { return audio_codec != AV_CODEC_ID_NONE; }
 	bool HasVideo() const { return video_codec != AV_CODEC_ID_NONE; }
@@ -101,6 +108,7 @@ struct FFmpegCodec {
 
 	FFmpegCodec(const char *name, int id, FFmpegCodecType type = UNKNOWN)
 		: name(name),
+		  long_name(nullptr),
 		  id(id),
 		  type(type)
 	{

--- a/UI/ffmpeg-utils.hpp
+++ b/UI/ffmpeg-utils.hpp
@@ -28,6 +28,25 @@ extern "C" {
 
 enum FFmpegCodecType { AUDIO, VIDEO, UNKNOWN };
 
+/* This needs to handle a few special cases due to how the format is used in the UI:
+ * - strequal(nullptr, "") must be true
+ * - strequal("", nullptr) must be true
+ * - strequal(nullptr, nullptr) must be true
+ */
+static bool strequal(const char *a, const char *b)
+{
+	if (!a && !b)
+		return true;
+	if (!a && *b == 0)
+		return true;
+	if (!b && *a == 0)
+		return true;
+	if (!a || !b)
+		return false;
+
+	return strcmp(a, b) == 0;
+}
+
 struct FFmpegFormat {
 	const char *name;
 	const char *long_name;
@@ -46,9 +65,10 @@ struct FFmpegFormat {
 
 	bool operator==(const FFmpegFormat &format) const
 	{
-		if (strcmp(name, format.name) != 0)
+		if (!strequal(name, format.name))
 			return false;
-		return strcmp(mime_type, format.mime_type) != 0;
+
+		return strequal(mime_type, format.mime_type);
 	}
 };
 Q_DECLARE_METATYPE(FFmpegFormat)
@@ -69,7 +89,8 @@ struct FFmpegCodec {
 	{
 		if (id != codec.id)
 			return false;
-		return strcmp(name, codec.name) != 0;
+
+		return strequal(name, codec.name);
 	}
 };
 Q_DECLARE_METATYPE(FFmpegCodec)

--- a/UI/ffmpeg-utils.hpp
+++ b/UI/ffmpeg-utils.hpp
@@ -58,6 +58,23 @@ struct FFmpegFormat {
 
 	FFmpegFormat() = default;
 
+	FFmpegFormat(const char *name, const char *mime_type)
+		: name(name),
+		  mime_type(mime_type)
+	{
+	}
+
+	FFmpegFormat(const AVOutputFormat *av_format)
+		: name(av_format->name),
+		  long_name(av_format->long_name),
+		  mime_type(av_format->mime_type),
+		  extensions(av_format->extensions),
+		  audio_codec(av_format->audio_codec),
+		  video_codec(av_format->video_codec),
+		  codec_tags(av_format->codec_tag)
+	{
+	}
+
 	const char *GetDefaultName(FFmpegCodecType codec_type) const;
 
 	bool HasAudio() const { return audio_codec != AV_CODEC_ID_NONE; }
@@ -84,6 +101,30 @@ struct FFmpegCodec {
 	FFmpegCodecType type;
 
 	FFmpegCodec() = default;
+
+	FFmpegCodec(const char *name, int id, FFmpegCodecType type = UNKNOWN)
+		: name(name),
+		  id(id),
+		  type(type)
+	{
+	}
+
+	FFmpegCodec(const AVCodec *codec)
+		: name(codec->name),
+		  long_name(codec->long_name),
+		  id(codec->id)
+	{
+		switch (codec->type) {
+		case AVMEDIA_TYPE_AUDIO:
+			type = AUDIO;
+			break;
+		case AVMEDIA_TYPE_VIDEO:
+			type = VIDEO;
+			break;
+		default:
+			type = UNKNOWN;
+		}
+	}
 
 	bool operator==(const FFmpegCodec &codec) const
 	{

--- a/UI/ffmpeg-utils.hpp
+++ b/UI/ffmpeg-utils.hpp
@@ -95,9 +95,6 @@ struct FFmpegCodec {
 	const char *long_name;
 	int id;
 
-	bool alias;
-	const char *base_name;
-
 	FFmpegCodecType type;
 
 	FFmpegCodec() = default;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2238,7 +2238,7 @@ void OBSBasicSettings::LoadAdvOutputRecordingEncoderProperties()
 static void SelectFormat(QComboBox *combo, const char *name,
 			 const char *mimeType)
 {
-	FFmpegFormat format{name, mimeType};
+	FFmpegFormat format{name, nullptr, mimeType};
 
 	for (int i = 0; i < combo->count(); i++) {
 		QVariant v = combo->itemData(i);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1136,9 +1136,11 @@ void OBSBasicSettings::LoadFormats()
 
 static void AddCodec(QComboBox *combo, const FFmpegCodec &codec)
 {
-	QString itemText(codec.name);
-	if (codec.alias)
-		itemText += QString(" (%1)").arg(codec.base_name);
+	QString itemText;
+	if (codec.long_name)
+		itemText = QString("%1 - %2").arg(codec.name, codec.long_name);
+	else
+		itemText = codec.name;
 
 	combo->addItem(itemText, QVariant::fromValue(codec));
 }

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -186,7 +186,7 @@ static inline QString GetComboData(QComboBox *combo)
 
 static int FindEncoder(QComboBox *combo, const char *name, int id)
 {
-	FFmpegCodec codec{name, nullptr, id};
+	FFmpegCodec codec{name, id};
 
 	for (int i = 0; i < combo->count(); i++) {
 		QVariant v = combo->itemData(i);
@@ -2238,7 +2238,7 @@ void OBSBasicSettings::LoadAdvOutputRecordingEncoderProperties()
 static void SelectFormat(QComboBox *combo, const char *name,
 			 const char *mimeType)
 {
-	FFmpegFormat format{name, nullptr, mimeType};
+	FFmpegFormat format{name, mimeType};
 
 	for (int i = 0; i < combo->count(); i++) {
 		QVariant v = combo->itemData(i);


### PR DESCRIPTION
### Description

This PR addresses a few things with the newly introduced FFmpeg utilities:
- Fixes the equality operator overload to have null checks
- Fixes one initialisation of `FFmpegFormat` 
- Removes the alias in the name because it's misleading/useless
- Refactors getting the encoders for a given format to remove an unnecessary indirection and quadratic search
- Adds long name to items in encoder list
- Refactors getting the default encoder from a format
- Adds constructors to `FFmpegFormat`/`FFmpegCodec` for their libav counterparts
- Cleans up some leftovers from the original C code (e.g. `NULL` instead of `nullptr`)

### Motivation and Context

Would prefer not to crash and cleaner code.

### How Has This Been Tested?

Opened settings, changed settings, closed settings, reopened settings.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code Cleanup

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
