### PR TITLE
UI/updater: Retain OBS launch arguments

### DIFF
--- a/UI/update/win-update.cpp
+++ b/UI/update/win-update.cpp
@@ -345,13 +345,25 @@ try {
 	execInfo.cbSize = sizeof(execInfo);
 	execInfo.lpFile = wUpdateFilePath;
 
-	string parameters = "";
-	if (App()->IsPortableMode())
-		parameters += "--portable";
-	if (branch != WIN_DEFAULT_BRANCH) {
+	string parameters;
+	if (branch != WIN_DEFAULT_BRANCH)
+		parameters += "--branch=" + branch;
+
+	obs_cmdline_args obs_args = obs_get_cmdline_args();
+	for (int idx = 1; idx < obs_args.argc; idx++) {
 		if (!parameters.empty())
 			parameters += " ";
-		parameters += "--branch=" + branch;
+
+		parameters += obs_args.argv[idx];
+	}
+
+	/* Portable mode can be enabled via sentinel files, so copying the
+	 * command line doesn't guarantee the flag to be there. */
+	if (App()->IsPortableMode() &&
+	    parameters.find("--portable") == string::npos) {
+		if (!parameters.empty())
+			parameters += " ";
+		parameters += "--portable";
 	}
 
 	BPtr<wchar_t> lpParameters;

--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -1833,7 +1833,7 @@ static void CancelUpdate(bool quit)
 	}
 }
 
-static void LaunchOBS(bool portable)
+static void LaunchOBS(LPWSTR lpCmdLine)
 {
 	wchar_t newCwd[MAX_PATH];
 	wchar_t obsPath[MAX_PATH];
@@ -1859,8 +1859,8 @@ static void LaunchOBS(bool portable)
 	execInfo.lpDirectory = newCwd;
 	execInfo.nShow = SW_SHOWNORMAL;
 
-	if (portable)
-		execInfo.lpParameters = L"--portable";
+	if (lpCmdLine[0])
+		execInfo.lpParameters = lpCmdLine;
 
 	ShellExecuteEx(&execInfo);
 }
@@ -1978,9 +1978,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
 	wchar_t cwd[MAX_PATH];
 	GetCurrentDirectoryW(_countof(cwd) - 1, cwd);
 
-	bool isPortable = wcsstr(lpCmdLine, L"Portable") != nullptr ||
-			  wcsstr(lpCmdLine, L"--portable") != nullptr;
-
 	if (!IsWindows10OrGreater()) {
 		MessageBox(
 			nullptr,
@@ -2015,7 +2012,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
 					obs_base_directory, nullptr);
 			SetCurrentDirectory(obs_base_directory);
 
-			LaunchOBS(isPortable);
+			LaunchOBS(lpCmdLine);
 		}
 
 		if (hLowMutex) {
@@ -2064,7 +2061,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, LPWSTR lpCmdLine, int)
 		WinHandle hMutex = OpenMutex(
 			SYNCHRONIZE, false, L"OBSUpdaterRunningAsNonAdminUser");
 		if (msg.wParam == 1 && !hMutex) {
-			LaunchOBS(isPortable);
+			LaunchOBS(lpCmdLine);
 		}
 
 		return (int)msg.wParam;


### PR DESCRIPTION
### Description

Updates the UI and updater to run relaunch OBS with the same arguments that were originally used to launch it.

### Motivation and Context

Options should be kept after updating, and @Warchamp7 complained.

### How Has This Been Tested?

- Launched updater via OBS to confirm that arguments are passed-through
- Launched OBS from updater to confirm that arguments are retained

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
