### PR TITLE
libobs: Rewrite macOS Hotkeys to use CGEventTap

### DIFF
--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -68,6 +68,7 @@ function(set_target_properties_obs target)
                    INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2012-${CURRENT_YEAR} Lain Bailey"
                    INFOPLIST_KEY_NSCameraUsageDescription "OBS needs to access the camera to enable camera sources to work."
                    INFOPLIST_KEY_NSMicrophoneUsageDescription "OBS needs to access the microphone to enable audio input."
+                   INFOPLIST_KEY_NSAppleEventsUsageDescription "OBS needs to access background events to enable hotkeys while not in focus."
       )
 
       get_property(obs_dependencies GLOBAL PROPERTY _OBS_DEPENDENCIES)

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -510,8 +510,10 @@ MacPermissions.Item.Camera="Camera"
 MacPermissions.Item.Camera.Details="This permission is needed in order to capture content from a webcam or capture card."
 MacPermissions.Item.Microphone="Microphone"
 MacPermissions.Item.Microphone.Details="OBS requires this permission if you want to capture your microphone or an external audio device."
+MacPermissions.Item.InputMonitoring="Input Monitoring"
+MacPermissions.Item.InputMonitoring.Details="This permission is required for hotkeys to work while OBS is in the background."
 MacPermissions.Item.Accessibility="Accessibility"
-MacPermissions.Item.Accessibility.Details="For keyboard shortcuts (hotkeys) to work while other apps are focused, please enable this permission."
+MacPermissions.Item.Accessibility.Details="On older installations, OBS may be listed in \"Accessibility\" instead of \"Input Monitoring\"."
 MacPermissions.Continue="Continue"
 
 # Source leak error message

--- a/frontend/dialogs/OBSPermissions.cpp
+++ b/frontend/dialogs/OBSPermissions.cpp
@@ -22,7 +22,7 @@
 #include "moc_OBSPermissions.cpp"
 
 OBSPermissions::OBSPermissions(QWidget *parent, MacPermissionStatus capture, MacPermissionStatus video,
-			       MacPermissionStatus audio, MacPermissionStatus accessibility)
+			       MacPermissionStatus audio, MacPermissionStatus inputMonitoring)
 	: QDialog(parent),
 	  ui(new Ui::OBSPermissions)
 {
@@ -30,7 +30,12 @@ OBSPermissions::OBSPermissions(QWidget *parent, MacPermissionStatus capture, Mac
 	SetStatus(ui->capturePermissionButton, capture, QTStr("MacPermissions.Item.ScreenRecording"));
 	SetStatus(ui->videoPermissionButton, video, QTStr("MacPermissions.Item.Camera"));
 	SetStatus(ui->audioPermissionButton, audio, QTStr("MacPermissions.Item.Microphone"));
-	SetStatus(ui->accessibilityPermissionButton, accessibility, QTStr("MacPermissions.Item.Accessibility"));
+	SetStatus(ui->inputMonitoringPermissionButton, inputMonitoring, QTStr("MacPermissions.Item.InputMonitoring"));
+
+	ui->accessibilityPermissionButton->setText(
+		QTStr("MacPermissions.OpenPreferences").arg(QTStr("MacPermissions.Item.Accessibility")));
+	ui->accessibilityPermissionButton->setVisible(inputMonitoring != kPermissionAuthorized);
+	ui->accessibilityPermissionLabel->setVisible(inputMonitoring != kPermissionAuthorized);
 }
 
 void OBSPermissions::SetStatus(QPushButton *btn, MacPermissionStatus status, const QString &preference)
@@ -74,10 +79,15 @@ void OBSPermissions::on_audioPermissionButton_clicked()
 	}
 }
 
+void OBSPermissions::on_inputMonitoringPermissionButton_clicked()
+{
+	OpenMacOSPrivacyPreferences("ListenEvent");
+	RequestPermission(kInputMonitoring);
+}
+
 void OBSPermissions::on_accessibilityPermissionButton_clicked()
 {
 	OpenMacOSPrivacyPreferences("Accessibility");
-	RequestPermission(kAccessibility);
 }
 
 void OBSPermissions::on_continueButton_clicked()

