### PR TITLE
obs-qsv11: Fix unusual CBR bitrate issues

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -345,15 +345,10 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 		if (pParams->nLADEPTH &&
 		    m_mfxEncParams.mfx.LowPower == MFX_CODINGOPTION_ON) {
 			m_co2.LookAheadDepth = pParams->nLADEPTH;
-			m_co3.ScenarioInfo = MFX_SCENARIO_GAME_STREAMING;
 		}
 		// CQM to follow UI setting
 		if (pParams->bCQM && !pParams->bRepeatHeaders) {
 			m_co3.AdaptiveCQM = MFX_CODINGOPTION_ON;
-			if (m_co3.ScenarioInfo != MFX_SCENARIO_GAME_STREAMING) {
-				m_co3.ScenarioInfo =
-					MFX_SCENARIO_GAME_STREAMING;
-			}
 		} else {
 			m_co3.AdaptiveCQM = MFX_CODINGOPTION_OFF;
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For some reason, using MFX_SCENARIO_GAME_STREAMING causes the keyframe quants to be higher than other frames, which is not desirable. In turn, this causes bitrate to be higher than the target bitrate for a sustained period of time after each keyframe.

Not setting the scenario removes this behavior and returns CBR to somewhat reasonable levels of consistency.

<details>
<summary>Initial approach no longer used</summary>

obs-qsv11: Adjust CBR parameters to reduce bitrate variance

For CBR, set MaxKbps to be the same as TargetKbps, and reduce the multiplier for BufferSizeInKB from 2 to 1. This should reduce the bitrate variance while using CBR.

obs-qsv11: Adjust CBR parameters to reduce initial bitrate spike

For CBR, reduce the InitialDelayInKB multiplier from 1 to 0.5. This should reduce the initial bitrate spike at the beginning of a CBR encoding session.
</details>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #9460.

Want to address target bitrate issues with QSV CBR as much as we are able to do so from within OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 with an Intel Arc A770M. @flaeri checked the output of files before and after these changes and confirmed a noted improvement.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
