### PR TITLE
UI: Log if user is ignoring service limits

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -822,6 +822,7 @@ void SimpleOutput::Update()
 					   audioSettings);
 
 	if (!enforceBitrate) {
+		blog(LOG_INFO, "User is ignoring service bitrate limits.");
 		obs_data_set_int(videoSettings, "bitrate", videoBitrate);
 		obs_data_set_int(audioSettings, "bitrate", audioBitrate);
 	}
@@ -1714,13 +1715,18 @@ void AdvancedOutput::UpdateStreamSettings()
 		int keyint_sec = (int)obs_data_get_int(settings, "keyint_sec");
 		obs_service_apply_encoder_settings(main->GetService(), settings,
 						   nullptr);
-		if (!enforceBitrate)
+		if (!enforceBitrate) {
+			blog(LOG_INFO,
+			     "User is ignoring service bitrate limits.");
 			obs_data_set_int(settings, "bitrate", bitrate);
+		}
 
 		int enforced_keyint_sec =
 			(int)obs_data_get_int(settings, "keyint_sec");
 		if (keyint_sec != 0 && keyint_sec < enforced_keyint_sec)
 			obs_data_set_int(settings, "keyint_sec", keyint_sec);
+	} else {
+		blog(LOG_WARNING, "User is ignoring service settings.");
 	}
 
 	if (dynBitrate && astrcmpi(streamEncoder, "jim_nvenc") == 0)


### PR DESCRIPTION
### Description

Adds log messages if user has the checkbox for ignoring service bitrate limits set. Additionally adds a higher severity message if the undocumented config flag for ignoring all service settings (including keyframe interval) is set.

### Motivation and Context

With #9442 we might see some people having trouble with services such as Twitch that have hard limits on ingest bitrate.

### How Has This Been Tested?

Disabled limits, got yelled at.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
