### PR TITLE
sndio:  Remove variable-length array usage

### DIFF
--- a/plugins/sndio/sndio-input.c
+++ b/plugins/sndio/sndio-input.c
@@ -97,7 +97,7 @@ static void *sndio_thread(void *attr)
 	struct sndio_thr_data *thrdata = attr;
 	size_t msgread = 0; // msg bytes read from socket
 	size_t nsiofds = sio_nfds(thrdata->hdl);
-	struct pollfd pfd[1 + nsiofds];
+	struct pollfd *pfd = bzalloc(sizeof(struct pollfd) * (1 + nsiofds));
 	struct sio_par par;
 	uint64_t ts;
 	ssize_t nread;
@@ -114,7 +114,6 @@ static void *sndio_thread(void *attr)
 		goto finish;
 	}
 
-	memset(pfd, 0, sizeof(pfd));
 	pfd[0].fd = thrdata->sock;
 
 	for (;;) {
@@ -237,6 +236,7 @@ finish:
 	close(thrdata->sock);
 	bfree(buf);
 	bfree(thrdata);
+	bfree(pfd);
 	return NULL;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix building with `ENABLE_SNDIO=ON`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix building even if it's disabled by default

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Quickly tested by adding a sndio source. I have no experience with SNDIO.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
