### PR TITLE
CI: Suppress and fix majority of macOS-specific warnings

### DIFF
--- a/deps/json11/CMakeLists.txt
+++ b/deps/json11/CMakeLists.txt
@@ -4,5 +4,6 @@ add_library(json11 INTERFACE)
 add_library(OBS::json11 ALIAS json11)
 
 target_include_directories(json11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_options(json11 INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-unqualified-std-cast-call>)
 
 target_sources(json11 INTERFACE json11.cpp json11.hpp)

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -43,7 +43,7 @@ static inline bool fill_buffer(struct audio_monitor *monitor)
 	circlebuf_pop_front(&monitor->new_data, buf->mAudioData,
 			    monitor->buffer_size);
 
-	buf->mAudioDataByteSize = monitor->buffer_size;
+	buf->mAudioDataByteSize = (UInt32)monitor->buffer_size;
 
 	stat = AudioQueueEnqueueBuffer(monitor->queue, buf, 0, NULL);
 	if (!success(stat, "AudioQueueEnqueueBuffer")) {
@@ -225,7 +225,7 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 
 	for (size_t i = 0; i < 3; i++) {
 		stat = AudioQueueAllocateBuffer(monitor->queue,
-						monitor->buffer_size,
+						(UInt32)monitor->buffer_size,
 						&monitor->buffers[i]);
 		if (!success(stat, "allocation of buffer")) {
 			return false;

--- a/libobs/cmake/os-macos.cmake
+++ b/libobs/cmake/os-macos.cmake
@@ -22,7 +22,7 @@ target_sources(
           util/threading-posix.h
           util/apple/cfstring-utils.h)
 
-target_compile_options(libobs PUBLIC -Wno-strict-prototypes)
+target_compile_options(libobs PUBLIC -Wno-strict-prototypes -Wno-shorten-64-to-32)
 
 set_property(SOURCE util/platform-cocoa.m obs-cocoa.m PROPERTY COMPILE_FLAGS -fobjc-arc)
 set_property(TARGET libobs PROPERTY FRAMEWORK TRUE)

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -322,7 +322,7 @@ obs_key_t obs_key_from_virtual_key(int code)
         return OBS_KEY_META;
     for (size_t i = 0; i < OBS_KEY_LAST_VALUE; i++) {
         if (virtual_keys[i] == code) {
-            return i;
+            return (obs_key_t) i;
         }
     }
     return OBS_KEY_NONE;

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -190,7 +190,7 @@ os_cpu_usage_info_t *os_cpu_usage_info_start(void)
         return NULL;
     }
 
-    info->core_count = sysconf(_SC_NPROCESSORS_ONLN);
+    info->core_count = (int) sysconf(_SC_NPROCESSORS_ONLN);
     return info;
 }
 

--- a/plugins/aja/CMakeLists.txt
+++ b/plugins/aja/CMakeLists.txt
@@ -58,7 +58,7 @@ elseif(OS_MACOS)
   find_library(APPKIT AppKit)
 
   target_link_libraries(aja PRIVATE ${IOKIT} ${COREFOUNDATION} ${APPKIT})
-  target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations)
+  target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations -Wno-shorten-64-to-32)
 elseif(OS_LINUX OR OS_FREEBSD)
   target_compile_options(aja PRIVATE -Wno-error=deprecated-declarations)
 endif()

--- a/plugins/decklink/CMakeLists.txt
+++ b/plugins/decklink/CMakeLists.txt
@@ -62,6 +62,7 @@ elseif(OS_MACOS)
   mark_as_advanced(COREFOUNDATION)
 
   target_sources(decklink PRIVATE mac/platform.cpp)
