### PR TITLE
obs-webrtc: Improve WHIP compliance

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -313,6 +313,8 @@ bool WHIPOutput::Connect()
 	curl_easy_setopt(c, CURLOPT_POST, 1L);
 	curl_easy_setopt(c, CURLOPT_COPYPOSTFIELDS, offer_sdp);
 	curl_easy_setopt(c, CURLOPT_TIMEOUT, 8L);
+	curl_easy_setopt(c, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(c, CURLOPT_UNRESTRICTED_AUTH, 1L);
 
 	auto cleanup = [&]() {
 		curl_easy_cleanup(c);

--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -45,7 +45,7 @@ static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
 static size_t curl_header_location_function(char *data, size_t size,
 					    size_t nmemb, void *priv_data)
 {
-	auto header_buffer = static_cast<std::string *>(priv_data);
+	auto header_buffer = static_cast<std::vector<std::string> *>(priv_data);
 
 	size_t real_size = size * nmemb;
 
@@ -54,8 +54,11 @@ static size_t curl_header_location_function(char *data, size_t size,
 
 	if (!astrcmpi_n(data, "location: ", LOCATION_HEADER_LENGTH)) {
 		char *val = data + LOCATION_HEADER_LENGTH;
-		header_buffer->append(val, real_size - LOCATION_HEADER_LENGTH);
-		*header_buffer = trim_string(*header_buffer);
+		auto header_temp =
+			std::string(val, real_size - LOCATION_HEADER_LENGTH);
+
+		header_temp = trim_string(header_temp);
+		header_buffer->push_back(header_temp);
 	}
 
 	return real_size;


### PR DESCRIPTION
### Description
Improves WHIP compliance around the handling of Location headers.

If the location header isn't present we don't allow the session to start. We also now support Absolute and Relative Location headers. 

This cherry-picks https://github.com/obsproject/obs-studio/pull/9306 and then adds additional checks

### Motivation and Context
I want to make sure we are as compliant as possible. If we ship a release with compliance issues we will have to support it forever. 

### How Has This Been Tested?
Tested against 
* AWS IVS
* Broadcast Box
* Cloudflare

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
