### PR TITLE
obs-scripting: Add obs_enter_graphics_timed as a deadlock workaround

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua-source.c
+++ b/deps/obs-scripting/obs-scripting-lua-source.c
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "obs-scripting-lua.h"
+#include <util/platform.h>
 #include "cstrcache.h"
 
 #include <obs-module.h>
@@ -694,15 +695,41 @@ fail:
 	return 0;
 }
 
+static int obs_lua_yield_source_defn(lua_State *script)
+{
+	struct obs_lua_script *data = current_lua_script;
+
+	int sleep_ms = (int)lua_tointeger(script, -2);
+	const char *id = get_table_string(script, -1, "id");
+
+	if (!id)
+		return 0;
+
+	struct obs_lua_source *existing = find_existing(id);
+
+	if (data)
+		pthread_mutex_unlock(&data->mutex);
+	if (existing)
+		pthread_mutex_unlock(&existing->definition_mutex);
+
+	os_sleep_ms(sleep_ms);
+
+	if (existing)
+		pthread_mutex_lock(&existing->definition_mutex);
+	if (data)
+		pthread_mutex_lock(&data->mutex);
+
+	return 0;
+}
+
 /* ========================================================================= */
 
 void add_lua_source_functions(lua_State *script)
 {
 	lua_getglobal(script, "obslua");
 
-	lua_pushstring(script, "obs_register_source");
-	lua_pushcfunction(script, obs_lua_register_source);
-	lua_rawset(script, -3);
+	add_func("obs_register_source", obs_lua_register_source);
+	add_func("yield_source_defn", obs_lua_yield_source_defn);
 
 	lua_pop(script, 1);
 }

--- a/deps/obs-scripting/obs-scripting-lua-source.c
+++ b/deps/obs-scripting/obs-scripting-lua-source.c
@@ -711,6 +711,9 @@ static inline void undef_source_type(struct obs_lua_script *data,
 				     struct obs_lua_source *ls)
 {
 	pthread_mutex_lock(&ls->definition_mutex);
+
+	struct obs_lua_script *__prev_script = current_lua_script;
+	current_lua_script = data;
 	pthread_mutex_lock(&data->mutex);
 
 	obs_enable_source_type(ls->id, false);
@@ -725,6 +728,8 @@ static inline void undef_source_type(struct obs_lua_script *data,
 	ls->script = NULL;
 
 	pthread_mutex_unlock(&data->mutex);
+	current_lua_script = __prev_script;
+
 	pthread_mutex_unlock(&ls->definition_mutex);
 }
 

--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -1011,16 +1011,27 @@ static int lua_script_log(lua_State *script)
 	return 0;
 }
 
