### PR TITLE
obs-ffmpeg: New default settings for AMD encoders

### DIFF
--- a/plugins/obs-ffmpeg/data/locale/en-US.ini
+++ b/plugins/obs-ffmpeg/data/locale/en-US.ini
@@ -25,6 +25,8 @@ FilePath="File Path"
 
 AMFOpts="AMF/FFmpeg Options"
 AMFOpts.ToolTip="Use to specify custom AMF or FFmpeg options. For example, \"level=5.2 profile=main\". Check the AMF encoder docs for more details."
+AMF.PreAnalysis="Pre-Analysis"
+AMF.PreAnalysis.ToolTip="Enables improved encoding quality at the cost of performance by calculating additional metrics such as activity and spatial complexity."
 
 GPU="GPU"
 BFrames="Max B-frames"

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1160,14 +1160,36 @@ static void check_texture_encode_capability(obs_encoder_t *encoder, amf_codec_ty
 
 #include "texture-amf-opts.hpp"
 
-static void amf_defaults(obs_data_t *settings)
+static void amf_avc_defaults(obs_data_t *settings)
 {
+	// These are initial recommended settings that may be lowered later
+	// once we know more info such as the resolution and frame rate.
+	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "cqp", 20);
-	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_string(settings, "preset", "quality");
 	obs_data_set_default_string(settings, "profile", "high");
-	obs_data_set_default_int(settings, "bf", 3);
+	obs_data_set_default_int(settings, "bf", 2);
+}
+
+static void amf_hevc_defaults(obs_data_t *settings)
+{
+	// These are initial recommended settings that may be lowered later
+	// once we know more info such as the resolution and frame rate.
+	obs_data_set_default_string(settings, "rate_control", "VBR");
+	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "cqp", 20);
+	obs_data_set_default_string(settings, "preset", "quality");
+}
+
+static void amf_av1_defaults(obs_data_t *settings)
+{
+	// These are initial recommended settings that may be lowered later
+	// once we know more info such as the resolution and frame rate.
+	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "cqp", 20);
+	obs_data_set_default_string(settings, "rate_control", "VBR");
+	obs_data_set_default_string(settings, "preset", "highQuality");
 }
 
 static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p, obs_data_t *settings)
@@ -1326,6 +1348,15 @@ static void amf_avc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 
 		if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR) {
 			set_avc_property(enc, FILLER_DATA_ENABLE, true);
+		} else if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
+			   rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
+			set_avc_property(enc, PEAK_BITRATE, bitrate * 1.5);
+			set_avc_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
+		} else if (rc ==
+			   AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+			int64_t framerate = enc->fps_num / enc->fps_den;
+			set_avc_property(enc, VBV_BUFFER_SIZE,
+					 (bitrate / framerate) * 1.1);
 		}
 	} else {
 		set_avc_property(enc, QP_I, qp);
@@ -1366,6 +1397,23 @@ try {
 	amf_base *enc = (amf_base *)data;
 	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
 	return false;
+}
+
+static inline void adjust_recommended_avc_defaults(amf_base *enc,
+						   obs_data_t *settings)
+{
+	int64_t framerate = enc->fps_num / enc->fps_den;
+	if ((enc->cx * enc->cy > 1920 * 1088) || (framerate > 60)) {
+
+		// Recommended base defaults
+		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "cqp", 20);
+		obs_data_set_default_string(settings, "rate_control", "CBR");
+		obs_data_set_default_string(settings, "preset", "quality");
+		obs_data_set_default_string(settings, "profile", "high");
+		obs_data_set_default_int(settings, "bf", 0);
+		info("Original base default settings were used according to resolution and framerate.");
+	}
 }
 
 static void amf_set_codec_level(amf_base *enc)
