### PR TITLE
UI: Avoid using newlines in error messages

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -420,7 +420,7 @@ Output.ConnectFail.Disconnected="Disconnected from server."
 # output streaming-related messages
 Output.StreamEncodeError.Title="Encoding error"
 Output.StreamEncodeError.Msg="An encoder error occurred while streaming."
-Output.StreamEncodeError.Msg.LastError="An encoder error occurred while streaming:\n\n%1"
+Output.StreamEncodeError.Msg.LastError="An encoder error occurred while streaming:<br><br>%1"
 
 # output recording-related messages
 Output.RecordFail.Title="Failed to start recording"
@@ -430,7 +430,7 @@ Output.RecordNoSpace.Msg="There is not sufficient disk space to continue recordi
 Output.RecordError.Title="Recording error"
 Output.RecordError.Msg="An unspecified error occurred while recording."
 Output.RecordError.EncodeErrorMsg="An encoder error occurred while recording."
-Output.RecordError.EncodeErrorMsg.LastError="An encoder error occurred while recording:\n\n%1"
+Output.RecordError.EncodeErrorMsg.LastError="An encoder error occurred while recording:<br><br>%1"
 
 # output recording messages
 Output.BadPath.Title="Bad File Path"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7730,8 +7730,8 @@ void OBSBasic::RecordingStop(int code, QString last_error)
 		errorDescription = Str("Output.RecordError.Msg");
 
 		if (use_last_error && !last_error.isEmpty())
-			dstr_printf(errorMessage, "%s\n\n%s", errorDescription,
-				    QT_TO_UTF8(last_error));
+			dstr_printf(errorMessage, "%s<br><br>%s",
+				    errorDescription, QT_TO_UTF8(last_error));
 		else
 			dstr_copy(errorMessage, errorDescription);
 


### PR DESCRIPTION
### Description
Some errors include HTML links directing users to e.g. driver updates or further information. Using a raw newline instead of `<br>` causes Qt to skip parsing the HTML, resulting in an ugly mess of HTML displayed to the user instead of the intended links.

### Motivation and Context
Hopefully avoid this:

![image](https://github.com/obsproject/obs-studio/assets/876345/1b153def-541a-4480-b897-df9d636ce8dd)

### How Has This Been Tested?
I only verified that `<br>` works as a newline in an error dialog. Didn't test all error conditions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
