### PR TITLE
UI: Include sceneitem locked state in copy-paste

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9976,6 +9976,7 @@ void OBSBasic::on_actionCopySource_triggered()
 		copyInfo.blend_method = obs_sceneitem_get_blending_method(item);
 		copyInfo.blend_mode = obs_sceneitem_get_blending_mode(item);
 		copyInfo.visible = obs_sceneitem_visible(item);
+		copyInfo.locked = obs_sceneitem_locked(item);
 
 		clipboard.push_back(copyInfo);
 	}

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -101,6 +101,7 @@ struct SavedProjectorInfo {
 struct SourceCopyInfo {
 	OBSWeakSource weak_source;
 	bool visible;
+	bool locked;
 	obs_sceneitem_crop crop;
 	obs_transform_info transform;
 	obs_blending_method blend_method;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When copy-pasting a source, so far it would always be unlocked. We already copy other attributes like whether the source is visible, so it makes sense to also include the locked state in there.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed that the status of whether a source is visible is copy-pasted, but not whether it's locked.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Copy-pasted with "Paste (Existing)" and "Paste (Duplicate)" and confirmed that a locked source would be locked when pasted.
Added new and existing sources via the dialog to confirm they were still always unlocked (since that code was modified).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
