### PR TITLE
plugins, UI: Remove unused static functions

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2965,51 +2965,6 @@ static bool update_reconnect(ConfigFile &config)
 	return false;
 }
 
-static void convert_x264_settings(obs_data_t *data)
-{
-	bool use_bufsize = obs_data_get_bool(data, "use_bufsize");
-
-	if (use_bufsize) {
-		int buffer_size = (int)obs_data_get_int(data, "buffer_size");
-		if (buffer_size == 0)
-			obs_data_set_string(data, "rate_control", "CRF");
-	}
-}
-
-static void convert_14_2_encoder_setting(const char *encoder, const char *file)
-{
-	OBSDataAutoRelease data =
-		obs_data_create_from_json_file_safe(file, "bak");
-	obs_data_item_t *cbr_item = obs_data_item_byname(data, "cbr");
-	obs_data_item_t *rc_item = obs_data_item_byname(data, "rate_control");
-	bool modified = false;
-	bool cbr = true;
-
-	if (cbr_item) {
-		cbr = obs_data_item_get_bool(cbr_item);
-		obs_data_item_unset_user_value(cbr_item);
-
-		obs_data_set_string(data, "rate_control", cbr ? "CBR" : "VBR");
-
-		modified = true;
-	}
-
-	if (!rc_item && astrcmpi(encoder, "obs_x264") == 0) {
-		if (!cbr_item)
-			obs_data_set_string(data, "rate_control", "CBR");
-		else if (!cbr)
-			convert_x264_settings(data);
-
-		modified = true;
-	}
-
-	if (modified)
-		obs_data_save_json_safe(data, file, "tmp", "bak");
-
-	obs_data_item_release(&rc_item);
-	obs_data_item_release(&cbr_item);
-}
-
 static void convert_nvenc_h264_presets(obs_data_t *data)
 {
 	const char *preset = obs_data_get_string(data, "preset");

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -360,27 +360,6 @@ void xcomp_cleanup_pixmap(Display *disp, struct xcompcap *s)
 	}
 }
 
-static enum gs_color_format gs_format_from_tex()
-{
-	GLint iformat = 0;
-	// consider GL_ARB_internalformat_query
-	glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT,
-				 &iformat);
-
-	// These formats are known to be wrong on Intel platforms. We intentionally
-	// use swapped internal formats here to preserve historic behavior which
-	// swapped colors accidentally and because D3D11 would not support a
-	// GS_RGBX format.
-	switch (iformat) {
-	case GL_RGB:
-		return GS_BGRX_UNORM;
-	case GL_RGBA:
-		return GS_RGBA_UNORM;
-	default:
-		return GS_RGBA_UNORM;
-	}
-}
-
 static int silence_x11_errors(Display *display, XErrorEvent *err)
 {
 	UNUSED_PARAMETER(display);

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -903,16 +903,6 @@ static bool init_preset(av_capture *capture, AVCaptureDevice *dev, obs_data_t *s
 static bool operator==(const CMVideoDimensions &a, const CMVideoDimensions &b);
 static CMVideoDimensions get_dimensions(AVCaptureDeviceFormat *format);
 
-static AVCaptureDeviceFormat *find_format(AVCaptureDevice *dev, CMVideoDimensions dims)
-{
-    for (AVCaptureDeviceFormat *format in dev.formats) {
-        if (get_dimensions(format) == dims)
-            return format;
-    }
-
-    return nullptr;
-}
-
 static CMTime convert(media_frames_per_second fps)
 {
     CMTime time {};

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -626,14 +626,6 @@ void ffmpeg_mpegts_data_free(struct ffmpeg_output *stream,
 	memset(data, 0, sizeof(struct ffmpeg_data));
 }
 
-static inline const char *safe_str(const char *s)
-{
-	if (s == NULL)
-		return "(NULL)";
-	else
-		return s;
-}
-
 bool ffmpeg_mpegts_data_init(struct ffmpeg_output *stream,
 			     struct ffmpeg_data *data,
 			     struct ffmpeg_cfg *config)

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -109,8 +109,6 @@ struct ftl_stream {
 	frame_of_nalus_t coded_pic_buffer;
 };
 
-static void log_libftl_messages(ftl_log_severity_t log_level,
-				const char *message);
 static int init_connect(struct ftl_stream *stream);
 static void *connect_thread(void *data);
 static void *status_thread(void *data);
@@ -120,12 +118,6 @@ static const char *ftl_stream_getname(void *unused)
 {
 	UNUSED_PARAMETER(unused);
 	return obs_module_text("FTLStream");
-}
-
-static void log_ftl(int level, const char *format, va_list args)
-{
-	blogva(LOG_INFO, format, args);
-	UNUSED_PARAMETER(level);
 }
 
 static inline size_t num_buffered_packets(struct ftl_stream *stream);
@@ -1010,13 +1002,6 @@ static void *connect_thread(void *data)
 
 	os_atomic_set_bool(&stream->connecting, false);
 	return NULL;
-}
-
-static void log_libftl_messages(ftl_log_severity_t log_level,
-				const char *message)
-{
-	UNUSED_PARAMETER(log_level);
-	blog(LOG_WARNING, "[libftl] %s", message);
 }
 
 static int init_connect(struct ftl_stream *stream)

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -227,13 +227,6 @@ static void rtmp_stream_stop(void *data, uint64_t ts)
 	}
 }
 
-static inline void set_rtmp_str(AVal *val, const char *str)
-{
-	bool valid = (str && *str);
-	val->av_val = valid ? (char *)str : NULL;
-	val->av_len = valid ? (int)strlen(str) : 0;
-}
-
 static inline void set_rtmp_dstr(AVal *val, struct dstr *str)
 {
 	bool valid = !dstr_is_empty(str);

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -837,12 +837,6 @@ static const char *rtmp_common_key(void *data)
 	return service->key;
 }
 
-static bool supports_multitrack(void *data)
-{
-	struct rtmp_common *service = data;
-	return service->supports_additional_audio_track;
-}
-
 static void rtmp_common_get_supported_resolutions(
 	void *data, struct obs_service_resolution **resolutions, size_t *count)
 {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR removes unused static functions under UI and plugins.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

There are some unused static functions such as `getparam()` found by #9498.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Used `lcov` on macOS and Linux (Fedora 37 and Ubuntsu 22.04) and searched white lines (not counted lines).

When removing, I also checked the function is never found by `git grep`.

Built on Fedora 37 and run it.

CI will also test the code can be built...

Note:
`session_set_prop_str` is also unused but I left the function because this is just one type of `session_set_prop_*` functions.
https://github.com/obsproject/obs-studio/blob/08f5a7bd4d62c3aae459b59a02eb927001d4fdbb/plugins/mac-videotoolbox/encoder.c#L271-L279

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
