### PR TITLE
cmake: Fix unknown warning option

### DIFF
--- a/deps/json11/CMakeLists.txt
+++ b/deps/json11/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(json11 INTERFACE)
 add_library(OBS::json11 ALIAS json11)
 
 target_include_directories(json11 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
-target_compile_options(json11 INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-unqualified-std-cast-call>)
+if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 14.0.3)
+  target_compile_options(json11 INTERFACE $<$<COMPILE_LANG_AND_ID:CXX,AppleClang,Clang>:-Wno-unqualified-std-cast-call>)
+endif()
 
 target_sources(json11 INTERFACE json11.cpp json11.hpp)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The option `-Wno-unqualified-std-cast-call` is not available on clang 14.0.0 and causes an error at build time.
To avoid the error, add a compiler version guard as same as `UI/cmake/os-macos.cmake`.
https://github.com/obsproject/obs-studio/blob/aaca2b6e73b49dc0685eaa6e7d3933ca343395c0/UI/cmake/os-macos.cmake#L12-L14

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The build flow started to fail on a GitHub Actions runner `macos-12`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: macOS 12
Xcode: 14.2
Clang: 14.0.0

On a GitHub Action workflow, checked-out obs-studio, apply this modification as a patch, and called `obs-studio/.github/actions/build-obs` as below.
```yaml
    - name: 'Build obs-studio'
      uses: ./obs-studio/.github/actions/build-obs
      with:
        workingDirectory: ${{ github.workspace }}/obs-studio/
        target: x86_64
        config: RelWithDebInfo
        codesign: false
```

Tested on a job below.
https://github.com/norihiro/obs-studio-cirun/actions/runs/6290817706/job/17078598887

Without this modification, it failed.
https://github.com/norihiro/obs-studio-cirun/actions/runs/6290745955/job/17078455411
The error message is as below.
```
error: unknown warning option '-Wno-unqualified-std-cast-call'; did you mean '-Wno-qualified-void-return-type'? [-Werror,-Wunknown-warning-option]
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
