### PR TITLE
UI: Add user interface for encoder fps

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -170,7 +170,7 @@
               <x>0</x>
               <y>0</y>
               <width>767</width>
-              <height>1326</height>
+              <height>1493</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -281,11 +281,11 @@
                    <string>Basic.Settings.General.Updater</string>
                   </property>
                   <layout class="QFormLayout" name="formLayout_20">
-                   <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
                    <property name="fieldGrowthPolicy">
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                   </property>
+                   <property name="labelAlignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                    </property>
                    <item row="0" column="0">
                     <widget class="QLabel" name="updateChannelLabel">
@@ -1571,8 +1571,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>772</width>
-                     <height>651</height>
+                     <width>758</width>
+                     <height>777</height>
                     </rect>
                    </property>
                    <property name="sizePolicy">
@@ -1757,7 +1757,7 @@
                        <item row="3" column="1">
                         <widget class="QComboBox" name="simpleOutPreset"/>
                        </item>
-                       <item row="4" column="1">
+                       <item row="5" column="1">
                         <widget class="QCheckBox" name="simpleOutAdvanced">
                          <property name="text">
                           <string>Basic.Settings.Output.Advanced</string>
@@ -1767,7 +1767,7 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="5" column="0">
+                       <item row="6" column="0">
                         <widget class="QLabel" name="label_23">
                          <property name="text">
                           <string>Basic.Settings.Output.CustomEncoderSettings</string>
@@ -1777,10 +1777,10 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="5" column="1">
+                       <item row="6" column="1">
                         <widget class="QLineEdit" name="simpleOutCustom"/>
                        </item>
-                       <item row="6" column="0">
+                       <item row="7" column="0">
                         <widget class="QLabel" name="simpleOutStrAEncoderLabel">
                          <property name="text">
                           <string>Basic.Settings.Output.Encoder.Audio</string>
@@ -1790,8 +1790,18 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="6" column="1">
+                       <item row="7" column="1">
                         <widget class="QComboBox" name="simpleOutStrAEncoder"/>
+                       </item>
+                       <item row="4" column="1">
+                        <widget class="QComboBox" name="simpleOutStreamFPS"/>
+                       </item>
+                       <item row="4" column="0">
+                        <widget class="QLabel" name="label_24">
+                         <property name="text">
+                          <string>FPS</string>
+                         </property>
+                        </widget>
                        </item>
                       </layout>
                      </widget>
@@ -2149,7 +2159,7 @@
                          </widget>
                         </widget>
                        </item>
-                       <item row="7" column="0">
+                       <item row="8" column="0">
                         <widget class="QLabel" name="label_420">
                          <property name="text">
                           <string>Basic.Settings.Output.CustomMuxerSettings</string>
@@ -2159,16 +2169,26 @@
                          </property>
                         </widget>
                        </item>
-                       <item row="7" column="1">
+                       <item row="8" column="1">
                         <widget class="QLineEdit" name="simpleOutMuxCustom"/>
                        </item>
-                       <item row="8" column="1">
+                       <item row="9" column="1">
                         <widget class="QCheckBox" name="simpleReplayBuf">
                          <property name="text">
                           <string>Basic.Settings.Output.UseReplayBuffer</string>
                          </property>
                          <property name="checked">
                           <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="7" column="1">
+                        <widget class="QComboBox" name="simpleOutRecFPS"/>
+                       </item>
+                       <item row="7" column="0">
+                        <widget class="QLabel" name="label_10">
+                         <property name="text">
+                          <string>FPS</string>
                          </property>
                         </widget>
                        </item>
@@ -2373,7 +2393,7 @@
                          <x>0</x>
                          <y>0</y>
                          <width>759</width>
-                         <height>616</height>
+                         <height>611</height>
                         </rect>
                        </property>
                        <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -2547,6 +2567,16 @@
                              </property>
                              <property name="editable">
                               <bool>true</bool>
