### PR TITLE
UI: Disable edit transform if item is locked

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8566,8 +8566,11 @@ void OBSBasic::UpdateEditMenu()
 	}
 	const bool canTransformSingle = videoCount == 1 && totalCount == 1;
 
+	OBSSceneItem curItem = GetCurrentSceneItem();
+	bool locked = obs_sceneitem_locked(curItem);
+
 	ui->actionCopySource->setEnabled(totalCount > 0);
-	ui->actionEditTransform->setEnabled(canTransformSingle);
+	ui->actionEditTransform->setEnabled(canTransformSingle && !locked);
 	ui->actionCopyTransform->setEnabled(canTransformSingle);
 	ui->actionPasteTransform->setEnabled(hasCopiedTransform &&
 					     videoCount > 0);

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -21,6 +21,7 @@ private:
 	OBSSignal removeSignal;
 	OBSSignal selectSignal;
 	OBSSignal deselectSignal;
+	OBSSignal lockSignal;
 
 	std::string undo_data;
 
@@ -45,6 +46,7 @@ private:
 	static void OBSSceneItemRemoved(void *param, calldata_t *data);
 	static void OBSSceneItemSelect(void *param, calldata_t *data);
 	static void OBSSceneItemDeselect(void *param, calldata_t *data);
+	static void OBSSceneItemLocked(void *param, calldata_t *data);
 
 private slots:
 	void RefreshControls();
@@ -52,6 +54,7 @@ private slots:
 	void OnBoundsType(int index);
 	void OnControlChanged();
 	void OnCropChanged();
+	void SetEnabled(bool enable);
 
 public:
 	OBSBasicTransform(OBSSceneItem item, OBSBasic *parent);


### PR DESCRIPTION
### Description
The transform window was still accessible if the scene item was locked.

### Motivation and Context
You shouldn't be able to edit the transform of a locked item.

### How Has This Been Tested?
Locked/unlocked scene items to make sure the transform window was disabled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
