### PR TITLE
cmake: Parse beta/rc version from override/git describe

### DIFF
--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -6,54 +6,37 @@
 
 include_guard(GLOBAL)
 
+set(_obs_version ${_obs_default_version})
+set(_obs_version_canonical ${_obs_default_version})
+
 # Attempt to automatically discover expected OBS version
-if(NOT DEFINED OBS_VERSION_OVERRIDE)
-  if(DEFINED RELEASE_CANDIDATE)
-    if(RELEASE_CANDIDATE MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+")
-      string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9])+" "\\1;\\2;\\3;\\4" _obs_release_candidate
-                           ${RELEASE_CANDIDATE})
-      list(GET _obs_release_candidate 0 1 2 _obs_version_canonical)
-      set(_obs_version ${RELEASE_CANDIDATE})
-    else()
-      message(FATAL_ERROR "Invalid release candidate version supplied - must be <MAJOR>.<MINOR>.<PATCH>-rc<CANDIDATE>.")
-    endif()
-  elseif(DEFINED BETA)
-    if(BETA MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+")
-      string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-beta([0-9])+" "\\1;\\2;\\3;\\4" _obs_beta ${BETA})
-      list(GET _obs_beta 0 1 2 _obs_version_canonical)
-      set(_obs_version ${BETA})
-    else()
-      message(FATAL_ERROR "Invalid beta version supplied - must be <MAJOR>.<MINOR>.<PATCH>-beta<RELEASE>.")
-    endif()
-  elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    execute_process(
-      COMMAND git describe --always --tags --dirty=-modified
-      OUTPUT_VARIABLE _obs_version
-      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-      RESULT_VARIABLE _obs_version_result
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT DEFINED OBS_VERSION_OVERRIDE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+  execute_process(
+    COMMAND git describe --always --tags --dirty=-modified
+    OUTPUT_VARIABLE _obs_version
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    RESULT_VARIABLE _obs_version_result
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    if(_obs_version_result EQUAL 0)
-      if(_obs_version MATCHES "rc[0-9]+$")
-        set(RELEASE_CANDIDATE ${_obs_version})
-      elseif(_obs_version MATCHES "beta[0-9]+$")
-        set(BETA ${_obs_version})
-      endif()
-
-      string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" _obs_version_canonical ${_obs_version})
-    else()
-      set(_obs_version ${_obs_default_version})
-      set(_obs_version_canonical ${_obs_default_version})
-    endif()
+  if(_obs_version_result EQUAL 0)
+    string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" _obs_version_canonical ${_obs_version})
   endif()
-else()
+elseif(DEFINED OBS_VERSION_OVERRIDE)
   if(OBS_VERSION_OVERRIDE MATCHES "([0-9]+)\\.([0-9]+)\\.([0-9]+).*")
     string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" _obs_version_canonical
                          ${OBS_VERSION_OVERRIDE})
     set(_obs_version ${OBS_VERSION_OVERRIDE})
   else()
-    message(FATAL_ERROR "Invalid version supplied - must be <MAJOR>.<MINOR>.<PATCH>.")
+    message(FATAL_ERROR "Invalid version supplied - must be <MAJOR>.<MINOR>.<PATCH>[-(rc|beta)<NUMBER>].")
   endif()
+endif()
+
+# Set beta/rc versions if suffix included in version string
+if(_obs_version MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+")
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9])+" "\\1;\\2;\\3;\\4" _obs_release_candidate
+                       ${_obs_version})
+elseif(_obs_version MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+")
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-beta([0-9])+" "\\1;\\2;\\3;\\4" _obs_beta ${_obs_version})
 endif()
 
 list(GET _obs_version_canonical 0 OBS_VERSION_MAJOR)


### PR DESCRIPTION
### Description

The cmake update broke parsing the beta/rc version from `git describe`, this PR restores it. It also removes the old `BETA` and `RELEASE_CANDIDATE` defines in favour of always using `OBS_VERSION_OVERRIDE` as the source of the version.

### Motivation and Context

Beta 1 on Windows did not have the beta version set, resulting in the update check still assuming that it is 29.1.3.

### How Has This Been Tested?

Tested tags and `OBS_VERSION_OVERRIDE` with beta/rc version strings.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