+                             </property>
+                            </widget>
+                           </item>
+                           <item row="5" column="1">
+                            <widget class="QComboBox" name="advOutStreamFPS"/>
+                           </item>
+                           <item row="5" column="0">
+                            <widget class="QLabel" name="label_27">
+                             <property name="text">
+                              <string>FPS</string>
                              </property>
                             </widget>
                            </item>
@@ -2730,7 +2760,7 @@
                              <x>0</x>
                              <y>0</y>
                              <width>759</width>
-                             <height>587</height>
+                             <height>580</height>
                             </rect>
                            </property>
                            <property name="sizePolicy">
@@ -2889,6 +2919,40 @@
                                  </property>
                                  <property name="currentText">
                                   <string/>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="3" column="0">
+                                <widget class="QLabel" name="advOutRecEncLabel">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Encoder.Video</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="3" column="1">
+                                <widget class="QComboBox" name="advOutRecEncoder">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="4" column="0">
+                                <widget class="QLabel" name="advOutRecAEncLabel">
+                                 <property name="text">
+                                  <string>Basic.Settings.Output.Encoder.Audio</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="4" column="1">
+                                <widget class="QComboBox" name="advOutRecAEncoder">
+                                 <property name="sizePolicy">
+                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                                   <horstretch>0</horstretch>
+                                   <verstretch>0</verstretch>
+                                  </sizepolicy>
                                  </property>
                                 </widget>
                                </item>
@@ -3100,40 +3164,6 @@
                                  </widget>
                                 </widget>
                                </item>
-                               <item row="4" column="0">
-                                <widget class="QLabel" name="advOutRecAEncLabel">
-                                 <property name="text">
-                                  <string>Basic.Settings.Output.Encoder.Audio</string>
-                                 </property>
-                                </widget>
-                               </item>
-                               <item row="4" column="1">
-                                <widget class="QComboBox" name="advOutRecAEncoder">
-                                 <property name="sizePolicy">
-                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                   <horstretch>0</horstretch>
-                                   <verstretch>0</verstretch>
-                                  </sizepolicy>
-                                 </property>
-                                </widget>
-                               </item>
-                               <item row="3" column="0">
-                                <widget class="QLabel" name="advOutRecEncLabel">
-                                 <property name="text">
-                                  <string>Basic.Settings.Output.Encoder.Video</string>
-                                 </property>
-                                </widget>
-                               </item>
-                               <item row="3" column="1">
-                                <widget class="QComboBox" name="advOutRecEncoder">
-                                 <property name="sizePolicy">
-                                  <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                                   <horstretch>0</horstretch>
-                                   <verstretch>0</verstretch>
-                                  </sizepolicy>
-                                 </property>
-                                </widget>
-                               </item>
                                <item row="6" column="0">
                                 <widget class="QCheckBox" name="advOutRecUseRescale">
                                  <property name="sizePolicy">
@@ -3184,14 +3214,14 @@
                                  </layout>
                                 </widget>
                                </item>
-                               <item row="7" column="0">
+                               <item row="8" column="0">
                                 <widget class="QLabel" name="label_9001">
                                  <property name="text">
                                   <string>Basic.Settings.Output.CustomMuxerSettings</string>
                                  </property>
                                 </widget>
                                </item>
-                               <item row="7" column="1">
+                               <item row="8" column="1">
                                 <widget class="QLineEdit" name="advOutMuxCustom">
                                  <property name="sizePolicy">
                                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -3201,7 +3231,7 @@
                                  </property>
                                 </widget>
                                </item>
-                               <item row="8" column="0">
+                               <item row="9" column="0">
                                 <widget class="QCheckBox" name="advOutSplitFile">
                                  <property name="sizePolicy">
                                   <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
@@ -3217,7 +3247,7 @@
                                  </property>
                                 </widget>
                                </item>
-                               <item row="8" column="1">
+                               <item row="9" column="1">
                                 <widget class="QComboBox" name="advOutSplitFileType">
                                  <property name="enabled">
                                   <bool>false</bool>
