### PR TITLE
obs-frontend-api: Silence errors when removing callbacks

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -360,7 +360,7 @@ void obs_frontend_add_event_callback(obs_frontend_event_cb callback,
 void obs_frontend_remove_event_callback(obs_frontend_event_cb callback,
 					void *private_data)
 {
-	if (callbacks_valid())
+	if (c)
 		c->obs_frontend_remove_event_callback(callback, private_data);
 }
 
@@ -429,7 +429,7 @@ void obs_frontend_add_save_callback(obs_frontend_save_cb callback,
 void obs_frontend_remove_save_callback(obs_frontend_save_cb callback,
 				       void *private_data)
 {
-	if (callbacks_valid())
+	if (c)
 		c->obs_frontend_remove_save_callback(callback, private_data);
 }
 
@@ -443,7 +443,7 @@ void obs_frontend_add_preload_callback(obs_frontend_save_cb callback,
 void obs_frontend_remove_preload_callback(obs_frontend_save_cb callback,
 					  void *private_data)
 {
-	if (callbacks_valid())
+	if (c)
 		c->obs_frontend_remove_preload_callback(callback, private_data);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR will remove the error message when the frontend API `c` is not available in `obs_frontend_remove_*_callback` functions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Less number of errors is better.

Some plugins, such as obs-websocket, try to remove their callbacks when unloading the module though the frontend API is no longer availbale.
When the frontend API is destroyed, the lists of the registered callbacks are also destroyed so that the callbacks are no longer called.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Run obs and exit it.
Checked there are no log lines like below.
```
Tried to call obs_frontend_remove_save_callback with no callbacks!
Tried to call obs_frontend_remove_event_callback with no callbacks!
Tried to call obs_frontend_remove_event_callback with no callbacks!
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
