### PR TITLE
UI: Use os_generate_uuid for new uuid

### DIFF
--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -127,18 +127,6 @@ try {
 
 /* ------------------------------------------------------------------------ */
 
-void GenerateGUID(std::string &guid)
-{
-	const char alphabet[] = "0123456789abcdef";
-	QRandomGenerator *rng = QRandomGenerator::system();
-
-	guid.resize(40);
-
-	for (size_t i = 0; i < 40; i++) {
-		guid[i] = alphabet[rng->bounded(0, 16)];
-	}
-}
-
 std::string GetProgramGUID()
 {
 	static std::mutex m;
@@ -154,7 +142,9 @@ std::string GetProgramGUID()
 		guid = pguid;
 
 	if (guid.empty()) {
-		GenerateGUID(guid);
+		BPtr<char> newId = os_generate_uuid();
+
+		guid = newId;
 
 		if (!guid.empty())
 			config_set_string(GetGlobalConfig(), "General",


### PR DESCRIPTION
### Description
This uses os_generate_uuid for UUID generation in the shared-update code. 

### Motivation and Context
Currently, the UUID is a random array of bytes. The 6 bits meant for version are missing meaning it's currently just a 128-bit random set of bytes. It doesn't follow the UUIDv4 format. In addition, the logic to generate the UUID is duplicated and different from what os_generate_uuid does already for us. This change makes it more consistent.

### How Has This Been Tested?
* Started the application with an empty global ini.
* Started the application with a populated INI (with the UUID already present).

### Types of changes
- Tweak
- Code cleanup

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
       (Hopefully I did this right...)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
