### PR TITLE
Add cleanup of stats callback on window close

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -30,6 +30,9 @@ void OBSBasicStats::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 		stats->ResetRecTimeLeft();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
+		// This is only reached when the non-closable (dock) stats
+		// window is being cleaned up. Thee closable stats window is
+		// already gone by this point as it's deleted on close.
 		obs_frontend_remove_event_callback(OBSFrontendEvent, stats);
 		break;
 	default:
@@ -230,6 +233,10 @@ void OBSBasicStats::closeEvent(QCloseEvent *event)
 				  saveGeometry().toBase64().constData());
 		config_save_safe(main->Config(), "tmp", nullptr);
 	}
+
+	// This code is only reached when the non-dockable stats window is
+	// manually closed or OBS is exiting.
+	obs_frontend_remove_event_callback(OBSFrontendEvent, this);
 
 	QWidget::closeEvent(event);
 }


### PR DESCRIPTION
### Description
This PR adds cleanup of the stats frontend event handler to window close.

Previously this was called in the destructor, but that is too late as the frontend API is gone by that point. It was then moved to the event handler for `OBS_FRONTEND_EVENT_EXIT` in #8735 but that doesn't account for the window being closed, leaking event handlers and causing crashes. Adding it to the window close handler should now account for both manual window closes / shutdown of OBS and the `OBS_FRONTEND_EVENT_EXIT` handler handles the dock cleanup.

### Motivation and Context
Fixes a crash introduced in #8735, [reported on Discord](https://discord.com/channels/348973006581923840/1141766543735275570/1150805117008891904).

### How Has This Been Tested?
Verified code paths of closing windows and exiting OBS both clean up the event handler for the standalone window and dock at an appropriate time.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
