### PR TITLE
UI: Fix YouTubeAppDock restore dock state

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -174,7 +174,12 @@ void YoutubeAuth::LoadUI()
 
 	if (firstLoad) {
 		chat->setVisible(true);
-	} else {
+	}
+#endif
+
+	main->NewYouTubeAppDock();
+
+	if (!firstLoad) {
 		const char *dockStateStr = config_get_string(
 			main->Config(), service(), "DockState");
 		QByteArray dockState =
@@ -183,7 +188,6 @@ void YoutubeAuth::LoadUI()
 		if (main->isVisible() || !main->isMaximized())
 			main->restoreState(dockState);
 	}
-#endif
 
 	uiLoaded = true;
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2190,6 +2190,12 @@ void OBSBasic::OBSInit()
 	}
 #endif
 
+#ifdef YOUTUBE_ENABLED
+	/* setup YouTube app dock */
+	if (YouTubeAppDock::IsYTServiceSelected())
+		youtubeAppDock = new YouTubeAppDock();
+#endif
+
 	const char *dockStateStr = config_get_string(
 		App()->GlobalConfig(), "BasicWindow", "DockState");
 
@@ -2333,12 +2339,6 @@ void OBSBasic::OBSInit()
 
 	UpdatePreviewProgramIndicators();
 	OnFirstLoad();
-
-#ifdef YOUTUBE_ENABLED
-	/* setup YouTube app dock */
-	if (YouTubeAppDock::IsYTServiceSelected())
-		youtubeAppDock = new YouTubeAppDock();
-#endif
 
 	if (!hideWindowOnStart)
 		activateWindow();

--- a/UI/window-dock-youtube-app.cpp
+++ b/UI/window-dock-youtube-app.cpp
@@ -128,15 +128,6 @@ void YouTubeAppDock::AddYouTubeAppDock(const QString &title)
 	if (IsYTServiceSelected()) {
 		const std::string url = InitYTUserUrl();
 		CreateBrowserWidget(url);
-
-		// reload panel layout
-		const char *dockStateStr = config_get_string(
-			App()->GlobalConfig(), "BasicWindow", "DockState");
-		if (dockStateStr) {
-			QByteArray dockState = QByteArray::fromBase64(
-				QByteArray(dockStateStr));
-			OBSBasic::Get()->restoreState(dockState);
-		}
 	} else {
 		this->setVisible(false);
 		actionYTAppDock->setVisible(false);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Creates the dock at the right moment to never require its own dock state restoration.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

YouTubeAppDock rather than being created before OBS Studio own dock state restore. Restore the dock state each time the dock are created so it can suddenly revert the actual dock state.

It also does not checks if the integration is enabled which doesn't use the same dock state config.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Run OBS with YouTube service selected in the config, no issue the dock is loaded.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
