### PR TITLE
docs: Add precision on editable string lists

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -664,6 +664,8 @@ Property Modification Functions
    :param    val:  The actual string value stored and will be returned by :c:func:`obs_data_get_string`
    :returns: The index of the list item.
 
+   `Note` : If ``p`` is of type OBS_COMBO_TYPE_EDITABLE, :c:func:`obs_data_get_string` will return ``name`` instead of ``val``.
+
 ---------------------
 
 .. function:: size_t obs_property_list_add_int(obs_property_t *p, const char *name, long long val)
@@ -693,6 +695,8 @@ Property Modification Functions
    :param    idx:  The index of the list item
    :param    name: Localized name shown to user
    :param    val:  The actual string value stored and will be returned by :c:func:`obs_data_get_string`
+
+   `Note` : If ``p`` is of type OBS_COMBO_TYPE_EDITABLE, :c:func:`obs_data_get_string` will return ``name`` instead of ``val``.
 
 ---------------------
 

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -741,6 +741,9 @@ Property Modification Functions
    :param    val:  The actual string value stored and will be returned by :c:func:`obs_data_get_string`
    :returns: The index of the list item.
 
+   Note: If ``p`` is of type OBS_COMBO_TYPE_EDITABLE, :c:func:`obs_data_get_string` will return ``name`` instead of
+   ``val``.
+
 ---------------------
 
 .. function:: size_t obs_property_list_add_int(obs_property_t *p, const char *name, long long val)
@@ -770,6 +773,9 @@ Property Modification Functions
    :param    idx:  The index of the list item
    :param    name: Localized name shown to user
    :param    val:  The actual string value stored and will be returned by :c:func:`obs_data_get_string`
+
+   Note: If ``p`` is of type OBS_COMBO_TYPE_EDITABLE, :c:func:`obs_data_get_string` will return ``name`` instead of
+   ``val``.
 
 ---------------------
 

--- a/docs/sphinx/reference-settings.rst
+++ b/docs/sphinx/reference-settings.rst
@@ -164,6 +164,8 @@ Get Functions
 
 .. function:: const char *obs_data_get_string(obs_data_t *data, const char *name)
 
+   `Note` : If the data object was generated from a OBS_COMBO_TYPE_EDITABLE property, the property's ``name`` will be returned instead of its ``val``.
+
 ---------------------
 
 .. function:: long long obs_data_get_int(obs_data_t *data, const char *name)

--- a/docs/sphinx/reference-settings.rst
+++ b/docs/sphinx/reference-settings.rst
@@ -188,6 +188,9 @@ Get Functions
 
 .. function:: const char *obs_data_get_string(obs_data_t *data, const char *name)
 
+   Note: If the data object was generated from a OBS_COMBO_TYPE_EDITABLE property, the property's ``name`` will be
+   returned instead of its ``val``.
+
 ---------------------
 
 .. function:: long long obs_data_get_int(obs_data_t *data, const char *name)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This adds a precision on the way editable string properties lists work.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The doc states that obs_data_get_string() returns the val parameter of a string list item, which is not true of editable lists, causing potential confusion.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built the doc.
Looked at the doc.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
