### PR TITLE
libobs-d3d11: Log VRAM in GiB

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1453,6 +1453,11 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 	}
 }
 
+static inline double to_GiB(size_t bytes)
+{
+	return static_cast<double>(bytes) / (1 << 30);
+}
+
 static inline void LogD3DAdapters()
 {
 	ComPtr<IDXGIFactory1> factory;
@@ -1480,10 +1485,11 @@ static inline void LogD3DAdapters()
 
 		os_wcs_to_utf8(desc.Description, 0, name, sizeof(name));
 		blog(LOG_INFO, "\tAdapter %u: %s", i, name);
-		blog(LOG_INFO, "\t  Dedicated VRAM: %" PRIu64,
-		     desc.DedicatedVideoMemory);
-		blog(LOG_INFO, "\t  Shared VRAM:    %" PRIu64,
-		     desc.SharedSystemMemory);
+		blog(LOG_INFO, "\t  Dedicated VRAM: %" PRIu64 " (%.01f GiB)",
+		     desc.DedicatedVideoMemory,
+		     to_GiB(desc.DedicatedVideoMemory));
+		blog(LOG_INFO, "\t  Shared VRAM:    %" PRIu64 " (%.01f GiB)",
+		     desc.SharedSystemMemory, to_GiB(desc.SharedSystemMemory));
 		blog(LOG_INFO, "\t  PCI ID:         %x:%.4x", desc.VendorId,
 		     desc.DeviceId);
 


### PR DESCRIPTION
### Description

Log VRAM in GiB.

### Motivation and Context

Bytes are not super useful to humans.

### How Has This Been Tested?

Verified that it gets logged somewhat more readable.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
