### PR TITLE
UI: Untangle ifdef'd if-statement to un-confuse Xcode

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2451,15 +2451,16 @@ void OBSBasic::ReceivedIntroJson(const QString &text)
 #if defined(OBS_RELEASE_CANDIDATE) && OBS_RELEASE_CANDIDATE > 0
 		if (major == OBS_RELEASE_CANDIDATE_MAJOR &&
 		    minor == OBS_RELEASE_CANDIDATE_MINOR &&
-		    item.RC == OBS_RELEASE_CANDIDATE) {
+		    item.RC == OBS_RELEASE_CANDIDATE)
 #elif OBS_BETA > 0
 		if (major == OBS_BETA_MAJOR && minor == OBS_BETA_MINOR &&
-		    item.Beta == OBS_BETA) {
+		    item.Beta == OBS_BETA)
 #else
 		if (major == LIBOBS_API_MAJOR_VER &&
 		    minor == LIBOBS_API_MINOR_VER && item.RC == 0 &&
-		    item.Beta == 0) {
+		    item.Beta == 0)
 #endif
+		{
 			info_url = item.url;
 			info_increment = item.increment;
 		}
@@ -9474,12 +9475,13 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 #ifdef BROWSER_AVAILABLE
 	if ((oldExtraDocks.size() || extraDocks.size() ||
 	     extraCustomDocks.size() || extraBrowserDocks.size()) &&
-	    !force) {
+	    !force)
 #else
 	if ((oldExtraDocks.size() || extraDocks.size() ||
 	     extraCustomDocks.size()) &&
-	    !force) {
+	    !force)
 #endif
+	{
 		QMessageBox::StandardButton button = QMessageBox::question(
 			this, QTStr("ResetUIWarning.Title"),
 			QTStr("ResetUIWarning.Text"));


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Like many IDEs, Xcode has this feature where it shows the declaration of the method currently being worked in. However it gets confused by scopes starting inside of preprocessor guards and ending outside them, resulting in the declaration of OBSBasic::ReceivedIntroJson always being shown in window-basic-main.cpp from that method downwards. We can work around that by starting and ending the if-scope outside of the ifdefs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I reported this problem to Apple a while back (FB12306380) but don't expect a fix in the foreseeable future.
The problem isn't big but does get a bit annoying after a while, and this workaround is quite trivial.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14, Xcode 15 Beta 8
Xcode now shows the correct declarations through the entirety of the file. Still compiles.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
