### PR TITLE
CI: Fix services validator being unable to create Pull Requests

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -38,6 +38,7 @@ jobs:
     permissions:
       checks: write
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - name: Check for Defunct Services 📉

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       checks: write
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add write permission to the pull-request scope for the services-availability and services-validation jobs to allow them to create and update Pull Requests.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The Scheduled workflow [began failing recently](https://github.com/obsproject/obs-studio/actions/runs/5733238307) once it tried to create a pull request to remove defunct services. In #9367, we added `write` permissions to the `contents` scope to the services-availability and services-validation jobs to try to resolve this error:
``` 
Wed, 02 Aug 2023 00:31:02 GMT   Pushing pull request branch to 'origin/automated/clean-services'
Wed, 02 Aug 2023 00:31:02 GMT   /usr/local/bin/git push --force-with-lease origin HEAD:refs/heads/automated/clean-services
Wed, 02 Aug 2023 00:31:02 GMT   remote: Permission to obsproject/obs-studio.git denied to github-actions[bot].
Wed, 02 Aug 2023 00:31:02 GMT   fatal: unable to access 'https://github.com/obsproject/obs-studio/': The requested URL returned error: 403
Wed, 02 Aug 2023 00:31:02 GMT   Error: The process '/usr/local/bin/git' failed with exit code 128
```

With the error seemingly being unable to push git commits, applying the permission `contents: write` at the job level was believed needed to resolve that. After merging that PR, the [next run of the job](https://github.com/obsproject/obs-studio/actions/runs/5773566542/job/15649655693) proceeded further, but failed at a later point: creating the pull request.
```
Sun, 06 Aug 2023 00:31:25 GMT   Create or update the pull request
Sun, 06 Aug 2023 00:31:25 GMT   Attempting creation of pull request
Sun, 06 Aug 2023 00:31:25 GMT   Error: Resource not accessible by integration
```

I dug into the GitHub Action that we use for creating the pull requests to figure out where the error occurs. I believe that is here:
https://github.com/peter-evans/create-pull-request/blob/f094b77505fb89581e68a1163fbd2fffece39da1/src/github-helper.ts#L49-L76

I further dug into what `this.octokit.rest.pulls.create` does and [it seems to be a wrapper](https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/v5.13.0/docs/pulls/create.md) for the GitHub API Endpoint `POST /repos/{owner}/{repo}/pulls`. The GitHub docs for that endpoint, and the docs for job permissions in workflows, suggest that the `write` permission is needed to use this endpoint:
* https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
* https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions
* https://docs.github.com/en/rest/overview/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This has not been tested. This is a best guess attempt to fix the issue.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
