### PR TITLE
libobs: Reuse existing memory when clearing async frame cache

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -803,6 +803,7 @@ struct obs_source {
 	uint32_t async_cache_height;
 	uint32_t async_convert_width[MAX_AV_PLANES];
 	uint32_t async_convert_height[MAX_AV_PLANES];
+	uint64_t async_last_clean;
 
 	pthread_mutex_t caption_cb_mutex;
 	DARRAY(struct caption_cb_info) caption_cb_list;


### PR DESCRIPTION
### Description

- If we hit the frame cache limit, reset the cache entries rather than freeing them and their memory
- Only run the `clean_cache` process once every second to give the cache enough time to fill up again after a reset

Sort of a newer take on 96c1a7652305784e4bf531933bc82535adcaf320 to avoid re-allocating a lot of memory if we have to invalidate the async frame cache, but keeps `clean_cache` to free unneeded memory allocations after a while.

### Motivation and Context

Want to avoid too many free/allocation loops if we have to churn through lots of frames at once (e.g. network issues, or after OBS was paused in a debugger)

### How Has This Been Tested?

Tested with additional logging in place to verify that memory is no longer allocated/free'd once we hit the cache size limit, and then is cleared once it actually isn't needed anymore.

Also tested an alternative of simply counting async frames since last clear and running clear once it hit `MAX_ASYNC_FRAMES` (https://github.com/derrod/obs-studio/commit/697a0a5bfd7fb248eeb2203da0627d5426050a4c), this also worked but using time seemed more like a more reliable option e.g. if the source is either a very low or very high frame rate.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
