### PR TITLE
Cleanup obs-x264 plugin

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -237,22 +237,6 @@ static obs_properties_t *obs_x264_props(void *unused)
 	return props;
 }
 
-static bool getparam(const char *param, char **name, const char **value)
-{
-	const char *assign;
-
-	if (!param || !*param || (*param == '='))
-		return false;
-
-	assign = strchr(param, '=');
-	if (!assign || !*assign || !*(assign + 1))
-		return false;
-
-	*name = bstrdup_n(param, assign - param);
-	*value = assign + 1;
-	return true;
-}
-
 static const char *validate(struct obs_x264 *obsx264, const char *val,
 			    const char *name, const char *const *list)
 {

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -342,13 +342,20 @@ static bool reset_x264_params(struct obs_x264 *obsx264, const char *preset,
 
 static void log_x264(void *param, int level, const char *format, va_list args)
 {
-	struct obs_x264 *obsx264 = param;
-	char str[1024];
+	static const int level_map[] = {
+		LOG_ERROR,
+		LOG_WARNING,
+		LOG_INFO,
+		LOG_DEBUG,
+	};
 
-	vsnprintf(str, sizeof(str), format, args);
-	info("%s", str);
+	UNUSED_PARAMETER(param);
+	if (level < X264_LOG_ERROR)
+		level = X264_LOG_ERROR;
+	else if (level > X264_LOG_DEBUG)
+		level = X264_LOG_DEBUG;
 
-	UNUSED_PARAMETER(level);
+	blogva(level_map[level], format, args);
 }
 
 static inline int get_x264_cs_val(const char *const name,


### PR DESCRIPTION
### Description
1. Remove unused getparam() function
2. Refactor log callback
   1. Remove limitation of message length.
   2. Improve performance by remove the local copy.
   3. Map x264 log level to obs.

### Motivation and Context
1. Remove dead code
2. Improve performance

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS: Windows 10
Test steps:
1. Enable software encoder x264
2. Set x264 options to "log=3" to see some debug message of x264
3. Run recording.

Here is part of log file:
```
11:51:20.743: [x264 encoder: 'advanced_video_recording'] preset: fast
11:51:20.743: [x264 encoder: 'advanced_video_recording'] profile: main
11:51:20.743: [x264 encoder: 'advanced_video_recording'] settings:
...

11:51:20.743: 
11:51:20.744: using SAR=1/1
11:51:20.744: 
11:51:20.744: using cpu capabilities: MMX2 SSE2Fast SSSE3 SSE4.2 AVX FMA3 BMI2 AVX2
11:51:20.744: 
11:51:20.747: profile Main, level 3.1, 4:2:0, 8-bit
11:51:20.747: 
11:51:52.232: frame I:4     Avg QP:10.98  size: 48578
11:51:52.232: 
11:51:52.232: frame P:246   Avg QP:23.91  size:  3544
11:51:52.232: 
11:51:52.232: frame B:638   Avg QP:29.95  size:   514
11:51:52.232: 
11:51:52.232: consecutive B-frames:  1.9%  4.9%  4.7% 88.4%
```

### Types of changes
* New feature (non-breaking change which adds functionality: map x264 log level to obs log level
* Performance enhancement (non-breaking change which improves efficiency
* Code cleanup

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
