### PR TITLE
UI: Fix memory leak in OBSQTDisplay

### DIFF
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -17,7 +17,7 @@ class SurfaceEventFilter : public QObject {
 	OBSQTDisplay *display;
 
 public:
-	SurfaceEventFilter(OBSQTDisplay *src) : display(src) {}
+	SurfaceEventFilter(OBSQTDisplay *src) : QObject(src), display(src) {}
 
 protected:
 	bool eventFilter(QObject *obj, QEvent *event) override


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Set the instance of OBSQTDisplay as the parent of the instance of SurfaceEventFilter so that the instance of SurfaceEventFilter will be destroyed when the OBSQTDisplay is destroyed.

Even if the instance of `SurfaceEventFilter` is deleted before the dispatcher of the event-filter, though I couldn't find documented information, this should be safe because the installed event filters are stored in a QPointer wrapper as below.
https://github.com/qt/qtbase/blob/50bce440277d4383dcf3a055cb9b5d513735bcbc/src/corelib/kernel/qobject_p.h#L95

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

A memory leak was introduced by my PR #9435.

Actually, there are similar memory leaks as described in #7557.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37
Tested with a temporary modification below and checked there is no memory leaks.

```patch
diff --git a/UI/qt-display.cpp b/UI/qt-display.cpp
index 7444c6cb5..a2d7894f3 100644
--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -15,9 +15,17 @@
 
 class SurfaceEventFilter : public QObject {
 	OBSQTDisplay *display;
+	void *ptr;
 
 public:
-	SurfaceEventFilter(OBSQTDisplay *src) : QObject(src), display(src) {}
+	SurfaceEventFilter(OBSQTDisplay *src) : QObject(src), display(src)
+	{
+		ptr = bmalloc(1);
+	}
+	~SurfaceEventFilter()
+	{
+		bfree(ptr);
+	}
 
 protected:
 	bool eventFilter(QObject *obj, QEvent *event) override
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