+static int lua_yield_script(lua_State *script)
+{
+	struct obs_lua_script *data = current_lua_script;
+
+	int sleep_ms = (int)lua_tointeger(script, 1);
+
+	if (data)
+		pthread_mutex_unlock(&data->mutex);
+
+	os_sleep_ms(sleep_ms);
+
+	if (data)
+		pthread_mutex_lock(&data->mutex);
+
+	return 0;
+}
+
 /* -------------------------------------------- */
 
 static void add_hook_functions(lua_State *script)
 {
-#define add_func(name, func)                     \
-	do {                                     \
-		lua_pushstring(script, name);    \
-		lua_pushcfunction(script, func); \
-		lua_rawset(script, -3);          \
-	} while (false)
 
 	lua_getglobal(script, "_G");
 
@@ -1063,6 +1074,7 @@ static void add_hook_functions(lua_State *script)
 	add_func("obs_property_set_modified_callback",
 		 property_set_modified_callback);
 	add_func("remove_current_callback", remove_current_callback);
+	add_func("yield_script", lua_yield_script);
 
 	lua_pop(script, 1);
 #undef add_func
@@ -1353,7 +1365,7 @@ void obs_lua_load(void)
 
 	pthread_mutex_init(&tick_mutex, NULL);
 	pthread_mutex_init_recursive(&timer_mutex);
-	pthread_mutex_init(&lua_source_def_mutex, NULL);
+	pthread_mutex_init_recursive(&lua_source_def_mutex);
 
 	/* ---------------------------------------------- */
 	/* Initialize Lua startup script                  */

--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -986,14 +986,15 @@ static int lua_script_log(lua_State *script)
 
 	/* ------------------- */
 
-	dstr_copy(&data->log_chunk, msg);
+	if (data)
+		dstr_copy(&data->log_chunk, msg);
 
-	const char *start = data->log_chunk.array;
+	const char *start = data ? data->log_chunk.array : msg;
 	char *endl = strchr(start, '\n');
 
 	while (endl) {
 		*endl = 0;
-		script_log(&data->base, log_level, "%s", start);
+		script_log(data ? &data->base : NULL, log_level, "%s", start);
 		*endl = '\n';
 
 		start = endl + 1;
@@ -1001,8 +1002,9 @@ static int lua_script_log(lua_State *script)
 	}
 
 	if (start && *start)
-		script_log(&data->base, log_level, "%s", start);
-	dstr_resize(&data->log_chunk, 0);
+		script_log(data ? &data->base : NULL, log_level, "%s", start);
+	if (data)
+		dstr_resize(&data->log_chunk, 0);
 
 	/* ------------------- */
 

--- a/deps/obs-scripting/obs-scripting-lua.h
+++ b/deps/obs-scripting/obs-scripting-lua.h
@@ -51,6 +51,12 @@
 #define warn(format, ...) do_log(LOG_WARNING, format, ##__VA_ARGS__)
 #define info(format, ...) do_log(LOG_INFO, format, ##__VA_ARGS__)
 #define debug(format, ...) do_log(LOG_DEBUG, format, ##__VA_ARGS__)
+#define add_func(name, func)                     \
+	do {                                     \
+		lua_pushstring(script, name);    \
+		lua_pushcfunction(script, func); \
+		lua_rawset(script, -3);          \
+	} while (false)
 
 /* ------------------------------------------------------------ */
 

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -535,6 +535,8 @@ EXPORT int gs_create(graphics_t **graphics, const char *module,
 EXPORT void gs_destroy(graphics_t *graphics);
 
 EXPORT void gs_enter_context(graphics_t *graphics);
+EXPORT int gs_enter_context_timed(graphics_t *graphics,
+				  const uint64_t duration);
 EXPORT void gs_leave_context(void);
 EXPORT graphics_t *gs_get_context(void);
 EXPORT void *gs_get_device_obj(void);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1783,6 +1783,14 @@ void obs_enter_graphics(void)
 		gs_enter_context(obs->video.graphics);
 }
 
+int obs_enter_graphics_timed(const uint64_t duration)
+{
+	if (obs->video.graphics)
+		return gs_enter_context_timed(obs->video.graphics, duration);
+	else
+		return 0;
+}
+
 void obs_leave_graphics(void)
 {
 	if (obs->video.graphics)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -644,6 +644,9 @@ EXPORT bool obs_enum_service_types(size_t idx, const char **id);
 /** Helper function for entering the OBS graphics context */
 EXPORT void obs_enter_graphics(void);
 
+/** Helper function for entering the OBS graphics context w/- timeout */
+EXPORT int obs_enter_graphics_timed(const uint64_t duration);
+
 /** Helper function for leaving the OBS graphics context */
 EXPORT void obs_leave_graphics(void);
 

--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -43,6 +43,14 @@ uint64_t os_gettime_ns(void)
     return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 }
 
+void os_realtime_ts(struct timespec *ts)
+{
+    const uint64_t NANOSEC_PER_SEC = 1000000000;
+    const uint64_t ns = os_gettime_ns();
+    ts->tv_sec = (time_t) (ns / NANOSEC_PER_SEC);
+    ts->tv_nsec = (long) (ns % NANOSEC_PER_SEC);
+}
+
 /* gets the location [domain mask]/Library/Application Support/[name] */
 static int os_get_path_internal(char *dst, size_t size, const char *name, NSSearchPathDomainMask domainMask)
 {

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -104,9 +104,11 @@ EXPORT void os_end_high_performance(os_performance_token_t *);
  */
 EXPORT bool os_sleepto_ns(uint64_t time_target);
 EXPORT bool os_sleepto_ns_fast(uint64_t time_target);
+EXPORT void os_sleep_ns(uint64_t duration);
 EXPORT void os_sleep_ms(uint32_t duration);
 
 EXPORT uint64_t os_gettime_ns(void);
+EXPORT void os_realtime_ts(struct timespec *ts);
 
 EXPORT int os_get_config_path(char *dst, size_t size, const char *name);
 EXPORT char *os_get_config_path_ptr(const char *name);


### PR DESCRIPTION
### Description

Adds a `obs_enter_graphics_timed` function to libobs that accepts a second argument for the time (in nanoseconds) to wait before abandoning the attempt to get the lock. The underlying timeout mechanism is managed by `pthread_mutex_timedlock`.

Also adds a 'realtime' clock accessor to libobs, called `os_realtime_ts`, that returns a `timespec` that can be passed on to functions like `pthread_mutex_timedlock`.

`pthread_mutex_timelock` is not implemented on MacOS, so instead a busy wait is used; this is a stop-gap measure for now (pending feedback on PR).

As an experiment, this PR also adds a `yield_script` and `yield_source_defn` function in `obslua` which provide a mechanism to release the lock on, respectively, the script, or the the script + source defn, for a given period of time (in ms). This allows the graphics thread to acquire locks on the script (or source) to perform an action that would have otherwise deadlocked; the script then attempts to re-acquire the locks.

Aside: I don't particularly like the 'yield', but it could be useful for people working on scripts that would otherwise experience deadlocks; it doesn't seem particularly advisable for a deployed script.


### Motivation and Context

The intention of these additions is to allow those writing Lua scripts (and eventually Python too) to handle failures to lock a mutex (specifically the graphics mutex) within a small amount of time when (re)loading the script, or adding/removing sources (see issue #6674). The experimental 'yields' allow a Lua script user/maintainer to respond to a failed lock attempt with a brief yield which would allow the graphics thread to perform some action, then (perhaps) attempt to acquire the lock again.

Note: there are still leftover deadlock issues in scripts that are _not_ addressed by this PR, in particular, those related to `sources_mutex` e.g. issue #5282. _Although I have yet to encounter one_. 


### How Has This Been Tested?

I have tested these changes with a custom `clock_source.lua` 
[clock-source-timed.tar.gz](https://github.com/obsproject/obs-studio/files/12550307/clock-source-timed.tar.gz)

The main change from the OG `clock_source.lua` are the parts where `obs_enter_graphics` is invoked, they now look like:

```lua
function ms_to_ns(ms) return ms * 1000000 end

source_def.destroy = function(data)
    while not (obs.obs_enter_graphics_timed(ms_to_ns(10)) == 0) do
        obs.script_log(obs.LOG_WARNING,
                       "destroy() yielding source definition")
        obs.yield_source_defn(10, source_def)
    end
-- clean up data ...
end
```

As per issue #6674 - repeatedly (re)loading the script shows that what would have been deadlocks (i.e. locks that took too long to acquire), however instead of locking, the script provides some warnings, yields the locks, and eventually re-acquires them. The graphics thread reports (sometimes) that it cannot render a source because it's definition lacks data - this is an expected side effect if the Lua (source) has to release the lock during construction. No other adverse behaviour is noted.

An alternative approach for the Lua (user) would be to have a flag for the state of the source data, e.g.:

```lua
source_def.create = function(source, settings)
    local data = {}
    data.is_valid_state = false
    if not (obs.obs_enter_graphics_timed(ms_to_ns(20)) == 0) then
        obs.script_log(obs.LOG_WARNING, "source_create failed to enter context")
        return data
    end
--  construct data ...
    data.is_valid_state = true
    return data
end

source_def.video_render = function(data)
    if not data.is_valid_state then return end
-- render...
end
```


### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

I have not documented the new features as I'm awaiting further feedback on this PR.