+  target_compile_options(decklink PRIVATE -Wno-shorten-64-to-32)
   target_link_libraries(decklink PRIVATE ${COREFOUNDATION})
 
   target_sources(

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(
           obs-ffmpeg-video-encoders.c
           obs-ffmpeg.c)
 
+target_compile_options(obs-ffmpeg PRIVATE $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wno-shorten-64-to-32>)
 target_compile_definitions(obs-ffmpeg PRIVATE $<$<BOOL:${ENABLE_FFMPEG_LOGGING}>:ENABLE_FFMPEG_LOGGING>)
 
 target_link_libraries(

--- a/plugins/obs-outputs/cmake/ftl.cmake
+++ b/plugins/obs-outputs/cmake/ftl.cmake
@@ -48,15 +48,19 @@ target_enable_feature(obs-outputs "FTL protocol support")
 get_target_property(target_sources ftl-sdk INTERFACE_SOURCES)
 
 if(NOT CMAKE_C_COMPILER_ID STREQUAL "MSVC")
-  set(silence_ftl -Wno-error=unused-parameter -Wno-error=unused-variable -Wno-error=sign-compare
-                  -Wno-error=pointer-sign -Wno-error=int-conversion)
+  set(silence_ftl -Wno-unused-parameter -Wno-unused-variable -Wno-sign-compare -Wno-pointer-sign -Wno-int-conversion)
 
   if(CMAKE_C_COMPILER_ID MATCHES "(Apple)?Clang")
-    list(APPEND silence_ftl -Wno-error=incompatible-function-pointer-types -Wno-error=implicit-int-conversion
-         -Wno-shorten-64-to-32 -Wno-macro-redefined)
+    list(
+      APPEND
+      silence_ftl
+      -Wno-incompatible-function-pointer-types
+      -Wno-implicit-int-conversion
+      -Wno-shorten-64-to-32
+      -Wno-macro-redefined
+      -Wno-enum-conversion)
   elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    list(APPEND silence_ftl -Wno-error=extra -Wno-error=incompatible-pointer-types -Wno-error=int-conversion
-         -Wno-error=builtin-macro-redefined)
+    list(APPEND silence_ftl -Wno-extra -Wno-incompatible-pointer-types -Wno-int-conversion -Wno-builtin-macro-redefined)
   endif()
 
   if((NOT CMAKE_C_COMPILER_ID STREQUAL "GNU") OR CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 10)

--- a/plugins/text-freetype2/find-font.c
+++ b/plugins/text-freetype2/find-font.c
@@ -226,7 +226,7 @@ static void create_bitmap_sizes(struct font_path_info *info, FT_Face face)
 	da_reserve(sizes, face->num_fixed_sizes);
 
 	for (int i = 0; i < face->num_fixed_sizes; i++) {
-		int val = face->available_sizes[i].size >> 6;
+		FT_Pos val = face->available_sizes[i].size >> 6;
 		da_push_back(sizes, &val);
 	}
 

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -26,7 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 struct glyph_info {
 	float u, v, u2, v2;
 	int32_t w, h, xoff, yoff;
-	int32_t xadv;
+	FT_Pos xadv;
 };
 
 struct ft2_source {

--- a/plugins/vlc-video/CMakeLists.txt
+++ b/plugins/vlc-video/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(vlc-video MODULE)
 add_library(OBS::vlc-video ALIAS vlc-video)
 
 target_sources(vlc-video PRIVATE vlc-video-plugin.c vlc-video-plugin.h vlc-video-source.c)
+target_compile_options(vlc-video PRIVATE $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wno-shorten-64-to-32>)
 target_link_libraries(vlc-video PRIVATE OBS::libobs)
 
 check_vlc_path()


### PR DESCRIPTION
### Description
Either suppresses or fixes a majority of warnings currently emitted by macOS builds.

### Motivation and Context
After reviewing the warnings currently emitted by macOS builds, a majority of them falls into these categories:

* Integer truncation: `libobs` uses 64-bit integers internally which are (with a few exceptions) stored in 16-bit integers. Given that most values used by code should fit within that smaller type, the truncation is possible, but improbable and even if it occurs should not lead to runtime issues.
* Outdated or abandoned vendored dependencies: Maintainers are aware of the status of these dependencies, with plans to either remove or replace them in due time. The warnings have been acknowledged and can thus be silenced.

Given the widespread occurrence of the warnings, it was not feasible to silence them specifically on each occasion (while leaving the warning overall intact for new code), which is unfortunate but the most pragmatic choice right now.

Warnings for macOS-specific code have been fixed instead (e.g. by using explicit casts).

### How Has This Been Tested?
Code successfully compiled and ran on macOS 13.4.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
