### PR TITLE
libobs: Fix obs_output_video and obs_output_audio for encoded output

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -857,14 +857,30 @@ void obs_output_set_media(obs_output_t *output, video_t *video, audio_t *audio)
 
 video_t *obs_output_video(const obs_output_t *output)
 {
-	return obs_output_valid(output, "obs_output_video") ? output->video
-							    : NULL;
+	if (!obs_output_valid(output, "obs_output_video"))
+		return NULL;
+
+	if (!flag_encoded(output))
+		return output->video;
+
+	obs_encoder_t *vencoder = obs_output_get_video_encoder(output);
+	return obs_encoder_video(vencoder);
 }
 
 audio_t *obs_output_audio(const obs_output_t *output)
 {
-	return obs_output_valid(output, "obs_output_audio") ? output->audio
-							    : NULL;
+	if (!obs_output_valid(output, "obs_output_audio"))
+		return NULL;
+
+	if (!flag_encoded(output))
+		return output->audio;
+
+	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+		if (output->audio_encoders[i])
+			return obs_encoder_audio(output->audio_encoders[i]);
+	}
+
+	return NULL;
 }
 
 static inline size_t get_first_mixer(const obs_output_t *output)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR tries to fix the issue described in #9536 by another way.

Let `obs_output_video` and `obs_output_audio` return the media (video and audio, respectively) from the encoder if the output type is encoded.


|   | 29.1 | master | #9536 | This PR |
|---|---|---|---|---|
| Auto-config wizard (addressed by #9409) | works fine | works fine | works fine | works fine |
| MPEG-TS (addressed by #9523) | works fine | works fine | works fine | works fine |
| #9550 obs-websocket `GetRecordStatus` duration is 0 | Correct | Always 0 | Correct | Correct |
| #9551 obs-websocket `GetRecordStatus` dangling pointer access | Use-after-free | Always 0 | Use-after-free | Correct |
| obs-ndi/obs-ndi#908 Start NDI output fail after restarting video  | Use-after-free | Use-after-free | Use-after-free | Use-after-free |

The PR #9536 try to be as same as 29.1. This PR try to fix further. I'd like to let the reviewers to judge which is preferable.
Especially, I'm not sure this is the right direction or not.

Probably, it's not a good idea to hold `obs_output_t*` pointer much before starting the output in `struct BasicOutputHandler`. On the other hand, decklink-output calls `obs_output_create` just before starting it's output so there is no issue so far.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The PR #9536 attempted to fix the issue introduced by fb57eff21 and 645e31fa1. Howevever, yet another issue was found as described in https://github.com/obsproject/obs-studio/pull/9536#issuecomment-1699104326.

The API `obs_output_video` and `obs_output_audio` returned valid pointers until the commit fb57eff21 and 645e31fa1.
The API `obs_output_video` is used by some plugins such as obs-websocket and obs-midi to calculate the duration of streaming and recording.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

Checked obs-websocket event `GetStreamStatus` returns correct duration for output even after restarting `video_t` by the step below.
1. Start recording
1. Stop recording
1. Open settings and toggle AutoRemux. <-- This will free the current `video_t`.
1. Start recording
1. Call obs-websocket event `GetRecordStatus`. <-- With the PR #9536, this will access the released `video_t *`.
(At each step, I also checked the allocated, freed, `video_t *` and return value of `obs_output_video` and ensure `obs_output_video` returns the newly allocated `video_t *` pointer.

Note that above use-after-free issue happens rarely on Linux because `video_output_open` is called just after `video_output_close` so that the newly allocated `video_t *` points to the same old `video_t *`.

Actually, replacing "recording" with "NDI output" in above step, OBS crashes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
