### PR TITLE
cmake: Fix regular expression for beta and RC version detection

### DIFF
--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -33,10 +33,10 @@ endif()
 
 # Set beta/rc versions if suffix included in version string
 if(_obs_version MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-rc[0-9]+")
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9])+" "\\1;\\2;\\3;\\4" _obs_release_candidate
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-rc([0-9]+).*$" "\\1;\\2;\\3;\\4" _obs_release_candidate
                        ${_obs_version})
 elseif(_obs_version MATCHES "[0-9]+\\.[0-9]+\\.[0-9]+-beta[0-9]+")
-  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-beta([0-9])+" "\\1;\\2;\\3;\\4" _obs_beta ${_obs_version})
+  string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)-beta([0-9]+).*$" "\\1;\\2;\\3;\\4" _obs_beta ${_obs_version})
 endif()
 
 list(GET _obs_version_canonical 0 OBS_VERSION_MAJOR)


### PR DESCRIPTION
### Description
Fixes the regular expression used to detect beta and RC builds.

### Motivation and Context
While CMake can do partial matching with regular expressions, replacements require the entire regular expression to match the entire string.

Commits branching off a tagged commit will contain the necessary beta suffix, but also have the modification suffix and commit distance added, which _can_ be available after the beta number and thus have to be ignored.

### How Has This Been Tested?
Tested with a branch off a tagged beta commit.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
