### PR TITLE
CI: Fix Steam prerelease detection for releases

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -98,7 +98,7 @@ runs:
               --clobber
 
             IFS=';' read -r description is_prerelease <<< \
-              "$(gh release view --json tagName,isPrerelease --jq 'join(";")')"
+              "$(gh release view ${{ inputs.tagName }} --json tagName,isPrerelease --jq 'join(";")')"
             ;;
           workflow_dispatch)
             if [[ '${{ inputs.tagName }}' =~ [0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)*$ ]] {


### PR DESCRIPTION
### Description
Fixes Steam upload action for runs triggered by a release.

### Motivation and Context
The GitHub CLI tool requires an explicit tag to be provided when attempting to fetch information of prerelease versions.

### How Has This Been Tested?
Needs be tested via the next release tag.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
