### PR TITLE
UI: Move restart to end of main()

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -110,6 +110,7 @@ string opt_starting_scene;
 
 bool restart = false;
 bool restart_safe = false;
+QStringList arguments;
 
 QPointer<OBSLogViewer> obsLogViewer;
 
@@ -2587,16 +2588,13 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	}
 
 	if (restart || restart_safe) {
-		auto args = qApp->arguments();
-		auto executable = args[0];
+		arguments = qApp->arguments();
 
 		if (restart_safe) {
-			args.append("--safe-mode");
+			arguments.append("--safe-mode");
 		} else {
-			args.removeAll("--safe-mode");
+			arguments.removeAll("--safe-mode");
 		}
-
-		QProcess::startDetached(executable, args);
 	}
 
 	return ret;
@@ -3511,5 +3509,11 @@ int main(int argc, char *argv[])
 	delete_safe_mode_sentinel();
 	blog(LOG_INFO, "Number of memory leaks: %ld", bnum_allocs());
 	base_set_log_handler(nullptr, nullptr);
+
+	if (restart || restart_safe) {
+		auto executable = arguments.takeFirst();
+		QProcess::startDetached(executable, arguments);
+	}
+
 	return ret;
 }


### PR DESCRIPTION
### Description

Moves the restarting of OBS to the end of `main()`.

### Motivation and Context

Fixes #9467 and an oversight where the executable path is copied to the new arguments list as well.

### How Has This Been Tested?

Verified safe mode no longer kicks in during regular restarts and that arguments are copied correctly (minus the first one).

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
