### PR TITLE
obs-ffmpeg: Remove media source mpegts format override for SRT and RIST

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -425,14 +425,7 @@ static void ffmpeg_source_tick(void *data, float seconds)
 	}
 }
 
-#define SRT_PROTO "srt"
 #define RIST_PROTO "rist"
-
-static bool requires_mpegts(const char *path)
-{
-	return !astrcmpi_n(path, SRT_PROTO, sizeof(SRT_PROTO) - 1) ||
-	       !astrcmpi_n(path, RIST_PROTO, sizeof(RIST_PROTO) - 1);
-}
 
 static void ffmpeg_source_update(void *data, obs_data_t *settings)
 {
@@ -468,10 +461,6 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 		should_restart_media = true;
 		input = obs_data_get_string(settings, "input");
 		input_format = obs_data_get_string(settings, "input_format");
-		if (requires_mpegts(input)) {
-			input_format = "mpegts";
-			obs_data_set_string(settings, "input_format", "mpegts");
-		}
 		s->reconnect_delay_sec =
 			(int)obs_data_get_int(settings, "reconnect_delay_sec");
 		s->reconnect_delay_sec = s->reconnect_delay_sec == 0


### PR DESCRIPTION
### Description
Removes the hardcoded format override for the media source

Fixes #9388

### Motivation and Context
FFmpeg is already very effective at detecting the correct input format for socket-style protocols (SRT, RIST, TCP, UDP etc). By overriding the format of SRT and RIST manually to mpegts, the user is being prevented from using other container formats via these protocols.

In the rare case that libavformat is unable to detect the correct container format for an SRT or RIST stream, the user may manually specify that format in the existing format field.

With the FFmpeg options field which was recently added, probe options may be specified by the user to further tune format detection.

### How Has This Been Tested?
Wasn't able to test due to not updating my Ubuntu 20.04 machine to 22 yet, but the change is dead simple.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
