### PR TITLE
UI: Use QGroupBox::toggled signal for group changes

### DIFF
--- a/UI/window-basic-settings-a11y.cpp
+++ b/UI/window-basic-settings-a11y.cpp
@@ -50,6 +50,7 @@ void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 {
 	config_t *config = GetGlobalConfig();
 
+	loading = true;
 	if (!presetChange) {
 		preset = config_get_int(config, "Accessibility", "ColorPreset");
 
@@ -107,6 +108,8 @@ void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 	}
 
 	UpdateA11yColors();
+
+	loading = false;
 }
 
 void OBSBasicSettings::SaveA11ySettings()

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -334,7 +334,7 @@ void RestrictResetBitrates(initializer_list<QComboBox *> boxes, int maxbitrate);
 #define EDIT_CHANGED    &QLineEdit::textChanged
 #define CBEDIT_CHANGED  &QComboBox::editTextChanged
 #define CHECK_CHANGED   &QCheckBox::clicked
-#define GROUP_CHANGED   &QGroupBox::clicked
+#define GROUP_CHANGED   &QGroupBox::toggled
 #define SCROLL_CHANGED  &QSpinBox::valueChanged
 #define DSCROLL_CHANGED &QDoubleSpinBox::valueChanged
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The QGroupBox::clicked is specifically for mouse clicks. This means that it's not emitted if the "checked" property is modified through other means than the mouse, for example programatically or through accessibility software like VoiceOver.
However, we do want to catch such events, so the QGroupBox::toggle signal (which as per the Qt documentation is the notified signal for the "checked" property) is the appropriate one to use.

As for the first commit, loading needs to be set to true to avoid the signal from activating the button while the settings are loading in. This should have always been done but just wasn't detected as the correct signal wasn't used so it wasn't triggered until now (also because there are no other settings in Accessibility that would have revealed this bug).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed when rebasing https://github.com/obsproject/obs-studio/pull/6700 (yet to be force-pushed).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested that without the fix, using VoiceOver to toggle the "Use Different Colors" GroupBox in the Accessibility settings (a bit ironic I must say :p), the Apply button didn't activate.
Tested that with the fix, it does activate when using VoiceOver to toggle it.
Tested that both with and without the fix, using the mouse to toggle the checkbox changes activates the Apply button.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
