### PR TITLE
CI: Specify tag for Steam action on release

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -91,7 +91,7 @@ runs:
 
         case ${GITHUB_EVENT_NAME} {
           release)
-            gh release download \
+            gh release download ${{ inputs.tagName }} \
               --pattern '*macOS*.dmg' \
               --pattern '*Windows*' \
               --pattern '*.zip' \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -147,4 +147,5 @@ jobs:
           steamUser: ${{ secrets.STEAM_USER }}
           steamPassword: ${{ secrets.STEAM_PASSWORD }}
           workflowSecret: ${{ github.token }}
+          tagName: ${{ github.ref_name }}
           preview: false


### PR DESCRIPTION
### Description

Specify tag when running Steam action in a release workflow.

`gh release download` will otherwise use the latest non-pre-release, see https://github.com/obsproject/obs-studio/actions/runs/5912931275/job/16036816503 where it downloads 29.1.3 instead.

### Motivation and Context

Hopefully fixe automated Steam uploads for pre-release versions.

### How Has This Been Tested?

Has not directly been tested, but on my fork I tested specifying the beta tag to download the correct release and that worked.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
