### PR TITLE
UI: Ignore empty Streamlabs hotkeys

### DIFF
--- a/UI/importers/sl.cpp
+++ b/UI/importers/sl.cpp
@@ -22,6 +22,10 @@ using namespace json11;
 
 static string translate_key(const string &sl_key)
 {
+	if (sl_key.empty()) {
+		return "IGNORE";
+	}
+
 	if (sl_key.substr(0, 6) == "Numpad" && sl_key.size() == 7) {
 		return "OBS_KEY_NUM" + sl_key.substr(6);
 	} else if (sl_key.substr(0, 3) == "Key") {
@@ -171,6 +175,9 @@ static void get_hotkey_bindings(Json::object &out_hotkeys,
 
 			string key =
 				translate_key(binding["key"].string_value());
+
+			if (key == "IGNORE")
+				continue;
 
 			out_hotkey.push_back(
 				Json::object{{"control", modifiers["ctrl"]},


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
This change fixes unwanted behavior with hotkeys when importing a scene collection from a recent version of Streamlabs Desktop. They have changed how empty hotkeys are stored in a users scene collection .json so this updates the importer to ignore empty hotkeys.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users in the community discord server have reported that scene collections they have imported from Streamlabs Desktop have unwanted hotkeys for various actions within OBS, which this fixes.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Took a scene collection exported from Streamlabs Desktop and imported it to OBS, saw that it no longer had the erroneous hotkeys as it did prior to this change. Compared the two scene collections from before and after this change to ensure there were no unwanted consequences.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
