### PR TITLE
libobs: Do not skip async frames unless one has been selected

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4256,7 +4256,8 @@ static bool ready_async_frame(obs_source_t *source, uint64_t sys_time)
 		 * helps smooth out async rendering to frame boundaries.  In
 		 * other words, tries to keep the framerate as smooth as
 		 * possible */
-		if ((source->last_frame_ts - next_frame->timestamp) < 2000000)
+		if (frame &&
+		    (source->last_frame_ts - next_frame->timestamp) < 2000000)
 			break;
 
 		if (frame)


### PR DESCRIPTION
### Description

This PR changes the behaviour of the async frame cache to only break out of the loop if `frame` is already set. This avoids a repeated failure of the frame cache to select a close frame resulting in more frames being dropped than necessary on the output for a period of several seconds until it recovers.  

This appears to happen when OBS and the input source's frame timestamps go in and out of sync, an inconsistent frame delivery from the source, e.g. 24-8-24-8 ms pattern instead of 16.6 ms ± 2 ms (while frame timestamps stay consistent 16.6 ± 0.1 ms) seems to also exacerbate this problem.

I'm not sure if this is the "right" fix, but it sure seems to work in my testing.

This will **not** improve frame skipping when buffering is disabled, but that is not avoidable unless we tie OBS's rendering to the source submitting frames (and that's a thought for a different time).

#### Without PR (+ logging)
```
Skipped when frame was NULL
no frame!
async cache size changed 2 -> 1
async cache size changed 1 -> 2
Rendered frame was late: 42650885000 -> 42684205400 (diff: 33320400)
Skipped when frame was NULL
no frame!
async cache size changed 2 -> 1
async cache size changed 1 -> 2
Rendered frame was late: 42717544600 -> 42750866100 (diff: 33321500)
Skipped when frame was NULL
no frame!
async cache size changed 2 -> 1
async cache size changed 1 -> 2
Rendered frame was late: 42800878000 -> 42834206300 (diff: 33328300)
Skipped when frame was NULL
no frame!
async cache size changed 2 -> 1
Rendered frame was late: 42834206300 -> 42867537900 (diff: 33331600)
Skipped when frame was NULL
no frame!
Rendered frame was late: 42884192700 -> 42917533700 (diff: 33341000)
Skipped when frame was NULL
no frame!
async cache size changed 1 -> 2
Rendered frame was late: 45001252600 -> 45034109700 (diff: 32857100)
```

Result: 5 frames skipped + 5 frames duplicated in a ~2.4 second period (it can get worse than this).

#### With PR (+ logging)
```
Rendered frame was late: 30145859800 -> 30179179400 (diff: 33319600)
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
Did NOT skip when frame was NULL
-- repeated for a few hundred lines before it recovers --
```

Result: 1 frame skipped (no duplication), cache size remains the same (it never got worse than this)

### Motivation and Context

Want (mainly) capture card inputs to actually be smooth when buffering is enabled.

### How Has This Been Tested?

Capture card input at 2160p60, XRGB.

- Additional debug logging (seen above)
- Additional metrics added to #9427 to measure source input and render frame time consistency/FPS
- Analyzing recorded video using a python script to find duplicated and skipped frames

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
