### PR TITLE
CI: Move language file upload to nightly runs and remove master push concurrency limits

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,9 +11,6 @@ on:
       - '*'
 permissions:
   contents: write
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.ref }}'
-  cancel-in-progress: false
 jobs:
   check-format:
     name: Format 🔍

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -79,30 +79,6 @@ jobs:
           runSchemaChecks: true
           runServiceChecks: false
 
-  upload-language-files:
-    name: Upload Language Files 🌐
-    if: github.repository_owner == 'obsproject' && github.ref_name == 'master'
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Check for Changed Files ✅
-        uses: ./.github/actions/check-changes
-        id: checks
-        with:
-          baseRef: ${{ github.event.before }}
-          checkGlob: '**/en-US.ini'
-
-      - name: Upload US English Language Files 🇺🇸
-        if: fromJSON(steps.checks.outputs.hasChangedFiles)
-        uses: obsproject/obs-crowdin-sync/upload@30b5446e3b5eb19595aa68a81ddf896a857302cf
-        env:
-          CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
-          GITHUB_EVENT_BEFORE: ${{ github.event.before }}
-
   update-documentation:
     name: Update Documentation 📖
     if: github.repository_owner == 'obsproject' && (github.ref_name == 'master' || github.ref_type == 'tag')

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -86,6 +86,48 @@ jobs:
     needs: cache-cleanup
     secrets: inherit
 
+  upload-language-files:
+    name: Upload Language Files 🌐
+    if: github.repository_owner == 'obsproject' && github.ref_name == 'master'
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Check Nightly Runs ☑️
+        id: nightly-checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          : Check Nightly Runs ☑️
+          if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+
+          local last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
+
+          if [[ "${GITHUB_SHA}" == "${last_nightly}" ]] {
+            print "passed=false" >> $GITHUB_OUTPUT
+          } else {
+            print "passed=true" >> $GITHUB_OUTPUT
+            print "lastNightly=${last_nightly}" >> $GITHUB_OUTPUT
+          }
+
+      - name: Check for Changed Files ✅
+        uses: ./.github/actions/check-changes
+        if: fromJSON(steps.nightly-checks.outputs.passed)
+        id: checks
+        with:
+          baseRef: ${{ steps.nighty-checks.outputs.lastNightly }}
+          checkGlob: '**/en-US.ini'
+
+      - name: Upload US English Language Files 🇺🇸
+        if: fromJSON(steps.checks.outputs.hasChangedFiles) && fromJSON(steps.nightly-checks.outputs.passed)
+        uses: obsproject/obs-crowdin-sync/upload@30b5446e3b5eb19595aa68a81ddf896a857302cf
+        env:
+          CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
+          GITHUB_EVENT_BEFORE: ${{ steps.nighty-checks.outputs.lastNightly }}
+
   steam-upload:
     name: Upload Steam Builds 🚂
     needs: [build-project]


### PR DESCRIPTION
### Description
Moves the upload of language files to the scheduled nightly workflow run to upload changes in bulk and removes concurrency limits on the push workflow.

### Motivation and Context
Current concurrency limits on the push workflow seem to prohibit GitHub Actions from _starting_ new workflow runs if there is an active one (even when canceling current runs is disabled) which means that desired actions are not run.

Language file upload is moved to nightly runs nevertheless because it might make more sense for translators to get changes in bulk as they will probably not look into untranslated strings after every push anyway.

### How Has This Been Tested?
Needs to be tested on CI with a nightly run and consecutive pushes to the master branch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
