### PR TITLE
libobs: Fix holding possibly released pointer in obs_output_t

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1100,7 +1100,6 @@ struct obs_output {
 
 	uint32_t starting_drawn_count;
 	uint32_t starting_lagged_count;
-	uint32_t starting_frame_count;
 
 	int total_frames;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -201,8 +201,10 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 	} else {
 		output->info = *info;
 	}
-	output->video = obs_get_video();
-	output->audio = obs_get_audio();
+	if (!flag_encoded(output)) {
+		output->video = obs_get_video();
+		output->audio = obs_get_audio();
+	}
 	if (output->info.get_defaults)
 		output->info.get_defaults(output->context.settings);
 
@@ -331,6 +333,8 @@ bool obs_output_actual_start(obs_output_t *output)
 	if (success && output->video) {
 		output->starting_frame_count =
 			video_output_get_total_frames(output->video);
+	}
+	if (success) {
 		output->starting_drawn_count = obs->video.total_frames;
 		output->starting_lagged_count = obs->video.lagged_frames;
 	}
@@ -1331,6 +1335,10 @@ static inline bool has_scaling(const struct obs_output *output)
 const struct video_scale_info *
 obs_output_get_video_conversion(struct obs_output *output)
 {
+	if (log_flag_encoded(output, __FUNCTION__, true) ||
+	    !log_flag_video(output, __FUNCTION__))
+		return NULL;
+
 	if (output->video_conversion_set) {
 		if (!output->video_conversion.width)
 			output->video_conversion.width =

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -330,10 +330,6 @@ bool obs_output_actual_start(obs_output_t *output)
 	if (output->context.data)
 		success = output->info.start(output->context.data);
 
-	if (success && output->video) {
-		output->starting_frame_count =
-			video_output_get_total_frames(output->video);
-	}
 	if (success) {
 		output->starting_drawn_count = obs->video.total_frames;
 		output->starting_lagged_count = obs->video.lagged_frames;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

In this PR, `video` and `audio` in `struct obs_output_t` will be left NULL if the output is an encoded output type.

To avoid NULL pointer access, adds a guard for `obs_output_get_video_conversion` to return NULL if not a raw-video output.

Also removes `starting_frame_count` because it's never read.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I observed random crashes while auto-configuration wizard in these environment.
- Windows running on a GitHub Actions runner.
  - Crash log: https://cdn.discordapp.com/attachments/697237531426685029/1137964909670441041/Crash_2023-08-06_13-28-47.txt
  - Log: https://cdn.discordapp.com/attachments/697237531426685029/1137964910001782794/2023-08-06_13-28-27.txt
- Ubuntu 22.04 running on Docker.

I also observed random crashes when started recording after changing advanced settings such as autoRemux.

Currently, the auto-configuration for x264, `AutoConfigTestPage::TestSoftwareEncoding`, processed as below and accessed a released pointer.

1. Calls the function `obs_output_create`. The `video` member variable is set.
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/UI/window-basic-auto-config-test.cpp#L580-L581
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/libobs/obs-output.c#L204-L205

2. Calls `testMode.SetVideo` to change the video settings. This will results the `video_t` to be destroyed.
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/UI/window-basic-auto-config-test.cpp#L703

3. Calls `obs_output_set_media`, however this does not update `video` since the output flag has `OBS_OUTPUT_ENCODED`.
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/UI/window-basic-auto-config-test.cpp#L709
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/libobs/obs-output.c#L845-L856
   This line was introduced by #8873.

4. Calls `obs_output_start` and it calls `obs_output_actual_start`.
   https://github.com/obsproject/obs-studio/blob/e02f782bc62f0497e118316871ba1d15f6b5a6be/UI/window-basic-auto-config-test.cpp#L726
   `video`, which has already been destroyed, is accessed as below.
   https://github.com/tt2468/obs-studio/blob/3175ba4b018b8995210eaeffc1083412cfd249e6/libobs/obs-output.c#L329-L334

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Added a modification as below to cause the crash always happens. (`video_output_open` followed by `video_output_close` usually allocates the same address on my environment so that I removed `bfree` to trigger the crash.)
```patch
diff --git a/libobs/media-io/video-io.c b/libobs/media-io/video-io.c
index 4ac8d357a..b0638a232 100644
--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -269,6 +269,8 @@ int video_output_open(video_t **video, struct video_output_info *info)
 
 	init_cache(out);
 
+	blog(LOG_DEBUG, "video_output_open video=%p", out);
+
 	*video = out;
 	return VIDEO_OUTPUT_SUCCESS;
 
@@ -304,7 +306,9 @@ void video_output_close(video_t *video)
 	pthread_mutex_destroy(&video->data_mutex);
 	pthread_mutex_destroy(&video->input_mutex);
 
-	bfree(video);
+	blog(LOG_DEBUG, "video_output_close video=%p", video);
+
+	memset(video, 0xef, sizeof(*video));
 }
 
 static size_t video_get_input_idx(const video_t *video,
```
Then, tested on Ubuntu 22.04 running on Docker.

Also reviewed `obs-output.c` by eyeball to check these items.
- `output->video` is not set nor read if `OBS_OUTPUT_ENCODED` flag is set.
- `output->audio` is not set nor read if `OBS_OUTPUT_ENCODED` flag is set.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