@@ -1454,6 +1502,10 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 {
 	amf_base *enc = (amf_base *)data;
 
+	// Initial high perceptual quality settings are set in the UI.
+	// Adjust during init based on resolution and framerate.
+	adjust_recommended_avc_defaults(enc, settings);
+
 	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
 	const char *preset = obs_data_get_string(settings, "preset");
@@ -1483,7 +1535,9 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	int rc = get_avc_rate_control(rc_str);
 
 	set_avc_property(enc, RATE_CONTROL_METHOD, rc);
-	if (rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP)
+	if (rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP &&
+	    rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR &&
+	    rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR)
 		set_avc_property(enc, ENABLE_VBAQ, true);
 
 	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
@@ -1681,7 +1735,7 @@ static void register_avc()
 	amf_encoder_info.destroy = amf_destroy;
 	amf_encoder_info.update = amf_avc_update;
 	amf_encoder_info.encode_texture = amf_encode_tex;
-	amf_encoder_info.get_defaults = amf_defaults;
+	amf_encoder_info.get_defaults = amf_avc_defaults;
 	amf_encoder_info.get_properties = amf_avc_properties;
 	amf_encoder_info.get_extra_data = amf_extra_data;
 	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE | OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI;
@@ -1748,6 +1802,15 @@ static void amf_hevc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t
 
 		if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR) {
 			set_hevc_property(enc, FILLER_DATA_ENABLE, true);
+		} else if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
+			   rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
+			set_hevc_property(enc, PEAK_BITRATE, bitrate * 1.5);
+			set_hevc_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
+		} else if (rc ==
+			   AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+			int64_t framerate = enc->fps_num / enc->fps_den;
+			set_hevc_property(enc, VBV_BUFFER_SIZE,
+					  (bitrate / framerate) * 1.1);
 		}
 	} else {
 		set_hevc_property(enc, QP_I, qp);
@@ -1789,9 +1852,28 @@ try {
 	return false;
 }
 
+static inline void adjust_recommended_hevc_defaults(amf_base *enc,
+						    obs_data_t *settings)
+{
+	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
+	const int64_t framerate = enc->fps_num / enc->fps_den;
+	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
+
+		// Recommended base defaults
+		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "cqp", 20);
+		obs_data_set_default_string(settings, "preset", "quality");
+		info("Original base default settings were used according to resolution and framerate.");
+	}
+}
+
 static bool amf_hevc_init(void *data, obs_data_t *settings)
 {
 	amf_base *enc = (amf_base *)data;
+
+	// Initial high perceptual quality settings are set in the UI.
+	// Adjust during init based on resolution and framerate.
+	adjust_recommended_hevc_defaults(enc, settings);
 
 	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
@@ -1801,7 +1883,9 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 	int rc = get_hevc_rate_control(rc_str);
 
 	set_hevc_property(enc, RATE_CONTROL_METHOD, rc);
-	if (rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP)
+	if (rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP &&
+	    rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR &&
+	    rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR)
 		set_hevc_property(enc, ENABLE_VBAQ, true);
 
 	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
@@ -1903,6 +1987,7 @@ static void amf_hevc_create_internal(amf_base *enc, obs_data_t *settings)
 	const bool hlg = is_hlg(enc);
 	const bool is_hdr = pq || hlg;
 	const char *preset = obs_data_get_string(settings, "preset");
+	obs_data_set_string(settings, "profile", is10bit ? "main10" : "main");
 
 	set_hevc_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
 	set_hevc_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
@@ -2013,6 +2098,17 @@ try {
 	return nullptr;
 }
 
+/* These are initial recommended settings that may be lowered later
+ * once we know more info such as the resolution and frame rate.
+ */
+static void amf_hevc_defaults(obs_data_t *settings)
+{
+	obs_data_set_default_string(settings, "rate_control", "CBR");
+	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "cqp", 20);
+	obs_data_set_default_string(settings, "preset", "quality");
+}
+
 static void register_hevc()
 {
 	struct obs_encoder_info amf_encoder_info = {};
@@ -2024,7 +2120,7 @@ static void register_hevc()
 	amf_encoder_info.destroy = amf_destroy;
 	amf_encoder_info.update = amf_hevc_update;
 	amf_encoder_info.encode_texture = amf_encode_tex;
-	amf_encoder_info.get_defaults = amf_defaults;
+	amf_encoder_info.get_defaults = amf_hevc_defaults;
 	amf_encoder_info.get_properties = amf_hevc_properties;
 	amf_encoder_info.get_extra_data = amf_extra_data;
 	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE | OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI;
@@ -2108,6 +2204,12 @@ static void amf_av1_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 		} else if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
 			   rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
 			set_av1_property(enc, PEAK_BITRATE, bitrate * 1.5);
