### PR TITLE
UI: Fix settings Apply button always being enabled

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2844,7 +2844,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 		config_get_string(main->Config(), "Output", "IPFamily");
 	bool confirmOnExit =
 		config_get_bool(GetGlobalConfig(), "General", "ConfirmOnExit");
-	ui->confirmOnExit->setChecked(confirmOnExit);
 
 	loading = true;
 
@@ -2854,6 +2853,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	    !SetComboByValue(ui->monitoringDevice, monDevId.toUtf8()))
 		SetInvalidValue(ui->monitoringDevice, monDevName.toUtf8(),
 				monDevId.toUtf8());
+
+	ui->confirmOnExit->setChecked(confirmOnExit);
 
 	ui->filenameFormatting->setText(filename);
 	ui->overwriteIfExists->setChecked(overwriteIfExists);


### PR DESCRIPTION
### Description

Fixes the settings window always having the "Apply" button enabled as though things have changed.

This was simply due to the state of the checkbox being changed before the "loading" flag was set.

### Motivation and Context

Fix UI.

### How Has This Been Tested?

Opened settings, apply button no longer enabled.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
