### PR TITLE
UI: Replace SourceTreeSubItemCheckBox class with Qt property

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -1291,24 +1291,24 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
     padding: 0px;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 12px;
     height: 12px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked,
-SourceTreeSubItemCheckBox::indicator:checked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked,
+QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked,
-SourceTreeSubItemCheckBox::indicator:unchecked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -697,21 +697,21 @@ OBSHotkeyLabel[hotkeyPairHover=true] {
 
 /* Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 10px;
     height: 10px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked {
     image: url(theme:Dark/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked {
     image: url(theme:Dark/collapse.svg);
 }
 

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -1279,24 +1279,24 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
     padding: 0px;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 12px;
     height: 12px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked,
-SourceTreeSubItemCheckBox::indicator:checked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked,
+QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked,
-SourceTreeSubItemCheckBox::indicator:unchecked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -1279,24 +1279,24 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
     padding: 0px;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 12px;
     height: 12px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked,
-SourceTreeSubItemCheckBox::indicator:checked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked,
+QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
     image: url(theme:Light/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked,
-SourceTreeSubItemCheckBox::indicator:unchecked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
     image: url(theme:Light/collapse.svg);
 }
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -1283,24 +1283,24 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
     padding: 0px;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 12px;
     height: 12px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked,
-SourceTreeSubItemCheckBox::indicator:checked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked,
+QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked,
-SourceTreeSubItemCheckBox::indicator:unchecked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -78,21 +78,21 @@ MuteCheckBox::indicator:unchecked {
     image: url(:/settings/images/settings/audio.svg);
 }
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 10px;
     height: 10px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked {
     image: url(:/res/images/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked {
     image: url(:/res/images/collapse.svg);
 }
 

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -1283,24 +1283,24 @@ OBSHotkeyWidget QPushButton {
 
 /* Sources List Group Collapse Checkbox */
 
-SourceTreeSubItemCheckBox {
+QCheckBox[sourceTreeSubItem=true] {
     background: transparent;
     outline: none;
     padding: 0px;
 }
 
-SourceTreeSubItemCheckBox::indicator {
+QCheckBox[sourceTreeSubItem=true]::indicator {
     width: 12px;
     height: 12px;
 }
 
-SourceTreeSubItemCheckBox::indicator:checked,
-SourceTreeSubItemCheckBox::indicator:checked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:checked,
+QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
     image: url(theme:Dark/expand.svg);
 }
 
-SourceTreeSubItemCheckBox::indicator:unchecked,
-SourceTreeSubItemCheckBox::indicator:unchecked:hover {
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
+QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
     image: url(theme:Dark/collapse.svg);
 }
 

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -577,7 +577,8 @@ void SourceTreeItem::Update(bool force)
 		boxLayout->insertItem(0, spacer);
 
 	} else if (type == Type::Group) {
-		expand = new SourceTreeSubItemCheckBox();
+		expand = new QCheckBox();
+		expand->setProperty("sourceTreeSubItem", true);
 		expand->setSizePolicy(QSizePolicy::Maximum,
 				      QSizePolicy::Maximum);
 		expand->setMaximumSize(10, 16);

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -22,10 +22,6 @@ class LockedCheckBox;
 class VisibilityCheckBox;
 class VisibilityItemWidget;
 
-class SourceTreeSubItemCheckBox : public QCheckBox {
-	Q_OBJECT
-};
-
 class SourceTreeItem : public QFrame {
 	Q_OBJECT
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replaces the empty `SourceTreeSubItemCheckBox` class which is only used for styling with a property.
IIRC @Warchamp7 wanted `themeID` to go the way of the dodo in favor of properties set to true, so I'm using this syntax. Needs confirmation though.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Having classes just for QSS styling seems a bit overkill to me when it's possible to achieve the same result without them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested in all themes that the expand checkbox still shows the icons, but when the group is expanded and when it's not.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
