### PR TITLE
CI: Add write permissions to contents scope to service validator

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -37,6 +37,7 @@ jobs:
     runs-on: macos-13
     permissions:
       checks: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Check for Defunct Services 📉

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: macos-13
     permissions:
       checks: write
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### Description
Adds the "write" permission to the contents scope for the service validator job in scheduled and dispatched workflows.

The action's documentation unfortunately does not spell out which API permissions are required for the token and neither GitHub's documentation spells this out directly, so this fix is based on an educated guess.

### Motivation and Context
Current implementation seems to lack required permissions to push a new branch to the repository, which leads to the job failing when actual unrecoverable changes to services are detected.

### How Has This Been Tested?
Needs to be tested after merging unfortunately as it needs to be merged on the master branch and then run as part of a scheduled or dispatched workflow run.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
