### PR TITLE
UI: Set advanced audio encoder to invalid if missing

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -920,6 +920,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		&OBSBasicSettings::AdvOutRecCheckCodecs);
 
 	// Set placeholder used when selection was reset due to incompatibilities
+	ui->advOutAEncoder->setPlaceholderText(
+		QTStr("CodecCompat.CodecPlaceholder"));
 	ui->advOutRecEncoder->setPlaceholderText(
 		QTStr("CodecCompat.CodecPlaceholder"));
 	ui->advOutRecAEncoder->setPlaceholderText(
@@ -2427,7 +2429,8 @@ void OBSBasicSettings::LoadOutputSettings()
 
 	const char *type =
 		config_get_string(main->Config(), "AdvOut", "AudioEncoder");
-	SetComboByValue(ui->advOutAEncoder, type);
+	if (!SetComboByValue(ui->advOutAEncoder, type))
+		ui->advOutAEncoder->setCurrentIndex(-1);
 
 	LoadAdvOutputRecordingSettings();
 	LoadAdvOutputRecordingEncoderProperties();
@@ -4970,6 +4973,11 @@ static void DisableIncompatibleCodecs(QComboBox *cbox, const QString &format,
 						 ? strEncLabel
 						 : obs_encoder_get_display_name(
 							   encoderId.c_str());
+
+		/* Something has gone horribly wrong and there's no encoder */
+		if (encoderId.empty())
+			continue;
+
 		const char *codec = obs_get_encoder_codec(encoderId.c_str());
 
 		bool is_compatible =


### PR DESCRIPTION
### Description

Somewhat addresses #9118 by making it at least possible to change the encoder if only one is available by setting the combobox to an invalid state. Users will be prevented from saving settings until they select a valid item.

### Motivation and Context

Want to make this issue recoverable without config editing.

### How Has This Been Tested?

Validated that when CoreAudio is missing the combobox will now show the placeholder instead, then once selecting "FFmpeg AAC" and saving the config will be in a working state again.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
