### PR TITLE
updater: Static analysis cleanups

### DIFF
--- a/UI/win-update/updater/hash.cpp
+++ b/UI/win-update/updater/hash.cpp
@@ -23,10 +23,10 @@ using namespace std;
 
 void HashToString(const B2Hash &in, string &out)
 {
-	const char alphabet[] = "0123456789abcdef";
+	constexpr char alphabet[] = "0123456789abcdef";
 	out.resize(kBlake2StrLength);
 
-	for (int i = 0; i != kBlake2HashLength; ++i) {
+	for (size_t i = 0; i != kBlake2HashLength; ++i) {
 		out[2 * i] = alphabet[(uint8_t)in[i] / 16];
 		out[2 * i + 1] = alphabet[(uint8_t)in[i] % 16];
 	}
@@ -37,9 +37,9 @@ void StringToHash(const string &in, B2Hash &out)
 	unsigned int temp;
 	const char *str = in.c_str();
 
-	for (int i = 0; i < kBlake2HashLength; i++) {
+	for (size_t i = 0; i < kBlake2HashLength; i++) {
 		sscanf_s(str + i * 2, "%02x", &temp);
-		out[i] = (std::byte)temp;
+		out[i] = static_cast<std::byte>(temp);
 	}
 }
 
@@ -59,18 +59,18 @@ bool CalculateFileHash(const wchar_t *path, B2Hash &hash)
 
 	for (;;) {
 		DWORD read = 0;
-		if (!ReadFile(handle, &hashBuffer[0], (DWORD)hashBuffer.size(),
-			      &read, nullptr))
+		if (!ReadFile(handle, hashBuffer.data(),
+			      (DWORD)hashBuffer.size(), &read, nullptr))
 			return false;
 
 		if (!read)
 			break;
 
-		if (blake2b_update(&blake2, &hashBuffer[0], read) != 0)
+		if (blake2b_update(&blake2, hashBuffer.data(), read) != 0)
 			return false;
 	}
 
-	if (blake2b_final(&blake2, &hash[0], hash.size()) != 0)
+	if (blake2b_final(&blake2, hash.data(), hash.size()) != 0)
 		return false;
 
 	return true;

--- a/UI/win-update/updater/helpers.hpp
+++ b/UI/win-update/updater/helpers.hpp
@@ -4,9 +4,6 @@
 #include <windows.h>
 #include <Wincrypt.h>
 
-#include <cstdint>
-#include <string>
-
 /* ------------------------------------------------------------------------ */
 
 template<typename T, void freefunc(T)> class CustomHandle {

--- a/UI/win-update/updater/updater.hpp
+++ b/UI/win-update/updater/updater.hpp
@@ -93,8 +93,8 @@ void StringToHash(const std::string &in, B2Hash &out);
 
 bool CalculateFileHash(const wchar_t *path, B2Hash &hash);
 
-int ApplyPatch(ZSTD_DCtx *zstdCtx, std::byte *patch_data,
-	       const size_t patch_size, const wchar_t *targetFile);
+int ApplyPatch(ZSTD_DCtx *zstdCtx, const std::byte *patch_data,
+	       size_t patch_size, const wchar_t *targetFile);
 
 extern HWND hwndMain;
 extern HCRYPTPROV hProvider;


### PR DESCRIPTION
### Description

Cleans up a number of complaints from clang-tidy and ReSharper C++.

### Motivation and Context

Code cleanup, fixing some longstanding issues (e.g. returning ints in a function with return type `bool`), replacing hacks like `CreateFoldersForPath` with modern std functions, some C++17 stuff.

Also removing some unused stuff, better const correctness, avoiding unnecessary copies in custom `std::hash` extension.

### How Has This Been Tested?

Compiled and updated an OBS install successfully.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
