### PR TITLE
updater: Remove non-error logging from multithreaded code

### DIFF
--- a/UI/win-update/updater/updater.cpp
+++ b/UI/win-update/updater/updater.cpp
@@ -445,8 +445,6 @@ bool DownloadWorkerThread()
 				return false;
 			}
 
-			Status(L"Downloading %s", update.outputPath.c_str());
-
 			auto &buf = download_data[update.downloadHash];
 			/* Reserve required memory */
 			buf.reserve(update.fileSize);
@@ -929,11 +927,6 @@ static bool MoveInUseFileAway(const update_t &file)
 static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 {
 	wchar_t oldFileRenamedPath[MAX_PATH];
-
-	if (file.patchable)
-		Status(L"Updating %s...", file.outputPath.c_str());
-	else
-		Status(L"Installing %s...", file.outputPath.c_str());
 
 	/* Grab the patch/file data from the global cache. */
 	vector<std::byte> &patch_data = download_data[file.downloadHash];
@@ -1625,6 +1618,7 @@ static bool Update(wchar_t *cmdLine)
 	/* ------------------------------------- *
 	 * Download Updates                      */
 
+	Status(L"Downloading updates...");
 	if (!RunDownloadWorkers(4))
 		return false;
 
@@ -1638,6 +1632,7 @@ static bool Update(wchar_t *cmdLine)
 
 	SendDlgItemMessage(hwndMain, IDC_PROGRESS, PBM_SETPOS, 0, 0);
 
+	Status(L"Installing updates...");
 	if (!RunUpdateWorkers(4))
 		return false;
 


### PR DESCRIPTION
### Description

Removes all non-error logging messages from multithreaded code.

### Motivation and Context

Error messages could be hidden by another thread printing an informative message.

The messages printed from multithreaded code are also not particularly useful as they do not reflect reality (multiple things are downloaded/updated at once) and do not really help users understand what's happening either.

### How Has This Been Tested?

Updated OBS locally.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
