### PR TITLE
build-aux: Enable QSV encoders on Flatpak

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -55,10 +55,13 @@
         "modules/40-luajit.json",
         "modules/40-plog.json",
         "modules/40-usrsctp.json",
+        "modules/50-intel-media-sdk.json",
         "modules/50-jansson.json",
         "modules/50-libdatachannel.json",
         "modules/50-libqrcodegencpp.json",
         "modules/50-ntv2.json",
+        "modules/50-onevpl-intel-gpu.json",
+        "modules/50-onevpl.json",
         "modules/50-pipewire.json",
         "modules/50-rnnoise.json",
         "modules/50-swig.json",
@@ -84,7 +87,7 @@
                 "-DENABLE_VLC=OFF",
                 "-DENABLE_AJA=ON",
                 "-DENABLE_LIBFDK=ON",
-                "-DENABLE_QSV11=OFF"
+                "-DENABLE_QSV11=ON"
             ],
             "secret-opts": [
                 "-DRESTREAM_CLIENTID=$RESTREAM_CLIENTID",

--- a/build-aux/modules/50-intel-media-sdk.json
+++ b/build-aux/modules/50-intel-media-sdk.json
@@ -1,0 +1,38 @@
+{
+    "name": "intel-media-sdk",
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_SAMPLES=OFF",
+        "-DBUILD_TUTORIALS=OFF",
+        "-DENABLE_OPENCL=OFF",
+        "-DENABLE_WAYLAND=OFF",
+        "-DENABLE_X11=OFF",
+        "-DENABLE_X11_DRI3=OFF"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/Intel-Media-SDK/MediaSDK.git",
+            "commit": "869b60a6c3d7b5e9f7c3b3b914986322dca4bbae",
+            "tag": "intel-mediasdk-23.2.2"
+        },
+        {
+            "type": "file",
+            "dest-filename": "010-intel-media-sdk-fix-reproducible-build.patch",
+            "url": "https://github.com/Intel-Media-SDK/MediaSDK/commit/f6925886f27a39eed2e43c5b7b6c342d00f7a970.patch",
+            "sha256": "f1d8a4edf953cfec1516f1a8383c5ee033245aba16cfae0bc79b7de1a6365fcc"
+        },
+        {
+            "type": "shell",
+            "commands": [
+                "patch -Np1 -i 010-intel-media-sdk-fix-reproducible-build.patch"
+            ]
+        }
+    ]
+}

--- a/build-aux/modules/50-onevpl-intel-gpu.json
+++ b/build-aux/modules/50-onevpl-intel-gpu.json
@@ -1,0 +1,28 @@
+{
+    "name": "onevpl-intel-gpu",
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_RUNTIME=ON",
+        "-DBUILD_TESTS=OFF",
+        "-DBUILD_TOOLS=OFF"
+    ],
+    "cleanup": [
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/oneapi-src/oneVPL-intel-gpu.git",
+            "commit": "a9fb0bcabef0b91ddfe0c70466513d33fab38557",
+            "tag": "intel-onevpl-23.3.1"
+        },
+        {
+            "type": "shell",
+            "commands": [
+                "sed -i 's/CMAKE_VERBOSE_MAKEFILE ON/CMAKE_VERBOSE_MAKEFILE OFF/g' builder/profiles/onevpl.cmake"
+            ]
+        }
+    ]
+}

--- a/build-aux/modules/50-onevpl.json
+++ b/build-aux/modules/50-onevpl.json
@@ -1,0 +1,28 @@
+{
+    "name": "onevpl",
+    "buildsystem": "cmake-ninja",
+    "builddir": true,
+    "config-opts": [
+        "-DCMAKE_BUILD_TYPE=Release",
+        "-DBUILD_DEV=ON",
+        "-DBUILD_PREVIEW=OFF",
+        "-DBUILD_TOOLS=OFF",
+        "-DBUILD_TOOLS_ONEVPL_EXPERIMENTAL=OFF",
+        "-DINSTALL_EXAMPLE_CODE=OFF",
+        "-DBUILD_EXAMPLES=OFF",
+        "-DBUILD_DISPATCHER_ONEVPL_EXPERIMENTAL=OFF",
+        "-DBUILD_SHARED_LIBS=ON"
+    ],
+    "cleanup": [
+        "/include",
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/oneapi-src/oneVPL.git",
+            "commit": "ca5bbbb057a6e84b103aca807612afb693ad046c",
+            "tag": "v2023.3.1"
+        }
+    ]
+}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add the 3 Intel libraries required to enable QSV in the Flatpak:
- OneVPL (Dispatcher for the following)
- OneVPL GPU for recent QSV capable hardware
- MediaSDK for Broadwell to Raptor Lake (excluded)

Most of unneeded feature are disabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Enable QSV

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Intel Core m3-7Y30 (Amber Lake Y), so Media SDK.

Made a RTMP stream with a QSV encoder and it worked.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
