### PR TITLE
mac-capture: Show physical instead of logical pixels in SCK properties

### DIFF
--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -102,12 +102,16 @@ bool build_display_list(struct screen_capture *sc, obs_properties_t *props)
             continue;
         }
 
+        CGDisplayModeRef display_mode = CGDisplayCopyDisplayMode(display.displayID);
         char dimension_buffer[4][12] = {};
         char name_buffer[256] = {};
-        snprintf(dimension_buffer[0], sizeof(dimension_buffer[0]), "%u", (uint32_t) display_screen.frame.size.width);
-        snprintf(dimension_buffer[1], sizeof(dimension_buffer[0]), "%u", (uint32_t) display_screen.frame.size.height);
+        snprintf(dimension_buffer[0], sizeof(dimension_buffer[0]), "%u",
+                 (uint32_t) CGDisplayModeGetPixelWidth(display_mode));
+        snprintf(dimension_buffer[1], sizeof(dimension_buffer[0]), "%u",
+                 (uint32_t) CGDisplayModeGetPixelHeight(display_mode));
         snprintf(dimension_buffer[2], sizeof(dimension_buffer[0]), "%d", (int32_t) display_screen.frame.origin.x);
         snprintf(dimension_buffer[3], sizeof(dimension_buffer[0]), "%d", (int32_t) display_screen.frame.origin.y);
+        CGDisplayModeRelease(display_mode);
 
         snprintf(name_buffer, sizeof(name_buffer), "%.200s: %.12sx%.12s @ %.12s,%.12s",
                  display_screen.localizedName.UTF8String, dimension_buffer[0], dimension_buffer[1], dimension_buffer[2],


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Currently, we show the logical "looks like" size of displays in the SCK properties, which gets confusing for high-DPI displays that most people have. It's more useful to show the actual pixel dimensions as that's what people are used to.

Before: 
<img width="400" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/8a5dcfbf-251c-4a3a-8548-a72fd66eda28">
After:
<img width="500" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/4a454a92-37e7-4c99-bcfe-b288255e7536">

Only downside is that the frame coordinates now don't match up. I think that tradeoff is worth it though.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Confused users, also https://ideas.obsproject.com/posts/2379.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
See screenshots above.
Tested that the source still works as before. We're only modifying the visible string.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
