### PR TITLE
UI: Avoid segfault on audio encoder lookup when choosing WHIP

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1441,10 +1441,14 @@ static QString get_adv_audio_fallback(const QString &enc)
 {
 	const char *codec = obs_get_encoder_codec(QT_TO_UTF8(enc));
 
+	QString aac_default = "ffmpeg_aac";
+
+	if (!codec)
+		return aac_default;
+
 	if (strcmp(codec, "aac") == 0)
 		return "ffmpeg_opus";
 
-	QString aac_default = "ffmpeg_aac";
 	if (EncoderAvailable("CoreAudio_AAC"))
 		aac_default = "CoreAudio_AAC";
 	else if (EncoderAvailable("libfdk_aac"))


### PR DESCRIPTION
This fixes a crash when selecting WHIP under Stream settings, which crashes for me due to `strcmp` being called on a NULL string. **UPDATE** a prerequisite is that the audio encoder lookup fails (e.g., due to a stale config).

### Description

To reproduce, start OBS and try to select WHIP (it's possible something in my existing settings is surfacing the issue and this may not be sufficient for others to reproduce)

![image](https://github.com/obsproject/obs-studio/assets/66862/6041cafa-c61d-4ee3-84ce-ddf607d57fe5)


<details><summary>Backtrace:</summary>

```
#0  __strcmp_avx2 () at ../sysdeps/x86_64/multiarch/strcmp-avx2.S:283
#1  0x00005555557a85c3 in get_adv_audio_fallback(QString const&) (enc=...) at /big-repos/obs-studio/UI/window-basic-settings-stream.cpp:1444
#2  0x00005555557b2f4b in OBSBasicSettings::ServiceSupportsCodecCheck() (this=this@entry=0x7fffffffbe90) at /big-repos/obs-studio/UI/window-basic-settings-stream.cpp:1524
#3  0x00005555557b4c31 in OBSBasicSettings::on_service_currentIndexChanged(int) (this=0x7fffffffbe90, idx=6) at /big-repos/obs-studio/UI/window-basic-settings-stream.cpp:502
#4  0x00005555555f9d78 in OBSBasicSettings::qt_metacall(QMetaObject::Call, int, void**) (this=0x7fffffffbe90, _c=QMetaObject::InvokeMetaMethod, _id=15, _a=0x7fffffffacb0)
    at /big-repos/obs-studio/build/UI/obs_autogen/EWIEGA46WW/moc_window-basic-settings.cpp:1164
#5  0x00007ffff4572408 in doActivate<false>(QObject*, int, void**) (sender=0x555558165b30, signal_index=12, argv=0x7fffffffacb0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qobject.cpp:4005
#6  0x00007ffff56a9175 in QComboBox::currentIndexChanged(int) (this=<optimized out>, _t1=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/obj-x86_64-linux-gnu/src/widgets/Widgets_autogen/include/moc_qcombobox.cpp:674
#7  0x00007ffff569fa5a in QComboBoxPrivate::_q_emitCurrentIndexChanged(QModelIndex const&) (this=this@entry=0x555555c634d0, index=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/obj-x86_64-linux-gnu/include/QtCore/../../../src/corelib/itemmodels/qabstractitemmodel.h:129
#8  0x00007ffff56a1baf in QComboBoxPrivate::setCurrentIndex(QModelIndex const&) (this=0x555555c634d0, mi=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qcombobox.cpp:2145
#9  0x00007ffff56b095c in QComboBoxPrivate::_q_itemSelected(QModelIndex const&) (item=..., this=0x555555c634d0) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qcombobox.cpp:1353
#10 QComboBox::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (_o=<optimized out>, _c=<optimized out>, _id=<optimized out>, _a=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/obj-x86_64-linux-gnu/src/widgets/Widgets_autogen/include/moc_qcombobox.cpp:485
#11 0x00007ffff45726d3 in doActivate<false>(QObject*, int, void**) (sender=0x5555577eba50, signal_index=7, argv=0x7fffffffb050)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qobject.cpp:3991
#12 0x00007ffff56a9326 in QComboBoxPrivateContainer::itemSelected(QModelIndex const&) (this=<optimized out>, _t1=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/obj-x86_64-linux-gnu/src/widgets/Widgets_autogen/include/moc_qcombobox_p.cpp:393
#13 0x00007ffff56a117a in QComboBoxPrivateContainer::eventFilter(QObject*, QEvent*) (this=0x5555577eba50, o=0x5555577e90b0, e=0x7fffffffb5e0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qcombobox.cpp:774
#14 0x00007ffff452546a in QCoreApplicationPrivate::sendThroughObjectEventFilters(QObject*, QEvent*) (receiver=receiver@entry=0x5555577e90b0, event=event@entry=0x7fffffffb5e0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1158
#15 0x00007ffff558ba9b in QApplicationPrivate::notify_helper(QObject*, QEvent*) (this=<optimized out>, receiver=0x5555577e90b0, e=0x7fffffffb5e0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:3309
#16 0x00007ffff55845a1 in QApplication::notify(QObject*, QEvent*) (this=<optimized out>, receiver=<optimized out>, e=0x7fffffffb5e0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:2803
#17 0x00007ffff4527858 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (receiver=0x5555577e90b0, event=0x7fffffffb5e0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1026
#18 0x00007ffff4527ddd in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (receiver=<optimized out>, event=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1456
#19 0x00007ffff5581018 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool)
    (receiver=0x5555577e90b0, event=0x7fffffffb5e0, alienWidget=0x5555577e90b0, nativeWidget=0x5555577eba50, buttonDown=<optimized out>, lastMouseReceiver=..., spontaneous=true, onlyDispatchEnterLeave=false) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:2387
#20 0x00007ffff55e02af in QWidgetWindow::handleMouseEvent(QMouseEvent*) (this=0x555558d93570, event=0x7fffffffba10) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qwidgetwindow.cpp:519
#21 0x00007ffff55e1015 in QWidgetWindow::event(QEvent*) (this=0x555558d93570, event=0x7fffffffba10) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qwidgetwindow.cpp:241
#22 0x00007ffff558baab in QApplicationPrivate::notify_helper(QObject*, QEvent*) (this=<optimized out>, receiver=0x555558d93570, e=0x7fffffffba10)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:3315
#23 0x00007ffff4527858 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (receiver=0x555558d93570, event=0x7fffffffba10)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1026
#24 0x00007ffff4527ddd in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (receiver=<optimized out>, event=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1456
#25 0x00007ffff4b94efb in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (e=0x5555591853a0)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/gui/kernel/qguiapplication.cpp:2249
#26 0x00007ffff4bde67c in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (flags=flags@entry=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/gui/kernel/qwindowsysteminterface.cpp:1103
#27 0x00007fffe9bda9ae in xcbSourceDispatch(GSource*, GSourceFunc, gpointer) (source=<optimized out>) at /usr/src/qt6-base-6.4.2+dfsg-6/src/plugins/platforms/xcb/qxcbeventdispatcher.cpp:57
#28 0x00007ffff3b1449d in g_main_dispatch (context=0x7fffe4000f10) at ../../../glib/gmain.c:3460
#29 g_main_context_dispatch (context=0x7fffe4000f10) at ../../../glib/gmain.c:4200
#30 0x00007ffff3b6f178 in g_main_context_iterate.constprop.0 (context=0x7fffe4000f10, block=<optimized out>, dispatch=1, self=<optimized out>) at ../../../glib/gmain.c:4276
--Type <RET> for more, q to quit, c to continue without paging--
#31 0x00007ffff3b131b0 in g_main_context_iteration (context=0x7fffe4000f10, may_block=1) at ../../../glib/gmain.c:4343
#32 0x00007ffff4714f20 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (this=0x555555bd9af0, flags=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qeventdispatcher_glib.cpp:393
#33 0x00007ffff45319aa in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (this=this@entry=0x7fffffffbdd0, flags=..., flags@entry=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/global/qflags.h:34
#34 0x00007ffff57af7cf in QDialog::exec() (this=this@entry=0x7fffffffbe90) at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/global/qflags.h:74
#35 0x00005555556f033f in OBSBasic::on_action_Settings_triggered() (this=0x555555c31370) at /big-repos/obs-studio/UI/window-basic-main.cpp:5272
#36 0x00005555555fd447 in OBSBasic::qt_metacall(QMetaObject::Call, int, void**) (this=0x555555c31370, _c=QMetaObject::InvokeMetaMethod, _id=194, _a=0x7fffffffc390)
    at /big-repos/obs-studio/build/UI/obs_autogen/EWIEGA46WW/moc_window-basic-main.cpp:2828
#37 0x00007ffff4572408 in doActivate<false>(QObject*, int, void**) (sender=0x555556200610, signal_index=9, argv=0x7fffffffc390)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qobject.cpp:4005
#38 0x00007ffff568d816 in QAbstractButton::clicked(bool) (this=<optimized out>, _t1=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/obj-x86_64-linux-gnu/src/widgets/Widgets_autogen/include/moc_qabstractbutton.cpp:368
#39 0x00007ffff568581e in QAbstractButtonPrivate::emitClicked() (this=0x555556206ca0) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qabstractbutton.cpp:379
#40 0x00007ffff5685bfe in QAbstractButtonPrivate::click() (this=0x555556206ca0) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qabstractbutton.cpp:372
#41 0x00007ffff56928b3 in QAbstractButton::mouseReleaseEvent(QMouseEvent*) (this=0x555556200610, e=0x7fffffffc960)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/widgets/qabstractbutton.cpp:973
#42 0x00007ffff55d20e4 in QWidget::event(QEvent*) (this=0x555556200610, event=0x7fffffffc960) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qwidget.cpp:8848
#43 0x00007ffff558baab in QApplicationPrivate::notify_helper(QObject*, QEvent*) (this=<optimized out>, receiver=0x555556200610, e=0x7fffffffc960)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:3315
#44 0x00007ffff55845a1 in QApplication::notify(QObject*, QEvent*) (this=<optimized out>, receiver=<optimized out>, e=0x7fffffffc960)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:2803
#45 0x00007ffff4527858 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (receiver=0x555556200610, event=0x7fffffffc960)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1026
#46 0x00007ffff4527ddd in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (receiver=<optimized out>, event=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1456
#47 0x00007ffff5581018 in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool)
    (receiver=0x555556200610, event=0x7fffffffc960, alienWidget=0x555556200610, nativeWidget=0x5555561c0380, buttonDown=<optimized out>, lastMouseReceiver=..., spontaneous=true, onlyDispatchEnterLeave=false) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:2387
#48 0x00007ffff55dfcb5 in QWidgetWindow::handleMouseEvent(QMouseEvent*) (this=0x5555576bcec0, event=0x7fffffffcd90) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qwidgetwindow.cpp:623
#49 0x00007ffff55e1015 in QWidgetWindow::event(QEvent*) (this=0x5555576bcec0, event=0x7fffffffcd90) at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qwidgetwindow.cpp:241
#50 0x00007ffff558baab in QApplicationPrivate::notify_helper(QObject*, QEvent*) (this=<optimized out>, receiver=0x5555576bcec0, e=0x7fffffffcd90)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:3315
#51 0x00007ffff4527858 in QCoreApplication::notifyInternal2(QObject*, QEvent*) (receiver=0x5555576bcec0, event=0x7fffffffcd90)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1026
#52 0x00007ffff4527ddd in QCoreApplication::sendSpontaneousEvent(QObject*, QEvent*) (receiver=<optimized out>, event=<optimized out>)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qcoreapplication.cpp:1456
#53 0x00007ffff4b94efb in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) (e=0x555557ef0e30)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/gui/kernel/qguiapplication.cpp:2249
#54 0x00007ffff4bde67c in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) (flags=flags@entry=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/gui/kernel/qwindowsysteminterface.cpp:1103
#55 0x00007fffe9bda9ae in xcbSourceDispatch(GSource*, GSourceFunc, gpointer) (source=<optimized out>) at /usr/src/qt6-base-6.4.2+dfsg-6/src/plugins/platforms/xcb/qxcbeventdispatcher.cpp:57
#56 0x00007ffff3b1449d in g_main_dispatch (context=0x7fffe4000f10) at ../../../glib/gmain.c:3460
#57 g_main_context_dispatch (context=0x7fffe4000f10) at ../../../glib/gmain.c:4200
#58 0x00007ffff3b6f178 in g_main_context_iterate.constprop.0 (context=0x7fffe4000f10, block=<optimized out>, dispatch=1, self=<optimized out>) at ../../../glib/gmain.c:4276
#59 0x00007ffff3b131b0 in g_main_context_iteration (context=0x7fffe4000f10, may_block=1) at ../../../glib/gmain.c:4343
#60 0x00007ffff4714f20 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (this=0x555555bd9af0, flags=...)
    at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/kernel/qeventdispatcher_glib.cpp:393
#61 0x00007ffff45319aa in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (this=0x7fffffffd150, flags=...) at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/global/qflags.h:34
#62 0x00007ffff452a71c in QCoreApplication::exec() () at /usr/src/qt6-base-6.4.2+dfsg-6/src/corelib/global/qflags.h:74
#63 0x00007ffff4b90550 in QGuiApplication::exec() () at /usr/src/qt6-base-6.4.2+dfsg-6/src/gui/kernel/qguiapplication.cpp:1859
#64 0x00007ffff557db49 in QApplication::exec() () at /usr/src/qt6-base-6.4.2+dfsg-6/src/widgets/kernel/qapplication.cpp:2595
--Type <RET> for more, q to quit, c to continue without paging--
#65 0x00005555555ecc6b in run_program (argv=<optimized out>, argc=<optimized out>, logFile=...) at /big-repos/obs-studio/UI/obs-app.cpp:2582
#66 main(int, char**) (argc=<optimized out>, argv=<optimized out>) at /big-repos/obs-studio/UI/obs-app.cpp:3497
```
</details>

### Motivation and Context
This fixes a segfault

### How Has This Been Tested?
I tested with and without this change to confirm that the crash is avoided

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (caveat I'm using clang-format 15.0.7 and thus had to remove a few options it didn't understand) 
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
