### PR TITLE
UI: Don't call obs_source_get_output_flags on a NULL source

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3391,16 +3391,20 @@ void OBSBasic::SourceToolBarActionsSetEnabled()
 
 void OBSBasic::UpdateTransformShortcuts()
 {
+	bool hasVideo = false;
+
 	OBSSource source = obs_sceneitem_get_source(GetCurrentSceneItem());
-	uint32_t flags = obs_source_get_output_flags(source);
-	bool audioOnly = (flags & OBS_SOURCE_VIDEO) == 0;
 
-	ui->actionEditTransform->setEnabled(!audioOnly);
-	ui->actionCopyTransform->setEnabled(!audioOnly);
-	ui->actionPasteTransform->setEnabled(audioOnly ? false
-						       : hasCopiedTransform);
+	if (source) {
+		uint32_t flags = obs_source_get_output_flags(source);
+		hasVideo = (flags & OBS_SOURCE_VIDEO) != 0;
+	}
 
-	ui->actionResetTransform->setEnabled(!audioOnly);
+	ui->actionEditTransform->setEnabled(hasVideo);
+	ui->actionCopyTransform->setEnabled(hasVideo);
+	ui->actionPasteTransform->setEnabled(hasVideo ? hasCopiedTransform
+						      : false);
+	ui->actionResetTransform->setEnabled(hasVideo);
 }
 
 void OBSBasic::UpdateContextBar(bool force)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
https://github.com/obsproject/obs-studio/commit/c33fa8b introduced a call to `obs_source_get_output_flags` which would always be called when the selection changes, even if things get unselected. This would result in `get_output_flags` being called on a `NULL` source which libobs yells about. This PR also inverts the `audioOnly` bool to make it a bit more obvious what is actually being checked (which is whether the source has video).
This PR leaves an existing bug w/r/t multiple scene items which I'm planning on addressing as well, but it may involve a minor refactor and I don't want this PR to get too large.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Got annoyed at debug warnings each time I unselect the current scene item.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested that everything (including the bugs) works the same as before, with both video sources as well as audio only sources.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
