### PR TITLE
cmake: Allow CMake 3.20 and 3.21 to be used to build OBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 if(CMAKE_HOST_SYSTEM_NAME MATCHES "(Darwin)" OR OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
   include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/UI/frontend-plugins/decklink-captions/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-captions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/UI/obs-frontend-api/CMakeLists.txt
+++ b/UI/obs-frontend-api/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/deps/blake2/CMakeLists.txt
+++ b/deps/blake2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(blake2 STATIC EXCLUDE_FROM_ALL )
 add_library(OBS::blake2 ALIAS blake2)

--- a/deps/file-updater/CMakeLists.txt
+++ b/deps/file-updater/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 find_package(CURL REQUIRED)
 

--- a/deps/glad/CMakeLists.txt
+++ b/deps/glad/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 find_package(OpenGL REQUIRED)
 

--- a/deps/happy-eyeballs/CMakeLists.txt
+++ b/deps/happy-eyeballs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(happy-eyeballs INTERFACE)
 add_library(OBS::happy-eyeballs ALIAS happy-eyeballs)

--- a/deps/json11/CMakeLists.txt
+++ b/deps/json11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(json11 INTERFACE)
 add_library(OBS::json11 ALIAS json11)

--- a/deps/libcaption/CMakeLists.txt
+++ b/deps/libcaption/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(caption STATIC EXCLUDE_FROM_ALL )
 add_library(OBS::caption ALIAS caption)

--- a/deps/media-playback/CMakeLists.txt
+++ b/deps/media-playback/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 find_package(FFmpeg REQUIRED COMPONENTS avcodec avdevice avutil avformat)
 

--- a/deps/obs-scripting/CMakeLists.txt
+++ b/deps/obs-scripting/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/deps/obs-scripting/obslua/CMakeLists.txt
+++ b/deps/obs-scripting/obslua/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/deps/opts-parser/CMakeLists.txt
+++ b/deps/opts-parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(opts-parser INTERFACE)
 add_library(OBS::opts-parser ALIAS opts-parser)

--- a/deps/uthash/CMakeLists.txt
+++ b/deps/uthash/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 add_library(uthash INTERFACE)
 add_library(OBS::uthash ALIAS uthash)

--- a/libobs-opengl/CMakeLists.txt
+++ b/libobs-opengl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 option(ENABLE_PLUGINS "Enable building OBS plugins" ON)
 

--- a/plugins/aja/CMakeLists.txt
+++ b/plugins/aja/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/decklink/CMakeLists.txt
+++ b/plugins/decklink/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/image-source/CMakeLists.txt
+++ b/plugins/image-source/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-filters/CMakeLists.txt
+++ b/plugins/obs-filters/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-transitions/CMakeLists.txt
+++ b/plugins/obs-transitions/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-vst/CMakeLists.txt
+++ b/plugins/obs-vst/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/obs-x264/CMakeLists.txt
+++ b/plugins/obs-x264/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/text-freetype2/CMakeLists.txt
+++ b/plugins/text-freetype2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 

--- a/plugins/vlc-video/CMakeLists.txt
+++ b/plugins/vlc-video/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22...3.25)
+cmake_minimum_required(VERSION 3.20...3.25)
 
 legacy_check()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
There does not appear to be anything preventing it from building on CMake 3.20, so let's permit it so that it can still be built for Fedora Extra Packages for Enterprise Linux 9.

### Motivation and Context
CentOS Stream 9 (and thus Red Hat Enterprise Linux 9) only have CMake 3.20.

### How Has This Been Tested?
Built OBS Studio 30~beta3 successfully in EPEL 9 (CMake 3.20) and Fedora 39+40 (CMake 3.27)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
