### PR TITLE
UI: Hide YouTube dock when switching profiles

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -784,13 +784,8 @@ void OBSBasic::ChangeProfile()
 	DestroyPanelCookieManager();
 
 #ifdef YOUTUBE_ENABLED
-	OBSBasic *main = OBSBasic::Get();
-	// This dock works with both stream key and auth
-	// so hide it here if required.
-	YouTubeAppDock *youtubeAppDock = main->GetYouTubeAppDock();
-	if (youtubeAppDock != NULL) {
+	if (youtubeAppDock)
 		youtubeAppDock->hide();
-	}
 #endif
 
 	config.Swap(basicConfig);

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -783,6 +783,16 @@ void OBSBasic::ChangeProfile()
 	auth.reset();
 	DestroyPanelCookieManager();
 
+#ifdef YOUTUBE_ENABLED
+	OBSBasic *main = OBSBasic::Get();
+	// This dock works with both stream key and auth
+	// so hide it here if required.
+	YouTubeAppDock *youtubeAppDock = main->GetYouTubeAppDock();
+	if (youtubeAppDock != NULL) {
+		youtubeAppDock->hide();
+	}
+#endif
+
 	config.Swap(basicConfig);
 	InitBasicConfigDefaults();
 	InitBasicConfigDefaults2();
@@ -813,6 +823,16 @@ void OBSBasic::ChangeProfile()
 			close();
 		}
 	}
+
+#ifdef YOUTUBE_ENABLED
+	if (YouTubeAppDock::IsYTServiceSelected()) {
+		// This is re-initialized in some cases.
+		youtubeAppDock = main->GetYouTubeAppDock();
+		if (youtubeAppDock != NULL) {
+			youtubeAppDock->show();
+		}
+	}
+#endif
 }
 
 void OBSBasic::CheckForSimpleModeX264Fallback()

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -820,13 +820,8 @@ void OBSBasic::ChangeProfile()
 	}
 
 #ifdef YOUTUBE_ENABLED
-	if (YouTubeAppDock::IsYTServiceSelected()) {
-		// This is re-initialized in some cases.
-		youtubeAppDock = main->GetYouTubeAppDock();
-		if (youtubeAppDock != NULL) {
-			youtubeAppDock->show();
-		}
-	}
+	if (YouTubeAppDock::IsYTServiceSelected() && youtubeAppDock)
+		youtubeAppDock->show();
 #endif
 }
 


### PR DESCRIPTION
### Description
Follow the same behaviour as the YouTube chat window for hiding the YouTube Live Control Panel, e.g. when switching to a profile that doesn't use YT.  See https://pasteboard.co/gmNkucqueZQQ.png for which docks I mean.

### Motivation and Context
Feedback from 30 beta. Users were annoyed at having to manually close the YT dock when switching to a non-YT profile, e.g. Twitch.

### How Has This Been Tested?
Tested manually on  windows.

### Types of changes

- Tweak (non-breaking change to improve existing functionality) 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
