### PR TITLE
UI: Allow hiding projector window frames

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -120,6 +120,7 @@ Automatic="Automatic"
 # warning for plugin load failures
 PluginsFailedToLoad.Title="Plugin Load Error"
 PluginsFailedToLoad.Text="The following OBS plugins failed to load:\n\n%1\nPlease update or remove these plugins."
+HideProjectorFrame="Hide the window frame"
 
 # warning if program already open
 AlreadyRunning.Title="OBS is already running"
@@ -896,6 +897,7 @@ Basic.Settings.General.WarnBeforeStoppingStream="Show confirmation dialog when s
 Basic.Settings.General.WarnBeforeStoppingRecord="Show confirmation dialog when stopping recording"
 Basic.Settings.General.Projectors="Projectors"
 Basic.Settings.General.HideProjectorCursor="Hide cursor over projectors"
+Basic.Settings.General.HideProjectorFrame="Hide window frames on projectors"
 Basic.Settings.General.ProjectorAlwaysOnTop="Make projectors always on top"
 Basic.Settings.General.Snapping="Source Alignment Snapping"
 Basic.Settings.General.ScreenSnapping="Snap Sources to edge of screen"

--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -553,20 +553,27 @@
                     </widget>
                    </item>
                    <item row="1" column="1">
+                    <widget class="QCheckBox" name="hideProjectorFrame">
+                     <property name="text">
+                      <string>Basic.Settings.General.HideProjectorFrame</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="1">
                     <widget class="QCheckBox" name="projectorAlwaysOnTop">
                      <property name="text">
                       <string>Basic.Settings.General.ProjectorAlwaysOnTop</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="2" column="1">
+                   <item row="3" column="1">
                     <widget class="QCheckBox" name="saveProjectors">
                      <property name="text">
                       <string>Basic.Settings.General.SaveProjectors</string>
                      </property>
                     </widget>
                    </item>
-                   <item row="3" column="1">
+                   <item row="4" column="1">
                     <widget class="QCheckBox" name="closeProjectors">
                      <property name="text">
                       <string>Basic.Settings.General.CloseExistingProjectors</string>
@@ -8501,6 +8508,7 @@
   <tabstop>sourceSnapping</tabstop>
   <tabstop>centerSnapping</tabstop>
   <tabstop>hideProjectorCursor</tabstop>
+  <tabstop>hideProjectorFrame</tabstop>
   <tabstop>projectorAlwaysOnTop</tabstop>
   <tabstop>saveProjectors</tabstop>
   <tabstop>closeProjectors</tabstop>

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -338,6 +338,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->warnBeforeStreamStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->warnBeforeRecordStop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->hideProjectorCursor,  CHECK_CHANGED,  GENERAL_CHANGED);
+	HookWidget(ui->hideProjectorFrame,   CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->projectorAlwaysOnTop, CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->recordWhenStreaming,  CHECK_CHANGED,  GENERAL_CHANGED);
 	HookWidget(ui->keepRecordStreamStops,CHECK_CHANGED,  GENERAL_CHANGED);
@@ -1304,6 +1305,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 
 	bool hideProjectorCursor = config_get_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorCursor");
 	ui->hideProjectorCursor->setChecked(hideProjectorCursor);
+
+	bool hideProjectorFrame = config_get_bool(
+		GetGlobalConfig(), "BasicWindow", "HideProjectorFrame");
+	ui->hideProjectorFrame->setChecked(hideProjectorFrame);
 
 	bool projectorAlwaysOnTop = config_get_bool(App()->GetUserConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
 	ui->projectorAlwaysOnTop->setChecked(projectorAlwaysOnTop);
@@ -2996,6 +3001,14 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorCursor",
 				ui->hideProjectorCursor->isChecked());
 		main->UpdateProjectorHideCursor();
+	}
+
+	if (WidgetChanged(ui->hideProjectorFrame)) {
+		config_set_bool(GetGlobalConfig(), "BasicWindow",
+				"HideProjectorFrame",
+				ui->hideProjectorFrame->isChecked());
+		main->UpdateProjectorHideFrame(
+			ui->hideProjectorFrame->isChecked());
 	}
 
 	if (WidgetChanged(ui->projectorAlwaysOnTop)) {

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -1306,8 +1306,7 @@ void OBSBasicSettings::LoadGeneralSettings()
 	bool hideProjectorCursor = config_get_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorCursor");
 	ui->hideProjectorCursor->setChecked(hideProjectorCursor);
 
-	bool hideProjectorFrame = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "HideProjectorFrame");
+	bool hideProjectorFrame = config_get_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorFrame");
 	ui->hideProjectorFrame->setChecked(hideProjectorFrame);
 
 	bool projectorAlwaysOnTop = config_get_bool(App()->GetUserConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
@@ -3004,11 +3003,9 @@ void OBSBasicSettings::SaveGeneralSettings()
 	}
 
 	if (WidgetChanged(ui->hideProjectorFrame)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
-				"HideProjectorFrame",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorFrame",
 				ui->hideProjectorFrame->isChecked());
