### PR TITLE
mac-videotoolbox: Set default keyframe interval to 2 seconds, Remove CRF 0 second keyint override

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -596,18 +596,6 @@ static bool create_encoder(struct vt_encoder *enc)
 
 	if (enc->codec_type == kCMVideoCodecType_H264 ||
 	    enc->codec_type == kCMVideoCodecType_HEVC) {
-		/* Apple's documentation states that a keyframe interval of 0 will result in
-		 * the encoder automatically picking times to insert them; However, Apple's
-		 * encoder, when in CRF mode, will never actually insert any keyframes past
-		 * the very first one, rendering the files near-unusable in editors or
-		 * video players. So to avoid that happening, enforce a reasonable default
-		 * of 10 seconds in CRF mode. */
-		if (enc->keyint == 0 && strcmp(enc->rate_control, "CRF") == 0) {
-			VT_BLOG(LOG_INFO,
-				"Enforcing non-zero keyframe interval in CRF mode");
-			enc->keyint = 10;
-		}
-
 		// This can fail when using GPU hardware encoding
 		code = session_set_prop_int(
 			s,

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -1548,7 +1548,7 @@ static void vt_defaults(obs_data_t *settings, void *data)
 	obs_data_set_default_bool(settings, "limit_bitrate", false);
 	obs_data_set_default_int(settings, "max_bitrate", 2500);
 	obs_data_set_default_double(settings, "max_bitrate_window", 1.5f);
-	obs_data_set_default_int(settings, "keyint_sec", 0);
+	obs_data_set_default_int(settings, "keyint_sec", 2);
 	obs_data_set_default_string(
 		settings, "profile",
 		type_data->codec_type == kCMVideoCodecType_H264 ? "high"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
0 seconds means "auto" according to the [documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_maxkeyframeinterval), but this appears
to be broken in many configurations (more than just CRF mode on Apple
Silicon). With some encoders it means that the encoder sets a keyframes
every 31st frame, other times it just doesn't set any keyframes at all
after the first one, only rarely does the "auto" interval actually
appear to work.
Lets just set the default to 2 seconds and be happy. In theory this is
the maximum keyframe interval and encoders are allowed to set more if
they so wish, but they never appear to do so.

Also removes the 0 second keyint override in CRF mode.
The 0 second default interval no longer happens per default, if
someone explicitly sets the interval to 0 seconds ("auto"), we should
allow them to do that.

This change will effect existing configurations, but probably for the better.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Videos without keyframes, from various encoders (Intel, Apple Silicon) and in various rate control configurations, still come up in support way too often.
This change should mostly eliminate them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested that in Advanced the default is now 2 seconds; and in Simple the encoder always has 2 seconds.
Verified that recordings come out with a 2 second keyframe interval via ffprobe.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
