### PR TITLE
UI: Remove unused ExpandCheckBox

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -172,7 +172,6 @@ target_sources(
           item-widget-helpers.hpp
           context-bar-controls.cpp
           context-bar-controls.hpp
-          expand-checkbox.hpp
           focus-list.cpp
           focus-list.hpp
           hotkey-edit.cpp

--- a/UI/cmake/ui-elements.cmake
+++ b/UI/cmake/ui-elements.cmake
@@ -11,7 +11,6 @@ target_sources(
           context-bar-controls.hpp
           double-slider.cpp
           double-slider.hpp
-          expand-checkbox.hpp
           focus-list.cpp
           focus-list.hpp
           horizontal-scroll-area.cpp

--- a/UI/expand-checkbox.hpp
+++ b/UI/expand-checkbox.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <QCheckBox>
-
-class ExpandCheckBox : public QCheckBox {
-	Q_OBJECT
-};

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -4,7 +4,6 @@
 #include "qt-wrappers.hpp"
 #include "visibility-checkbox.hpp"
 #include "locked-checkbox.hpp"
-#include "expand-checkbox.hpp"
 #include "platform.hpp"
 
 #include <obs-frontend-api.h>


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`ExpandCheckBox` was introduced in 88b6c63, but the seemingly replaced by `SourceTreeSubItemCheckBox` during development. This means that it became completely unused.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this empty class. Saw that it was unused.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14, compiled successfully.
Git grep'd for `ExpandCheckBox` and `expand-checkbox` to confirm it isn't used for styling (like `SourceTreeSubItemCheckBox` is).
Ran OBS to confirm groups still work.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
