### PR TITLE
obs-outputs: Refine certificate selection on macOS

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -315,13 +315,13 @@ RTMP_TLS_LoadCerts(RTMP *r) {
     CertFreeCertificateContext(pCertContext);
     CertCloseStore(hCertStore, 0);
 #elif defined(__APPLE__)
-    CFTypeRef keys[4] = {kSecClass, kSecMatchLimit, kSecReturnAttributes,
-                 kSecReturnData};
+    CFTypeRef keys[6] = {kSecClass, kSecMatchLimit, kSecReturnAttributes,
+                 kSecReturnData, kSecMatchTrustedOnly, kSecMatchValidOnDate};
 
-    CFTypeRef values[4] = {kSecClassCertificate, kSecMatchLimitAll,
-                   kCFBooleanFalse, kCFBooleanTrue};
+    CFTypeRef values[6] = {kSecClassCertificate, kSecMatchLimitAll,
+                   kCFBooleanFalse, kCFBooleanTrue, kCFBooleanTrue, kCFNull};
     CFDictionaryRef query =
-        CFDictionaryCreate(kCFAllocatorDefault, keys, values, 4,
+        CFDictionaryCreate(kCFAllocatorDefault, keys, values, 6,
                    &kCFTypeDictionaryKeyCallBacks,
                    &kCFTypeDictionaryValueCallBacks);
 


### PR DESCRIPTION
### Description
Updates Keychain query on macOS to limit returned data to certificates that are valid (based on current datetime) and trusted only.

### Motivation and Context
Refines implementation on macOS, as only valid and trusted certificates should have been used in the first place.

### How Has This Been Tested?
Tested on macOS 13.4.1. and successfully streamed via RTMPS and HLS.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
