### PR TITLE
CI: Add brute-force workaround for macOS disk image creation failure

### DIFF
--- a/.github/scripts/utils.zsh/create_diskimage
+++ b/.github/scripts/utils.zsh/create_diskimage
@@ -27,6 +27,7 @@ safe_hdiutil() {
 
     if (( _status )) {
       log_warning "Unable to run 'hdiutil ${@}' (attempt #${i}). Retrying."
+      if (( ${+CI} )) sudo pkill -9 XProtect >/dev/null || true
       sleep ${_backoff[${i}]}
     } else {
       break


### PR DESCRIPTION
### Description
Kills the `XProtectBehaviorService` between attempts to macOS create disk image for distribution.

### Motivation and Context
Workaround has been suggested by maintainer of GitHub Actions macOS runners (https://github.com/actions/runner-images/issues/7522#issuecomment-1566746364) as a fix for the "Resource Busy" issue that we run into semi-regularly on those runners.

### How Has This Been Tested?
Needs to be tested by having a CI run running into this actual issue.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
