### PR TITLE
UI: Fix compiling without nlohmann JSON

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -84,6 +84,10 @@
 #include "windows.h"
 #endif
 
+#ifdef WHATSNEW_ENABLED
+#include "update/models/whatsnew.hpp"
+#endif
+
 #if !defined(_WIN32) && defined(WHATSNEW_ENABLED)
 #include "update/shared-update.hpp"
 #endif
@@ -96,8 +100,6 @@
 #include "ui_ColorSelect.h"
 
 #include <QWindow>
-
-#include "update/models/whatsnew.hpp"
 
 #ifdef ENABLE_WAYLAND
 #include <obs-nix-platform.h>


### PR DESCRIPTION
### Description

This moves the inclusion of

`UI/update/models/whatsnew.hpp`

within

`#if !defined(_WIN32) && defined(WHATSNEW_ENABLED)`

to fix compiling without nlohmann JSON and `ENABLE_WHATSNEW=OFF`.

### Motivation and Context

This enables compiling without nlohmann JSON, which is used only for browser, websocket, and the whatsnew features (as far as I am aware).

### How Has This Been Tested?

Texted by compiling without nlohmann JSON installed, and the browser, websocket, and whatsnew features disabled on Gentoo Linux.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
