### PR TITLE
obs-qsv11: Fix crash in QSV test process

### DIFF
--- a/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
+++ b/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
@@ -162,7 +162,13 @@ try {
 		throw "CreateDXGIFactory1 failed";
 
 	mfxLoader loader = MFXLoad();
+	if (!loader)
+		throw "MFXLoad failed";
+
 	mfxConfig cfg = MFXCreateConfig(loader);
+	if (!cfg)
+		throw "MFXCreateConfig failed";
+
 	mfxVariant impl;
 
 	// Low latency is disabled due to encoding capabilities not being provided before TGL for VPL
@@ -171,14 +177,16 @@ try {
 	MFXSetConfigFilterProperty(
 		cfg, (const mfxU8 *)"mfxImplDescription.Impl", impl);
 
-	mfxSession m_session;
+	mfxSession m_session = nullptr;
 	mfxStatus sts = MFXCreateSession(loader, 0, &m_session);
 
 	uint32_t idx = 0;
 	while (get_adapter_caps(factory, loader, m_session, idx++) == true)
 		;
 
-	MFXClose(m_session);
+	if (m_session)
+		MFXClose(m_session);
+
 	MFXUnload(loader);
 
 	for (auto &[idx, caps] : adapter_info) {


### PR DESCRIPTION
### Description
The code added in #9142 assumed `MFXCreateSession` would always succeed, but it fails on systems with no QSV implementations, causing a crash when we call `MFXClose` later. Additional success checks for the other API calls were also added.

### Motivation and Context
Crashes are bad. Even if users don't see them happening, this can trigger WER to collect dump files so can impact system performance on every OBS launch.

### How Has This Been Tested?
Only tested on my system without any QSV capable devices, but should be fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
