### PR TITLE
image-source: Fix slideshow audio rendering buffer overrun

### DIFF
--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -810,9 +810,7 @@ static inline bool ss_audio_render_(obs_source_t *transition, uint64_t *ts_out,
 			float *out = audio_output->output[mix].data[ch];
 			float *in = child_audio.output[mix].data[ch];
 
-			memcpy(out, in,
-			       AUDIO_OUTPUT_FRAMES * MAX_AUDIO_CHANNELS *
-				       sizeof(float));
+			memcpy(out, in, AUDIO_OUTPUT_FRAMES * sizeof(float));
 		}
 	}
 


### PR DESCRIPTION
### Description

Fixes a buffer overrun in the slideshow source's audio rendering functions.

### Motivation and Context

Fix bug discovered when working on the original variant of #9524.

### How Has This Been Tested?

Hasn't (this source doesn't actually support audio, but has to implement `.audio_render` as it's a composite source).

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
