### PR TITLE
CI: Fix open issues and macOS disk image creation

### DIFF
--- a/.github/actions/check-changes/action.yaml
+++ b/.github/actions/check-changes/action.yaml
@@ -38,7 +38,7 @@ runs:
         shopt -s extglob
         shopt -s dotglob
 
-        if ! git cat-file -e ${GIT_BASE_REF}; then
+        if ! git rev-parse --verify ${GIT_BASE_REF} &> /dev/null; then
           echo "::warning::Provided base reference ${GIT_BASE_REF} is invalid"
           if [[ "${USE_FALLBACK}" == 'true' ]]; then
             GIT_BASE_REF='HEAD~1'

--- a/.github/actions/qt-xml-validator/action.yaml
+++ b/.github/actions/qt-xml-validator/action.yaml
@@ -46,7 +46,9 @@ runs:
         shopt -s extglob
         shopt -s globstar
 
-        if (( ! GITHUB_REF_BEFORE )); then GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'; fi
+        if ! git rev-parse --verify "${GITHUB_REF_BEFORE}" &> /dev/null; then
+          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        fi
 
         changes=($(git diff --name-only HEAD~1 HEAD -- UI/forms/**/*.ui))
         case "${GITHUB_EVENT_NAME}" in

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -43,7 +43,9 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if (( ! GITHUB_REF_BEFORE )) GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        fi
 
         local -a changes=($(git diff --name-only HEAD~1 HEAD))
         case ${GITHUB_EVENT_NAME} {

--- a/.github/actions/run-cmake-format/action.yaml
+++ b/.github/actions/run-cmake-format/action.yaml
@@ -42,7 +42,9 @@ runs:
         : Run cmake-format 🎛️
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if (( ! GITHUB_REF_BEFORE )) GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        fi
 
         local -a changes=($(git diff --name-only HEAD~1 HEAD))
         case ${GITHUB_EVENT_NAME} {

--- a/.github/actions/run-swift-format/action.yaml
+++ b/.github/actions/run-swift-format/action.yaml
@@ -42,7 +42,9 @@ runs:
         : Run swift-format 🔥
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if (( ! GITHUB_REF_BEFORE )) GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+        fi
 
         local -a changes=($(git diff --name-only HEAD~1 HEAD))
         case ${GITHUB_EVENT_NAME} {

--- a/.github/scripts/utils.zsh/create_diskimage
+++ b/.github/scripts/utils.zsh/create_diskimage
@@ -44,7 +44,7 @@ safe_hdiutil create \
   -volname "${volume_name}" \
   -srcfolder ${source} \
   -ov \
-  -fs APFS \
+  -fs HFS+ \
   -format UDRW \
   temp.dmg
 safe_hdiutil attach \
@@ -70,7 +70,7 @@ log_info "Converting disk image..."
 safe_hdiutil detach /Volumes/${output_name}
 
 safe_hdiutil convert \
-  -format ULMO \
+  -format ULFO \
   -ov \
   -o ${output_name}.dmg temp.dmg
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.ref }}'
-  cancel-in-progress: ${{ fromJSON(github.ref_type == 'tag') }}
+  cancel-in-progress: false
 jobs:
   check-format:
     name: Format 🔍


### PR DESCRIPTION
### Description
Fixes open issues with CI workflows:

* Concurrency rules are enforced even for non-tagged pushes to master branch
* Checks against invalid git references fail in specific scenarios leading to false positives

Also downgrades the compression used for generated macOS disk images.

### Motivation and Context
The disk images created by the packaging script are based on APFS (which is the default as of 2023) and `lzma` compression. The latter is only supported on Mac OS X 10.15+, which leads to a cryptic error message about a corrupted disk image for users on those older systems.

Using `lzfse` is supported on Mac OS X 10.11+ (with APFS being supported on Mac OS X 10.13+) so those older versions will be able to open the disk image.

> [!NOTE] 
> Even though users can open the disk image and copy the application bundle to their Applications directory, the app will not run because it requires macOS 11+, but macOS is more explicit about that issue when launching an application vs opening the disk image.
>
> One might argue that failing earlier is better than allowing people to install the Application and then failing, but the cryptic nature of the error message for the incompatible disk image seems to create a higher support burden.

### How Has This Been Tested?
Needs testing on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
