### PR TITLE
obs-ffmpeg: Allow the user to set metadata

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -421,6 +421,8 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 {
 	const AVOutputFormat *format = data->output->oformat;
 	int ret;
+	const char *metadata_prefix = "metadata_";
+	const size_t len_metadata_prefix = strlen(metadata_prefix);
 
 	AVDictionary *dict = NULL;
 	if ((ret = av_dict_parse_string(&dict, data->config.muxer_settings, "=",
@@ -455,6 +457,27 @@ static inline bool open_output_file(struct ffmpeg_data *data)
 			av_dict_free(&dict);
 			return false;
 		}
+	}
+
+	// Handle metdata if requested by the user.
+	// We need to do this before the header write
+	if (av_dict_count(dict) > 0) {
+		struct dstr meta_str = {0};
+		AVDictionaryEntry *meta_entry = NULL;
+		while ((meta_entry = av_dict_get(dict, metadata_prefix,
+						 meta_entry,
+						 AV_DICT_IGNORE_SUFFIX))) {
+			if (strlen(meta_entry->key) > len_metadata_prefix) {
+				dstr_catf(&meta_str, "\n\t%s=%s",
+					  meta_entry->key, meta_entry->value);
+				av_dict_set(&data->output->metadata,
+					    (char *)(meta_entry->key +
+						     len_metadata_prefix),
+					    meta_entry->value, 0);
+			}
+		}
+		blog(LOG_INFO, "Using metadata settings: %s", meta_str.array);
+		dstr_free(&meta_str);
 	}
 
 	ret = avformat_write_header(data->output, &dict);


### PR DESCRIPTION
Adds parsing for metadata to pass along to ffmpeg for stream outputs

### Description
This allows a user to provide options in the muxer settings under the recording tab using the ffmpeg output to set metadata on the output stream. Please note that I've only tested this with mpegts using both the mpegts and rtp_mpegts muxers with the format set to mpeg2video.

### Motivation and Context
Implements a feature that was sort of requested on the forums and that I needed.
This allows setting [the metadata options in mpegts](https://ffmpeg.org/ffmpeg-formats.html#Options-14) but also applies to other codecs that allow metadata. The use case I needed this for was easily compositing streams in OBS while feeding the output via the recording output with FFMpeg to a DVB converter to show video and audio on TVs hooked into a coax network.

One of the forum posts which was trying to use such a feature was [here](https://obsproject.com/forum/threads/problem-setting-metadata-in-mpeg-ts.100770/).

Another situation is allowing metadata to be added to files that are recorded to disk or sent across the network for other reasons as [the metadata standard is somewhat open to whatever the user wants to record](https://wiki.multimedia.cx/index.php/FFmpeg_Metadata).

### How Has This Been Tested?
I tested this using the above mentioned muxers and format with the receiver being a device to convert to DVB-T. I could confirm that both the service_name and service_provider were being set correctly and read correctly on the receiver's end.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

I've tried to format with `clang-format-15` (also 14) but the versions I have access to in Debian produce errors with the project's provided config file. I've commented those options out and the CI seems to like the output.

Let me know of any documentation that needs to be provided and I can add that to the PR.