+			set_av1_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
+		} else if (rc ==
+			   AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+			int64_t framerate = enc->fps_num / enc->fps_den;
+			set_av1_property(enc, VBV_BUFFER_SIZE,
+					 (bitrate / framerate) * 1.1);
 		}
 	} else {
 		int64_t qp = cq_value * 4;
@@ -2150,9 +2252,30 @@ try {
 	return false;
 }
 
+static inline void adjust_recommended_av1_defaults(amf_base *enc,
+						   obs_data_t *settings)
+{
+	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
+	const int64_t framerate = enc->fps_num / enc->fps_den;
+	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
+
+		// Recommended base defaults
+		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "cqp", 20);
+		obs_data_set_default_string(settings, "preset", "balanced");
+		obs_data_set_default_string(settings, "profile", "main");
+		obs_data_set_default_int(settings, "bf", 0);
+		info("Original base default settings were used according to resolution and framerate.");
+	}
+}
+
 static bool amf_av1_init(void *data, obs_data_t *settings)
 {
 	amf_base *enc = (amf_base *)data;
+
+	// Initial high perceptual quality settings are set in the UI.
+	// Adjust during init based on resolution and framerate.
+	adjust_recommended_av1_defaults(enc, settings);
 
 	int64_t bitrate = obs_data_get_int(settings, "bitrate");
 	int64_t qp = obs_data_get_int(settings, "cqp");
@@ -2171,6 +2294,11 @@ static bool amf_av1_init(void *data, obs_data_t *settings)
 
 	int rc = get_av1_rate_control(rc_str);
 	set_av1_property(enc, RATE_CONTROL_METHOD, rc);
+	if (rc != AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CONSTANT_QP &&
+	    rc != AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR &&
+	    rc != AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
+		set_av1_property(enc, AQ_MODE, 1);
+	}
 
 	amf_av1_update_data(enc, rc, bitrate * 1000, qp);
 
@@ -2209,18 +2337,23 @@ static bool amf_av1_init(void *data, obs_data_t *settings)
 	}
 
 	info("settings:\n"
-	     "\trate_control: %s\n"
-	     "\tbitrate:      %d\n"
-	     "\tcqp:          %d\n"
-	     "\tkeyint:       %d\n"
-	     "\tpreset:       %s\n"
-	     "\tprofile:      %s\n"
-	     "\tlevel:        %s\n"
-	     "\tb-frames:     %d\n"
-	     "\twidth:        %d\n"
-	     "\theight:       %d\n"
-	     "\tparams:       %s",
-	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, bf, enc->cx, enc->cy, ffmpeg_opts);
+	     "\trate_control:         %s\n"
+	     "\tbitrate:              %d\n"
+	     "\tcqp:                  %d\n"
+	     "\tkeyint:               %d\n"
+	     "\tpreset:               %s\n"
+	     "\tprofile:              %s\n"
+	     "\tlevel:                %s\n"
+	     "\tb-frames:             %d\n"
+	     "\twidth:                %d\n"
+	     "\theight:               %d\n"
+	     "\tscreen content tools: %s\n"
+	     "\tpalette mode:         %s\n"
+	     "\tpre-analysis:         %s\n"
+	     "\tparams:               %s",
+	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, bf, enc->cx, enc->cy,
+	     screen_content_tools_enabled ? "true" : "false", palette_mode_enabled ? "true" : "false",
+	     pa_enabled ? "true" : "false", ffmpeg_opts);
 
 	return true;
 }
@@ -2244,6 +2377,7 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 
 	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
 	const char *preset = obs_data_get_string(settings, "preset");
+	obs_data_set_string(settings, "profile", "main");
 
 	set_av1_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
 	set_av1_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
@@ -2256,7 +2390,8 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 	set_av1_property(enc, OUTPUT_COLOR_PROFILE, enc->amf_color_profile);
 	set_av1_property(enc, OUTPUT_TRANSFER_CHARACTERISTIC, enc->amf_characteristic);
 	set_av1_property(enc, OUTPUT_COLOR_PRIMARIES, enc->amf_primaries);
-	set_av1_property(enc, FRAMERATE, enc->amf_frame_rate);
+	set_av1_property(enc, SCREEN_CONTENT_TOOLS, true);
+	set_av1_property(enc, PALETTE_MODE, true);
 
 	amf_av1_init(enc, settings);
 
@@ -2346,13 +2481,15 @@ try {
 	return nullptr;
 }
 
