### PR TITLE
UI: Fix transform shortcuts with multiple items selected

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3391,28 +3391,9 @@ void OBSBasic::SourceToolBarActionsSetEnabled()
 	RefreshToolBarStyling(ui->sourcesToolbar);
 }
 
-void OBSBasic::UpdateTransformShortcuts()
-{
-	bool hasVideo = false;
-
-	OBSSource source = obs_sceneitem_get_source(GetCurrentSceneItem());
-
-	if (source) {
-		uint32_t flags = obs_source_get_output_flags(source);
-		hasVideo = (flags & OBS_SOURCE_VIDEO) != 0;
-	}
-
-	ui->actionEditTransform->setEnabled(hasVideo);
-	ui->actionCopyTransform->setEnabled(hasVideo);
-	ui->actionPasteTransform->setEnabled(hasVideo ? hasCopiedTransform
-						      : false);
-	ui->actionResetTransform->setEnabled(hasVideo);
-}
-
 void OBSBasic::UpdateContextBar(bool force)
 {
 	SourceToolBarActionsSetEnabled();
-	UpdateTransformShortcuts();
 
 	if (!ui->contextContainer->isVisible() && !force)
 		return;
@@ -8523,10 +8504,10 @@ void OBSBasic::DeleteYouTubeAppDock()
 void OBSBasic::UpdateEditMenu()
 {
 	QModelIndexList items = GetAllSelectedSourceItems();
-	int count = items.count();
+	int totalCount = items.count();
 	size_t filter_count = 0;
 
-	if (count == 1) {
+	if (totalCount == 1) {
 		OBSSceneItem sceneItem =
 			ui->sources->Get(GetTopSelectedSourceItem());
 		OBSSource source = obs_sceneitem_get_source(sceneItem);
@@ -8549,39 +8530,48 @@ void OBSBasic::UpdateEditMenu()
 			allowPastingDuplicate = false;
 	}
 
-	ui->actionCopySource->setEnabled(count > 0);
-	ui->actionEditTransform->setEnabled(count == 1);
-	ui->actionCopyTransform->setEnabled(count == 1);
-	ui->actionPasteTransform->setEnabled(hasCopiedTransform && count > 0);
+	int videoCount = 0;
+	bool canTransformMultiple = false;
+	for (int i = 0; i < totalCount; i++) {
+		OBSSceneItem item = ui->sources->Get(items.value(i).row());
+		OBSSource source = obs_sceneitem_get_source(item);
+		const uint32_t flags = obs_source_get_output_flags(source);
+		const bool hasVideo = (flags & OBS_SOURCE_VIDEO) != 0;
+		if (hasVideo && !obs_sceneitem_locked(item))
+			canTransformMultiple = true;
+
+		if (hasVideo)
+			videoCount++;
+	}
+	const bool canTransformSingle = videoCount == 1 && totalCount == 1;
+
+	ui->actionCopySource->setEnabled(totalCount > 0);
+	ui->actionEditTransform->setEnabled(canTransformSingle);
+	ui->actionCopyTransform->setEnabled(canTransformSingle);
+	ui->actionPasteTransform->setEnabled(hasCopiedTransform &&
+					     videoCount > 0);
 	ui->actionCopyFilters->setEnabled(filter_count > 0);
 	ui->actionPasteFilters->setEnabled(
-		!obs_weak_source_expired(copyFiltersSource) && count > 0);
+		!obs_weak_source_expired(copyFiltersSource) && totalCount > 0);
 	ui->actionPasteRef->setEnabled(!!clipboard.size());
 	ui->actionPasteDup->setEnabled(allowPastingDuplicate);
 
-	ui->actionMoveUp->setEnabled(count > 0);
-	ui->actionMoveDown->setEnabled(count > 0);
-	ui->actionMoveToTop->setEnabled(count > 0);
-	ui->actionMoveToBottom->setEnabled(count > 0);
+	ui->actionMoveUp->setEnabled(totalCount > 0);
+	ui->actionMoveDown->setEnabled(totalCount > 0);
+	ui->actionMoveToTop->setEnabled(totalCount > 0);
+	ui->actionMoveToBottom->setEnabled(totalCount > 0);
 
-	bool canTransform = false;
-	for (int i = 0; i < count; i++) {
-		OBSSceneItem item = ui->sources->Get(items.value(i).row());
-		if (!obs_sceneitem_locked(item))
-			canTransform = true;
-	}
-
-	ui->actionResetTransform->setEnabled(canTransform);
-	ui->actionRotate90CW->setEnabled(canTransform);
-	ui->actionRotate90CCW->setEnabled(canTransform);
-	ui->actionRotate180->setEnabled(canTransform);
-	ui->actionFlipHorizontal->setEnabled(canTransform);
-	ui->actionFlipVertical->setEnabled(canTransform);
-	ui->actionFitToScreen->setEnabled(canTransform);
-	ui->actionStretchToScreen->setEnabled(canTransform);
-	ui->actionCenterToScreen->setEnabled(canTransform);
-	ui->actionVerticalCenter->setEnabled(canTransform);
-	ui->actionHorizontalCenter->setEnabled(canTransform);
+	ui->actionResetTransform->setEnabled(canTransformMultiple);
+	ui->actionRotate90CW->setEnabled(canTransformMultiple);
+	ui->actionRotate90CCW->setEnabled(canTransformMultiple);
+	ui->actionRotate180->setEnabled(canTransformMultiple);
+	ui->actionFlipHorizontal->setEnabled(canTransformMultiple);
+	ui->actionFlipVertical->setEnabled(canTransformMultiple);
+	ui->actionFitToScreen->setEnabled(canTransformMultiple);
+	ui->actionStretchToScreen->setEnabled(canTransformMultiple);
+	ui->actionCenterToScreen->setEnabled(canTransformMultiple);
+	ui->actionVerticalCenter->setEnabled(canTransformMultiple);
+	ui->actionHorizontalCenter->setEnabled(canTransformMultiple);
 }
 
 void OBSBasic::on_actionEditTransform_triggered()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -671,8 +671,6 @@ private:
 
 	bool restartingVCam = false;
 
-	void UpdateTransformShortcuts();
-
 public slots:
 	void DeferSaveBegin();
 	void DeferSaveEnd();


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Firstly, removes the `UpdateTransformShortcuts()` method introduced in c33fa8b which was trying to re-implement the behavior of `UpdateEditMenu()`.
Secondly, updates `UpdateEditMenu()` to account for sources without video. Sources without video shouldn't be able to have their transform edited, copied, pasted, or changed in any other way (because they don't have one).

