### PR TITLE
UI: Add theme data search paths

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -166,7 +166,7 @@ QMenu::item:disabled {
 }
 
 QMenu::right-arrow {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 /* Top Menu Bar Items */
@@ -304,8 +304,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/close.svg');
-    titlebar-normal-icon: url('./Dark/popout.svg');
+    titlebar-close-icon: url(theme:Dark/close.svg);
+    titlebar-normal-icon: url(theme:Dark/popout.svg);
 }
 
 QDockWidget::title {
@@ -453,11 +453,11 @@ QScrollBar::handle:horizontal {
 }
 
 QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -493,55 +493,55 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Dark/plus.svg);
+    qproperty-icon: url(theme:Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Dark/trash.svg);
+    qproperty-icon: url(theme:Dark/trash.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Dark/entry-clear.svg);
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Dark/refresh.svg);
+    qproperty-icon: url(theme:Dark/refresh.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Dark/cogs.svg);
+    qproperty-icon: url(theme:Dark/cogs.svg);
 }
 
 #sourceInteractButton {
-    qproperty-icon: url(./Dark/interact.svg);
+    qproperty-icon: url(theme:Dark/interact.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Dark/up.svg);
+    qproperty-icon: url(theme:Dark/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Dark/down.svg);
+    qproperty-icon: url(theme:Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Dark/media-pause.svg);
+    qproperty-icon: url(theme:Dark/media-pause.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 QToolBarExtension {
@@ -551,7 +551,7 @@ QToolBarExtension {
     padding: 4px 0px;
     margin-left: 0px;
 
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 
@@ -647,7 +647,7 @@ QDateTimeEdit::drop-down {
 QComboBox::down-arrow,
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/updown.svg);
+    image: url(theme:Dark/updown.svg);
     width: 100%;
 }
 
@@ -669,7 +669,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 8%;
 }
 
@@ -757,13 +757,13 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Dark/up.svg);
+    image: url(theme:Dark/up.svg);
     width: 100%;
     margin: 2px;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
     padding: 2px;
 }
@@ -844,7 +844,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -995,15 +995,15 @@ QHeaderView::section {
 /* Mute CheckBox */
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -1102,14 +1102,14 @@ OBSBasicFilters #widget_2 QPushButton {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Dark/settings/general.svg);
-    qproperty-streamIcon: url(./Dark/settings/stream.svg);
-    qproperty-outputIcon: url(./Dark/settings/output.svg);
-    qproperty-audioIcon: url(./Dark/settings/audio.svg);
-    qproperty-videoIcon: url(./Dark/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Dark/settings/general.svg);
+    qproperty-streamIcon: url(theme:Dark/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Dark/settings/output.svg);
+    qproperty-audioIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Dark/settings/advanced.svg);
 }
 
 /* Checkboxes */
