### PR TITLE
obs-filters: Update NVIDIA Effects SDK versions

### DIFF
--- a/plugins/obs-filters/nvafx-load.h
+++ b/plugins/obs-filters/nvafx-load.h
@@ -9,7 +9,7 @@
 #define NVAFX_API
 
 #ifdef LIBNVAFX_ENABLED
-#define MIN_AFX_SDK_VERSION (1 << 24 | 2 << 16 | 13 << 0)
+#define MIN_AFX_SDK_VERSION (1 << 24 | 3 << 16 | 0 << 0)
 static HMODULE nv_audiofx = NULL;
 static HMODULE nv_cuda = NULL;
 

--- a/plugins/obs-filters/nvvfx-load.h
+++ b/plugins/obs-filters/nvvfx-load.h
@@ -39,7 +39,7 @@ extern "C" {
 #define CUDARTAPI
 
 #ifdef LIBNVVFX_ENABLED
-#define MIN_VFX_SDK_VERSION (0 << 24 | 7 << 16 | 1 << 8 | 0 << 0)
+#define MIN_VFX_SDK_VERSION (0 << 24 | 7 << 16 | 2 << 8 | 0 << 0)
 static HMODULE nv_videofx = NULL;
 static HMODULE nv_cvimage = NULL;
 static HMODULE nv_cudart = NULL;


### PR DESCRIPTION
### Description
We need to check for new versions of the NVIDIA Effects redistributables because mismatched versions of the AUDIO and VIDEO sdk can have different CUDA versions of the deps, which has caused crashes in obs.
It'd be way better that NVIDIA either ships a single installer with both audio and video effects or that they auto-install with the drivers.
But meanwhile, we provide a warning to users which requires us to keep in sync with what's released.

### Motivation and Context
Crashes are bad.
Try to pre-emptively mitigate the risks by warning the user the sdk needs to be updated.

### How Has This Been Tested?
There's a warning displayed if the audio or video sdk are not the latest.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
