### PR TITLE
UI: Fix possible race condition in DrawSpacingHelpers

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2461,10 +2461,10 @@ void OBSBasicPreview::DrawSpacingHelpers()
 
 	obs_scene_enum_items(main->GetCurrentScene(), FindSelected, &data);
 
-	if (data.sceneItems.size() > 1)
+	if (data.sceneItems.size() != 1)
 		return;
 
-	OBSSceneItem item = main->GetCurrentSceneItem();
+	OBSSceneItem item = data.sceneItems[0];
 	if (!item)
 		return;
 


### PR DESCRIPTION
### Description
Replace direct lookup of currently selected scene item on the Qt selection model with data available through prior call to `obs_scene_enum_items`.

### Motivation and Context
The use of GetCurrentSceneItem can lead to a race condition between the graphics thread (where this function will be run) and the main UI thread, as both access the scene list model and iterate through its members which can change during iteration (as there is no lock around its access).

### How Has This Been Tested?
Tested on macOS 13, confirmed that spacing helpers are only drawn on a single selected item.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
