### PR TITLE
obs-qsv11: Fix VPL initialization on intel-mediaSDK

### DIFF
--- a/cmake/Modules/FindLibva.cmake
+++ b/cmake/Modules/FindLibva.cmake
@@ -15,6 +15,8 @@ find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(_LIBVA libva)
   pkg_check_modules(_LIBVA_DRM libva-drm)
+  pkg_check_modules(_LIBVA_WAYLAND libva-wayland)
+  pkg_check_modules(_LIBVA_X11 libva-x11)
 endif()
 
 find_path(
@@ -35,14 +37,29 @@ find_library(
   HINTS ${_LIBVA_DRM_LIBRARY_DIRS}
   PATHS /usr/lib /usr/local/lib /opt/local/lib)
 
+find_library(
+  LIBVA_WAYLAND_LIB
+  NAMES ${_LIBVA_WAYLAND_LIBRARIES} libva-wayland
+  HINTS ${_LIBVA_WAYLAND_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib)
+
+find_library(
+  LIBVA_X11_LIB
+  NAMES ${_LIBVA_X11_LIBRARIES} libva-x11
+  HINTS ${_LIBVA_X11_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/local/lib /opt/local/lib)
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libva REQUIRED_VARS LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
-mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
+find_package_handle_standard_args(Libva REQUIRED_VARS LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB LIBVA_WAYLAND_LIB
+                                                      LIBVA_X11_LIB)
+mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB LIBVA_WAYLAND_LIB LIBVA_X11_LIB)
 
 if(LIBVA_FOUND)
   set(LIBVA_INCLUDE_DIRS ${LIBVA_INCLUDE_DIR})
   set(LIBVA_LIBRARIES ${LIBVA_LIB})
   set(LIBVA_DRM_LIBRARIES ${LIBVA_DRM_LIB})
+  set(LIBVA_WAYLAND_LIBRARIES ${LIBVA_WAYLAND_LIB})
+  set(LIBVA_X11_LIBRARIES ${LIBVA_X11_LIB})
 
   if(NOT TARGET Libva::va)
     if(IS_ABSOLUTE "${LIBVA_LIBRARIES}")
@@ -66,5 +83,29 @@ if(LIBVA_FOUND)
     endif()
 
     set_target_properties(Libva::drm PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
+  endif()
+
+  if(NOT TARGET Libva::wayland)
+    if(IS_ABSOLUTE "${LIBVA_WAYLAND_LIBRARIES}")
+      add_library(Libva::wayland UNKNOWN IMPORTED)
+      set_target_properties(Libva::wayland PROPERTIES IMPORTED_LOCATION "${LIBVA_WAYLAND_LIBRARIES}")
+    else()
+      add_library(Libva::wayland INTERFACE IMPORTED)
+      set_target_properties(Libva::wayland PROPERTIES IMPORTED_LIBNAME "${LIBVA_WAYLAND_LIBRARIES}")
+    endif()
+
+    set_target_properties(Libva::wayland PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
+  endif()
+
+  if(NOT TARGET Libva::x11)
+    if(IS_ABSOLUTE "${LIBVA_X11_LIBRARIES}")
+      add_library(Libva::x11 UNKNOWN IMPORTED)
+      set_target_properties(Libva::x11 PROPERTIES IMPORTED_LOCATION "${LIBVA_X11_LIBRARIES}")
+    else()
+      add_library(Libva::x11 INTERFACE IMPORTED)
+      set_target_properties(Libva::x11 PROPERTIES IMPORTED_LIBNAME "${LIBVA_X11_LIBRARIES}")
+    endif()
+
+    set_target_properties(Libva::x11 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
   endif()
 endif()

--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -58,5 +58,5 @@ elseif(OS_LINUX)
 
   target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
 
-  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm)
+  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm Libva::wayland Libva::x11)
 endif()

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -195,9 +195,7 @@ mfxStatus QSV_Encoder_Internal::Open(qsv_param_t *pParams, enum qsv_codec codec)
 
 	m_pmfxENC = new MFXVideoENCODE(m_session);
 
-	sts = InitParams(pParams, codec);
-	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
-
+	InitParams(pParams, codec);
 	sts = m_pmfxENC->Query(&m_mfxEncParams, &m_mfxEncParams);
 	MSDK_IGNORE_MFX_STS(sts, MFX_WRN_INCOMPATIBLE_VIDEO_PARAM);
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);

--- a/plugins/obs-qsv11/cmake/legacy.cmake
+++ b/plugins/obs-qsv11/cmake/legacy.cmake
@@ -55,7 +55,7 @@ elseif(OS_LINUX)
 
   target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
 
-  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm)
+  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm Libva::wayland Libva::x11)
 endif()
 
 set_target_properties(obs-qsv11 PROPERTIES FOLDER "plugins/obs-qsv11")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

VPL does not have a consistent initialization process for the various
backends it dispatches to. So this resolves the new VPL dispatcher
failing to initialize the video session when it dispatches to
intel-mediaSDK backend. On the oneVPL-intel-gpu backend VA-API sessions
are correctly initialized so this wasnt noticed when tested on newer
hardware.

I also tried to sneak in a small fixup for the low power fallback inside `InitParams`.
we call Query internally and possibly fixup the low power state and expect the
next status check to be done after the 2nd Query call.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
QSV Should work on 7th gen like it did before the shift to the vpl dispatcher.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Arc card and 7th gen chip both work again.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
