### PR TITLE
libobs: Fix duplicate symbol resolution for obs plugins

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -83,7 +83,13 @@ void *os_dlopen(const char *path)
 		dstr_cat(&dylib_name, ".so");
 
 #ifdef __APPLE__
-	void *res = dlopen(dylib_name.array, RTLD_LAZY | RTLD_FIRST);
+	int dlopen_flags = RTLD_LAZY | RTLD_FIRST;
+	if (dstr_find(&dylib_name, "Python")) {
+		dlopen_flags = dlopen_flags | RTLD_GLOBAL;
+	} else {
+		dlopen_flags = dlopen_flags | RTLD_LOCAL;
+	}
+	void *res = dlopen(dylib_name.array, dlopen_flags);
 #else
 	void *res = dlopen(dylib_name.array, RTLD_LAZY);
 #endif


### PR DESCRIPTION
### Description
Forces loading of obs-studio plugins to always hide all imported symbols to avoid symbol duplication issues (particularly noticeable with `asio`).

### Motivation and Context
By default duplicate non-static symbols loaded by dynamic libraries are de-duplicated by the dynamic library loader. This can lead to issues with statically linked libraries inside obs plugins if the symbols share their signature: Whichever plugin is loaded first gets to "set" the symbol (which can become problematic especially for C++ template functions).

Using RTLD_LOCAL ensures that all symbols are hidden and can only be explicitly loaded using dlsym() which avoids this issue.

Unfortunately due to the way scripting works in obs-studio, Python still needs to be loaded with RTLD_GLOBAL, hence the branch in the fix.

> [!NOTE] 
> Following discussions on compiler mailing lists, `RTLD_LOCAL` should have been used from the beginning, as it's especially well-tailored to runtime plugins, even though its support for C++ peculiarities might be quite recent.

### How Has This Been Tested?
* Tested on macOS 13.5.2 with obs-websocket as the "primary" `asio` provider and current release of "Advanced Scene Switcher" as the secondary provider.
* Both were loaded correctly and no crashes occurred.
* Python was also loaded and an API test script finished successfully.
* No obvious issues or errors were encountered, but hardware-specific plugins (AJA, DeckLink) could not be tested due to lack of hardware

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
