### PR TITLE
obs-ffmpeg: Do not include sys/timeb.h on non-Windows system

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -20,6 +20,9 @@
 #include "obs-ffmpeg-url.h"
 #include <srt/srt.h>
 #include <libavformat/avformat.h>
+#ifdef _WIN32
+#include <sys/timeb.h>
+#endif
 
 #define POLLING_TIME 100 /// Time in milliseconds between interrupt check
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-url.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-url.h
@@ -6,7 +6,6 @@
 #include <libavutil/time.h>
 #include <libavutil/error.h>
 #include <stdio.h>
-#include <sys/timeb.h>
 #include <time.h>
 
 #define HTTP_PROTO "http"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Moves `#include <sys/timeb.h>` from `obs-ffmpeg-url.h` to `obs-ffmpeg-srt.h`, which is the actual file that uses `struct timeb`.
- Adds `#ifdef _WIN32` so that `timeb.h` is not included on *nix system.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The `struct timeb` is used on `obs-ffmpeg-srt.h` for only Windows.

The header file `sys/timeb.h` is deprecated on FreeBSD so we want to not include the header file.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
CI has passed to build the code.
Not tested on FreeBSD.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
