### PR TITLE
mac-virtualcam: Switch pixel format of camera extension to BGRA

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
+++ b/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
@@ -52,7 +52,7 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
         let dimensions = CMVideoDimensions(width: 1920, height: 1080)
         CMVideoFormatDescriptionCreate(
             allocator: kCFAllocatorDefault,
-            codecType: kCVPixelFormatType_32ARGB,
+            codecType: kCVPixelFormatType_32BGRA,
             width: dimensions.width,
             height: dimensions.height,
             extensions: nil,
@@ -179,7 +179,7 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
                     bitsPerComponent: 8,
                     bytesPerRow: rowBytes,
                     space: CGColorSpaceCreateDeviceRGB(),
-                    bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue
+                    bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue | CGBitmapInfo.byteOrder32Little.rawValue
                 )!
                 let graphicsContext = NSGraphicsContext(cgContext: cgContext, flipped: false)
 


### PR DESCRIPTION
### Description
Changes pixel format used by camera extension device to use BGRA instead of the more obscure ARGB.

### Motivation and Context
BGRA was used by default in Apple's example code and is also already supported by OBS.

### How Has This Been Tested?
Tested on macOS 13.5.1 and checked reported format via Video Input Source.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
