### PR TITLE
UI: Increase YouTube API timeout 

### DIFF
--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -90,7 +90,7 @@ bool YoutubeApiWrappers::TryInsertCommand(const char *url,
 	std::string output;
 	std::string error;
 	// Increase timeout by the time it takes to transfer `data_size` at 1 Mbps
-	int timeout = 5 + data_size / 125000;
+	int timeout = 60 + data_size / 125000;
 	bool success = GetRemoteFile(url, output, error, &httpStatusCode,
 				     content_type, request_type, data,
 				     {"Authorization: Bearer " + token},


### PR DESCRIPTION
The OBS client side timeout for the YouTube API is too short. New changes proposed to the YouTube API will cause this to fail for creating a broadcast. Increase to a minimum of 60.

### Description
Increase the timeout for the API used to create a YouTube broadcast to a minimum of 60 seconds.

### Motivation and Context
The server side timeout is significantly higher. New changes to the create process are causing OBS
to prematurely timeout.

### How Has This Been Tested?
Tested on Windows.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
