### PR TITLE
Quote process paths and add some logging

### DIFF
--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -70,6 +70,11 @@ static inline bool create_process(const char *cmd_line, HANDLE stdin_handle,
 		if (success) {
 			*process = pi.hProcess;
 			CloseHandle(pi.hThread);
+		} else {
+			// Not logging the full command line is intentional
+			// as it may contain stream keys etc.
+			blog(LOG_ERROR, "CreateProcessW failed: %lu",
+			     GetLastError());
 		}
 
 		bfree(cmd_line_w);

--- a/plugins/obs-ffmpeg/obs-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/obs-nvenc-helpers.c
@@ -257,7 +257,10 @@ static bool av1_supported(void)
 	bool av1_supported = false;
 	config_t *config = NULL;
 
-	dstr_copy(&cmd, test_exe);
+	dstr_init_move_array(&cmd, test_exe);
+	dstr_insert_ch(&cmd, 0, '\"');
+	dstr_cat(&cmd, "\"");
+
 	enum_graphics_device_luids(enum_luids, &cmd);
 
 	os_process_pipe_t *pp = os_process_pipe_create(cmd.array, "r");
@@ -310,8 +313,6 @@ fail:
 		config_close(config);
 	dstr_free(&caps_str);
 	dstr_free(&cmd);
-	if (test_exe)
-		bfree(test_exe);
 
 	return av1_supported;
 }

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -2230,7 +2230,9 @@ try {
 	std::stringstream cmd;
 	std::string caps_str;
 
+	cmd << '"';
 	cmd << test_exe;
+	cmd << '"';
 	enum_graphics_device_luids(enum_luids, &cmd);
 
 	os_process_pipe_t *pp = os_process_pipe_create(cmd.str().c_str(), "r");

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -215,7 +215,10 @@ void check_adapters(struct adapter_info *adapters, size_t *adapter_count)
 	const char *error = nullptr;
 	size_t config_adapter_count;
 
-	dstr_copy(&cmd, test_exe);
+	dstr_init_move_array(&cmd, test_exe);
+	dstr_insert_ch(&cmd, 0, '\"');
+	dstr_cat(&cmd, "\"");
+
 	enum_graphics_device_luids(enum_luids, &cmd);
 
 	pp = os_process_pipe_create(cmd.array, "r");
@@ -276,7 +279,6 @@ fail:
 	dstr_free(&caps_str);
 	dstr_free(&cmd);
 	os_process_pipe_destroy(pp);
-	bfree(test_exe);
 }
 
 /* (Lain) Functions currently unused */

--- a/plugins/win-capture/load-graphics-offsets.c
+++ b/plugins/win-capture/load-graphics-offsets.c
@@ -163,6 +163,7 @@ bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache,
 	struct dstr config_ini = {0};
 	struct dstr offset_exe = {0};
 	struct dstr str = {0};
+	struct dstr cmd = {0};
 	os_process_pipe_t *pp;
 	bool success = false;
 	char data[2048];
@@ -177,7 +178,11 @@ bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache,
 	dstr_cat(&offset_exe, is32bit ? "32.exe" : "64.exe");
 	offset_exe_path = obs_module_file(offset_exe.array);
 
-	pp = os_process_pipe_create(offset_exe_path, "r");
+	dstr_init_move_array(&cmd, offset_exe_path);
+	dstr_insert_ch(&cmd, 0, '\"');
+	dstr_cat(&cmd, "\"");
+
+	pp = os_process_pipe_create(cmd.array, "r");
 	if (!pp) {
 		blog(LOG_INFO, "load_graphics_offsets: Failed to start '%s'",
 		     offset_exe.array);
@@ -219,9 +224,9 @@ bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache,
 	os_process_pipe_destroy(pp);
 
 error:
-	bfree(offset_exe_path);
 	dstr_free(&offset_exe);
 	dstr_free(&str);
+	dstr_free(&cmd);
 	return success;
 }
 


### PR DESCRIPTION
### Description
A user is reporting (#9293) an encoder test program failing to run, however we don't have any code to log why `CreateProcess` would fail. This PR adds logging if `CreateProcessW` fails and also (in a separate commit) quotes the executable paths used in `obs-ffmpeg`, `win-capture` and `obs-qsv11` as they are open to misinterpretation if the path has spaces in it.

### Motivation and Context
Try to debug process creation failures and fix a potential issue.

Fixes #9293

### How Has This Been Tested?
Tested graphics offsets, NVENC and QSV test programs locally. No AMF DLL so could not test that but I think this code is correct?

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
