### PR TITLE
obs-qsv11: Fix Linux build/runtime issues and clean up Windows code

### DIFF
--- a/cmake/Modules/FindLibva.cmake
+++ b/cmake/Modules/FindLibva.cmake
@@ -15,8 +15,6 @@ find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)
   pkg_check_modules(_LIBVA libva)
   pkg_check_modules(_LIBVA_DRM libva-drm)
-  pkg_check_modules(_LIBVA_WAYLAND libva-wayland)
-  pkg_check_modules(_LIBVA_X11 libva-x11)
 endif()
 
 find_path(
@@ -37,29 +35,14 @@ find_library(
   HINTS ${_LIBVA_DRM_LIBRARY_DIRS}
   PATHS /usr/lib /usr/local/lib /opt/local/lib)
 
-find_library(
-  LIBVA_WAYLAND_LIB
-  NAMES ${_LIBVA_WAYLAND_LIBRARIES} libva-wayland
-  HINTS ${_LIBVA_WAYLAND_LIBRARY_DIRS}
-  PATHS /usr/lib /usr/local/lib /opt/local/lib)
-
-find_library(
-  LIBVA_X11_LIB
-  NAMES ${_LIBVA_X11_LIBRARIES} libva-x11
-  HINTS ${_LIBVA_X11_LIBRARY_DIRS}
-  PATHS /usr/lib /usr/local/lib /opt/local/lib)
-
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Libva REQUIRED_VARS LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB LIBVA_WAYLAND_LIB
-                                                      LIBVA_X11_LIB)
-mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB LIBVA_WAYLAND_LIB LIBVA_X11_LIB)
+find_package_handle_standard_args(Libva REQUIRED_VARS LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
+mark_as_advanced(LIBVA_INCLUDE_DIR LIBVA_LIB LIBVA_DRM_LIB)
 
 if(LIBVA_FOUND)
   set(LIBVA_INCLUDE_DIRS ${LIBVA_INCLUDE_DIR})
   set(LIBVA_LIBRARIES ${LIBVA_LIB})
   set(LIBVA_DRM_LIBRARIES ${LIBVA_DRM_LIB})
-  set(LIBVA_WAYLAND_LIBRARIES ${LIBVA_WAYLAND_LIB})
-  set(LIBVA_X11_LIBRARIES ${LIBVA_X11_LIB})
 
   if(NOT TARGET Libva::va)
     if(IS_ABSOLUTE "${LIBVA_LIBRARIES}")
@@ -85,27 +68,4 @@ if(LIBVA_FOUND)
     set_target_properties(Libva::drm PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
   endif()
 
-  if(NOT TARGET Libva::wayland)
-    if(IS_ABSOLUTE "${LIBVA_WAYLAND_LIBRARIES}")
-      add_library(Libva::wayland UNKNOWN IMPORTED)
-      set_target_properties(Libva::wayland PROPERTIES IMPORTED_LOCATION "${LIBVA_WAYLAND_LIBRARIES}")
-    else()
-      add_library(Libva::wayland INTERFACE IMPORTED)
-      set_target_properties(Libva::wayland PROPERTIES IMPORTED_LIBNAME "${LIBVA_WAYLAND_LIBRARIES}")
-    endif()
-
-    set_target_properties(Libva::wayland PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
-  endif()
-
-  if(NOT TARGET Libva::x11)
-    if(IS_ABSOLUTE "${LIBVA_X11_LIBRARIES}")
-      add_library(Libva::x11 UNKNOWN IMPORTED)
-      set_target_properties(Libva::x11 PROPERTIES IMPORTED_LOCATION "${LIBVA_X11_LIBRARIES}")
-    else()
-      add_library(Libva::x11 INTERFACE IMPORTED)
-      set_target_properties(Libva::x11 PROPERTIES IMPORTED_LIBNAME "${LIBVA_X11_LIBRARIES}")
-    endif()
-
-    set_target_properties(Libva::x11 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${LIBVA_INCLUDE_DIRS}")
-  endif()
 endif()

--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -58,5 +58,5 @@ elseif(OS_LINUX)
 
   target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
 
-  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm Libva::wayland Libva::x11)
+  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm)
 endif()

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -61,6 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include "common_utils.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -91,12 +92,6 @@ static const char *const qsv_usage_names[] = {"TU1: Slowest (Best Quality)",
 static const char *const qsv_latency_names[] = {"ultra-low", "low", "normal",
 						0};
 typedef struct qsv_t qsv_t;
-
-enum qsv_codec {
-	QSV_CODEC_AVC,
-	QSV_CODEC_AV1,
-	QSV_CODEC_HEVC,
-};
 
 typedef struct {
 	mfxU16 nTargetUsage; /* 1 through 7, 1 being best quality and 7

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -180,15 +180,16 @@ mfxStatus QSV_Encoder_Internal::Open(qsv_param_t *pParams, enum qsv_codec codec)
 	if (m_bUseD3D11)
 		// Use D3D11 surface
 		sts = Initialize(m_ver, &m_session, &m_mfxAllocator,
-				 &g_DX_Handle, false, false);
+				 &g_DX_Handle, false, false, codec);
 	else if (m_bD3D9HACK)
 		// Use hack
 		sts = Initialize(m_ver, &m_session, &m_mfxAllocator,
-				 &g_DX_Handle, false, true);
+				 &g_DX_Handle, false, true, codec);
 	else
-		sts = Initialize(m_ver, &m_session, NULL, NULL, NULL, NULL);
+		sts = Initialize(m_ver, &m_session, NULL, NULL, NULL, NULL,
+				 codec);
 #else
-	sts = Initialize(m_ver, &m_session, NULL, NULL, false, false);
+	sts = Initialize(m_ver, &m_session, NULL, NULL, false, false, codec);
 #endif
 
 	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -963,9 +963,9 @@ mfxStatus QSV_Encoder_Internal::ClearData()
 	}
 
 	if ((m_bUseTexAlloc) && (g_numEncodersOpen <= 0)) {
-		Release();
 		g_DX_Handle = NULL;
 	}
+	Release();
 	MFXVideoENCODE_Close(m_session);
 	return sts;
 }

--- a/plugins/obs-qsv11/cmake/legacy.cmake
+++ b/plugins/obs-qsv11/cmake/legacy.cmake
@@ -55,7 +55,7 @@ elseif(OS_LINUX)
 
   target_sources(obs-qsv11 PRIVATE common_utils_linux.cpp)
 
-  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm Libva::wayland Libva::x11)
+  target_link_libraries(obs-qsv11 PRIVATE Libva::va Libva::drm)
 endif()
 
 set_target_properties(obs-qsv11 PROPERTIES FOLDER "plugins/obs-qsv11")

--- a/plugins/obs-qsv11/common_directx11.cpp
+++ b/plugins/obs-qsv11/common_directx11.cpp
@@ -2,10 +2,10 @@
 
 #include <map>
 
-ID3D11Device *g_pD3D11Device;
-ID3D11DeviceContext *g_pD3D11Ctx;
-IDXGIFactory2 *g_pDXGIFactory;
-IDXGIAdapter *g_pAdapter;
+ID3D11Device *g_pD3D11Device = nullptr;
+ID3D11DeviceContext *g_pD3D11Ctx = nullptr;
+IDXGIFactory2 *g_pDXGIFactory = nullptr;
+IDXGIAdapter *g_pAdapter = nullptr;
 
 std::map<mfxMemId *, mfxHDL> allocResponses;
 std::map<mfxHDL, mfxFrameAllocResponse> allocDecodeResponses;

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -4,6 +4,31 @@
 
 // Most of this file shouldnt be accessed from C.
 #ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+enum qsv_codec {
+	QSV_CODEC_AVC,
+	QSV_CODEC_AV1,
+	QSV_CODEC_HEVC,
+};
+
+struct adapter_info {
+	bool is_intel;
+	bool is_dgpu;
+	bool supports_av1;
+	bool supports_hevc;
+};
+
+#define MAX_ADAPTERS 10
+extern struct adapter_info adapters[MAX_ADAPTERS];
+extern size_t adapter_count;
+
+void util_cpuid(int cpuinfo[4], int flags);
+void check_adapters(struct adapter_info *adapters, size_t *adapter_count);
+
+#ifdef __cplusplus
+}
 
 #include <vpl/mfxvideo++.h>
 #include <vpl/mfxdispatcher.h>
@@ -136,7 +161,8 @@ int GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize);
 // Initialize Intel VPL Session, device/display and memory manager
 mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 		     mfxFrameAllocator *pmfxAllocator, mfxHDL *deviceHandle,
-		     bool bCreateSharedHandles, bool dx9hack); //vpl change
+		     bool bCreateSharedHandles, bool dx9hack,
+		     enum qsv_codec codec); //vpl change
 
 // Release resources (device/display)
 void Release();
@@ -149,23 +175,4 @@ void mfxGetTime(mfxTime *timestamp);
 //void mfxInitTime();  might need this for Windows
 double TimeDiffMsec(mfxTime tfinish, mfxTime tstart);
 
-extern "C" {
 #endif // __cplusplus
-
-struct adapter_info {
-	bool is_intel;
-	bool is_dgpu;
-	bool supports_av1;
-	bool supports_hevc;
-};
-
-#define MAX_ADAPTERS 10
-extern struct adapter_info adapters[MAX_ADAPTERS];
-extern size_t adapter_count;
-
-void util_cpuid(int cpuinfo[4], int flags);
-void check_adapters(struct adapter_info *adapters, size_t *adapter_count);
-
-#ifdef __cplusplus
-}
-#endif

--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -5,8 +5,6 @@
 #include <util/c99defs.h>
 #include <util/dstr.h>
 #include <va/va_drm.h>
-#include <va/va_x11.h>
-#include <va/va_wayland.h>
 #include <va/va_str.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -17,6 +15,12 @@
 
 #include <obs.h>
 #include <obs-nix-platform.h>
+
+// Set during check_adapters to work-around VPL dispatcher not setting a VADisplay
+// for the MSDK runtime.
+static const char *default_h264_device = nullptr;
+static const char *default_hevc_device = nullptr;
+static const char *default_av1_device = nullptr;
 
 mfxStatus simple_alloc(mfxHDL pthis, mfxFrameAllocRequest *request,
 		       mfxFrameAllocResponse *response)
@@ -77,7 +81,8 @@ void ClearRGBSurfaceVMem(mfxMemId memId);
 // Initialize Intel VPL Session, device/display and memory manager
 mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 		     mfxFrameAllocator *pmfxAllocator, mfxHDL *deviceHandle,
-		     bool bCreateSharedHandles, bool dx9hack)
+		     bool bCreateSharedHandles, bool dx9hack,
+		     enum qsv_codec codec)
 {
 	UNUSED_PARAMETER(ver);
 	UNUSED_PARAMETER(pmfxAllocator);
@@ -107,22 +112,39 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 		cfg, (const mfxU8 *)"mfxImplDescription.AccelerationMode",
 		impl);
 
-	mfxHDL vaDisplay = nullptr;
-	if (obs_get_nix_platform() == OBS_NIX_PLATFORM_X11_EGL) {
-		vaDisplay =
-			vaGetDisplay((Display *)obs_get_nix_platform_display());
-	} else if (obs_get_nix_platform() == OBS_NIX_PLATFORM_WAYLAND) {
-		vaDisplay = vaGetDisplayWl(
-			(wl_display *)obs_get_nix_platform_display());
+	// We cant cleanup FDs because Release() is only called for gpu texture sharing cases.
+	int fd = -1;
+	if (codec == QSV_CODEC_AVC)
+		fd = open(default_h264_device, O_RDWR);
+	if (codec == QSV_CODEC_HEVC)
+		fd = open(default_hevc_device, O_RDWR);
+	if (codec == QSV_CODEC_AV1)
+		fd = open(default_av1_device, O_RDWR);
+	if (fd < 0) {
+		blog(LOG_ERROR, "Failed to open device '%s'",
+		     default_h264_device);
+		return MFX_ERR_DEVICE_FAILED;
+	}
+
+	mfxHDL vaDisplay = vaGetDisplayDRM(fd);
+	if (!vaDisplay) {
+		return MFX_ERR_DEVICE_FAILED;
 	}
 
 	sts = MFXCreateSession(loader, 0, pSession);
-	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+	if (MFX_ERR_NONE > sts) {
+		blog(LOG_ERROR, "Failed to initialize MFX");
+		MSDK_PRINT_RET_MSG(sts);
+		close(fd);
+		return sts;
+	}
 
 	// VPL expects the VADisplay to be initialized.
 	int major;
 	int minor;
 	if (vaInitialize(vaDisplay, &major, &minor) != VA_STATUS_SUCCESS) {
+		blog(LOG_ERROR, "Failed to initialize VA-API");
+		close(fd);
 		vaTerminate(vaDisplay);
 		return MFX_ERR_DEVICE_FAILED;
 	}
@@ -315,6 +337,18 @@ void check_adapters(struct adapter_info *adapters, size_t *adapter_count)
 				vaapi_supports_av1(device.display);
 			adapter->supports_hevc =
 				vaapi_supports_hevc(device.display);
+
+			if (adapter->is_intel && default_h264_device == nullptr)
+				default_h264_device = strdup(full_path.array);
+
+			if (adapter->supports_av1 &&
+			    default_av1_device == nullptr)
+				default_av1_device = strdup(full_path.array);
+
+			if (adapter->supports_hevc &&
+			    default_hevc_device == nullptr)
+				default_hevc_device = strdup(full_path.array);
+
 			vaapi_close(&device);
 
 		next_entry:

--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -162,7 +162,7 @@ struct vaapi_device {
 	const char *driver;
 };
 
-void vaapi_open(char *device_path, struct vaapi_device *device)
+static void vaapi_open(char *device_path, struct vaapi_device *device)
 {
 	int fd = open(device_path, O_RDWR);
 	if (fd < 0) {
@@ -201,7 +201,7 @@ void vaapi_open(char *device_path, struct vaapi_device *device)
 	device->driver = driver;
 }
 
-void vaapi_close(struct vaapi_device *device)
+static void vaapi_close(struct vaapi_device *device)
 {
 	vaTerminate(device->display);
 	close(device->fd);
@@ -231,7 +231,7 @@ static uint32_t vaapi_check_support(VADisplay display, VAProfile profile,
 	return (rc & VA_RC_CBR || rc & VA_RC_CQP || rc & VA_RC_VBR);
 }
 
-bool vaapi_supports_h264(VADisplay display)
+static bool vaapi_supports_h264(VADisplay display)
 {
 	bool ret = false;
 	ret |= vaapi_check_support(display, VAProfileH264ConstrainedBaseline,
@@ -254,7 +254,7 @@ bool vaapi_supports_h264(VADisplay display)
 	return ret;
 }
 
-bool vaapi_supports_av1(VADisplay display)
+static bool vaapi_supports_av1(VADisplay display)
 {
 	bool ret = false;
 	// Are there any devices with non-LowPower entrypoints?
@@ -265,7 +265,7 @@ bool vaapi_supports_av1(VADisplay display)
 	return ret;
 }
 
-bool vaapi_supports_hevc(VADisplay display)
+static bool vaapi_supports_hevc(VADisplay display)
 {
 	bool ret = false;
 	ret |= vaapi_check_support(display, VAProfileHEVCMain,

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -24,10 +24,10 @@
 
 mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 		     mfxFrameAllocator *pmfxAllocator, mfxHDL *deviceHandle,
-		     bool bCreateSharedHandles, bool dx9hack)
+		     bool bCreateSharedHandles, bool dx9hack,
+		     enum qsv_codec codec)
 {
-	bCreateSharedHandles; // (Lain) Currently unused
-	pmfxAllocator;        // (Lain) Currently unused
+	UNUSED_PARAMETER(codec);
 
 	mfxStatus sts = MFX_ERR_NONE;
 	mfxVariant impl;


### PR DESCRIPTION
### Description
Fixes the wayland/x11 dependencies
Hopefully fixes QSV failing to initialize on multi-gpu systems like laptops.
Includes minor fix-ups I'm trying to sneak into this review.

Largely this is just a lot of shuffling of code so i can pass the codec being used into `Initialize` and use it to make a better decision on the device to use based on initial device enumeration. And some tweaks to avoid leaking resources that are hard to track with the current plugin design, while hopefully not impacting windows. And removing the previous attempt that used x11/wayland as a source of defaults.

### Motivation and Context
People prefer when OBS works.

### How Has This Been Tested?
Encoding still works on Arc 750 and 7100U systems.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
