### PR TITLE
libobs: Fix obs_output_video and obs_output_audio for encoded output

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -201,10 +201,8 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 	} else {
 		output->info = *info;
 	}
-	if (!flag_encoded(output)) {
-		output->video = obs_get_video();
-		output->audio = obs_get_audio();
-	}
+	output->video = obs_get_video();
+	output->audio = obs_get_audio();
 	if (output->info.get_defaults)
 		output->info.get_defaults(output->context.settings);
 
@@ -846,13 +844,9 @@ void obs_output_set_media(obs_output_t *output, video_t *video, audio_t *audio)
 {
 	if (!obs_output_valid(output, "obs_output_set_media"))
 		return;
-	if (log_flag_encoded(output, __FUNCTION__, true))
-		return;
 
-	if (flag_video(output))
-		output->video = video;
-	if (flag_audio(output))
-		output->audio = audio;
+	output->video = video;
+	output->audio = audio;
 }
 
 video_t *obs_output_video(const obs_output_t *output)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR partially reverts fb57eff21 and 645e31fa1 so that `obs_output_video` can return a valid pointer instead of NULL.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Some plugins such as obs-websocket and obs-midi expect `obs_output_video` to return a valid pointer to calculate the duration of streaming and recording regardless of the output type is raw or encoded.

- https://github.com/obsproject/obs-websocket/blob/3cd81639457b789bda564cca58badf35f0285106/src/utils/Obs_NumberHelper.cpp#L31
- https://github.com/cpyarger/obs-midi/blob/6b9d12632370a994767284acf27482da73025b83/src/events.cpp#L340

The commit 645e31fa1 blocked `obs_output_set_media` to update `video` and `audio` pointers if it's an encoded type.  It resulted in the encoded output holding a released video pointer at the auto-config wizard.

Another commit fb57eff21 tried to fix the output context holding the released pointer. However, it broke the compatibility with the plugins.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

1. Ran OBS and enabled obs-websocket.
2. Started streaming.
3. Called a request `GetStreamStatus` and checked it returns non-zero `outputDuration` field.

Also tested the auto-config wizard with the modification to accelerate the crash described in #9409 and checked it does not crash.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
