### PR TITLE
linux-v4l2: add support for linear alpha blending

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -125,6 +125,7 @@ static void v4l2_prep_obs_frame(struct v4l2_data *data,
 
 	const enum video_format format = v4l2_to_obs_video_format(data->pixfmt);
 
+	frame->flags = OBS_SOURCE_FRAME_LINEAR_ALPHA;
 	frame->width = data->width;
 	frame->height = data->height;
 	frame->format = format;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This copies the linear alpha settings UI and translation strings from `image-source` and applies the setting to the V4L2 `obs_source_frame`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I am supplying non-premultiplied alpha to OBS, but OBS seems to be converting the frame to premulitplied alpha, and then render it as if it *wasn't* premulitplied, which gives a very wrong look. With this setting enabled, it looks correct.

I am not sure why this is called "linear" alpha in OBS - to my knowledge alpha is always *linear*.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

By trying it with a v4l2loopback source, AR24 format, non-premultiplied alpha. I have also tested that changes to the checkbox are visible in the preview immediately.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
  - (could not find any)

The changes to the V4L2 source UI look like this:

![screenshot_2023-09-21_23:08:15](https://github.com/obsproject/obs-studio/assets/96552222/b50ee63b-6ffb-46cd-8a9f-9452bf674929)
