### PR TITLE
obs-qsv11: Fix adapter enumeration in test app

### DIFF
--- a/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
+++ b/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
@@ -60,6 +60,7 @@ static bool get_adapter_caps(IDXGIFactory *factory, mfxLoader loader,
 			     mfxSession m_session, uint32_t adapter_idx)
 {
 	HRESULT hr;
+	static uint32_t idx_adjustment = 0;
 
 	ComPtr<IDXGIAdapter> adapter;
 	hr = factory->EnumAdapters(adapter_idx, &adapter);
@@ -71,15 +72,18 @@ static bool get_adapter_caps(IDXGIFactory *factory, mfxLoader loader,
 
 	uint32_t luid_idx = get_adapter_idx(adapter_idx, desc.AdapterLuid);
 	adapter_caps &caps = adapter_info[luid_idx];
-	if (desc.VendorId != INTEL_VENDOR_ID)
+	if (desc.VendorId != INTEL_VENDOR_ID) {
+		idx_adjustment++;
 		return true;
+	}
 
 	caps.is_intel = true;
 
 	mfxImplDescription *idesc;
-	mfxStatus sts = MFXEnumImplementations(
-		loader, adapter_idx, MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
-		reinterpret_cast<mfxHDL *>(&idesc));
+	mfxStatus sts =
+		MFXEnumImplementations(loader, adapter_idx - idx_adjustment,
+				       MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
+				       reinterpret_cast<mfxHDL *>(&idesc));
 
 	if (sts != MFX_ERR_NONE)
 		return false;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
MFXEnumImplementations expects the adapter index to be within a range of valid Intel adapters produced by MFXLoad and the config filter. If a system has one non-Intel high performance GPU and one Intel iGPU, OBS and the test app will see the Intel iGPU as index 1 due to high performance hints, but MFXEnumImplementations will expect only one valid index, 0. In this scenario, passing a value of 1 to MFXEnumImplementations will cause it to abort and return MFX_ERR_NOT_FOUND (Provided index is out of possible range). This causes subsequent capabilities testing to fail.

To avoid this, let's track how many non-Intel adapters we see and subtract that number from adapterIdx to only pass valid index to MFXEnumImplementations.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want QSV to be correctly detected on multi-GPU mixed vendor systems.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my Windows 10 machine (i7-7700HQ + NVIDIA GTX 1060 + Intel HD Graphics 630). Made sure that after this change `obs-qsv-test.exe` produced the correct output and that QSV options were correctly available in the OBS UI and that I could use them.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
