### PR TITLE
cmake: Restrict FindCEF path to omit default paths on Windows

### DIFF
--- a/cmake/finders/FindCEF.cmake
+++ b/cmake/finders/FindCEF.cmake
@@ -98,6 +98,7 @@ if(CMAKE_HOST_SYSTEM_NAME STREQUAL Windows)
   find_program(
     CEF_LIBRARY_RELEASE
     NAMES cef.dll libcef.dll
+    NO_DEFAULT_PATH
     PATHS "${CEF_ROOT_DIR}" "${CEF_ROOT_DIR}/Release"
     DOC "Chromium Embedded Framework library location")
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
On Windows, if CEF libraries were present in default paths, they would be picked up in this find_program call, and it could later cause a build failure in the CMake custom copy commands on install if the components we are trying to copy do not exist. I recently ran into this after installing Intel PresentMon, which included CEF components, and was picked up by this find_program call. Let's apply NO_DEFAULT_PATH here the same as the find_library calls in this finder.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want OBS to build even when the dev has other software installed.

<https://cmake.org/cmake/help/v3.25/command/find_program.html>

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built OBS locally on Windows 11 with Intel PresentMon installed. Verified that the build failed before this PR, but succeeded after this PR. Manually inspected the paths picked up by CMake in both.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
