### PR TITLE
Update .clang-format rules for ObjC files for version 16

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -111,14 +111,13 @@ AlignArrayOfStructures: Right
 AlignConsecutiveAssignments: None
 AlignConsecutiveBitFields: None
 AlignConsecutiveDeclarations: None
-AlignConsecutiveMacros: AcrossComments
-#AlignConsecutiveMacros:
-#  Enabled: true
-#  AcrossEmptyLines: false
-#  AcrossComments: true
+AlignConsecutiveMacros:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortEnumsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLambdasOnASingleLine: None
 AttributeMacros: ['__unused', '__autoreleasing', '_Nonnull', '__bridge']
@@ -144,11 +143,10 @@ BraceWrapping:
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: true
-#BreakAfterAttributes: Never                                        # clang-format 16
-#BreakArrays: false                                                 # clang-format 16
-#BreakBeforeConceptDeclarations: Allowed
-BreakBeforeConceptDeclarations: true
-#BreakBeforeInlineASMColon: OnlyMultiline                           # clang-format 16
+BreakAfterAttributes: Never
+BreakArrays: false
+BreakBeforeConceptDeclarations: Allowed
+BreakBeforeInlineASMColon: OnlyMultiline
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterComma
 ColumnLimit: 120
@@ -163,18 +161,13 @@ IndentCaseBlocks: false
 IndentCaseLabels: true
 IndentExternBlock: Indent
 IndentGotoLabels: false
-#IndentRequiresClause: true                                         # clang-format 15
+IndentRequiresClause: true
 IndentWidth: 4
 IndentWrappedFunctionNames: true
-#InsertBraces: false                                                # clang-format 15
-#InsertNewlineAtEOF: true                                           # clang-format 16
-#IntegerLiteralSeparator:                                           # clang-format 16
-#  Binary: 0
-#  Decimal: 3
-#  Hex: -1
+InsertBraces: false
+InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 LambdaBodyIndentation: Signature
-#LineEnding: LF                                                     # clang-format 16
 NamespaceIndentation: All
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 4
@@ -182,14 +175,13 @@ ObjCBreakBeforeNestedBlockParam: false
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: true
 PPIndentWidth: -1
-#PackConstructorInitializers: NextLine                              # clang-format 14
-#QualifierAlignment: Left                                           # clang-format 14
-#QualifierOrder: ['inline', 'static', 'type', 'const', 'volatile' ] # clang-format 14
+PackConstructorInitializers: NextLine
+QualifierAlignment: Leave
 ReferenceAlignment: Right
-#RemoveSemicolon: false                                             # clang-format 16
-#RequiresClausePosition: WithPreceding                              # clang-format 15
-#RequiresExpressionIndentation: OuterScope                          # clang-format 16
-#SeparateDefinitionBlocks: Always                                   # clang-format 14
+RemoveSemicolon: false
+RequiresClausePosition: WithPreceding
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Always
 ShortNamespaceLines: 1
 SortIncludes: false
 #SortUsingDeclarations: LexicographicNumeric

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher-osx.mm
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher-osx.mm
@@ -42,5 +42,4 @@ void GetCurrentWindowTitle(string &title)
     }
 }
 
-void CleanupSceneSwitcher()
-{}
+void CleanupSceneSwitcher() {}

--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -183,12 +183,14 @@ void EnableOSXDockIcon(bool enable)
 @end
 
 @implementation DockView
+
 - (id)initWithIcon:(QIcon)icon
 {
     self = [super init];
     _icon = icon;
     return self;
 }
+
 - (void)drawRect:(NSRect)dirtyRect
 {
     CGSize size = dirtyRect.size;
@@ -205,6 +207,7 @@ void EnableOSXDockIcon(bool enable)
         context, CGRectMake(size.width * (1 - iconSize), 0, size.width * iconSize, size.height * iconSize), image);
     CGImageRelease(image);
 }
+
 @end
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type, bool prompt_for_permission)
@@ -304,8 +307,8 @@ void SetMacOSDarkMode(bool dark)
     }
 }
 
-void TaskbarOverlayInit()
-{}
+void TaskbarOverlayInit() {}
+
 void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
 {
     QIcon icon;
@@ -335,12 +338,14 @@ void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
 @end
 
 @implementation OBSApplication
+
 - (void)sendEvent:(NSEvent *)event
 {
     _handlingSendEvent = YES;
     [super sendEvent:event];
     _handlingSendEvent = NO;
 }
+
 @end
 
 void InstallNSThreadLocks()

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -173,6 +173,7 @@ static void hotkeys_retain(struct obs_hotkeys_platform *plat)
 }
 
 static inline void free_hotkeys_platform(obs_hotkeys_platform_t *plat);
+
 static void hotkeys_release(struct obs_hotkeys_platform *plat)
 {
     if (os_atomic_dec_long(&plat->refs) == -1)
@@ -556,6 +557,7 @@ err:
 }
 
 #define OBS_COCOA_MODIFIER_SIZE 7
