### PR TITLE
CI: Fix ccache status output for workflow jobs

### DIFF
--- a/.github/actions/build-obs/action.yaml
+++ b/.github/actions/build-obs/action.yaml
@@ -101,8 +101,6 @@ runs:
     - name: Create Summary 📊
       if: contains(fromJSON('["Linux", "macOS"]'), runner.os)
       shell: zsh --no-rcs --errexit --pipefail {0}
-      env:
-        CCACHE_CONFIGPATH: ${{ inputs.workingDirectory }}/.ccache.conf
       run: |
         : Create Summary 📊
 


### PR DESCRIPTION
### Description
Removes custom Ccache configuration path for cache status output step in `build-obs` action.

### Motivation and Context
CCache configuration path was configurable until the CI script cleanup (as scripts were still intended to be used locally then), which is not needed anymore.

By specifying a custom path, the stats output of `ccache` will use the default cache directory (vs the custom one used on CI) and thus no cache hits will be reported.

### How Has This Been Tested?
Needs to be tested by CI run for pull request.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
