### PR TITLE
obs-ffmpeg: Set avg_frame_rate for AVStream video output

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -262,6 +262,7 @@ static bool create_video_stream(struct ffmpeg_data *data)
 	context->thread_count = 0;
 
 	data->video->time_base = context->time_base;
+	data->video->avg_frame_rate = (AVRational){ovi.fps_num, ovi.fps_den};
 
 	if (data->output->oformat->flags & AVFMT_GLOBALHEADER)
 		context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR sets the `avg_frame_rate` field on the video `AVStream` in obs-ffmpeg-output.
This sets the frame rate on container files when recording using "Custom Output (FFmpeg)".

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Setting the frame rate on container files will report the accurate frame rate to tools such as ffprobe, and on associated files such as MPEG-DASH manifests (see before/after patch tests below for examples).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This was tested by recording videos before applying this patch, applying the patch, recording videos using the same settings, and ensuring the videos playback the same as before the patch.

Additionally the frame rate is present or more precise on the container or associated files with the patch.

Tests with recordings using Advanced -> "Custom Output (FFmpeg)" at 60 FPS:

MPEG-DASH before patch (note the absence of the `frameRate` attribute in `AdaptationSet` 0):
```
<?xml version="1.0" encoding="utf-8"?>
<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="urn:mpeg:dash:schema:mpd:2011"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
        profiles="urn:mpeg:dash:profile:isoff-live:2011"
        type="static"
        mediaPresentationDuration="PT53.2S"
        maxSegmentDuration="PT5.0S"
        minBufferTime="PT12.3S">
        <ProgramInformation>
        </ProgramInformation>
        <ServiceDescription id="0">
        </ServiceDescription>
        <Period id="0" start="PT0.0S">
                <AdaptationSet id="0" contentType="video" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true" maxWidth="1920" maxHeight="1080" par="16:9">
                        <Representation id="0" mimeType="video/mp4" codecs="avc1.64002a" bandwidth="2500000" width="1920" height="1080" scanType="unknown" sar="1:1">
                                <SegmentTemplate timescale="15360" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
                                        <SegmentTimeline>
                                                <S t="0" d="118528" />
                                                <S d="117760" />
                                                <S d="129280" />
                                                <S d="128000" />
                                                <S d="80640" />
                                                <S d="102400" />
                                                <S d="94720" />
                                                <S d="46336" />
                                        </SegmentTimeline>
                                </SegmentTemplate>
                        </Representation>
                </AdaptationSet>
                <AdaptationSet id="1" contentType="audio" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true">
                        <Representation id="1" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="160000" audioSamplingRate="48000">
                                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
                                <SegmentTemplate timescale="48000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
                                        <SegmentTimeline>
                                                <S t="0" d="239616" />
                                                <S d="240640" r="8" />
                                                <S d="183296" />
                                        </SegmentTimeline>
                                </SegmentTemplate>
                        </Representation>
                </AdaptationSet>
        </Period>
</MPD>
```

MPEG-DASH after patch (note the presence of the `frameRate` attribute in `AdaptationSet` 0):
```
<?xml version="1.0" encoding="utf-8"?>
<MPD xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns="urn:mpeg:dash:schema:mpd:2011"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        xsi:schemaLocation="urn:mpeg:DASH:schema:MPD:2011 http://standards.iso.org/ittf/PubliclyAvailableStandards/MPEG-DASH_schema_files/DASH-MPD.xsd"
        profiles="urn:mpeg:dash:profile:isoff-live:2011"
        type="static"
        mediaPresentationDuration="PT13.7S"
        maxSegmentDuration="PT5.0S"
        minBufferTime="PT11.6S">
        <ProgramInformation>
        </ProgramInformation>
        <ServiceDescription id="0">
        </ServiceDescription>
        <Period id="0" start="PT0.0S">
                <AdaptationSet id="0" contentType="video" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true" frameRate="60/1" maxWidth="1920" maxHeight="1080" par="16:9">
                        <Representation id="0" mimeType="video/mp4" codecs="avc1.64002a" bandwidth="2500000" width="1920" height="1080" scanType="unknown" sar="1:1">
                                <SegmentTemplate timescale="15360" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
                                        <SegmentTimeline>
                                                <S t="0" d="80896" />
                                                <S d="89600" />
                                                <S d="41216" />
                                        </SegmentTimeline>
                                </SegmentTemplate>
                        </Representation>
                </AdaptationSet>
                <AdaptationSet id="1" contentType="audio" startWithSAP="1" segmentAlignment="true" bitstreamSwitching="true">
                        <Representation id="1" mimeType="audio/mp4" codecs="mp4a.40.2" bandwidth="160000" audioSamplingRate="48000">
                                <AudioChannelConfiguration schemeIdUri="urn:mpeg:dash:23003:3:audio_channel_configuration:2011" value="2" />
                                <SegmentTemplate timescale="48000" initialization="init-stream$RepresentationID$.m4s" media="chunk-stream$RepresentationID$-$Number%05d$.m4s" startNumber="1">
                                        <SegmentTimeline>
                                                <S t="0" d="239616" />
                                                <S d="240640" />
                                                <S d="214016" />
                                        </SegmentTimeline>
                                </SegmentTemplate>
                        </Representation>
                </AdaptationSet>
        </Period>
</MPD>
```