@@ -3239,14 +3269,14 @@
                                  </item>
                                 </widget>
                                </item>
-                               <item row="9" column="0">
+                               <item row="10" column="0">
                                 <widget class="QLabel" name="advOutSplitFileTimeLabel">
                                  <property name="text">
                                   <string>Basic.Settings.Output.SplitFile.Time</string>
                                  </property>
                                 </widget>
                                </item>
-                               <item row="9" column="1">
+                               <item row="10" column="1">
                                 <widget class="QSpinBox" name="advOutSplitFileTime">
                                  <property name="suffix">
                                   <string> min</string>
@@ -3262,14 +3292,14 @@
                                  </property>
                                 </widget>
                                </item>
-                               <item row="10" column="0">
+                               <item row="11" column="0">
                                 <widget class="QLabel" name="advOutSplitFileSizeLabel">
                                  <property name="text">
                                   <string>Basic.Settings.Output.SplitFile.Size</string>
                                  </property>
                                 </widget>
                                </item>
-                               <item row="10" column="1">
+                               <item row="11" column="1">
                                 <widget class="QSpinBox" name="advOutSplitFileSize">
                                  <property name="suffix">
                                   <string> MB</string>
@@ -3282,6 +3312,16 @@
                                  </property>
                                  <property name="value">
                                   <number>2048</number>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item row="7" column="1">
+                                <widget class="QComboBox" name="advOutRecFPS"/>
+                               </item>
+                               <item row="7" column="0">
+                                <widget class="QLabel" name="label_45">
+                                 <property name="text">
+                                  <string>FPS</string>
                                  </property>
                                 </widget>
                                </item>
@@ -3373,8 +3413,8 @@
                             <rect>
                              <x>0</x>
                              <y>0</y>
-                             <width>759</width>
-                             <height>587</height>
+                             <width>806</width>
+                             <height>522</height>
                             </rect>
                            </property>
                            <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -3893,7 +3933,7 @@
                             <x>0</x>
                             <y>0</y>
                             <width>759</width>
-                            <height>616</height>
+                            <height>611</height>
                            </rect>
                           </property>
                           <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -4966,7 +5006,7 @@
               <x>0</x>
               <y>0</y>
               <width>781</width>
-              <height>640</height>
+              <height>633</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -5899,7 +5939,7 @@
               <x>0</x>
               <y>0</y>
               <width>761</width>
-              <height>644</height>
+              <height>643</height>
              </rect>
             </property>
             <layout class="QFormLayout" name="hotkeyFormLayout">
@@ -5976,8 +6016,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>799</width>
-              <height>666</height>
+              <width>906</width>
+              <height>665</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_42">
@@ -6885,8 +6925,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>826</width>
-              <height>1000</height>
+              <width>915</width>
+              <height>1095</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -528,19 +528,25 @@ void SimpleOutput::LoadRecordingPreset_Lossless()
 
 void SimpleOutput::LoadRecordingPreset_Lossy(const char *encoderId)
 {
+	int divisor =
+		config_get_int(main->Config(), "SimpleOutput", "RecFPSDivisor");
 	videoRecording = obs_video_encoder_create(
 		encoderId, "simple_video_recording", nullptr, nullptr);
 	if (!videoRecording)
 		throw "Failed to create video recording encoder (simple output)";
+	obs_encoder_set_frame_rate_divisor(videoRecording, divisor);
 	obs_encoder_release(videoRecording);
 }
 
 void SimpleOutput::LoadStreamingPreset_Lossy(const char *encoderId)
 {
+	int divisor = config_get_int(main->Config(), "SimpleOutput",
+				     "StreamFPSDivisor");
 	videoStreaming = obs_video_encoder_create(
 		encoderId, "simple_video_stream", nullptr, nullptr);
 	if (!videoStreaming)
 		throw "Failed to create video streaming encoder (simple output)";
+	obs_encoder_set_frame_rate_divisor(videoStreaming, divisor);
 	obs_encoder_release(videoStreaming);
 }
 