The Transform menu items are now enabled/disabled as per the following ("AV" in this context means both sources with audio *and* video as well as sources with only video, they behave the same. "Paste Transform if applicable" means "Paste Transform is enabled if a transform got copied before".):
- No item selected: 
  - No Transform items enabled.
- Single item selected:
  - Audio-only: No Transform items enabled
  - AV, locked: Edit and Copy Transform enabled. Paste Transform if applicable.
  - AV, unlocked: All Transform items enabled, except Paste Transform as applicable.
- Multiple items selected: Copy and Edit Transform always disabled
  - Only audio-only: No Transform items enabled.
  - Only AV, locked: No Transform items enabled, except Paste if Applicable.
  - Only AV, unlocked: All items enabled except Copy and Edit, and Paste if applicable.
  - Audio-only + AV, locked: No Transform items enabled.
  - Audio-only + AV, unlocked: All items enabled except Copy and Edit, and Paste if applicable.
  - AV, locked + AV, unlocked: All items enabled except Copy and Edit, and Paste if applicable.
  - Audio-only + AV, locked + AV, unlocked: All items enabled except Copy and Edit, and Paste if applicable.

(The combinations are the power set of the set of the relevant source/sceneitem types {"Audio-only", "AV, locked", "AV, unlocked"} , plus one instance of multiple items of one type for each type, making 2^3+3=11 different situations)
~~Also something something unit tests :p.~~

I noticed that the right-click menu something doesn't even include Transform when it should (it should always except when No Transform items are enabled), but that is a separate issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
As noted in https://github.com/obsproject/obs-studio/pull/9349, `UpdateTransformShortcuts()` was still buggy, it would enable and disable items when it shouldn't, particularly when multiple sceneitems are selected.
I now noticed that it isn't needed at all.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Checked all situations described above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
