### PR TITLE
obs-qsv11: Ensure default devices are Intel devices

### DIFF
--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -348,11 +348,11 @@ void check_adapters(struct adapter_info *adapters, size_t *adapter_count)
 			if (adapter->is_intel && default_h264_device == nullptr)
 				default_h264_device = strdup(full_path.array);
 
-			if (adapter->supports_av1 &&
+			if (adapter->is_intel && adapter->supports_av1 &&
 			    default_av1_device == nullptr)
 				default_av1_device = strdup(full_path.array);
 
-			if (adapter->supports_hevc &&
+			if (adapter->is_intel && adapter->supports_hevc &&
 			    default_hevc_device == nullptr)
 				default_hevc_device = strdup(full_path.array);
 


### PR DESCRIPTION
### Description
Users with newer amd chips might get the default set to the wrong gpu.

### Motivation and Context
Fixes recording on multi-gpu systems.

### How Has This Been Tested?
It still picks the same devices in my one gpu systems as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