--- a/frontend/dialogs/OBSPermissions.hpp
+++ b/frontend/dialogs/OBSPermissions.hpp
@@ -40,6 +40,7 @@ private slots:
 	void on_capturePermissionButton_clicked();
 	void on_videoPermissionButton_clicked();
 	void on_audioPermissionButton_clicked();
+	void on_inputMonitoringPermissionButton_clicked();
 	void on_accessibilityPermissionButton_clicked();
 	void on_continueButton_clicked();
 };

--- a/frontend/forms/OBSPermissions.ui
+++ b/frontend/forms/OBSPermissions.ui
@@ -344,7 +344,7 @@
               </font>
              </property>
              <property name="text">
-              <string>MacPermissions.Item.Accessibility</string>
+              <string>MacPermissions.Item.InputMonitoring</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -354,11 +354,62 @@
            <item row="6" column="1">
             <widget class="QLabel" name="label_13">
              <property name="text">
-              <string>MacPermissions.Item.Accessibility.Details</string>
+              <string>MacPermissions.Item.InputMonitoring.Details</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
            <item row="7" column="1">
+            <layout class="QHBoxLayout" name="horizontalLayout_5">
+             <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <item>
+              <widget class="QWidget"/>
+             </item>
+             <item>
+              <widget class="QPushButton" name="inputMonitoringPermissionButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>300</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>300</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="baseSize">
+                <size>
+                 <width>300</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="8" column="1">
+            <widget class="QLabel" name="accessibilityPermissionLabel">
+             <property name="text">
+              <string>MacPermissions.Item.Accessibility.Details</string>
+             </property>
+             <property name="wordWrap">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
             <layout class="QHBoxLayout" name="horizontalLayout_5">
              <property name="sizeConstraint">
               <enum>QLayout::SetDefaultConstraint</enum>

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -673,14 +673,14 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #ifdef __APPLE__
 		MacPermissionStatus audio_permission = CheckPermission(kAudioDeviceAccess);
 		MacPermissionStatus video_permission = CheckPermission(kVideoDeviceAccess);
-		MacPermissionStatus accessibility_permission = CheckPermission(kAccessibility);
+		MacPermissionStatus input_monitoring_permission = CheckPermission(kInputMonitoring);
 		MacPermissionStatus screen_permission = CheckPermission(kScreenCapture);
 
 		int permissionsDialogLastShown =
 			config_get_int(App()->GetAppConfig(), "General", "MacOSPermissionsDialogLastShown");
 		if (permissionsDialogLastShown < MACOS_PERMISSIONS_DIALOG_VERSION) {
 			OBSPermissions check(nullptr, screen_permission, video_permission, audio_permission,
-					     accessibility_permission);
+					     input_monitoring_permission);
 			check.exec();
 		}
 #endif

--- a/frontend/utility/platform-osx.mm
+++ b/frontend/utility/platform-osx.mm
@@ -267,16 +267,14 @@ MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type, bool promp
 
             break;
         }
