### PR TITLE
UI: Fix alignment of status bar message

### DIFF
--- a/UI/forms/StatusBarWidget.ui
+++ b/UI/forms/StatusBarWidget.ui
@@ -36,17 +36,50 @@
     <number>0</number>
    </property>
    <item>
-    <spacer name="horizontalSpacer_11">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QFrame" name="messageFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>2</width>
-       <height>2</height>
-      </size>
+     <property name="styleSheet">
+      <string notr="true">border: none;</string>
      </property>
-    </spacer>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_9">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="message">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Ignored" vsizetype="Maximum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Message</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QFrame" name="delayFrame">

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -55,12 +55,19 @@ OBSBasicStatusBar::OBSBasicStatusBar(QWidget *parent)
 	statusWidget->ui->issuesFrame->hide();
 	statusWidget->ui->kbps->hide();
 
-	addPermanentWidget(statusWidget);
+	addPermanentWidget(statusWidget, 1);
 	setMinimumHeight(statusWidget->height());
 
 	UpdateIcons();
 	connect(App(), &OBSApp::StyleChanged, this,
 		&OBSBasicStatusBar::UpdateIcons);
+
+	messageTimer = new QTimer(this);
+	messageTimer->setSingleShot(true);
+	connect(messageTimer, &QTimer::timeout, this,
+		&OBSBasicStatusBar::clearMessage);
+
+	clearMessage();
 }
 
 void OBSBasicStatusBar::Activate()
@@ -605,4 +612,19 @@ void OBSBasicStatusBar::UpdateIcons()
 	if (!recording)
 		statusWidget->ui->recordIcon->setPixmap(
 			recordingInactivePixmap);
+}
+
+void OBSBasicStatusBar::showMessage(const QString &message, int timeout)
+{
+	messageTimer->stop();
+
+	statusWidget->ui->message->setText(message);
+
+	if (timeout)
+		messageTimer->start(timeout);
+}
+
+void OBSBasicStatusBar::clearMessage()
+{
+	statusWidget->ui->message->setText("");
 }

--- a/UI/window-basic-status-bar.hpp
+++ b/UI/window-basic-status-bar.hpp
@@ -72,6 +72,7 @@ private:
 	float lastCongestion = 0.0f;
 
 	QPointer<QTimer> refreshTimer;
+	QPointer<QTimer> messageTimer;
 
 	obs_output_t *GetOutput();
 
@@ -89,6 +90,9 @@ private:
 
 public slots:
 	void UpdateCPUUsage();
+
+	void clearMessage();
+	void showMessage(const QString &message, int timeout = 0);
 
 private slots:
 	void Reconnect(int seconds);


### PR DESCRIPTION
### Description
The status bar message was not vertically aligned properly to other widgets in the status bar. We have to implement our own message system here, as the default status bar in Qt has hardcoded paddings.

Before:
![Screenshot from 2023-08-21 03-17-06](https://github.com/obsproject/obs-studio/assets/19962531/f3633336-1ff2-4b87-91c2-8b68a0f9517a)

After:
![Screenshot from 2023-08-21 03-01-37](https://github.com/obsproject/obs-studio/assets/19962531/c98a5c2a-76ff-4e9d-8e49-e54a2fdca935)

### Motivation and Context
Fix status bar visual bug

### How Has This Been Tested?
Saved recording to make sure status bar message looked correct

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