+/* These are initial recommended settings that may be lowered later
+ * once we know more info such as the resolution and frame rate.
+ */
 static void amf_av1_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "cqp", 20);
 	obs_data_set_default_string(settings, "rate_control", "CBR");
-	obs_data_set_default_string(settings, "preset", "quality");
-	obs_data_set_default_string(settings, "profile", "high");
+	obs_data_set_default_string(settings, "preset", "highQuality");
 	obs_data_set_default_int(settings, "bf", 2);
 }
 

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -543,6 +543,38 @@ static inline int64_t convert_to_obs_ts(amf_base *enc, int64_t ts)
 	return ts * (int64_t)enc->fps_den / amf_timebase;
 }
 
+static inline const char *convert_amf_memory_type_to_string(AMF_MEMORY_TYPE type)
+{
+	switch (type) {
+	case AMF_MEMORY_UNKNOWN:
+		return "Unknown";
+	case AMF_MEMORY_HOST:
+		return "Host";
+	case AMF_MEMORY_DX9:
+		return "DX9";
+	case AMF_MEMORY_DX11:
+		return "DX11";
+	case AMF_MEMORY_OPENCL:
+		return "OpenCL";
+	case AMF_MEMORY_OPENGL:
+		return "OpenGL";
+	case AMF_MEMORY_XV:
+		return "XV";
+	case AMF_MEMORY_GRALLOC:
+		return "Gralloc";
+	case AMF_MEMORY_COMPUTE_FOR_DX9:
+		return "Compute For DX9";
+	case AMF_MEMORY_COMPUTE_FOR_DX11:
+		return "Compute For DX11";
+	case AMF_MEMORY_VULKAN:
+		return "Vulkan";
+	case AMF_MEMORY_DX12:
+		return "DX12";
+	default:
+		return "Invalid";
+	}
+}
+
 static void convert_to_encoder_packet(amf_base *enc, AMFDataPtr &data, encoder_packet *packet)
 {
 	if (!data)
@@ -1160,36 +1192,16 @@ static void check_texture_encode_capability(obs_encoder_t *encoder, amf_codec_ty
 
 #include "texture-amf-opts.hpp"
 
+/* These are initial recommended settings that may be lowered later once we know more info such as the resolution and
+ * frame rate. */
 static void amf_avc_defaults(obs_data_t *settings)
 {
-	// These are initial recommended settings that may be lowered later
-	// once we know more info such as the resolution and frame rate.
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "cqp", 20);
 	obs_data_set_default_string(settings, "preset", "quality");
 	obs_data_set_default_string(settings, "profile", "high");
 	obs_data_set_default_int(settings, "bf", 2);
-}
-
-static void amf_hevc_defaults(obs_data_t *settings)
-{
-	// These are initial recommended settings that may be lowered later
-	// once we know more info such as the resolution and frame rate.
-	obs_data_set_default_string(settings, "rate_control", "VBR");
-	obs_data_set_default_int(settings, "bitrate", 2500);
-	obs_data_set_default_int(settings, "cqp", 20);
-	obs_data_set_default_string(settings, "preset", "quality");
-}
-
-static void amf_av1_defaults(obs_data_t *settings)
-{
-	// These are initial recommended settings that may be lowered later
-	// once we know more info such as the resolution and frame rate.
-	obs_data_set_default_int(settings, "bitrate", 2500);
-	obs_data_set_default_int(settings, "cqp", 20);
-	obs_data_set_default_string(settings, "rate_control", "VBR");
-	obs_data_set_default_string(settings, "preset", "highQuality");
 }
 
 static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p, obs_data_t *settings)
@@ -1255,6 +1267,9 @@ static obs_properties_t *amf_properties_internal(amf_codec_type codec)
 			add_profile("baseline");
 #undef add_profile
 	}
+
+	p = obs_properties_add_bool(props, "pre_analysis", obs_module_text("AMF.PreAnalysis"));
+	obs_property_set_long_description(p, obs_module_text("AMF.PreAnalysis.ToolTip"));
 
 	if (amf_codec_type::AVC == codec || amf_codec_type::AV1 == codec) {
 		obs_properties_add_int(props, "bf", obs_module_text("BFrames"), 0, 5, 1);
@@ -1352,11 +1367,9 @@ static void amf_avc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 			   rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
 			set_avc_property(enc, PEAK_BITRATE, bitrate * 1.5);
 			set_avc_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
-		} else if (rc ==
-			   AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+		} else if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
 			int64_t framerate = enc->fps_num / enc->fps_den;
