### PR TITLE
mac-avcapture: Log if portrait or studio light effects are active

### DIFF
--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -1118,6 +1118,18 @@ static void capture_device(av_capture *capture, AVCaptureDevice *dev, obs_data_t
     obs_data_set_string(settings, "device_name", name);
     obs_data_set_string(settings, "device", dev.uniqueID.UTF8String);
     AVLOG(LOG_INFO, "Selected device '%s'", name);
+    if (@available(macOS 12.0, *)) {
+        if ([dev isPortraitEffectActive])
+            AVLOG(LOG_WARNING, "Portrait effect is active on selected device");
+    }
+    if (@available(macOS 12.3, *)) {
+        if ([dev isCenterStageActive])
+            AVLOG(LOG_WARNING, "Center Stage effect is active on selected device");
+    }
+    if (@available(macOS 13.0, *)) {
+        if ([dev isStudioLightActive])
+            AVLOG(LOG_WARNING, "Studio Light effect is active on selected device");
+    }
 
     if ((capture->use_preset = obs_data_get_bool(settings, "use_preset"))) {
         if (!init_preset(capture, dev, settings))


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
These effects can remain enabled between devices (so enabling it on one device can mean it's later also enabled on another device), leading to cases of capture cards getting blurred.
Logging that the effects are enabled should make it easier to spot this in support.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Blurred capture cards come up sometimes in support.
Medium term I'd also like to put a warning about it somewhere in the UI (maybe via the properties of the source, or the notifications system once it exists), but that brings UI/UX discussion with it. This PR just adds a log line on device selection (so on OBS startup or when a user switches the device).
Would like to get this into OBS 30.0 if possible (therefore the small scope).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Enabled the effects on my camera and saw it being logged upon device selection. Disabled the effects and saw that upon reselecting it would no longer be logged.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
