### PR TITLE
libobs: Remove old macOS guards for NSProcessInfo

### DIFF
--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -223,13 +223,8 @@ void os_cpu_usage_info_destroy(os_cpu_usage_info_t *info)
 os_performance_token_t *os_request_high_performance(const char *reason)
 {
     @autoreleasepool {
-        NSProcessInfo *pi = [NSProcessInfo processInfo];
-        SEL sel = @selector(beginActivityWithOptions:reason:);
-        if (![pi respondsToSelector:sel])
-            return nil;
-
-        //taken from http://stackoverflow.com/a/20100906
-        id activity = [pi beginActivityWithOptions:0x00FFFFFF reason:@(reason)];
+        NSProcessInfo *processInfo = NSProcessInfo.processInfo;
+        id activity = [processInfo beginActivityWithOptions:NSActivityUserInitiated reason:@(reason ? reason : "")];
 
         return CFBridgingRetain(activity);
     }
@@ -238,12 +233,8 @@ os_performance_token_t *os_request_high_performance(const char *reason)
 void os_end_high_performance(os_performance_token_t *token)
 {
     @autoreleasepool {
-        NSProcessInfo *pi = [NSProcessInfo processInfo];
-        SEL sel = @selector(beginActivityWithOptions:reason:);
-        if (![pi respondsToSelector:sel])
-            return;
-
-        [pi endActivity:CFBridgingRelease(token)];
+        NSProcessInfo *processInfo = NSProcessInfo.processInfo;
+        [processInfo endActivity:CFBridgingRelease(token)];
     }
 }
 


### PR DESCRIPTION
### Description
Updates `NSProcessInfo` code to interact with the class directly instead of indirect ObjC message calls.

### Motivation and Context
With the lowest deployment target being macOS 11.0, there is no need to check for the availability of the selectors on the NSProcessInfo class anymore.

The API was added in Mac OSX 10.9, so we are safe:

```
- (id <NSObject>)beginActivityWithOptions:(NSActivityOptions)options reason:(NSString *)reason API_AVAILABLE(macos(10.9), ios(7.0), watchos(2.0), tvos(9.0));
```

### How Has This Been Tested?
Tested on macOS 13.5.1.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
