### PR TITLE
libobs: Make video frame header public

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -273,6 +273,7 @@ set(public_headers
     media-io/audio-io.h
     media-io/frame-rate.h
     media-io/media-io-defs.h
+    media-io/video-frame.h
     media-io/video-io.h
     obs-audio-controls.h
     obs-config.h


### PR DESCRIPTION
### Description
This fixes compilation of third party plugins that need this header.

### Motivation and Context
My plugin, https://github.com/cg2121/obs-decklink-output-filter, currently fails compilation on macOS, as the header cannot be found.

### How Has This Been Tested?
Hasn't been tested because the plugin template pulls the released OBS Studio. It doesn't fail on my Linux machine, just on macOS in the CI. I can't test on macOS because I don't have an up to date machine. It should just be a harmless change, though.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
