### PR TITLE
CI: Update checks for changed files to detect empty GHA references

### DIFF
--- a/.github/actions/check-changes/action.yaml
+++ b/.github/actions/check-changes/action.yaml
@@ -38,7 +38,7 @@ runs:
         shopt -s extglob
         shopt -s dotglob
 
-        if ! git rev-parse --verify ${GIT_BASE_REF} &> /dev/null; then
+        if ! git cat-file -e "${GIT_BASE_REF}" &> /dev/null; then
           echo "::warning::Provided base reference ${GIT_BASE_REF} is invalid"
           if [[ "${USE_FALLBACK}" == 'true' ]]; then
             GIT_BASE_REF='HEAD~1'

--- a/.github/actions/qt-xml-validator/action.yaml
+++ b/.github/actions/qt-xml-validator/action.yaml
@@ -46,7 +46,7 @@ runs:
         shopt -s extglob
         shopt -s globstar
 
-        if ! git rev-parse --verify "${GITHUB_REF_BEFORE}" &> /dev/null; then
+        if ! git cat-file -e "${GITHUB_REF_BEFORE}" &> /dev/null; then
           GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
         fi
 

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -43,7 +43,7 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
           GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
         fi
 

--- a/.github/actions/run-cmake-format/action.yaml
+++ b/.github/actions/run-cmake-format/action.yaml
@@ -42,7 +42,7 @@ runs:
         : Run cmake-format 🎛️
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
           GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
         fi
 

--- a/.github/actions/run-swift-format/action.yaml
+++ b/.github/actions/run-swift-format/action.yaml
@@ -42,7 +42,7 @@ runs:
         : Run swift-format 🔥
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if ! git rev-parse --verify ${GITHUB_REF_BEFORE} &> /dev/null; then
+        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
           GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
         fi
 

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -87,14 +87,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Get Commit Information 🆔
-        id: setup
-        run: |
-          : Get Commit Hash 🆔
-          echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/generate-docs
-        with:
-          commitHash: ${{ steps.checks.setup.commitHash }}
 
   update-documentation-cloudflare:
     name: Update Documentation for Cloudflare ☁️
@@ -102,14 +95,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: Get Commit Information 🆔
-        id: setup
-        run: |
-          : Get Commit Hash 🆔
-          echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
       - uses: ./.github/actions/generate-docs
         with:
-          commitHash: ${{ steps.checks.setup.commitHash }}
           disableLinkExtensions: true
 
   deploy-documentation:
@@ -133,14 +120,6 @@ jobs:
         with:
           name: OBS Studio Docs (No Extensions) ${{ steps.setup.outputs.commitHash }}
           path: docs
-
-      - name: Set Up Redirects 🔄
-        run: |
-          : Set Up Redirects 🔄
-          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
-
-          echo "/previous/27.2 https://obsproject.com/docs/27.2 302" >> docs/_redirects
-          echo "/previous/:major.:minor https://:major-:minor.${{ vars.CF_PAGES_PROJECT }}.pages.dev 302" >> docs/_redirects
 
       - name: Publish to Live Page
         uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check for Changed Files ✅
-        if: github.ref_name != 'tag'
+        if: github.ref_type != 'tag'
         uses: ./.github/actions/check-changes
         id: checks
         with:


### PR DESCRIPTION
### Description
Updates steps checking for changes to use `git cat-file` as the "empty" git reference passed by GitHub Actions will be considered a valid "commit-ish" hash by `git rev-parse --verify` (but not by `cat-file`).

Also updates the dispatch workflow to not create redirects to older (now non-existing) documentation pages and removes superfluous provision of the commit hash and fixes the condition for a documentation upload to always(!) happen for a pushed tag.

### Motivation and Context
Unbreak tagged pushes and checks in general.


### How Has This Been Tested?
Changes to `git cat-file` were tested locally, changes to dispatch workflow need to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
