### PR TITLE
UI: Fix source enumeration in source select aborting prematurely

### DIFF
--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -33,7 +33,7 @@ struct AddSourceData {
 bool OBSBasicSourceSelect::EnumSources(void *data, obs_source_t *source)
 {
 	if (obs_source_is_hidden(source))
-		return false;
+		return true;
 
 	OBSBasicSourceSelect *window =
 		static_cast<OBSBasicSourceSelect *>(data);


### PR DESCRIPTION
### Description

Fixes an issue when enumerating sources for the "add existing" option. This clearly is meant to ignore hidden sources, not abort the enumeration when it encounters one.

### Motivation and Context

OBS itself doesn't use them (yet), but third-party plugins do. Also fixes an issue observed with #9524.

### How Has This Been Tested?

Verified sources are now listed properly.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