+
 static void unichar_to_utf8(const UniChar *c, char *buff)
 {
     CFStringRef string = CFStringCreateWithCharactersNoCopy(NULL, c, 2, kCFAllocatorNull);
@@ -578,6 +580,7 @@ static char ctrl_str[OBS_COCOA_MODIFIER_SIZE];
 static char opt_str[OBS_COCOA_MODIFIER_SIZE];
 static char shift_str[OBS_COCOA_MODIFIER_SIZE];
 static char cmd_str[OBS_COCOA_MODIFIER_SIZE];
+
 static void init_utf_8_strings(void)
 {
     const UniChar ctrl_uni[] = {kControlUnicode, 0};
@@ -592,6 +595,7 @@ static void init_utf_8_strings(void)
 }
 
 static pthread_once_t strings_token = PTHREAD_ONCE_INIT;
+
 void obs_key_combination_to_str(obs_key_combination_t key, struct dstr *str)
 {
     struct dstr key_str = {0};
@@ -785,6 +789,7 @@ void obs_hotkeys_platform_free(struct obs_core_hotkeys *hotkeys)
 }
 
 typedef unsigned long NSUInteger;
+
 static bool mouse_button_pressed(obs_key_t key, bool *pressed)
 {
     int button = 0;

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -101,8 +101,7 @@ namespace {
     struct observer_handle : unique_ptr<remove_pointer<id>::type, decltype(remove_observer)> {
         using base = unique_ptr<remove_pointer<id>::type, decltype(remove_observer)>;
 
-        explicit observer_handle(id observer = nullptr) : base(observer, remove_observer)
-        {}
+        explicit observer_handle(id observer = nullptr) : base(observer, remove_observer) {}
     };
 
     struct av_video_info {
@@ -636,6 +635,7 @@ static inline bool update_audio(obs_source_audio *audio, CMSampleBufferRef sampl
 }
 
 @implementation OBSAVCaptureDelegate
+
 - (void)captureOutput:(AVCaptureOutput *)out
     didDropSampleBuffer:(CMSampleBufferRef)sampleBuffer
          fromConnection:(AVCaptureConnection *)connection
@@ -688,6 +688,7 @@ static inline bool update_audio(obs_source_audio *audio, CMSampleBufferRef sampl
         obs_source_output_audio(capture->source, audio);
     }
 }
+
 @end
 
 static void av_capture_enable_buffering(av_capture *capture, bool enabled)
@@ -1579,6 +1580,7 @@ static media_frames_per_second convert(CMTime time_)
 }
 
 using frame_rates_t = vector<pair<media_frames_per_second, media_frames_per_second>>;
+
 static frame_rates_t enumerate_frame_rates(AVCaptureDevice *dev, const CMVideoDimensions *dims = nullptr)
 {
     frame_rates_t res;
@@ -2159,6 +2161,7 @@ static void av_capture_update(void *data, obs_data_t *settings)
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("mac-avcapture", "en-US")
+
 MODULE_EXPORT const char *obs_module_description(void)
 {
     return "MacOS AVFoundation Capture source";

--- a/plugins/mac-syphon/SyphonOBSClient.m
+++ b/plugins/mac-syphon/SyphonOBSClient.m
@@ -14,4 +14,5 @@
 {
     return [self newSurface];
 }
+
 @end

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALMachClient.mm
@@ -12,6 +12,7 @@
 @interface OBSDALMachClient () <NSPortDelegate> {
     NSPort *_receivePort;
 }
+
 @end
 
 @implementation OBSDALMachClient

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugIn.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugIn.mm
@@ -37,6 +37,7 @@ typedef enum {
     //! Timeout timer when we haven't received frames for 5s
     dispatch_source_t _timeoutTimer;
 }
+
 @property OBSDALPlugInState state;
 @property OBSDALMachClient *machClient;
 

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALPlugInInterface.mm
@@ -243,6 +243,7 @@ OSStatus HardwarePlugIn_ObjectSetPropertyData(CMIOHardwarePlugInRef self, CMIOOb
 }
 
 #pragma mark CMIOStream Operations
+
 OSStatus HardwarePlugIn_StreamCopyBufferQueue(CMIOHardwarePlugInRef self, CMIOStreamID streamID,
                                               CMIODeviceStreamQueueAlteredProc queueAlteredProc,
                                               void *queueAlteredRefCon, CMSimpleQueueRef *queue)
@@ -262,6 +263,7 @@ OSStatus HardwarePlugIn_StreamCopyBufferQueue(CMIOHardwarePlugInRef self, CMIOSt
 }
 
 #pragma mark CMIODevice Operations
+
 OSStatus HardwarePlugIn_DeviceStartStream(CMIOHardwarePlugInRef self, CMIODeviceID deviceID, CMIOStreamID streamID)
 {
     DLogFunc(@"self=%p device=%d stream=%d", self, deviceID, streamID);

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -7,6 +7,7 @@
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("mac-virtualcam", "en-US")
+
 MODULE_EXPORT const char *obs_module_description(void)
 {
     return "macOS virtual webcam output";


### PR DESCRIPTION
### Description
Updates ObjC-specific `clang-format` rules to coincide with https://github.com/obsproject/obs-studio/pull/9401.

### Motivation and Context
Update files to updated `clang-format` version.

### How Has This Been Tested?
Tested locally on macOS 13 with `clang-format` 16.0.5.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
