### PR TITLE
mac-virtualcam: Fix crash on macOS when starting virtualcam output

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -376,7 +376,9 @@ static bool virtualcam_output_start(void *data)
         vcam->deviceID = 0;
         NSString *OBSVirtualCamUUID = [[NSBundle bundleWithIdentifier:@"com.obsproject.mac-virtualcam"]
             objectForInfoDictionaryKey:@"OBSCameraDeviceUUID"];
-        for (size_t i = 0; i < (used * sizeof(CMIOObjectID)); i++) {
+
+        size_t num_elements = size / sizeof(CMIOObjectID);
+        for (size_t i = 0; i < num_elements; i++) {
             CMIOObjectID cmioDevice;
             [cmioDevices getBytes:&cmioDevice range:NSMakeRange(i * sizeof(CMIOObjectID), sizeof(CMIOObjectID))];
 
@@ -406,7 +408,7 @@ static bool virtualcam_output_start(void *data)
         void *stream_data = [streamIds mutableBytes];
         CMIOObjectGetPropertyData(vcam->deviceID, &address, 0, NULL, size, &used, stream_data);
 
-        if (used < (2 * sizeof(CMIOStreamID))) {
+        if (size < (2 * sizeof(CMIOStreamID))) {
             obs_output_set_last_error(vcam->output, obs_module_text("Error.SystemExtension.CameraNotStarted"));
             return false;
         }


### PR DESCRIPTION
### Description
Fixes a crash on start of virtualcam output on macOS introduced by a recent change to use `NSData` instead of variable-length arrays.

### Motivation and Context
Array iterations need to be determined by _dividing_ the byte size of the returned data by the size of a single object (not multiplied).

The actual value of `used` is undocumented, so using the more obvious `size` parameter makes the code also safer to use.

### How Has This Been Tested?
Tested on macOS 13.4, actively running virtual camera output with the new camera extension.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