-			set_avc_property(enc, VBV_BUFFER_SIZE,
-					 (bitrate / framerate) * 1.1);
+			set_avc_property(enc, VBV_BUFFER_SIZE, (bitrate / framerate) * 1.1);
 		}
 	} else {
 		set_avc_property(enc, QP_I, qp);
@@ -1399,12 +1412,10 @@ try {
 	return false;
 }
 
-static inline void adjust_recommended_avc_defaults(amf_base *enc,
-						   obs_data_t *settings)
+static inline void adjust_recommended_avc_defaults(amf_base *enc, obs_data_t *settings)
 {
 	int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || (framerate > 60)) {
-
 		// Recommended base defaults
 		obs_data_set_default_int(settings, "bitrate", 2500);
 		obs_data_set_default_int(settings, "cqp", 20);
@@ -1512,6 +1523,11 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	const char *profile = obs_data_get_string(settings, "profile");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int64_t bf = obs_data_get_int(settings, "bf");
+	bool pa_enabled = obs_data_get_bool(settings, "pre_analysis");
+
+	if (pa_enabled) {
+		set_avc_property(enc, PRE_ANALYSIS_ENABLE, pa_enabled);
+	}
 
 	if (enc->bframes_supported) {
 		set_avc_property(enc, MAX_CONSECUTIVE_BPICTURES, bf);
@@ -1521,7 +1537,7 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 		 * as those with high motion. This only takes effect if
 		 * Pre-Analysis is enabled.
 		 */
-		if (bf > 0) {
+		if (bf > 0 && pa_enabled == true) {
 			set_avc_property(enc, ADAPTIVE_MINIGOP, true);
 		}
 
@@ -1537,8 +1553,9 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	set_avc_property(enc, RATE_CONTROL_METHOD, rc);
 	if (rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CONSTANT_QP &&
 	    rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR &&
-	    rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR)
+	    rc != AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
 		set_avc_property(enc, ENABLE_VBAQ, true);
+	}
 
 	amf_avc_update_data(enc, rc, bitrate * 1000, qp);
 
@@ -1595,8 +1612,10 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	     "\tb-frames:     %d\n"
 	     "\twidth:        %d\n"
 	     "\theight:       %d\n"
+	     "\tpre-analysis: %s\n"
 	     "\tparams:       %s",
-	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, bf, enc->cx, enc->cy, ffmpeg_opts);
+	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, bf, enc->cx, enc->cy,
+	     pa_enabled ? "true" : "false", ffmpeg_opts);
 
 	return true;
 }
@@ -1806,11 +1825,9 @@ static void amf_hevc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t
 			   rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
 			set_hevc_property(enc, PEAK_BITRATE, bitrate * 1.5);
 			set_hevc_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
-		} else if (rc ==
-			   AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+		} else if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
 			int64_t framerate = enc->fps_num / enc->fps_den;
-			set_hevc_property(enc, VBV_BUFFER_SIZE,
-					  (bitrate / framerate) * 1.1);
+			set_hevc_property(enc, VBV_BUFFER_SIZE, (bitrate / framerate) * 1.1);
 		}
 	} else {
 		set_hevc_property(enc, QP_I, qp);
@@ -1852,13 +1869,11 @@ try {
 	return false;
 }
 
-static inline void adjust_recommended_hevc_defaults(amf_base *enc,
-						    obs_data_t *settings)
+static inline void adjust_recommended_hevc_defaults(amf_base *enc, obs_data_t *settings)
 {
 	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
 	const int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
-
 		// Recommended base defaults
 		obs_data_set_default_int(settings, "bitrate", 2500);
 		obs_data_set_default_int(settings, "cqp", 20);
@@ -1881,12 +1896,18 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 	const char *profile = obs_data_get_string(settings, "profile");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
 	int rc = get_hevc_rate_control(rc_str);
+	bool pa_enabled = obs_data_get_bool(settings, "pre_analysis");
+
+	if (pa_enabled) {
+		set_hevc_property(enc, PRE_ANALYSIS_ENABLE, pa_enabled);
+	}
 
 	set_hevc_property(enc, RATE_CONTROL_METHOD, rc);
 	if (rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CONSTANT_QP &&
 	    rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR &&
-	    rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR)
+	    rc != AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
 		set_hevc_property(enc, ENABLE_VBAQ, true);
+	}
 
 	amf_hevc_update_data(enc, rc, bitrate * 1000, qp);
 
@@ -1936,8 +1957,10 @@ static bool amf_hevc_init(void *data, obs_data_t *settings)
 	     "\tlevel:        %s\n"
 	     "\twidth:        %d\n"
 	     "\theight:       %d\n"
+	     "\tpre-analysis: %s\n"
 	     "\tparams:       %s",
-	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, enc->cx, enc->cy, ffmpeg_opts);
+	     rc_str, bitrate, qp, gop_size, preset, profile, level_str, enc->cx, enc->cy, pa_enabled ? "true" : "false",
+	     ffmpeg_opts);
 
 	return true;
 }
