### PR TITLE
UI: Center vertical volume control buttons

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -301,12 +301,15 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		controlLayout->setContentsMargins(0, 0, 0, 0);
 		controlLayout->setSpacing(0);
 
-		if (showConfig)
+		if (showConfig) {
 			controlLayout->addWidget(config);
+			controlLayout->setAlignment(config, Qt::AlignVCenter);
+		}
 
 		controlLayout->addItem(new QSpacerItem(3, 0));
 		// Add Headphone (audio monitoring) widget here
 		controlLayout->addWidget(mute);
+		controlLayout->setAlignment(mute, Qt::AlignVCenter);
 
 		meterLayout->setContentsMargins(0, 0, 0, 0);
 		meterLayout->setSpacing(0);


### PR DESCRIPTION
### Description
The mute and config buttons were not vertically centered in vertical mode.

Before:
![Screenshot from 2023-08-21 05-44-56](https://github.com/obsproject/obs-studio/assets/19962531/e0b3dcc6-b8c5-4be1-b6f0-8edb2622839b)

After:
![Screenshot from 2023-08-21 05-41-17](https://github.com/obsproject/obs-studio/assets/19962531/67d05df4-96d5-46b7-a785-c83caa6fa9e1)

### Motivation and Context
Make the volume controls look better.

### How Has This Been Tested?
Looked at volume controls

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