@@ -1129,34 +1129,34 @@ QGroupBox::indicator {
 
 QCheckBox::indicator:unchecked,
 QGroupBox::indicator:unchecked {
-    image: url(./Yami/checkbox_unchecked.svg);
+    image: url(theme:Yami/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
 QGroupBox::indicator:unchecked:hover {
     border: none;
-    image: url(./Yami/checkbox_unchecked_focus.svg);
+    image: url(theme:Yami/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    image: url(./Yami/checkbox_checked.svg);
+    image: url(theme:Yami/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
 QGroupBox::indicator:checked:hover {
     border: none;
-    image: url(./Yami/checkbox_checked_focus.svg);
+    image: url(theme:Yami/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
-    image: url(./Yami/checkbox_checked_disabled.svg);
+    image: url(theme:Yami/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
-    image: url(./Yami/checkbox_unchecked_disabled.svg);
+    image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 
 /* Locked CheckBox */
@@ -1173,7 +1173,7 @@ LockedCheckBox::indicator {
 
 LockedCheckBox::indicator:checked,
 LockedCheckBox::indicator:checked:hover {
-    image: url(./Dark/locked.svg);
+    image: url(theme:Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked,
@@ -1195,7 +1195,7 @@ VisibilityCheckBox::indicator {
 
 VisibilityCheckBox::indicator:checked,
 VisibilityCheckBox::indicator:checked:hover {
-    image: url(./Dark/visible.svg);
+    image: url(theme:Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked,
@@ -1204,7 +1204,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Dark/revert.svg);
+    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -1233,35 +1233,35 @@ MuteCheckBox::indicator {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:focus {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:checked:hover {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:focus {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:disabled {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked:disabled {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 #hotkeyFilterReset {
@@ -1304,33 +1304,33 @@ SourceTreeSubItemCheckBox::indicator {
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/collapse.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Dark/sources/image.svg);
-    qproperty-colorIcon: url(./Dark/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
-    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
-    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
-    qproperty-textIcon: url(./Dark/sources/text.svg);
-    qproperty-mediaIcon: url(./Dark/sources/media.svg);
-    qproperty-browserIcon: url(./Dark/sources/globe.svg);
-    qproperty-groupIcon: url(./Dark/sources/group.svg);
-    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
-    qproperty-defaultIcon: url(./Dark/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Dark/sources/image.svg);
+    qproperty-colorIcon: url(theme:Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Dark/sources/camera.svg);
+    qproperty-textIcon: url(theme:Dark/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Dark/sources/media.svg);
+    qproperty-browserIcon: url(theme:Dark/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Dark/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */
@@ -1366,7 +1366,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Dark/save.svg);
+    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -1396,32 +1396,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Dark/media/media_play.svg);
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Dark/media/media_pause.svg);
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Dark/media/media_restart.svg);
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Dark/media/media_stop.svg);
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Dark/media/media_next.svg);
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Dark/media/media_previous.svg);
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -1449,7 +1449,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -1472,7 +1472,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1482,13 +1482,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -132,8 +132,8 @@ QMainWindow::separator {
 /* Dock Widget */
 
 QDockWidget {
-    titlebar-close-icon: url('./Dark/close.svg');
-    titlebar-normal-icon: url('./Dark/popout.svg');
+    titlebar-close-icon: url(theme:Dark/close.svg);
+    titlebar-normal-icon: url(theme:Dark/popout.svg);
 }
 
 QDockWidget::title {
@@ -242,15 +242,15 @@ QScrollBar::left-arrow:horizontal, QScrollBar::right-arrow:horizontal, QScrollBa
 }
 
 #contextContainer QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 #contextContainer QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 #contextContainer QPushButton#sourceInteractButton {
-    qproperty-icon: url(./Dark/interact.svg);
+    qproperty-icon: url(theme:Dark/interact.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -286,51 +286,51 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Dark/plus.svg);
+    qproperty-icon: url(theme:Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Dark/minus.svg);
+    qproperty-icon: url(theme:Dark/minus.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Dark/entry-clear.svg);
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Dark/refresh.svg);
+    qproperty-icon: url(theme:Dark/refresh.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Dark/up.svg);
+    qproperty-icon: url(theme:Dark/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Dark/down.svg);
+    qproperty-icon: url(theme:Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Dark/media-pause.svg);
+    qproperty-icon: url(theme:Dark/media-pause.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Dark/cogs.svg);
+    qproperty-icon: url(theme:Dark/cogs.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 /* Tab Widget */
@@ -407,7 +407,7 @@ QComboBox::drop-down {
 QDateTimeEdit::down-arrow,
 QComboBox::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/updown.svg);
+    image: url(theme:Dark/updown.svg);
     width: 100%;
 }
 
@@ -431,7 +431,7 @@ QComboBox::drop-down:editable {
 QDateTimeEdit::down-arrow:editable,
 QComboBox::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 8%;
 }
 
@@ -497,12 +497,12 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Dark/up.svg);
+    image: url(theme:Dark/up.svg);
     width: 100%;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -540,7 +540,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -680,15 +680,15 @@ MuteCheckBox {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -708,11 +708,11 @@ SourceTreeSubItemCheckBox::indicator {
 }
 
 SourceTreeSubItemCheckBox::indicator:checked {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked {
-    image: url(./Dark/collapse.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 
@@ -780,14 +780,14 @@ OBSQTDisplay {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Dark/settings/general.svg);
-    qproperty-streamIcon: url(./Dark/settings/stream.svg);
-    qproperty-outputIcon: url(./Dark/settings/output.svg);
-    qproperty-audioIcon: url(./Dark/settings/audio.svg);
-    qproperty-videoIcon: url(./Dark/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Dark/settings/general.svg);
+    qproperty-streamIcon: url(theme:Dark/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Dark/settings/output.svg);
+    qproperty-audioIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Dark/settings/advanced.svg);
 }
 
 OBSBasicSettings QListWidget::item {
@@ -803,7 +803,7 @@ LockedCheckBox {
 }
 
 LockedCheckBox::indicator:checked {
-    image: url(./Dark/locked.svg);
+    image: url(theme:Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked {
@@ -818,7 +818,7 @@ VisibilityCheckBox {
 }
 
 VisibilityCheckBox::indicator:checked {
-    image: url(./Dark/visible.svg);
+    image: url(theme:Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked {
@@ -826,7 +826,7 @@ VisibilityCheckBox::indicator:unchecked {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Dark/revert.svg);
+    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -842,28 +842,28 @@ QPushButton#extraPanelDelete:pressed {
 }
 
 OBSMissingFiles {
-    qproperty-warningIcon: url(./Dark/alert.svg);
+    qproperty-warningIcon: url(theme:Dark/alert.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Dark/sources/image.svg);
-    qproperty-colorIcon: url(./Dark/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
-    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
-    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
-    qproperty-textIcon: url(./Dark/sources/text.svg);
-    qproperty-mediaIcon: url(./Dark/sources/media.svg);
-    qproperty-browserIcon: url(./Dark/sources/globe.svg);
-    qproperty-groupIcon: url(./Dark/sources/group.svg);
-    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
-    qproperty-defaultIcon: url(./Dark/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Dark/sources/image.svg);
+    qproperty-colorIcon: url(theme:Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Dark/sources/camera.svg);
+    qproperty-textIcon: url(theme:Dark/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Dark/sources/media.svg);
+    qproperty-browserIcon: url(theme:Dark/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Dark/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree */
@@ -903,7 +903,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Dark/save.svg);
+    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -933,32 +933,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Dark/media/media_play.svg);
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Dark/media/media_pause.svg);
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Dark/media/media_restart.svg);
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Dark/media/media_stop.svg);
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Dark/media/media_next.svg);
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Dark/media/media_previous.svg);
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -981,7 +981,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -1004,7 +1004,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1014,13 +1014,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -166,7 +166,7 @@ QMenu::item:disabled {
 }
 
 QMenu::right-arrow {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 /* Top Menu Bar Items */
@@ -304,8 +304,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/close.svg');
-    titlebar-normal-icon: url('./Dark/popout.svg');
+    titlebar-close-icon: url(theme:Dark/close.svg);
+    titlebar-normal-icon: url(theme:Dark/popout.svg);
 }
 
 QDockWidget::title {
@@ -453,11 +453,11 @@ QScrollBar::handle:horizontal {
 }
 
 QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -491,55 +491,55 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Dark/plus.svg);
+    qproperty-icon: url(theme:Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Dark/trash.svg);
+    qproperty-icon: url(theme:Dark/trash.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Dark/entry-clear.svg);
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Dark/refresh.svg);
+    qproperty-icon: url(theme:Dark/refresh.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Dark/cogs.svg);
+    qproperty-icon: url(theme:Dark/cogs.svg);
 }
 
 #sourceInteractButton {
-    qproperty-icon: url(./Dark/interact.svg);
+    qproperty-icon: url(theme:Dark/interact.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Dark/up.svg);
+    qproperty-icon: url(theme:Dark/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Dark/down.svg);
+    qproperty-icon: url(theme:Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Dark/media-pause.svg);
+    qproperty-icon: url(theme:Dark/media-pause.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 QToolBarExtension {
@@ -549,7 +549,7 @@ QToolBarExtension {
     padding: 4px 0px;
     margin-left: 0px;
 
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 
@@ -645,7 +645,7 @@ QDateTimeEdit::drop-down {
 QComboBox::down-arrow,
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/updown.svg);
+    image: url(theme:Dark/updown.svg);
     width: 100%;
 }
 
@@ -667,7 +667,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 8%;
 }
 
@@ -755,13 +755,13 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Dark/up.svg);
+    image: url(theme:Dark/up.svg);
     width: 100%;
     margin: 2px;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
     padding: 2px;
 }
@@ -833,7 +833,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -983,15 +983,15 @@ QHeaderView::section {
 /* Mute CheckBox */
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -1090,14 +1090,14 @@ OBSBasicFilters #widget_2 QPushButton {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Dark/settings/general.svg);
-    qproperty-streamIcon: url(./Dark/settings/stream.svg);
-    qproperty-outputIcon: url(./Dark/settings/output.svg);
-    qproperty-audioIcon: url(./Dark/settings/audio.svg);
-    qproperty-videoIcon: url(./Dark/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Dark/settings/general.svg);
+    qproperty-streamIcon: url(theme:Dark/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Dark/settings/output.svg);
+    qproperty-audioIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Dark/settings/advanced.svg);
 }
 
 /* Checkboxes */
@@ -1117,34 +1117,34 @@ QGroupBox::indicator {
 
 QCheckBox::indicator:unchecked,
 QGroupBox::indicator:unchecked {
-    image: url(./Yami/checkbox_unchecked.svg);
+    image: url(theme:Yami/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
 QGroupBox::indicator:unchecked:hover {
     border: none;
-    image: url(./Yami/checkbox_unchecked_focus.svg);
+    image: url(theme:Yami/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    image: url(./Yami/checkbox_checked.svg);
+    image: url(theme:Yami/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
 QGroupBox::indicator:checked:hover {
     border: none;
-    image: url(./Yami/checkbox_checked_focus.svg);
+    image: url(theme:Yami/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
-    image: url(./Yami/checkbox_checked_disabled.svg);
+    image: url(theme:Yami/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
-    image: url(./Yami/checkbox_unchecked_disabled.svg);
+    image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 
 /* Locked CheckBox */
@@ -1161,7 +1161,7 @@ LockedCheckBox::indicator {
 
 LockedCheckBox::indicator:checked,
 LockedCheckBox::indicator:checked:hover {
-    image: url(./Dark/locked.svg);
+    image: url(theme:Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked,
@@ -1183,7 +1183,7 @@ VisibilityCheckBox::indicator {
 
 VisibilityCheckBox::indicator:checked,
 VisibilityCheckBox::indicator:checked:hover {
-    image: url(./Dark/visible.svg);
+    image: url(theme:Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked,
@@ -1192,7 +1192,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Dark/revert.svg);
+    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -1221,35 +1221,35 @@ MuteCheckBox::indicator {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:focus {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:checked:hover {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:focus {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:disabled {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked:disabled {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 #hotkeyFilterReset {
@@ -1292,33 +1292,33 @@ SourceTreeSubItemCheckBox::indicator {
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/collapse.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Dark/sources/image.svg);
-    qproperty-colorIcon: url(./Dark/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
-    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
-    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
-    qproperty-textIcon: url(./Dark/sources/text.svg);
-    qproperty-mediaIcon: url(./Dark/sources/media.svg);
-    qproperty-browserIcon: url(./Dark/sources/globe.svg);
-    qproperty-groupIcon: url(./Dark/sources/group.svg);
-    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
-    qproperty-defaultIcon: url(./Dark/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Dark/sources/image.svg);
+    qproperty-colorIcon: url(theme:Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Dark/sources/camera.svg);
+    qproperty-textIcon: url(theme:Dark/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Dark/sources/media.svg);
+    qproperty-browserIcon: url(theme:Dark/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Dark/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */
@@ -1354,7 +1354,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Dark/save.svg);
+    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -1384,32 +1384,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Dark/media/media_play.svg);
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Dark/media/media_pause.svg);
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Dark/media/media_restart.svg);
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Dark/media/media_stop.svg);
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Dark/media/media_next.svg);
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Dark/media/media_previous.svg);
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -1437,7 +1437,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -1460,7 +1460,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1470,13 +1470,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -166,7 +166,7 @@ QMenu::item:disabled {
 }
 
 QMenu::right-arrow {
-    image: url(./Light/expand.svg);
+    image: url(theme:Light/expand.svg);
 }
 
 /* Top Menu Bar Items */
@@ -304,8 +304,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Light/close.svg');
-    titlebar-normal-icon: url('./Light/popout.svg');
+    titlebar-close-icon: url(theme:Light/close.svg);
+    titlebar-normal-icon: url(theme:Light/popout.svg);
 }
 
 QDockWidget::title {
@@ -453,11 +453,11 @@ QScrollBar::handle:horizontal {
 }
 
 QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Light/settings/general.svg);
+    qproperty-icon: url(theme:Light/settings/general.svg);
 }
 
 QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Light/filter.svg);
+    qproperty-icon: url(theme:Light/filter.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -491,55 +491,55 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Light/plus.svg);
+    qproperty-icon: url(theme:Light/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Light/trash.svg);
+    qproperty-icon: url(theme:Light/trash.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Light/entry-clear.svg);
+    qproperty-icon: url(theme:Light/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Light/settings/general.svg);
+    qproperty-icon: url(theme:Light/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Light/settings/general.svg);
+    qproperty-icon: url(theme:Light/settings/general.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Light/dots-vert.svg);
+    qproperty-icon: url(theme:Light/dots-vert.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Light/refresh.svg);
+    qproperty-icon: url(theme:Light/refresh.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Light/cogs.svg);
+    qproperty-icon: url(theme:Light/cogs.svg);
 }
 
 #sourceInteractButton {
-    qproperty-icon: url(./Light/interact.svg);
+    qproperty-icon: url(theme:Light/interact.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Light/up.svg);
+    qproperty-icon: url(theme:Light/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Light/down.svg);
+    qproperty-icon: url(theme:Light/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Light/media-pause.svg);
+    qproperty-icon: url(theme:Light/media-pause.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Light/filter.svg);
+    qproperty-icon: url(theme:Light/filter.svg);
 }
 
 QToolBarExtension {
@@ -549,7 +549,7 @@ QToolBarExtension {
     padding: 4px 0px;
     margin-left: 0px;
 
-    qproperty-icon: url(./Light/dots-vert.svg);
+    qproperty-icon: url(theme:Light/dots-vert.svg);
 }
 
 
@@ -645,7 +645,7 @@ QDateTimeEdit::drop-down {
 QComboBox::down-arrow,
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Light/updown.svg);
+    image: url(theme:Light/updown.svg);
     width: 100%;
 }
 
@@ -667,7 +667,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Light/down.svg);
+    image: url(theme:Light/down.svg);
     width: 8%;
 }
 
@@ -755,13 +755,13 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Light/up.svg);
+    image: url(theme:Light/up.svg);
     width: 100%;
     margin: 2px;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Light/down.svg);
+    image: url(theme:Light/down.svg);
     width: 100%;
     padding: 2px;
 }
@@ -833,7 +833,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Light/down.svg);
+    image: url(theme:Light/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -983,15 +983,15 @@ QHeaderView::section {
 /* Mute CheckBox */
 
 MuteCheckBox::indicator:checked {
-    image: url(./Light/mute.svg);
+    image: url(theme:Light/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Light/settings/audio.svg);
+    image: url(theme:Light/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -1090,14 +1090,14 @@ OBSBasicFilters #widget_2 QPushButton {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Light/settings/general.svg);
-    qproperty-streamIcon: url(./Light/settings/stream.svg);
-    qproperty-outputIcon: url(./Light/settings/output.svg);
-    qproperty-audioIcon: url(./Light/settings/audio.svg);
-    qproperty-videoIcon: url(./Light/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Light/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Light/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Light/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Light/settings/general.svg);
+    qproperty-streamIcon: url(theme:Light/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Light/settings/output.svg);
+    qproperty-audioIcon: url(theme:Light/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Light/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Light/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Light/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Light/settings/advanced.svg);
 }
 
 /* Checkboxes */
@@ -1117,34 +1117,34 @@ QGroupBox::indicator {
 
 QCheckBox::indicator:unchecked,
 QGroupBox::indicator:unchecked {
-    image: url(./Light/checkbox_unchecked.svg);
+    image: url(theme:Light/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
 QGroupBox::indicator:unchecked:hover {
     border: none;
-    image: url(./Light/checkbox_unchecked_focus.svg);
+    image: url(theme:Light/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    image: url(./Light/checkbox_checked.svg);
+    image: url(theme:Light/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
 QGroupBox::indicator:checked:hover {
     border: none;
-    image: url(./Light/checkbox_checked_focus.svg);
+    image: url(theme:Light/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
-    image: url(./Light/checkbox_checked_disabled.svg);
+    image: url(theme:Light/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
-    image: url(./Light/checkbox_unchecked_disabled.svg);
+    image: url(theme:Light/checkbox_unchecked_disabled.svg);
 }
 
 /* Locked CheckBox */
@@ -1161,7 +1161,7 @@ LockedCheckBox::indicator {
 
 LockedCheckBox::indicator:checked,
 LockedCheckBox::indicator:checked:hover {
-    image: url(./Light/locked.svg);
+    image: url(theme:Light/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked,
@@ -1183,7 +1183,7 @@ VisibilityCheckBox::indicator {
 
 VisibilityCheckBox::indicator:checked,
 VisibilityCheckBox::indicator:checked:hover {
-    image: url(./Light/visible.svg);
+    image: url(theme:Light/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked,
@@ -1192,7 +1192,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Light/revert.svg);
+    qproperty-icon: url(theme:Light/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -1221,35 +1221,35 @@ MuteCheckBox::indicator {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Light/mute.svg);
+    image: url(theme:Light/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Light/settings/audio.svg);
+    image: url(theme:Light/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:hover {
-    image: url(./Light/settings/audio.svg);
+    image: url(theme:Light/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:focus {
-    image: url(./Light/settings/audio.svg);
+    image: url(theme:Light/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:checked:hover {
-    image: url(./Light/mute.svg);
+    image: url(theme:Light/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:focus {
-    image: url(./Light/mute.svg);
+    image: url(theme:Light/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:disabled {
-    image: url(./Light/mute.svg);
+    image: url(theme:Light/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked:disabled {
-    image: url(./Light/settings/audio.svg);
+    image: url(theme:Light/settings/audio.svg);
 }
 
 #hotkeyFilterReset {
@@ -1292,33 +1292,33 @@ SourceTreeSubItemCheckBox::indicator {
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Light/expand.svg);
+    image: url(theme:Light/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Light/collapse.svg);
+    image: url(theme:Light/collapse.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Light/sources/image.svg);
-    qproperty-colorIcon: url(./Light/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Light/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Light/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Light/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Light/settings/video.svg);
-    qproperty-windowCapIcon: url(./Light/sources/window.svg);
-    qproperty-gameCapIcon: url(./Light/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Light/sources/camera.svg);
-    qproperty-textIcon: url(./Light/sources/text.svg);
-    qproperty-mediaIcon: url(./Light/sources/media.svg);
-    qproperty-browserIcon: url(./Light/sources/globe.svg);
-    qproperty-groupIcon: url(./Light/sources/group.svg);
-    qproperty-sceneIcon: url(./Light/sources/scene.svg);
-    qproperty-defaultIcon: url(./Light/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Light/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Light/sources/image.svg);
+    qproperty-colorIcon: url(theme:Light/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Light/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Light/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Light/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Light/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Light/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Light/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Light/sources/camera.svg);
+    qproperty-textIcon: url(theme:Light/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Light/sources/media.svg);
+    qproperty-browserIcon: url(theme:Light/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Light/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Light/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Light/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Light/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */
@@ -1354,7 +1354,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Light/save.svg);
+    qproperty-icon: url(theme:Light/save.svg);
 }
 
 /* Studio Mode Labels */
@@ -1390,32 +1390,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Light/media/media_play.svg);
+    qproperty-icon: url(theme:Light/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Light/media/media_pause.svg);
+    qproperty-icon: url(theme:Light/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Light/media/media_restart.svg);
+    qproperty-icon: url(theme:Light/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Light/media/media_stop.svg);
+    qproperty-icon: url(theme:Light/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Light/media/media_next.svg);
+    qproperty-icon: url(theme:Light/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Light/media/media_previous.svg);
+    qproperty-icon: url(theme:Light/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Light/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Light/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -1443,7 +1443,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Light/down.svg);
+    image: url(theme:Light/down.svg);
     width: 100%;
 }
 
@@ -1466,7 +1466,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Light/down.svg);
+    image: url(theme:Light/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1476,13 +1476,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Light/left.svg);
+    qproperty-icon: url(theme:Light/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Light/right.svg);
+    qproperty-icon: url(theme:Light/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -168,7 +168,7 @@ QMenu::item:disabled {
 }
 
 QMenu::right-arrow {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 /* Top Menu Bar Items */
@@ -306,8 +306,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/close.svg');
-    titlebar-normal-icon: url('./Dark/popout.svg');
+    titlebar-close-icon: url(theme:Dark/close.svg);
+    titlebar-normal-icon: url(theme:Dark/popout.svg);
 }
 
 QDockWidget::title {
@@ -456,11 +456,11 @@ QScrollBar::handle:horizontal {
 }
 
 QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -499,55 +499,55 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Dark/plus.svg);
+    qproperty-icon: url(theme:Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Dark/trash.svg);
+    qproperty-icon: url(theme:Dark/trash.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Dark/entry-clear.svg);
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Dark/refresh.svg);
+    qproperty-icon: url(theme:Dark/refresh.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Dark/cogs.svg);
+    qproperty-icon: url(theme:Dark/cogs.svg);
 }
 
 #sourceInteractButton {
-    qproperty-icon: url(./Dark/interact.svg);
+    qproperty-icon: url(theme:Dark/interact.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Dark/up.svg);
+    qproperty-icon: url(theme:Dark/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Dark/down.svg);
+    qproperty-icon: url(theme:Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Dark/media-pause.svg);
+    qproperty-icon: url(theme:Dark/media-pause.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 QToolBarExtension {
@@ -557,7 +557,7 @@ QToolBarExtension {
     padding: 4px 0px;
     margin-left: 0px;
 
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 
@@ -652,7 +652,7 @@ QDateTimeEdit::drop-down {
 QComboBox::down-arrow,
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/updown.svg);
+    image: url(theme:Dark/updown.svg);
     width: 100%;
 }
 
@@ -674,7 +674,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 8%;
 }
 
@@ -759,13 +759,13 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Dark/up.svg);
+    image: url(theme:Dark/up.svg);
     width: 100%;
     margin: 2px;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
     padding: 2px;
 }
@@ -837,7 +837,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -987,15 +987,15 @@ QHeaderView::section {
 /* Mute CheckBox */
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -1094,14 +1094,14 @@ OBSBasicFilters #widget_2 QPushButton {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Dark/settings/general.svg);
-    qproperty-streamIcon: url(./Dark/settings/stream.svg);
-    qproperty-outputIcon: url(./Dark/settings/output.svg);
-    qproperty-audioIcon: url(./Dark/settings/audio.svg);
-    qproperty-videoIcon: url(./Dark/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Dark/settings/general.svg);
+    qproperty-streamIcon: url(theme:Dark/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Dark/settings/output.svg);
+    qproperty-audioIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Dark/settings/advanced.svg);
 }
 
 /* Checkboxes */
@@ -1121,34 +1121,34 @@ QGroupBox::indicator {
 
 QCheckBox::indicator:unchecked,
 QGroupBox::indicator:unchecked {
-    image: url(./Yami/checkbox_unchecked.svg);
+    image: url(theme:Yami/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
 QGroupBox::indicator:unchecked:hover {
     border: none;
-    image: url(./Yami/checkbox_unchecked_focus.svg);
+    image: url(theme:Yami/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    image: url(./Yami/checkbox_checked.svg);
+    image: url(theme:Yami/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
 QGroupBox::indicator:checked:hover {
     border: none;
-    image: url(./Yami/checkbox_checked_focus.svg);
+    image: url(theme:Yami/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
-    image: url(./Yami/checkbox_checked_disabled.svg);
+    image: url(theme:Yami/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
-    image: url(./Yami/checkbox_unchecked_disabled.svg);
+    image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 
 /* Locked CheckBox */
@@ -1165,7 +1165,7 @@ LockedCheckBox::indicator {
 
 LockedCheckBox::indicator:checked,
 LockedCheckBox::indicator:checked:hover {
-    image: url(./Dark/locked.svg);
+    image: url(theme:Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked,
@@ -1187,7 +1187,7 @@ VisibilityCheckBox::indicator {
 
 VisibilityCheckBox::indicator:checked,
 VisibilityCheckBox::indicator:checked:hover {
-    image: url(./Dark/visible.svg);
+    image: url(theme:Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked,
@@ -1196,7 +1196,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Dark/revert.svg);
+    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -1225,35 +1225,35 @@ MuteCheckBox::indicator {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:focus {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:checked:hover {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:focus {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:disabled {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked:disabled {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 #hotkeyFilterReset {
@@ -1296,33 +1296,33 @@ SourceTreeSubItemCheckBox::indicator {
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/collapse.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Dark/sources/image.svg);
-    qproperty-colorIcon: url(./Dark/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
-    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
-    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
-    qproperty-textIcon: url(./Dark/sources/text.svg);
-    qproperty-mediaIcon: url(./Dark/sources/media.svg);
-    qproperty-browserIcon: url(./Dark/sources/globe.svg);
-    qproperty-groupIcon: url(./Dark/sources/group.svg);
-    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
-    qproperty-defaultIcon: url(./Dark/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Dark/sources/image.svg);
+    qproperty-colorIcon: url(theme:Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Dark/sources/camera.svg);
+    qproperty-textIcon: url(theme:Dark/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Dark/sources/media.svg);
+    qproperty-browserIcon: url(theme:Dark/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Dark/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */
@@ -1358,7 +1358,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Dark/save.svg);
+    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -1388,32 +1388,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Dark/media/media_play.svg);
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Dark/media/media_pause.svg);
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Dark/media/media_restart.svg);
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Dark/media/media_stop.svg);
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Dark/media/media_next.svg);
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Dark/media/media_previous.svg);
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -1441,7 +1441,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -1464,7 +1464,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1474,13 +1474,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/System.qss
+++ b/UI/data/themes/System.qss
@@ -71,7 +71,7 @@ MuteCheckBox::indicator:checked {
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
@@ -378,7 +378,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 2px;
@@ -393,13 +393,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -166,7 +166,7 @@ QMenu::item:disabled {
 }
 
 QMenu::right-arrow {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 /* Top Menu Bar Items */
@@ -308,8 +308,8 @@ QDockWidget {
     font-size: 10.5pt;
     font-weight: bold;
 
-    titlebar-close-icon: url('./Dark/close.svg');
-    titlebar-normal-icon: url('./Dark/popout.svg');
+    titlebar-close-icon: url(theme:Dark/close.svg);
+    titlebar-normal-icon: url(theme:Dark/popout.svg);
 }
 
 QDockWidget::title {
@@ -457,11 +457,11 @@ QScrollBar::handle:horizontal {
 }
 
 QPushButton#sourcePropertiesButton {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 QPushButton#sourceFiltersButton {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 /* Scenes and Sources toolbar */
@@ -495,55 +495,55 @@ QToolButton:pressed {
 }
 
 * [themeID="addIconSmall"] {
-    qproperty-icon: url(./Dark/plus.svg);
+    qproperty-icon: url(theme:Dark/plus.svg);
 }
 
 * [themeID="removeIconSmall"] {
-    qproperty-icon: url(./Dark/trash.svg);
+    qproperty-icon: url(theme:Dark/trash.svg);
 }
 
 * [themeID="clearIconSmall"] {
-    qproperty-icon: url(./Dark/entry-clear.svg);
+    qproperty-icon: url(theme:Dark/entry-clear.svg);
 }
 
 * [themeID="propertiesIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="configIconSmall"] {
-    qproperty-icon: url(./Dark/settings/general.svg);
+    qproperty-icon: url(theme:Dark/settings/general.svg);
 }
 
 * [themeID="menuIconSmall"] {
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 * [themeID="refreshIconSmall"] {
-    qproperty-icon: url(./Dark/refresh.svg);
+    qproperty-icon: url(theme:Dark/refresh.svg);
 }
 
 * [themeID="cogsIcon"] {
-    qproperty-icon: url(./Dark/cogs.svg);
+    qproperty-icon: url(theme:Dark/cogs.svg);
 }
 
 #sourceInteractButton {
-    qproperty-icon: url(./Dark/interact.svg);
+    qproperty-icon: url(theme:Dark/interact.svg);
 }
 
 * [themeID="upArrowIconSmall"] {
-    qproperty-icon: url(./Dark/up.svg);
+    qproperty-icon: url(theme:Dark/up.svg);
 }
 
 * [themeID="downArrowIconSmall"] {
-    qproperty-icon: url(./Dark/down.svg);
+    qproperty-icon: url(theme:Dark/down.svg);
 }
 
 * [themeID="pauseIconSmall"] {
-    qproperty-icon: url(./Dark/media-pause.svg);
+    qproperty-icon: url(theme:Dark/media-pause.svg);
 }
 
 * [themeID="filtersIcon"] {
-    qproperty-icon: url(./Dark/filter.svg);
+    qproperty-icon: url(theme:Dark/filter.svg);
 }
 
 QToolBarExtension {
@@ -553,7 +553,7 @@ QToolBarExtension {
     padding: 4px 0px;
     margin-left: 0px;
 
-    qproperty-icon: url(./Dark/dots-vert.svg);
+    qproperty-icon: url(theme:Dark/dots-vert.svg);
 }
 
 
@@ -649,7 +649,7 @@ QDateTimeEdit::drop-down {
 QComboBox::down-arrow,
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/updown.svg);
+    image: url(theme:Dark/updown.svg);
     width: 100%;
 }
 
@@ -671,7 +671,7 @@ QDateTimeEdit::drop-down:editable {
 QComboBox::down-arrow:editable,
 QDateTimeEdit::down-arrow:editable {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 8%;
 }
 
@@ -759,13 +759,13 @@ QDoubleSpinBox::up-button:disabled, QDoubleSpinBox::up-button:off, QDoubleSpinBo
 }
 
 QSpinBox::up-arrow, QDoubleSpinBox::up-arrow {
-    image: url(./Dark/up.svg);
+    image: url(theme:Dark/up.svg);
     width: 100%;
     margin: 2px;
 }
 
 QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
     padding: 2px;
 }
@@ -837,7 +837,7 @@ QPushButton:disabled, QToolButton:disabled {
 }
 
 QPushButton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     subcontrol-origin: padding;
     width: 25px;
@@ -987,15 +987,15 @@ QHeaderView::section {
 /* Mute CheckBox */
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:indeterminate {
-    image: url(./Dark/unassigned.svg);
+    image: url(theme:Dark/unassigned.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 OBSHotkeyLabel[hotkeyPairHover=true] {
@@ -1094,14 +1094,14 @@ OBSBasicFilters #widget_2 QPushButton {
 /* Settings Icons */
 
 OBSBasicSettings {
-    qproperty-generalIcon: url(./Dark/settings/general.svg);
-    qproperty-streamIcon: url(./Dark/settings/stream.svg);
-    qproperty-outputIcon: url(./Dark/settings/output.svg);
-    qproperty-audioIcon: url(./Dark/settings/audio.svg);
-    qproperty-videoIcon: url(./Dark/settings/video.svg);
-    qproperty-hotkeysIcon: url(./Dark/settings/hotkeys.svg);
-    qproperty-accessibilityIcon: url(./Dark/settings/accessibility.svg);
-    qproperty-advancedIcon: url(./Dark/settings/advanced.svg);
+    qproperty-generalIcon: url(theme:Dark/settings/general.svg);
+    qproperty-streamIcon: url(theme:Dark/settings/stream.svg);
+    qproperty-outputIcon: url(theme:Dark/settings/output.svg);
+    qproperty-audioIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-videoIcon: url(theme:Dark/settings/video.svg);
+    qproperty-hotkeysIcon: url(theme:Dark/settings/hotkeys.svg);
+    qproperty-accessibilityIcon: url(theme:Dark/settings/accessibility.svg);
+    qproperty-advancedIcon: url(theme:Dark/settings/advanced.svg);
 }
 
 /* Checkboxes */
@@ -1121,34 +1121,34 @@ QGroupBox::indicator {
 
 QCheckBox::indicator:unchecked,
 QGroupBox::indicator:unchecked {
-    image: url(./Yami/checkbox_unchecked.svg);
+    image: url(theme:Yami/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
 QGroupBox::indicator:unchecked:hover {
     border: none;
-    image: url(./Yami/checkbox_unchecked_focus.svg);
+    image: url(theme:Yami/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
 QGroupBox::indicator:checked {
-    image: url(./Yami/checkbox_checked.svg);
+    image: url(theme:Yami/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
 QGroupBox::indicator:checked:hover {
     border: none;
-    image: url(./Yami/checkbox_checked_focus.svg);
+    image: url(theme:Yami/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
 QGroupBox::indicator:checked:disabled {
-    image: url(./Yami/checkbox_checked_disabled.svg);
+    image: url(theme:Yami/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
 QGroupBox::indicator:unchecked:disabled {
-    image: url(./Yami/checkbox_unchecked_disabled.svg);
+    image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 
 /* Locked CheckBox */
@@ -1165,7 +1165,7 @@ LockedCheckBox::indicator {
 
 LockedCheckBox::indicator:checked,
 LockedCheckBox::indicator:checked:hover {
-    image: url(./Dark/locked.svg);
+    image: url(theme:Dark/locked.svg);
 }
 
 LockedCheckBox::indicator:unchecked,
@@ -1187,7 +1187,7 @@ VisibilityCheckBox::indicator {
 
 VisibilityCheckBox::indicator:checked,
 VisibilityCheckBox::indicator:checked:hover {
-    image: url(./Dark/visible.svg);
+    image: url(theme:Dark/visible.svg);
 }
 
 VisibilityCheckBox::indicator:unchecked,
@@ -1196,7 +1196,7 @@ VisibilityCheckBox::indicator:unchecked:hover {
 }
 
 * [themeID="revertIcon"] {
-    qproperty-icon: url(./Dark/revert.svg);
+    qproperty-icon: url(theme:Dark/revert.svg);
 }
 
 QPushButton#extraPanelDelete {
@@ -1225,35 +1225,35 @@ MuteCheckBox::indicator {
 }
 
 MuteCheckBox::indicator:checked {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:unchecked:focus {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 MuteCheckBox::indicator:checked:hover {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:focus {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:checked:disabled {
-    image: url(./Dark/mute.svg);
+    image: url(theme:Dark/mute.svg);
 }
 
 MuteCheckBox::indicator:unchecked:disabled {
-    image: url(./Dark/settings/audio.svg);
+    image: url(theme:Dark/settings/audio.svg);
 }
 
 #hotkeyFilterReset {
@@ -1296,33 +1296,33 @@ SourceTreeSubItemCheckBox::indicator {
 
 SourceTreeSubItemCheckBox::indicator:checked,
 SourceTreeSubItemCheckBox::indicator:checked:hover {
-    image: url(./Dark/expand.svg);
+    image: url(theme:Dark/expand.svg);
 }
 
 SourceTreeSubItemCheckBox::indicator:unchecked,
 SourceTreeSubItemCheckBox::indicator:unchecked:hover {
-    image: url(./Dark/collapse.svg);
+    image: url(theme:Dark/collapse.svg);
 }
 
 /* Source Icons */
 
 OBSBasic {
-    qproperty-imageIcon: url(./Dark/sources/image.svg);
-    qproperty-colorIcon: url(./Dark/sources/brush.svg);
-    qproperty-slideshowIcon: url(./Dark/sources/slideshow.svg);
-    qproperty-audioInputIcon: url(./Dark/sources/microphone.svg);
-    qproperty-audioOutputIcon: url(./Dark/settings/audio.svg);
-    qproperty-desktopCapIcon: url(./Dark/settings/video.svg);
-    qproperty-windowCapIcon: url(./Dark/sources/window.svg);
-    qproperty-gameCapIcon: url(./Dark/sources/gamepad.svg);
-    qproperty-cameraIcon: url(./Dark/sources/camera.svg);
-    qproperty-textIcon: url(./Dark/sources/text.svg);
-    qproperty-mediaIcon: url(./Dark/sources/media.svg);
-    qproperty-browserIcon: url(./Dark/sources/globe.svg);
-    qproperty-groupIcon: url(./Dark/sources/group.svg);
-    qproperty-sceneIcon: url(./Dark/sources/scene.svg);
-    qproperty-defaultIcon: url(./Dark/sources/default.svg);
-    qproperty-audioProcessOutputIcon: url(./Dark/sources/windowaudio.svg);
+    qproperty-imageIcon: url(theme:Dark/sources/image.svg);
+    qproperty-colorIcon: url(theme:Dark/sources/brush.svg);
+    qproperty-slideshowIcon: url(theme:Dark/sources/slideshow.svg);
+    qproperty-audioInputIcon: url(theme:Dark/sources/microphone.svg);
+    qproperty-audioOutputIcon: url(theme:Dark/settings/audio.svg);
+    qproperty-desktopCapIcon: url(theme:Dark/settings/video.svg);
+    qproperty-windowCapIcon: url(theme:Dark/sources/window.svg);
+    qproperty-gameCapIcon: url(theme:Dark/sources/gamepad.svg);
+    qproperty-cameraIcon: url(theme:Dark/sources/camera.svg);
+    qproperty-textIcon: url(theme:Dark/sources/text.svg);
+    qproperty-mediaIcon: url(theme:Dark/sources/media.svg);
+    qproperty-browserIcon: url(theme:Dark/sources/globe.svg);
+    qproperty-groupIcon: url(theme:Dark/sources/group.svg);
+    qproperty-sceneIcon: url(theme:Dark/sources/scene.svg);
+    qproperty-defaultIcon: url(theme:Dark/sources/default.svg);
+    qproperty-audioProcessOutputIcon: url(theme:Dark/sources/windowaudio.svg);
 }
 
 /* Scene Tree Grid Mode */
@@ -1358,7 +1358,7 @@ SceneTree {
 /* Save icon */
 
 * [themeID="replayIconSmall"] {
-    qproperty-icon: url(./Dark/save.svg);
+    qproperty-icon: url(theme:Dark/save.svg);
 }
 
 /* Studio Mode T-Bar */
@@ -1388,32 +1388,32 @@ QSlider::handle:horizontal[themeID="tBarSlider"] {
 /* Media icons */
 
 * [themeID="playIcon"] {
-    qproperty-icon: url(./Dark/media/media_play.svg);
+    qproperty-icon: url(theme:Dark/media/media_play.svg);
 }
 
 * [themeID="pauseIcon"] {
-    qproperty-icon: url(./Dark/media/media_pause.svg);
+    qproperty-icon: url(theme:Dark/media/media_pause.svg);
 }
 
 * [themeID="restartIcon"] {
-    qproperty-icon: url(./Dark/media/media_restart.svg);
+    qproperty-icon: url(theme:Dark/media/media_restart.svg);
 }
 
 * [themeID="stopIcon"] {
-    qproperty-icon: url(./Dark/media/media_stop.svg);
+    qproperty-icon: url(theme:Dark/media/media_stop.svg);
 }
 
 * [themeID="nextIcon"] {
-    qproperty-icon: url(./Dark/media/media_next.svg);
+    qproperty-icon: url(theme:Dark/media/media_next.svg);
 }
 
 * [themeID="previousIcon"] {
-    qproperty-icon: url(./Dark/media/media_previous.svg);
+    qproperty-icon: url(theme:Dark/media/media_previous.svg);
 }
 
 /* YouTube Integration */
 OBSYoutubeActions {
-    qproperty-thumbPlaceholder: url(./Dark/sources/image.svg);
+    qproperty-thumbPlaceholder: url(theme:Dark/sources/image.svg);
 }
 
 #ytEventList QLabel {
@@ -1441,7 +1441,7 @@ OBSYoutubeActions {
 /* Calendar Widget */
 QDateTimeEdit::down-arrow {
     qproperty-alignment: AlignTop;
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     width: 100%;
 }
 
@@ -1464,7 +1464,7 @@ QCalendarWidget QToolButton {
 }
 
 #qt_calendar_monthbutton::menu-indicator {
-    image: url(./Dark/down.svg);
+    image: url(theme:Dark/down.svg);
     subcontrol-position: right;
     padding-top: 2px;
     padding-right: 6px;
@@ -1474,13 +1474,13 @@ QCalendarWidget QToolButton {
 
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/left.svg);
+    qproperty-icon: url(theme:Dark/left.svg);
     icon-size: 16px, 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
-    qproperty-icon: url(./Dark/right.svg);
+    qproperty-icon: url(theme:Dark/right.svg);
     icon-size: 16px, 16px;
 }
 

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -31,6 +31,7 @@
 #include <obs-config.h>
 #include <obs.hpp>
 
+#include <QDir>
 #include <QFile>
 #include <QGuiApplication>
 #include <QScreen>
@@ -1271,6 +1272,19 @@ bool OBSApp::InitTheme()
 {
 	defaultPalette = palette();
 	setStyle(new OBSProxyStyle());
+
+	/* Set search paths for custom 'theme:' URI prefix */
+	string searchDir;
+	if (GetDataFilePath("themes", searchDir)) {
+		auto installSearchDir = filesystem::u8path(searchDir);
+		QDir::addSearchPath("theme", absolute(installSearchDir));
+	}
+
+	char userDir[512];
+	if (GetConfigPath(userDir, sizeof(userDir), "obs-studio/themes")) {
+		auto configSearchDir = filesystem::u8path(userDir);
+		QDir::addSearchPath("theme", absolute(configSearchDir));
+	}
 
 	const char *themeName =
 		config_get_string(globalConfig, "General", "CurrentTheme3");

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1664,11 +1664,8 @@ void SourceTree::AddGroup()
 
 void SourceTree::UpdateNoSourcesMessage()
 {
-	std::string darkPath;
-	GetDataFilePath("themes/Dark/no_sources.svg", darkPath);
-
 	QString file = !App()->IsThemeDark() ? ":res/images/no_sources.svg"
-					     : darkPath.c_str();
+					     : "theme:Dark/no_sources.svg";
 	iconNoSources.load(file);
 
 	QTextOption opt(Qt::AlignHCenter);

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -569,19 +569,9 @@ void OBSBasicStatusBar::RecordingUnpaused()
 
 static QPixmap GetPixmap(const QString &filename)
 {
-	bool darkTheme = obs_frontend_is_theme_dark();
-	QString path;
-
-	if (darkTheme) {
-		std::string darkPath;
-		QString themePath = QString("themes/Dark/") + filename;
-		GetDataFilePath(QT_TO_UTF8(themePath), darkPath);
-		path = QT_UTF8(darkPath.c_str());
-	} else {
-		path = QString(":/res/images/" + filename);
-	}
-
-	return QIcon(path).pixmap(QSize(16, 16));
+	QString path = obs_frontend_is_theme_dark() ? "theme:Dark/"
+						    : ":/res/images/";
+	return QIcon(path + filename).pixmap(QSize(16, 16));
 }
 
 void OBSBasicStatusBar::UpdateIcons()


### PR DESCRIPTION
### Description

Adds search paths for Qt `theme:` prefix upon initialising style for the first time so theme data can be referenced with relative paths anywhere within Qt (e.g. stylesheets, QUrl).

### Motivation and Context

While exploring options for making the appearance of OBS more customisable without requiring users to write their own theme files I encountered the issue that all image files use relative paths.  
If we do not load QSS from a path but instead a runtime generated stylesheet this won't work, so instead use a search path with custom prefix that will work regardless of where the file is loaded from.

### How Has This Been Tested?

Loaded up themes, confirmed they still work.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