@@ -2098,9 +2121,8 @@ try {
 	return nullptr;
 }
 
-/* These are initial recommended settings that may be lowered later
- * once we know more info such as the resolution and frame rate.
- */
+/* These are initial recommended settings that may be lowered later once we know more info such as the resolution and
+ * frame rate. */
 static void amf_hevc_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_string(settings, "rate_control", "CBR");
@@ -2205,11 +2227,9 @@ static void amf_av1_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 			   rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
 			set_av1_property(enc, PEAK_BITRATE, bitrate * 1.5);
 			set_av1_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);
-		} else if (rc ==
-			   AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
+		} else if (rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_LATENCY_CONSTRAINED_VBR) {
 			int64_t framerate = enc->fps_num / enc->fps_den;
-			set_av1_property(enc, VBV_BUFFER_SIZE,
-					 (bitrate / framerate) * 1.1);
+			set_av1_property(enc, VBV_BUFFER_SIZE, (bitrate / framerate) * 1.1);
 		}
 	} else {
 		int64_t qp = cq_value * 4;
@@ -2252,13 +2272,11 @@ try {
 	return false;
 }
 
-static inline void adjust_recommended_av1_defaults(amf_base *enc,
-						   obs_data_t *settings)
+static inline void adjust_recommended_av1_defaults(amf_base *enc, obs_data_t *settings)
 {
 	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
 	const int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
-
 		// Recommended base defaults
 		obs_data_set_default_int(settings, "bitrate", 2500);
 		obs_data_set_default_int(settings, "cqp", 20);
@@ -2282,11 +2300,27 @@ static bool amf_av1_init(void *data, obs_data_t *settings)
 	const char *preset = obs_data_get_string(settings, "preset");
 	const char *profile = obs_data_get_string(settings, "profile");
 	const char *rc_str = obs_data_get_string(settings, "rate_control");
+	bool pa_enabled = obs_data_get_bool(settings, "pre_analysis");
+	bool screen_content_tools_enabled = obs_data_get_bool(settings, "screen_content_tools");
+	bool palette_mode_enabled = obs_data_get_bool(settings, "palette_mode");
 	int64_t bf = obs_data_get_int(settings, "bf");
+
+	if (pa_enabled) {
+		set_av1_property(enc, PRE_ANALYSIS_ENABLE, pa_enabled);
+	}
 
 	if (enc->bframes_supported) {
 		set_av1_property(enc, MAX_CONSECUTIVE_BPICTURES, bf);
 		set_av1_property(enc, B_PIC_PATTERN, bf);
+
+		/* AdaptiveMiniGOP is suggested for some types of content such
+		 * as those with high motion. This only takes effect if
+		 * Pre-Analysis is enabled.
+		 */
+		if (bf > 0 && pa_enabled == true) {
+			set_av1_property(enc, ADAPTIVE_MINIGOP, true);
+		}
+
 	} else if (bf != 0) {
 		warn("B-Frames set to %lld but b-frames are not supported by this device", bf);
 		bf = 0;
@@ -2377,7 +2411,11 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 
 	const bool is10bit = enc->amf_format == AMF_SURFACE_P010;
 	const char *preset = obs_data_get_string(settings, "preset");
+	const bool enable_screen_content_tools = true;
+	const bool enable_palette_mode = true;
 	obs_data_set_string(settings, "profile", "main");
+	obs_data_set_bool(settings, "screen_content_tools", enable_screen_content_tools);
+	obs_data_set_bool(settings, "palette_mode", enable_palette_mode);
 
 	set_av1_property(enc, FRAMESIZE, AMFConstructSize(enc->cx, enc->cy));
 	set_av1_property(enc, USAGE, AMF_VIDEO_ENCODER_USAGE_TRANSCODING);
@@ -2390,8 +2428,9 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 	set_av1_property(enc, OUTPUT_COLOR_PROFILE, enc->amf_color_profile);
 	set_av1_property(enc, OUTPUT_TRANSFER_CHARACTERISTIC, enc->amf_characteristic);
 	set_av1_property(enc, OUTPUT_COLOR_PRIMARIES, enc->amf_primaries);
-	set_av1_property(enc, SCREEN_CONTENT_TOOLS, true);
-	set_av1_property(enc, PALETTE_MODE, true);
+	set_av1_property(enc, FRAMERATE, enc->amf_frame_rate);
+	set_av1_property(enc, SCREEN_CONTENT_TOOLS, enable_screen_content_tools);
+	set_av1_property(enc, PALETTE_MODE, enable_palette_mode);
 
 	amf_av1_init(enc, settings);
 
@@ -2481,9 +2520,8 @@ try {
 	return nullptr;
 }
 
-/* These are initial recommended settings that may be lowered later
- * once we know more info such as the resolution and frame rate.
- */
+/* These are initial recommended settings that may be lowered later once we know more info such as the resolution and
+ * frame rate. */
 static void amf_av1_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "bitrate", 2500);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Introducing new default AMD encoder settings for improved perceptual quality for AVC/HEVC/AV1. These new default settings have been tuned to target stable recording on RX 5700 XT and up on the recent driver.


|                      |                     AVC                      |                     AVC                      |                     HEVC                     |                     HEVC                     |                     AV1                      |                     AV1                      |
| -------------------- | :------------------------------------------: | :------------------------------------------: | :------------------------------------------: | :------------------------------------------: | :------------------------------------------: | :------------------------------------------: |
|                      |               Up to 1080p60fps               |                 > 1080p60fps                 |               Up to 1080p60fps               |                 > 1080p60fps                 |               Up to 1080p60fps               |                 > 1080p60fps                 |
| RATE_CONTROL_METHOD  |                     CBR                      |                     CBR                      |                     CBR                      |                     CBR                      |                     CBR                      |                     CBR                      |
| PEAK_BITRATE         |           Same as   TARGET_BITRATE           |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |
| VBV_BUFFER_SIZE      |           Same as   TARGET_BITRATE           |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |            Same as TARGET_BITRATE            |
| FILLER_DATA_ENABLE   |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |
| ENFORCE_HRD          |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |                     TRUE                     |
| MAX_B_FRAMES         |                      2                       |                      0                       |                      -                       |                      -                       |                      2                       |                      0                       |
| B_PIC_PATTERN        |                      2                       |                      0                       |                      -                       |                      -                       |                      2                       |                      0                       |
| SCREEN_CONTENT_TOOLS |                      -                       |                      -                       |                      -                       |                      -                       |                     TRUE                     |                     TRUE                     |
| PALETTE_MODE         |                      -                       |                      -                       |                      -                       |                      -                       |                     TRUE                     |                     TRUE                     |
| PRESET               |                   Quality                    |                   Quality                    |                   Quality                    |                   Quality                    |                 high quality                 |                   Balanced                   |
| PROFILE              |                     high                     |                     high                     |                 main/main10                  |                 main/main10                  |                     main                     |                     main                     |
| ENABLE_VBAQ/AQ_MODE  | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) | TRUE for RCMethod != (CQP \| HQVBR \| HQCBR) |
| ADAPTIVE_MINIGOP     |     TRUE for B-frames > 0 and PA enabled     |     TRUE for B-frames > 0 and PA enabled     |                   Not set                    |                   Not set                    |     TRUE for B-frames > 0 and PA enabled     |     TRUE for B-frames > 0 and PA enabled     |


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This PR provides new recommended defaults for the AMD encoders that have been optimized for perceptual quality. The settings are automatically applied depending on the resolution and framerate. The default settings can be overridden as expected and only provide an improved base foundation for encoder settings targeted at improving perceptual quality.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on RX 5000, 6000, and 7000 series cards using public driver version 24.2.1.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
