### PR TITLE
CI: Remove optimistic continuation of disk image creation for macOS

### DIFF
--- a/.github/scripts/utils.zsh/create_diskimage
+++ b/.github/scripts/utils.zsh/create_diskimage
@@ -26,14 +26,6 @@ safe_hdiutil() {
   local -r -a _backoff=(2 5 10 15 30)
 
   for i ({1..5}) {
-    if [[ ${1} == detach ]] {
-      if ! [[ -d ${@[-1]} ]] {
-        log_warning "Volume at mountpoint ${@[-1]} is not mounted anymore. Continuing."
-        _status=0
-        break
-      }
-    }
-
     hdiutil ${@} && _status=0 || _status=1
 
     if (( _status )) {


### PR DESCRIPTION
### Description
Remove code that optimistically continues with disk image creation if mount point is gone after unsuccessful detach attempt.

### Motivation and Context
The situation of the mount point being unmounted after an unsuccessful detach attempt leads to an unrecoverable situation. Instead of optimistically continuing, the script has to fail.

### How Has This Been Tested?
Was tested on CI before the extra branch was added.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