@@ -1558,6 +1564,10 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 		config_get_string(main->Config(), "AdvOut", "RecEncoder");
 	const char *recAudioEncoder =
 		config_get_string(main->Config(), "AdvOut", "RecAudioEncoder");
+	int streamDivisor =
+		config_get_int(main->Config(), "AdvOut", "StreamFPSDivisor");
+	int recDivisor =
+		config_get_int(main->Config(), "AdvOut", "RecFPSDivisor");
 #ifdef __APPLE__
 	translate_macvth264_encoder(streamEncoder);
 	translate_macvth264_encoder(recordEncoder);
@@ -1626,6 +1636,8 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 			if (!videoRecording)
 				throw "Failed to create recording video "
 				      "encoder (advanced output)";
+			obs_encoder_set_frame_rate_divisor(videoRecording,
+							   recDivisor);
 			obs_encoder_release(videoRecording);
 		}
 	}
@@ -1636,6 +1648,7 @@ AdvancedOutput::AdvancedOutput(OBSBasic *main_) : BasicOutputHandler(main_)
 	if (!videoStreaming)
 		throw "Failed to create streaming video encoder "
 		      "(advanced output)";
+	obs_encoder_set_frame_rate_divisor(videoStreaming, streamDivisor);
 	obs_encoder_release(videoStreaming);
 
 	const char *rate_control = obs_data_get_string(

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1613,6 +1613,9 @@ bool OBSBasic::InitBasicConfigDefaults()
 				  "RecAudioEncoder", "aac");
 	config_set_default_uint(basicConfig, "SimpleOutput", "RecTracks",
 				(1 << 0));
+	config_set_default_int(basicConfig, "SimpleOutput", "RecFPSDivisor", 1);
+	config_set_default_int(basicConfig, "SimpleOutput", "StreamFPSDivisor",
+			       1);
 
 	config_set_default_bool(basicConfig, "AdvOut", "ApplyServiceSettings",
 				true);
@@ -1657,6 +1660,9 @@ bool OBSBasic::InitBasicConfigDefaults()
 	config_set_default_bool(basicConfig, "AdvOut", "RecRB", false);
 	config_set_default_uint(basicConfig, "AdvOut", "RecRBTime", 20);
 	config_set_default_int(basicConfig, "AdvOut", "RecRBSize", 512);
+
+	config_set_default_int(basicConfig, "AdvOut", "RecFPSDivisor", 1);
+	config_set_default_int(basicConfig, "AdvOut", "StreamFPSDivisor", 1);
 
 	config_set_default_uint(basicConfig, "Video", "BaseCX", cx);
 	config_set_default_uint(basicConfig, "Video", "BaseCY", cy);

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -225,6 +225,7 @@ private:
 	void LoadColorFormats();
 	void LoadFormats();
 	void ReloadCodecs(const FFmpegFormat &format);
+	void LoadFPSCombos();
 
 	void UpdateColorFormatSpaceWarning();
 


### PR DESCRIPTION
### Description
The backend functionality of fps divisors was already added. This adds an ui for it. It is added for both simple and advanced modes of streaming and recording.

![Screenshot from 2023-08-22 06-46-41](https://github.com/obsproject/obs-studio/assets/19962531/ed8dfd78-7afb-45ca-aa42-bad9d61a1f3c)

### Motivation and Context
libobs functionality was added with #9001 

This is not ready at all to be merged as there are bugs with #9001. Such as: if the output is set to 60fps and recording is set to 30fps, the video will show up in VLC as 60fps and be played back incorrectly. Also when the recording is stopped, the record button is stuck at "Stopping Recording..."

With the UI, the backend functionality is easier to test.

### How Has This Been Tested?
Recorded at a different fps than the output

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
