### PR TITLE
linux-pipewire: Replace dynamic arrays with allocations

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -811,21 +811,12 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 
 	if (buffer->datas[0].type == SPA_DATA_DmaBuf) {
 		uint32_t planes = buffer->n_datas;
-		DARRAY(uint32_t) offsets;
-		DARRAY(uint32_t) strides;
-		DARRAY(uint64_t) modifiers;
-		DARRAY(int) fds;
+		uint32_t *offsets = alloca(sizeof(uint32_t) * planes);
+		uint32_t *strides = alloca(sizeof(uint32_t) * planes);
+		uint64_t *modifiers = alloca(sizeof(uint64_t) * planes);
+		int *fds = alloca(sizeof(int) * planes);
 		bool use_modifiers;
 		bool corrupt = false;
-
-		da_init(offsets);
-		da_reserve(offsets, planes);
-		da_init(strides);
-		da_reserve(strides, planes);
-		da_init(modifiers);
-		da_reserve(modifiers, planes);
-		da_init(fds);
-		da_reserve(fds, planes);
 
 #ifdef DEBUG_PIPEWIRE
 		blog(LOG_DEBUG,
@@ -847,13 +838,11 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		}
 
 		for (uint32_t plane = 0; plane < planes; plane++) {
-			da_push_back(fds, &buffer->datas[plane].fd);
-			da_push_back(offsets,
-				     &buffer->datas[plane].chunk->offset);
-			da_push_back(strides,
-				     &buffer->datas[plane].chunk->stride);
-			da_push_back(modifiers,
-				     &obs_pw_stream->format.info.raw.modifier);
+			fds[plane] = buffer->datas[plane].fd;
+			offsets[plane] = buffer->datas[plane].chunk->offset;
+			strides[plane] = buffer->datas[plane].chunk->stride;
+			modifiers[plane] =
+				obs_pw_stream->format.info.raw.modifier;
 			corrupt |= (buffer->datas[plane].chunk->flags &
 				    SPA_CHUNK_FLAG_CORRUPTED) > 0;
 		}
@@ -861,12 +850,6 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		if (corrupt) {
 			blog(LOG_DEBUG,
 			     "[pipewire] buffer contains corrupted data");
-
-			da_free(offsets);
-			da_free(strides);
-			da_free(modifiers);
-			da_free(fds);
-
 			goto read_metadata;
 		}
 
@@ -877,14 +860,8 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		obs_pw_stream->texture = gs_texture_create_from_dmabuf(
 			obs_pw_stream->format.info.raw.size.width,
 			obs_pw_stream->format.info.raw.size.height,
-			format_data.drm_format, GS_BGRX, planes, fds.array,
-			strides.array, offsets.array,
-			use_modifiers ? modifiers.array : NULL);
-
-		da_free(offsets);
-		da_free(strides);
-		da_free(modifiers);
-		da_free(fds);
+			format_data.drm_format, GS_BGRX, planes, fds, strides,
+			offsets, use_modifiers ? modifiers : NULL);
 
 		if (obs_pw_stream->texture == NULL) {
 			remove_modifier_from_format(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Replace dynamic arrays introduced in #9339 by allocations.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm not used to use alloc as variable-length arrays and so I used dynamic arrays in this previous PR.
With #9412 and this PR, I wanted to give a try.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I didn't get nay issue while using a window capture.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