QuickTime MOV before patch (ffprobe output; note that the frame rate is listed as 60.06 FPS):
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '../dash/2023-08-10_12-23-04.mov':
  Metadata:
    major_brand     : qt  
    minor_version   : 512
    compatible_brands: qt  
    encoder         : Lavf60.3.100
  Duration: 00:00:16.55, start: 0.000000, bitrate: 2648 kb/s
  Stream #0:0[0x1]: Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 1920x1080, 2593 kb/s, 60.06 fps, 60 tbr, 15360 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : FFMP
  Stream #0:1[0x2]: Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 160 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
      vendor_id       : [0][0][0][0]
```

QuickTime MOV after patch (ffprobe output; note that the frame rate is exactly 60 FPS):
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '2023-08-10_12-24-14.mov':
  Metadata:
    major_brand     : qt  
    minor_version   : 512
    compatible_brands: qt  
    encoder         : Lavf60.3.100
  Duration: 00:00:51.03, start: 0.000000, bitrate: 2831 kb/s
  Stream #0:0[0x1]: Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 1920x1080, 2693 kb/s, 60 fps, 60 tbr, 15360 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : FFMP
  Stream #0:1[0x2]: Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 162 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
      vendor_id       : [0][0][0][0]
```

Matroska before patch (ffprobe output; note that the frame rate is 62.50 FPS):
```
Input #0, matroska,webm, from '../dash/2023-08-10_14-11-15.mkv':
  Metadata:
    ENCODER         : Lavf60.3.100
  Duration: 00:00:30.57, start: 0.000000, bitrate: 2973 kb/s
  Stream #0:0: Video: h264 (High), yuv420p(tv, bt709, progressive), 1920x1080, 62.50 fps, 60 tbr, 1k tbn
    Metadata:
      DURATION        : 00:00:29.853000000
  Stream #0:1: Audio: vorbis, 48000 Hz, stereo, fltp
    Metadata:
      DURATION        : 00:00:30.574000000
```

Matroska after patch (ffprobe output; note that the frame rate is exactly 60 FPS): 
```
Input #0, matroska,webm, from '2023-08-10_14-09-43.mkv':
  Metadata:
    ENCODER         : Lavf60.3.100
  Duration: 00:00:15.53, start: 0.000000, bitrate: 2604 kb/s
  Stream #0:0: Video: h264 (High), yuv420p(tv, bt709, progressive), 1920x1080, 60 fps, 60 tbr, 1k tbn
    Metadata:
      DURATION        : 00:00:14.803000000
  Stream #0:1: Audio: vorbis, 48000 Hz, stereo, fltp
    Metadata:
      DURATION        : 00:00:15.528000000
```

MP4 before patch (ffprobe output; note that the frame rate is 60.02 FPS):
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '../dash/2023-08-10_14-29-20.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf60.3.100
  Duration: 00:00:40.23, start: 0.000000, bitrate: 2934 kb/s
  Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 1920x1080 [SAR 1:1 DAR 16:9], 2770 kb/s, 60.02 fps, 60 tbr, 15360 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : [0][0][0][0]
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 162 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
      vendor_id       : [0][0][0][0]
```

MP4 after patch (ffprobe output; note that the frame rate is exactly 60 FPS):
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '2023-08-10_14-27-48.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf60.3.100
  Duration: 00:00:21.21, start: 0.000000, bitrate: 2320 kb/s
  Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 1920x1080 [SAR 1:1 DAR 16:9], 2161 kb/s, 60 fps, 60 tbr, 15360 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : [0][0][0][0]
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 159 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
      vendor_id       : [0][0][0][0]
```

System Information:

```
12:46:02.019: Platform: Wayland
12:46:02.019: CPU Name: AMD Ryzen 9 3900X 12-Core Processor
12:46:02.019: CPU Speed: 4172.103MHz
12:46:02.020: Physical Cores: 12, Logical Cores: 24
12:46:02.020: Physical Memory: 32019MB Total, 13767MB Free
12:46:02.020: Kernel Version: Linux 6.4.9-arch1-1
12:46:02.020: Distribution: "Arch Linux" Unknown
12:46:02.020: Desktop Environment: KDE (plasmawayland)
12:46:02.020: Session Type: wayland
12:46:02.022: Qt Version: 6.5.2 (runtime), 6.5.2 (compiled)
12:46:02.022: Portable mode: false
12:46:02.052: OBS 29.0.0-1224-gc81f531ed-modified (linux)
12:46:02.052: ---------------------------------
12:46:02.053: ---------------------------------
12:46:02.053: audio settings reset:
12:46:02.053: 	samples per sec: 48000
12:46:02.053: 	speakers:        2
12:46:02.053: 	max buffering:   960 milliseconds
12:46:02.053: 	buffering type:  dynamically increasing
12:46:02.057: ---------------------------------
12:46:02.057: Initializing OpenGL...
12:46:02.057: Using EGL/Wayland
12:46:02.094: Initialized EGL 1.5
12:46:02.111: Loading up OpenGL on adapter AMD AMD Radeon RX 6400 (navi24, LLVM 15.0.7, DRM 3.52, 6.4.9-arch1-1)
12:46:02.112: OpenGL loaded successfully, version 4.6 (Core Profile) Mesa 23.1.5, shading language 4.60
```


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