-		main->UpdateProjectorHideFrame(
-			ui->hideProjectorFrame->isChecked());
+		main->UpdateProjectorHideFrame(ui->hideProjectorFrame->isChecked());
 	}
 
 	if (WidgetChanged(ui->projectorAlwaysOnTop)) {

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -800,6 +800,7 @@ private:
 	void Nudge(int dist, MoveDir dir);
 
 	void UpdateProjectorHideCursor();
+	void UpdateProjectorHideFrame(bool hideFrame);
 	void UpdateProjectorAlwaysOnTop(bool top);
 	void ResetProjectors();
 

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -555,6 +555,12 @@ void OBSBasic::UpdateProjectorHideCursor()
 		projectors[i]->SetHideCursor();
 }
 
+void OBSBasic::UpdateProjectorHideFrame(bool hideFrame)
+{
+	for (size_t i = 0; i < projectors.size(); i++)
+		projectors[i]->SetHideFrame(hideFrame);
+}
+
 void OBSBasic::UpdateProjectorAlwaysOnTop(bool top)
 {
 	for (size_t i = 0; i < projectors.size(); i++)

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -32,8 +32,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, 
 	if (isAlwaysOnTop)
 		setWindowFlag(Qt::WindowStaysOnTopHint, isAlwaysOnTop);
 
-	hideFrame = config_get_bool(GetGlobalConfig(), "BasicWindow",
-				    "HideProjectorFrame");
+	hideFrame = config_get_bool(App()->GetUserConfig(), "BasicWindow", "HideProjectorFrame");
 
 	if (hideFrame)
 		setWindowFlag(Qt::FramelessWindowHint, hideFrame);
@@ -168,10 +167,8 @@ void OBSProjector::SetHideFrame(bool hideFrame)
 		if (hideFrame) {
 			move(contentPos.x(), contentPos.y());
 		} else {
-			QPoint offset = QPoint(contentPos.x() - geometry().x(),
-					       contentPos.y() - geometry().y());
-			move(contentPos.x() + offset.x(),
-			     contentPos.y() + offset.y());
+			QPoint offset = QPoint(contentPos.x() - geometry().x(), contentPos.y() - geometry().y());
+			move(contentPos.x() + offset.x(), contentPos.y() + offset.y());
 		}
 	}
 
@@ -304,16 +301,14 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 			popup.addAction(QTStr("ResizeProjectorWindowToContent"), this, &OBSProjector::ResizeToContent);
 		}
 
-		QAction *hideFrameAction =
-			new QAction(QTStr("HideProjectorFrame"), this);
+		QAction *hideFrameAction = new QAction(QTStr("HideProjectorFrame"), this);
 		hideFrameAction->setCheckable(true);
 		hideFrameAction->setChecked(hideFrame);
 		if (isFullScreen()) {
 			hideFrameAction->setDisabled(true);
 		}
 
-		connect(hideFrameAction, &QAction::toggled, this,
-			&OBSProjector::SetHideFrame);
+		connect(hideFrameAction, &QAction::toggled, this, &OBSProjector::SetHideFrame);
 
 		popup.addAction(hideFrameAction);
 

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -30,7 +30,13 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, 
 	isAlwaysOnTop = config_get_bool(App()->GetUserConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
 
 	if (isAlwaysOnTop)
-		setWindowFlags(Qt::WindowStaysOnTopHint);
+		setWindowFlag(Qt::WindowStaysOnTopHint, isAlwaysOnTop);
+
+	hideFrame = config_get_bool(GetGlobalConfig(), "BasicWindow",
+				    "HideProjectorFrame");
+
+	if (hideFrame)
+		setWindowFlag(Qt::FramelessWindowHint, hideFrame);
 
 	// Mark the window as a projector so SetDisplayAffinity
 	// can skip it
@@ -138,6 +144,38 @@ void OBSProjector::SetHideCursor()
 		setCursor(Qt::BlankCursor);
 	else
 		setCursor(Qt::ArrowCursor);
+}
+
+void OBSProjector::SetHideFrame(bool hideFrame)
+{
+	if (isFullScreen())
+		return;
+
+	// Calculate the current content position.
+	QRect contentBox = geometry();
+
+	// Calculate the current window geometry position.
+	QPoint contentPos = pos();
+
+	// Only update window if setting changed.
+	if (this->hideFrame != hideFrame) {
+		setWindowFlag(Qt::FramelessWindowHint, hideFrame);
+
+		// Restore the window.
+		showNormal();
+
+		// Keep content in the same screen location.
+		if (hideFrame) {
+			move(contentPos.x(), contentPos.y());
+		} else {
+			QPoint offset = QPoint(contentPos.x() - geometry().x(),
+					       contentPos.y() - geometry().y());
+			move(contentPos.x() + offset.x(),
+			     contentPos.y() + offset.y());
+		}
+	}
+
+	this->hideFrame = hideFrame;
 }
 
 void OBSProjector::OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy)
