### PR TITLE
countdown: Add prefix + suffix script properties

### DIFF
--- a/UI/frontend-plugins/frontend-tools/data/scripts/countdown.lua
+++ b/UI/frontend-plugins/frontend-tools/data/scripts/countdown.lua
@@ -4,6 +4,8 @@ total_seconds = 0
 
 cur_seconds   = 0
 last_text     = ""
+prefix_text   = ""
+suffix_text   = ""
 stop_text     = ""
 activated     = false
 
@@ -15,7 +17,9 @@ function set_time_text()
 	local total_minutes = math.floor(cur_seconds / 60)
 	local minutes       = math.floor(total_minutes % 60)
 	local hours         = math.floor(total_minutes / 60)
-	local text          = string.format("%02d:%02d:%02d", hours, minutes, seconds)
+	local text          = prefix_text ..
+		string.format("%02d:%02d:%02d", hours, minutes, seconds) ..
+		suffix_text
 
 	if cur_seconds < 1 then
 		text = stop_text
@@ -107,7 +111,8 @@ function script_properties()
 	local props = obs.obs_properties_create()
 	obs.obs_properties_add_int(props, "duration", "Duration (minutes)", 1, 100000, 1)
 
-	local p = obs.obs_properties_add_list(props, "source", "Text Source", obs.OBS_COMBO_TYPE_EDITABLE, obs.OBS_COMBO_FORMAT_STRING)
+	local p = obs.obs_properties_add_list(props, "source", "Text Source", obs.OBS_COMBO_TYPE_EDITABLE,
+		obs.OBS_COMBO_FORMAT_STRING)
 	local sources = obs.obs_enum_sources()
 	if sources ~= nil then
 		for _, source in ipairs(sources) do
@@ -120,6 +125,8 @@ function script_properties()
 	end
 	obs.source_list_release(sources)
 
+	obs.obs_properties_add_text(props, "prefix_text", "Prefix Text", obs.OBS_TEXT_DEFAULT) -- Optional text prefix that if not empty is inserted before the timer text
+	obs.obs_properties_add_text(props, "suffix_text", "Suffix Text", obs.OBS_TEXT_DEFAULT) -- Optional text suffix that if not empty is inserted after the timer text
 	obs.obs_properties_add_text(props, "stop_text", "Final Text", obs.OBS_TEXT_DEFAULT)
 	obs.obs_properties_add_button(props, "reset_button", "Reset Timer", reset_button_clicked)
 
@@ -138,6 +145,8 @@ function script_update(settings)
 
 	total_seconds = obs.obs_data_get_int(settings, "duration") * 60
 	source_name = obs.obs_data_get_string(settings, "source")
+	prefix_text = obs.obs_data_get_string(settings, "prefix_text")
+	suffix_text = obs.obs_data_get_string(settings, "suffix_text")
 	stop_text = obs.obs_data_get_string(settings, "stop_text")
 
 	reset(true)


### PR DESCRIPTION
### Description
Added two new script properties, prefix_text and suffix_text, to the countdown script. These properties allow users to insert optional text before and after the countdown timer.
![Screenshot_2023-08-27_03-38-50](https://github.com/obsproject/obs-studio/assets/12934156/65639ae5-de5a-4398-a728-cd30e22efbc8)

### Motivation and Context
This change provides users with the flexibility to add contextual information alongside the countdown timer. It's a feature that enhances user customization without affecting existing functionality.

### How Has This Been Tested?
Manually tested on OS: Ubuntu 20.04 LTS, kernel: 5.8.0-53-generic, CPU arch: x86_64.
Added and removed prefix and suffix text, and verified that the timer displayed the text correctly in all scenarios.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
