### PR TITLE
obs-webrtc: Add AAC Support

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -1,6 +1,5 @@
 #include "whip-output.h"
 #include "whip-utils.h"
-
 /*
  * Sets the maximum size for a video fragment. Effective range is
  * 576-1470, with a lower value equating to more packets created,
@@ -23,6 +22,7 @@ const uint8_t video_payload_type = 96;
 
 WHIPOutput::WHIPOutput(obs_data_t *, obs_output_t *output)
 	: output(output),
+	  is_aac(false),
 	  endpoint_url(),
 	  bearer_token(),
 	  resource_url(),
@@ -53,6 +53,11 @@ WHIPOutput::~WHIPOutput()
 bool WHIPOutput::Start()
 {
 	std::lock_guard<std::mutex> l(start_stop_mutex);
+
+	auto encoder = obs_output_get_audio_encoder(output, 0);
+	if (encoder != nullptr) {
+		is_aac = (strcmp("aac", obs_encoder_get_codec(encoder)) == 0);
+	}
 
 	if (!obs_output_can_begin_data_capture(output, 0))
 		return false;
@@ -85,6 +90,30 @@ void WHIPOutput::Data(struct encoder_packet *packet)
 
 	if (audio_track && packet->type == OBS_ENCODER_AUDIO) {
 		int64_t duration = packet->dts_usec - last_audio_timestamp;
+
+		if (is_aac) {
+			/*
+			// Latm to write, StreamMuxConfig:out of band
+			// RFC6416 6.3. Fragmentation of MPEG-4 Audio Bitstream (p17)
+			// It is RECOMMENDED to put one audioMuxElement in each RTP packet. If
+			// the size of an audioMuxElement can be kept small enough that the size
+			// of the RTP packet containing it does not exceed the size of the Path
+			// MTU, this will be no problem.
+			// in this case , PayloadLengthInfo will not be writen in rtp payload.
+
+			uint8_t buf[1200] = {0};
+			// PayloadLengthInfo()
+			int header_size = packet->size/0xFF + 1;
+			memset(buf, 0xFF, header_size - 1);
+			buf[header_size - 1] = packet->size % 0xFF;
+
+			//PayloadMux
+			memcpy(buf + header_size, packet->data, packet->size);
+
+			Send(buf, header_size + packet->size, duration, audio_track);
+			*/
+		}
+
 		Send(packet->data, packet->size, duration, audio_track,
 		     audio_sr_reporter);
 		last_audio_timestamp = packet->dts_usec;
@@ -94,6 +123,84 @@ void WHIPOutput::Data(struct encoder_packet *packet)
 		     video_sr_reporter);
 		last_video_timestamp = packet->dts_usec;
 	}