@@ -265,6 +303,19 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 		} else if (!this->isMaximized()) {
 			popup.addAction(QTStr("ResizeProjectorWindowToContent"), this, &OBSProjector::ResizeToContent);
 		}
+
+		QAction *hideFrameAction =
+			new QAction(QTStr("HideProjectorFrame"), this);
+		hideFrameAction->setCheckable(true);
+		hideFrameAction->setChecked(hideFrame);
+		if (isFullScreen()) {
+			hideFrameAction->setDisabled(true);
+		}
+
+		connect(hideFrameAction, &QAction::toggled, this,
+			&OBSProjector::SetHideFrame);
+
+		popup.addAction(hideFrameAction);
 
 		QAction *alwaysOnTopButton = new QAction(QTStr("Basic.MainMenu.View.AlwaysOnTop"), this);
 		alwaysOnTopButton->setCheckable(true);

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -157,19 +157,20 @@ void OBSProjector::SetHideFrame(bool hideFrame)
 	QPoint contentPos = pos();
 
 	// Only update window if setting changed.
-	if (this->hideFrame != hideFrame) {
-		setWindowFlag(Qt::FramelessWindowHint, hideFrame);
+	if (this->hideFrame == hideFrame)
+		return;
 
-		// Restore the window.
-		showNormal();
+	setWindowFlag(Qt::FramelessWindowHint, hideFrame);
 
-		// Keep content in the same screen location.
-		if (hideFrame) {
-			move(contentPos.x(), contentPos.y());
-		} else {
-			QPoint offset = QPoint(contentPos.x() - geometry().x(), contentPos.y() - geometry().y());
-			move(contentPos.x() + offset.x(), contentPos.y() + offset.y());
-		}
+	// Restore the window.
+	showNormal();
+
+	// Keep content in the same screen location.
+	if (hideFrame) {
+		move(contentPos.x(), contentPos.y());
+	} else {
+		QPoint offset = QPoint(contentPos.x() - contentBox.x(), contentPos.y() - contentBox.y());
+		move(contentPos.x() + offset.x(), contentPos.y() + offset.y());
 	}
 
 	this->hideFrame = hideFrame;

--- a/frontend/widgets/OBSProjector.hpp
+++ b/frontend/widgets/OBSProjector.hpp
@@ -28,6 +28,7 @@ private:
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void closeEvent(QCloseEvent *event) override;
 
+	bool hideFrame;
 	bool isAlwaysOnTop;
 	bool isAlwaysOnTopOverridden = false;
 	int savedMonitor = -1;
@@ -64,5 +65,6 @@ public:
 
 	bool IsAlwaysOnTop() const;
 	bool IsAlwaysOnTopOverridden() const;
+	void SetHideFrame(bool hideFrame);
 	void SetIsAlwaysOnTop(bool isAlwaysOnTop, bool isOverridden);
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Support toggling projector window border via context menu or settings.




### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This branch is created by rebasing #5818 from master and resolved conflicts. Open a new PR since I don't have permission to write to original PR. The branch is over 1.5 years old, have conflicts, and it seems the author isn't available to update the branch. Make this PR so it could be reviewed and merged in.

Note: some open discussion items on #5818:

1. Linux testing: I did [one](https://github.com/obsproject/obs-studio/pull/5818#issuecomment-1326156804) in Nov.2022 and it looked fine
2. `QSizeGrip`: per [this comment](https://github.com/obsproject/obs-studio/pull/5818#issuecomment-1127156359) it seems not supported in MacOS. But I suppose resize in frameless mode can be covered in #7851. Also, users can toggle frame/frameless from context menu so I personally think this is not necessary to be a blocker.
3. Warchamp7's [comment ](https://github.com/obsproject/obs-studio/pull/5818#issuecomment-1166372734), which is already implemented:
     > The setting under General is only a default. I would expect the same behaviour here.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Build and tested on Windows 10
```
Edition	Windows 10 Pro
Version	21H2
Installed on	‎6/‎6/‎2020
OS build	19044.3086
Experience	Windows Feature Experience Pack 1000.19041.1000.0
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
