### PR TITLE
UI: Don't paste transform on locked item

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8569,8 +8569,8 @@ void OBSBasic::UpdateEditMenu()
 	ui->actionCopySource->setEnabled(totalCount > 0);
 	ui->actionEditTransform->setEnabled(canTransformSingle);
 	ui->actionCopyTransform->setEnabled(canTransformSingle);
-	ui->actionPasteTransform->setEnabled(hasCopiedTransform &&
-					     videoCount > 0);
+	ui->actionPasteTransform->setEnabled(
+		canTransformMultiple && hasCopiedTransform && videoCount > 0);
 	ui->actionCopyFilters->setEnabled(filter_count > 0);
 	ui->actionPasteFilters->setEnabled(
 		!obs_weak_source_expired(copyFiltersSource) && totalCount > 0);
@@ -8642,6 +8642,8 @@ void OBSBasic::on_actionPasteTransform_triggered()
 		obs_scene_save_transform_states(GetCurrentScene(), false);
 	auto func = [](obs_scene_t *, obs_sceneitem_t *item, void *data) {
 		if (!obs_sceneitem_selected(item))
+			return true;
+		if (obs_sceneitem_locked(item))
 			return true;
 
 		OBSBasic *main = reinterpret_cast<OBSBasic *>(data);


### PR DESCRIPTION
### Description
This disables pasting transforms on an item that is locked.

### Motivation and Context
Transformations shouldn't be modified if a scene item is locked.

### How Has This Been Tested?
Tried pasting with locked scene items to make sure it didn't work anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
