### PR TITLE
UI: Use inline function instead of macro to set color

### DIFF
--- a/UI/window-basic-settings-a11y.cpp
+++ b/UI/window-basic-settings-a11y.cpp
@@ -133,26 +133,25 @@ void OBSBasicSettings::SaveA11ySettings()
 	main->RefreshVolumeColors();
 }
 
-#define SetStyle(label, colorVal)                                             \
-	color = color_from_int(colorVal);                                     \
-	color.setAlpha(255);                                                  \
-	palette = QPalette(color);                                            \
-	label->setFrameStyle(QFrame::Sunken | QFrame::Panel);                 \
-	label->setText(color.name(QColor::HexRgb));                           \
-	label->setPalette(palette);                                           \
-	label->setStyleSheet(QString("background-color: %1; color: %2;")      \
-				     .arg(palette.color(QPalette::Window)     \
-						  .name(QColor::HexRgb))      \
-				     .arg(palette.color(QPalette::WindowText) \
-						  .name(QColor::HexRgb)));    \
-	label->setAutoFillBackground(true);                                   \
+static void SetStyle(QLabel *label, uint32_t colorVal)
+{
+	QColor color = color_from_int(colorVal);
+	color.setAlpha(255);
+	QPalette palette = QPalette(color);
+	label->setFrameStyle(QFrame::Sunken | QFrame::Panel);
+	label->setText(color.name(QColor::HexRgb));
+	label->setPalette(palette);
+	label->setStyleSheet(QString("background-color: %1; color: %2;")
+				     .arg(palette.color(QPalette::Window)
+						  .name(QColor::HexRgb))
+				     .arg(palette.color(QPalette::WindowText)
+						  .name(QColor::HexRgb)));
+	label->setAutoFillBackground(true);
 	label->setAlignment(Qt::AlignCenter);
+}
 
 void OBSBasicSettings::UpdateA11yColors()
 {
-	QPalette palette;
-	QColor color;
-
 	SetStyle(ui->color1, selectRed);
 	SetStyle(ui->color2, selectGreen);
 	SetStyle(ui->color3, selectBlue);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the `SetStyle` macro in a11y settings to a static inline function.
Macros can be hard to read and are usually not very friendly to use in a debugger. Using a static inline function instead [gives the same result](https://gcc.gnu.org/onlinedocs/gcc-3.1.1/gcc/Inline.html) when compiling with optimizations,  with the advantage of better syntax highlighting in IDEs and better debugger support.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this when working on https://github.com/obsproject/obs-studio/pull/9402. Like to fix (change? Not sure "fix" is the right word since it's not really a bug) small things like these when I see them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested that colors in Accessibility settings are still correctly set, as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
