### PR TITLE
CI: Fix scheduled language file upload

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -102,16 +102,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           : Check Nightly Runs ☑️
-          if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+          if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          local last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
+          last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
 
-          if [[ "${GITHUB_SHA}" == "${last_nightly}" ]] {
-            print "passed=false" >> $GITHUB_OUTPUT
-          } else {
-            print "passed=true" >> $GITHUB_OUTPUT
-            print "lastNightly=${last_nightly}" >> $GITHUB_OUTPUT
-          }
+          if [[ "${GITHUB_SHA}" == "${last_nightly}" ]]; then
+            echo "passed=false" >> $GITHUB_OUTPUT
+          else
+            echo "passed=true" >> $GITHUB_OUTPUT
+            echo "lastNightly=${last_nightly}" >> $GITHUB_OUTPUT
+          fi
 
       - name: Check for Changed Files ✅
         uses: ./.github/actions/check-changes


### PR DESCRIPTION
### Description
Fixes step in nightly language file upload that is based on Zsh but has to be based on Bash instead.

### Motivation and Context
Fix nightly CI runs.

### How Has This Been Tested?
Tested shell script in local bash environment with manually set `GITHUB_SHA` environment variable.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
