### PR TITLE
obs-qsv11: Fix target usage migration string comparisons

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -328,33 +328,31 @@ static bool update_enhancements(obs_data_t *settings)
 	return true;
 }
 
-static bool update_targetusage(obs_data_t *settings)
+static void update_targetusage(obs_data_t *settings)
 {
 	const char *target_usage =
 		obs_data_get_string(settings, "target_usage");
 
-	if ((astrcmpi(target_usage, "veryslow") ||
-	     astrcmpi(target_usage, "quality")) == 0)
+	if (astrcmpi(target_usage, "veryslow") == 0 ||
+	    astrcmpi(target_usage, "quality") == 0)
 		obs_data_set_string(settings, "target_usage",
 				    "TU1: Slowest (Best Quality)");
 	else if (astrcmpi(target_usage, "slower") == 0)
 		obs_data_set_string(settings, "target_usage", "TU2: Slower");
 	else if (astrcmpi(target_usage, "slow") == 0)
 		obs_data_set_string(settings, "target_usage", "TU3: Slow");
-	else if ((astrcmpi(target_usage, "medium") ||
-		  astrcmpi(target_usage, "balanced")) == 0)
+	else if (astrcmpi(target_usage, "medium") == 0 ||
+		 astrcmpi(target_usage, "balanced") == 0)
 		obs_data_set_string(settings, "target_usage",
 				    "TU4: Balanced (Medium Quality)");
 	else if (astrcmpi(target_usage, "fast") == 0)
 		obs_data_set_string(settings, "target_usage", "TU5: Fast");
 	else if (astrcmpi(target_usage, "faster") == 0)
 		obs_data_set_string(settings, "target_usage", "TU6: Faster");
-	else if ((astrcmpi(target_usage, "vertfast") ||
-		  astrcmpi(target_usage, "speed")) == 0)
+	else if (astrcmpi(target_usage, "veryfast") == 0 ||
+		 astrcmpi(target_usage, "speed") == 0)
 		obs_data_set_string(settings, "target_usage",
 				    "TU7: Fastest (Best Speed)");
-
-	return true;
 }
 
 static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes problems with the astrcmpi logic, as well as a typo that said "vertfast" instead "veryfast".
Also makes the method a void because it always returns true and isn't checked anyways.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Was found while investigating https://github.com/obsproject/obs-studio/issues/9574.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
