### PR TITLE
Revert "UI: Support DnD overlay in linuxbrowser"

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -122,7 +122,6 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 	OBSDataAutoRelease settings = obs_data_create();
 	const char *type = nullptr;
-	std::vector<const char *> types;
 	QString name;
 
 	obs_video_info ovi;
@@ -165,19 +164,12 @@ void OBSBasic::AddDropSource(const char *data, DropType image)
 		obs_data_set_int(settings, "width", ovi.base_width);
 		obs_data_set_int(settings, "height", ovi.base_height);
 		name = QUrl::fromLocalFile(QString(data)).fileName();
-		types = {"browser_source", "linuxbrowser-source"};
+		type = "browser_source";
 		break;
 	case DropType_Url:
 		AddDropURL(data, name, settings, ovi);
-		types = {"browser_source", "linuxbrowser-source"};
+		type = "browser_source";
 		break;
-	}
-
-	for (char const *t : types) {
-		if (obs_source_get_display_name(t)) {
-			type = t;
-			break;
-		}
 	}
 
 	type = obs_get_latest_input_type_id(type);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This reverts commit aeed4a3aa1b81f154f10d047aad4974a7c293dd0, PR #2317.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

https://github.com/obsproject/obs-studio/pull/9490#pullrequestreview-1587053356

The source type `browser_source` is now available for all supported platforms so we don't need to fallback to `linuxbrowser-source`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

Dropped a URL into OBS and checked the browser source is created.

Note: I didn't check if there is a 3rd party package that does not have `browser_source` but has `linuxbrowser-source`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
