### PR TITLE
UI: Fix ifdef for YouTube dock integration

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -4250,7 +4250,7 @@ void OBSBasicSettings::on_listWidget_itemSelectionChanged()
 
 void OBSBasicSettings::UpdateYouTubeAppDockSettings()
 {
-#if defined(BROWSER_ENABLED) && defined(YOUTUBE_ENABLED)
+#if defined(BROWSER_AVAILABLE) && defined(YOUTUBE_ENABLED)
 	if (cef_js_avail) {
 		std::string service = ui->service->currentText().toStdString();
 		if (IsYouTubeService(service)) {


### PR DESCRIPTION
### Description

Fixes ifdef disabling the function that actually destroys the YouTube dock when switching away from a YouTube service.

For some reason this used `BROWSER_ENABLED` which isn't a thing.

### Motivation and Context

Doesn't need to stick around when you switch to a different service.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