-        case kAccessibility: {
-            permissionResponse = (AXIsProcessTrusted() ? kPermissionAuthorized : kPermissionDenied);
+        case kInputMonitoring: {
+            permissionResponse = (CGPreflightListenEventAccess() ? kPermissionAuthorized : kPermissionDenied);
 
             if (permissionResponse != kPermissionAuthorized && prompt_for_permission) {
-                NSDictionary *options = @{(__bridge id) kAXTrustedCheckOptionPrompt: @YES};
-                permissionResponse = (AXIsProcessTrustedWithOptions((CFDictionaryRef) options) ? kPermissionAuthorized
-                                                                                               : kPermissionDenied);
+                permissionResponse = (CGRequestListenEventAccess() ? kPermissionAuthorized : kPermissionDenied);
             }
 
-            blog(LOG_INFO, "[macOS] Permission for accessibility %s.",
+            blog(LOG_INFO, "[macOS] Permission for input monitoring %s.",
                  permissionResponse == kPermissionAuthorized ? "granted" : "denied");
             break;
         }

--- a/frontend/utility/platform.hpp
+++ b/frontend/utility/platform.hpp
@@ -84,7 +84,7 @@ typedef enum {
 	kAudioDeviceAccess = 0,
 	kVideoDeviceAccess = 1,
 	kScreenCapture = 2,
-	kAccessibility = 3
+	kInputMonitoring = 3
 } MacPermissionType;
 
 typedef enum {

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -219,7 +219,7 @@ void OBSBasic::on_actionShowMacPermissions_triggered()
 {
 #ifdef __APPLE__
 	OBSPermissions check(this, CheckPermission(kScreenCapture), CheckPermission(kVideoDeviceAccess),
-			     CheckPermission(kAudioDeviceAccess), CheckPermission(kAccessibility));
+			     CheckPermission(kAudioDeviceAccess), CheckPermission(kInputMonitoring));
 	check.exec();
 #endif
 }

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -421,8 +421,7 @@ static const macOS_glyph_desc_t key_glyphs[(keyCodeMask >> 8)] = {
 
 struct obs_hotkeys_platform {
     volatile long refs;
-    CFTypeRef monitor;
-    CFTypeRef local_monitor;
+    CFMachPortRef eventTap;
     bool is_key_down[OBS_KEY_LAST_VALUE];
     TISInputSourceRef tis;
     CFDataRef layout_data;
@@ -456,14 +455,10 @@ static void hotkeys_release(obs_hotkeys_platform_t *platform)
             platform->layout_data = NULL;
         }
 
-        if (platform->monitor) {
-            [NSEvent removeMonitor:(__bridge id _Nonnull)(platform->monitor)];
-            platform->monitor = NULL;
-        }
-
-        if (platform->local_monitor) {
-            [NSEvent removeMonitor:(__bridge id _Nonnull)(platform->local_monitor)];
-            platform->local_monitor = NULL;
+        if (platform->eventTap) {
+            CGEventTapEnable(platform->eventTap, false);
+            CFRelease(platform->eventTap);
+            platform->eventTap = NULL;
         }
 
         bfree(platform);
@@ -521,20 +516,40 @@ static bool log_layout_name(TISInputSourceRef tis)
 
 // MARK: macOS Hotkey CoreFoundation Callbacks
 
-static void MonitorEventHandlerProc(obs_hotkeys_platform_t *platform, NSEvent *event)
+static CGEventRef KeyboardEventProc(CGEventTapProxy proxy __unused, CGEventType type, CGEventRef event, void *userInfo)
 {
-    NSEventModifierFlags flags = event.modifierFlags;
-    platform->is_key_down[OBS_KEY_CAPSLOCK] = !!(flags & NSEventModifierFlagCapsLock);
-    platform->is_key_down[OBS_KEY_SHIFT] = !!(flags & NSEventModifierFlagShift);
-    platform->is_key_down[OBS_KEY_ALT] = !!(flags & NSEventModifierFlagOption);
-    platform->is_key_down[OBS_KEY_META] = !!(flags & NSEventModifierFlagCommand);
-    platform->is_key_down[OBS_KEY_CONTROL] = !!(flags & NSEventModifierFlagControl);
+    obs_hotkeys_platform_t *platform = userInfo;
 
-    if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp) {
-        obs_key_t obsKey = obs_key_from_virtual_key(event.keyCode);
+    const CGEventFlags flags = CGEventGetFlags(event);
+    platform->is_key_down[OBS_KEY_SHIFT] = !!(flags & kCGEventFlagMaskShift);
+    platform->is_key_down[OBS_KEY_ALT] = !!(flags & kCGEventFlagMaskAlternate);
+    platform->is_key_down[OBS_KEY_META] = !!(flags & kCGEventFlagMaskCommand);
+    platform->is_key_down[OBS_KEY_CONTROL] = !!(flags & kCGEventFlagMaskControl);
 
-        platform->is_key_down[obsKey] = (event.type == NSEventTypeKeyDown);
+    switch (type) {
+        case kCGEventKeyDown: {
+            const int64_t keycode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+            platform->is_key_down[obs_key_from_virtual_key(keycode)] = true;
+            break;
+        }
+        case kCGEventKeyUp: {
+            const int64_t keycode = CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode);
+            platform->is_key_down[obs_key_from_virtual_key(keycode)] = false;
+            break;
+        }
+        case kCGEventFlagsChanged: {
+            break;
+        }
+        case kCGEventTapDisabledByTimeout: {
+            blog(LOG_DEBUG, "[hotkeys-cocoa]: Hotkey event tap disabled by timeout. Reenabling...");
+            CGEventTapEnable(platform->eventTap, true);
+            break;
+        }
+        default: {
+            blog(LOG_WARNING, "[hotkeys-cocoa]: Received unexpected event with code '%d'", type);
+        }
     }
+    return event;
 }
 
 static void InputMethodChangedProc(CFNotificationCenterRef center __unused, void *observer,
@@ -577,19 +592,26 @@ bool obs_hotkeys_platform_init(struct obs_core_hotkeys *hotkeys)
 
     obs_hotkeys_platform_t *platform = bzalloc(sizeof(obs_hotkeys_platform_t));
 
-    platform->monitor =
-        (__bridge CFTypeRef)([NSEvent addGlobalMonitorForEventsMatchingMask:NSEventMaskKeyUp | NSEventMaskKeyDown
-                                                                    handler:^(NSEvent *_Nonnull event) {
-                                                                        MonitorEventHandlerProc(platform, event);
-                                                                    }]);
+    const bool has_event_access = CGPreflightListenEventAccess();
+    if (has_event_access) {
+        platform->eventTap = CGEventTapCreate(kCGHIDEventTap, kCGHeadInsertEventTap, kCGEventTapOptionListenOnly,
+                                              CGEventMaskBit(kCGEventKeyDown) | CGEventMaskBit(kCGEventKeyUp) |
+                                                  CGEventMaskBit(kCGEventFlagsChanged),
+                                              KeyboardEventProc, platform);
+        if (!platform->eventTap) {
+            blog(LOG_WARNING, "[hotkeys-cocoa]: Couldn't create hotkey event tap.");
+            hotkeys_release(platform);
+            platform = NULL;
+            return false;
+        }
+        CFRunLoopSourceRef source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, platform->eventTap, 0);
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), source, kCFRunLoopCommonModes);
+        CFRelease(source);
 
-    platform->local_monitor = (__bridge CFTypeRef)([NSEvent
-        addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp | NSEventMaskKeyDown
-                                     handler:^NSEvent *_Nullable(NSEvent *_Nonnull event) {
-                                         MonitorEventHandlerProc(platform, event);
-
-                                         return event;
-                                     }]);
+        CGEventTapEnable(platform->eventTap, true);
+    } else {
+        blog(LOG_WARNING, "[hotkeys-cocoa]: No event permissions, could not add global hotkeys.");
+    }
 
     platform->tis = TISCopyCurrentKeyboardLayoutInputSource();
     platform->layout_data = (CFDataRef) TISGetInputSourceProperty(platform->tis, kTISPropertyUnicodeKeyLayoutData);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Using CGEventTapCreate instead of addGlobalMonitorForEventsMatchingMask to listen to global hotkeys has the advantage of tighter control over what permissions we need. Since we only listen to and do not modify the event, it is enough to have "Input Monitoring" instead of the full "Accessibility" (which would allow modifying the event after catching it).

It also might fix the issues we have with hotkeys randomly breaking down after a while. I suspect that addGlobalMonitor could just be a wrapper around CGEventTap and not handle timeouts.
This is why I'd like people who currently have issues with hotkeys randomly dying after a while testing this Pull Request. That can be a bit tricky, as the binaries will not be signed. You will probably first have to remove OBS from the permissions list (and maybe even uninstall the release version). After that, open the test version and allow "Input Monitoring" ("Accessibility" is no longer needed). Re-open the test version and check if it works. If not, check the log file for `hotkeys-cocoa: No permissions, could not add global hotkeys`. If you see that, permissions were not set successfully, try again.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Got annoyed that our Hotkeys require "Accessibility" permissions. Saw an opportunity to maybe also fix the other issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested a list of hotkeys both out-of-focus as well as in-focus. This included hotkeys with each type of modifier.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