+}
+
+int WHIPOutput::GetAudioSpecificConfigOffset(uint8_t *extradata, size_t size)
+{
+	int object_type;
+	int sampling_index;
+	int sample_rate;
+	int chan_config;
+	int sbr; ///< -1 implicit, 1 presence
+	int ext_object_type;
+	int ext_sampling_index;
+	int ext_sample_rate;
+	int channels;
+	int ps; ///< -1 implicit, 1 presence
+
+	int specific_config_bitindex = 0;
+	int bit_length = (int)size << 3;
+	int start_bit_index = 0;
+
+	GetBitContext gb = {extradata, bit_length, 0};
+	object_type = get_object_type(&gb);
+	sample_rate = get_sample_rate(&gb, &sampling_index);
+	chan_config = get_bits(&gb, 4);
+	if (chan_config < 9)
+		channels = ff_mpeg4audio_channels[chan_config];
+
+	sbr = -1;
+	ps = -1;
+	if (object_type == 5 /*AOT_SBR*/
+	    || (object_type == 29 /*AOT_PS*/ &&
+		!(show_bits(&gb, 3) & 0x03 && !(show_bits(&gb, 9) & 0x3F)))) {
+		if (object_type == 29 /*AOT_PS*/)
+			ps = 1;
+		ext_object_type = 5 /*AOT_SBR*/;
+		sbr = 1;
+
+		ext_sample_rate = get_sample_rate(&gb, &ext_sampling_index);
+		object_type = get_object_type(&gb);
+		if (object_type == 22 /*AOT_ER_BSAC*/)
+			get_bits(&gb, 4);
+	} else {
+		ext_object_type = 0;
+		ext_sample_rate = 0;
+	}
+	specific_config_bitindex = gb.bit_index;
+
+	//no support AOT_ALS
+	return specific_config_bitindex - start_bit_index;
+}
+
+void WHIPOutput::LatmWriteStreamMuxConfig(PutBitContext *pb, uint8_t *extradata,
+					  size_t size)
+{
+	int asc_off = GetAudioSpecificConfigOffset(extradata, size);
+	/* StreamMuxConfig */
+	put_bits(pb, 1, 0); /* audioMuxVersion */
+	put_bits(pb, 1, 1); /* allStreamsSameTimeFraming */
+	put_bits(pb, 6, 0); /* numSubFrames */
+	put_bits(pb, 4, 0); /* numProgram */
+	put_bits(pb, 3, 0); /* numLayer */
+
+	/* AudioSpecificConfig */
+	// + 3 assumes not scalable and dependsOnCoreCoder == 0,
+	// see decode_ga_specific_config in libavcodec/aacdec.c
+	// no support AOT_ALS
+	int header_size = asc_off + 3;
+	int words = header_size >> 4;
+	int bits = header_size & 15;
+	const uint8_t *src = extradata;
+	for (int i = 0; i < words; i++)
+		put_bits(pb, 16, AV_RB16(src + 2 * i));
+	put_bits(pb, bits, AV_RB16(src + 2 * words) >> (16 - bits));
+
+	put_bits(pb, 3, 0);    /* frameLengthType */
+	put_bits(pb, 8, 0xff); /* latmBufferFullness */
+
+	put_bits(pb, 1, 0); /* otherDataPresent */
+	put_bits(pb, 1, 0); /* crcCheckPresent */
 }
 
 void WHIPOutput::ConfigureAudioTrack(std::string media_stream_id,
@@ -111,7 +218,35 @@ void WHIPOutput::ConfigureAudioTrack(std::string media_stream_id,
 
 	rtc::Description::Audio audio_description(
 		audio_mid, rtc::Description::Direction::SendOnly);
-	audio_description.addOpusCodec(audio_payload_type);
+	if (!is_aac) {
+		audio_description.addOpusCodec(audio_payload_type);
+	} else {
+		auto encoder = obs_output_get_audio_encoder(output, 0);
+
+		uint8_t *data = 0; /**< Packet data */
+		size_t size = 0;   /**< Packet size */
+
+		obs_encoder_get_extra_data(encoder, &data, &size);
+
+		uint8_t buf[1024] = {0};
+		PutBitContext pb{buf, 1024, 0, 0, 32};
+		LatmWriteStreamMuxConfig(&pb, data, size);
+		if (pb.bit_left < 32) {
+			put_bits(&pb, pb.bit_left, 0);
+		}
+
+		std::stringstream muxbuf;
+		for (int i = 0; i < pb.index; i++) {
+			muxbuf.fill('0');
+			muxbuf.width(2);
+			muxbuf << std::hex
+			       << static_cast<unsigned int>(pb.buf[i]);
+		}
+		std::string profile = "cpresent=0;config=" + muxbuf.str();
+
+		audio_description.addAACCodec(audio_payload_type, profile);
+	}
+
 	audio_description.addSSRC(ssrc, cname, media_stream_id,
 				  media_stream_track_id);
 	audio_track = peer_connection->addTrack(audio_description);

--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -13,6 +13,8 @@
 
 #include <rtc/rtc.hpp>
 
+#include "whip-utils.h"
+
 class WHIPOutput {
 public:
 	WHIPOutput(obs_data_t *settings, obs_output_t *output);
@@ -42,7 +44,12 @@ private:
 		  std::shared_ptr<rtc::Track> track,
 		  std::shared_ptr<rtc::RtcpSrReporter> rtcp_sr_reporter);
 
+	int GetAudioSpecificConfigOffset(uint8_t *extradata, size_t size);
+	void LatmWriteStreamMuxConfig(PutBitContext *pb, uint8_t *extradata,
+				      size_t size);
+
 	obs_output_t *output;
+	bool is_aac;
 
 	std::string endpoint_url;
 	std::string bearer_token;

--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -1,6 +1,6 @@
 #include "whip-service.h"
 
-const char *audio_codecs[] = {"opus", nullptr};
+const char *audio_codecs[] = {"opus", "aac", nullptr};
 const char *video_codecs[] = {"h264", "hevc", "av1", nullptr};
 
 WHIPService::WHIPService(obs_data_t *settings, obs_service_t *)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
according to rfc6416, This adds AAC support to obs-webrtc
https://datatracker.ietf.org/doc/rfc6416/

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
My motivation is to support RTP AAC in WebRTC according to RFC-6416.



### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
All testing during development was performed on macos-13.5.1 (22G90).   
used aac encoder:
FFmpeg aac
coreaudio aac

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

New feature (non-breaking change which adds functionality)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
