### PR TITLE
UI: Add setting to copy screenshots to clipboard

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -658,6 +658,7 @@ Basic.StatusBar.DelayStartingStoppingIn="Delay (stopping in %1 sec, starting in 
 Basic.StatusBar.RecordingSavedTo="Recording saved to '%1'"
 Basic.StatusBar.ReplayBufferSavedTo="Replay buffer saved to '%1'"
 Basic.StatusBar.ScreenshotSavedTo="Screenshot saved to '%1'"
+Basic.StatusBar.ScreenshotSavedToClipboard="Screenshot saved to clipboard and '%1'"
 Basic.StatusBar.AutoRemuxedTo="Recording auto remuxed to '%1'"
 
 # filters window
@@ -1058,6 +1059,7 @@ Basic.Settings.Output.Adv.Recording.Type.FFmpegOutput="Custom Output (FFmpeg)"
 Basic.Settings.Output.Adv.Recording.UseStreamEncoder="(Use stream encoder)"
 Basic.Settings.Output.Adv.Recording.Filename="Filename Formatting"
 Basic.Settings.Output.Adv.Recording.OverwriteIfExists="Overwrite if file exists"
+Basic.Settings.Output.Adv.Recording.ClipboardScreenshots="Copy screenshots to clipboard"
 Basic.Settings.Output.Adv.FFmpeg.Type="FFmpeg Output Type"
 Basic.Settings.Output.Adv.FFmpeg.Type.URL="Output to URL"
 Basic.Settings.Output.Adv.FFmpeg.Type.RecordToFile="Output to File"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7314,6 +7314,29 @@
                      </property>
                     </spacer>
                    </item>
+                   <item row="4" column="0">
+                    <spacer name="clipboardScreenshotSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>170</width>
+                       <height>20</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="4" column="1">
+                    <widget class="QCheckBox" name="clipboardScreenshot">
+                     <property name="text">
+                      <string>Basic.Settings.Output.Adv.Recording.ClipboardScreenshots</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -7940,6 +7963,7 @@
   <tabstop>autoRemux</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
+  <tabstop>clipboardScreenshot</tabstop>
   <tabstop>streamDelayEnable</tabstop>
   <tabstop>streamDelaySec</tabstop>
   <tabstop>streamDelayPreserve</tabstop>

--- a/UI/screenshot-obj.hpp
+++ b/UI/screenshot-obj.hpp
@@ -24,16 +24,19 @@ class ScreenshotObj : public QObject {
 	Q_OBJECT
 
 public:
-	ScreenshotObj(obs_source_t *source);
+	ScreenshotObj(obs_source_t *source, bool clipboard);
 	~ScreenshotObj() override;
 	void Screenshot();
 	void Download();
 	void Copy();
 	void MuxAndFinish();
 
-	gs_texrender_t *texrender = nullptr;
-	gs_stagesurf_t *stagesurf = nullptr;
+	gs_texrender_t *texrender_sdr = nullptr;
+	gs_stagesurf_t *stagesurf_sdr = nullptr;
+	gs_texrender_t *texrender_hdr = nullptr;
+	gs_stagesurf_t *stagesurf_hdr = nullptr;
 	OBSWeakSource weakSource;
+	bool use_clipboard = false;
 	std::string path;
 	QImage image;
 	std::vector<uint8_t> half_bytes;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1671,6 +1671,8 @@ bool OBSBasic::InitBasicConfigDefaults()
 
 	config_set_default_string(basicConfig, "Output", "FilenameFormatting",
 				  "%CCYY-%MM-%DD %hh-%mm-%ss");
+	config_set_default_bool(basicConfig, "Output", "ClipboardScreenshot",
+				true);
 
 	config_set_default_bool(basicConfig, "Output", "DelayEnable", false);
 	config_set_default_uint(basicConfig, "Output", "DelaySec", 20);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1123,7 +1123,7 @@ private slots:
 	void VCamButtonClicked();
 	void VCamConfigButtonClicked();
 	void on_settingsButton_clicked();
-	void Screenshot(OBSSource source_ = nullptr);
+	void Screenshot(OBSSource source_);
 	void ScreenshotSelectedSource();
 	void ScreenshotProgram();
 	void ScreenshotScene();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -553,6 +553,9 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->overwriteIfExists,    CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->simpleRBPrefix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBSuffix,       EDIT_CHANGED,   ADV_CHANGED);
+#if defined(_WIN32) || defined(__APPLE__)
+	HookWidget(ui->clipboardScreenshot,  CHECK_CHANGED,  ADV_CHANGED);
+#endif
 	HookWidget(ui->streamDelayEnable,    CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->streamDelaySec,       SCROLL_CHANGED, ADV_CHANGED);
 	HookWidget(ui->streamDelayPreserve,  CHECK_CHANGED,  ADV_CHANGED);
@@ -644,6 +647,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #ifdef __linux__
 	delete ui->browserHWAccel;
 	delete ui->sourcesGroup;
+	delete ui->clipboardScreenshot;
 #endif
 	delete ui->disableAudioDucking;
 
@@ -659,6 +663,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #ifdef __linux__
 	ui->browserHWAccel = nullptr;
 	ui->sourcesGroup = nullptr;
+	ui->clipboardScreenshot = nullptr;
 #endif
 	ui->disableAudioDucking = nullptr;
 #endif
@@ -2826,6 +2831,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 						 "FilenameFormatting");
 	bool overwriteIfExists =
 		config_get_bool(main->Config(), "Output", "OverwriteIfExists");
+#if defined(_WIN32) || defined(__APPLE__)
+	bool clipboardScreenshot = config_get_bool(main->Config(), "Output",
+						   "ClipboardScreenshot");
+#endif
 	const char *bindIP =
 		config_get_string(main->Config(), "Output", "BindIP");
 	const char *rbPrefix = config_get_string(main->Config(), "SimpleOutput",
@@ -2860,6 +2869,9 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
+#if defined(_WIN32) || defined(__APPLE__)
+	ui->clipboardScreenshot->setChecked(clipboardScreenshot);
+#endif
 
 	ui->advReplayBuf->setChecked(replayBuf);
 	ui->advRBSecMax->setValue(rbTime);
@@ -3608,6 +3620,9 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveEdit(ui->simpleRBPrefix, "SimpleOutput", "RecRBPrefix");
 	SaveEdit(ui->simpleRBSuffix, "SimpleOutput", "RecRBSuffix");
 	SaveCheckBox(ui->overwriteIfExists, "Output", "OverwriteIfExists");
+#if defined(_WIN32) || defined(__APPLE__)
+	SaveCheckBox(ui->clipboardScreenshot, "Output", "ClipboardScreenshot");
+#endif
 	SaveCheckBox(ui->streamDelayEnable, "Output", "DelayEnable");
 	SaveSpinBox(ui->streamDelaySec, "Output", "DelaySec");
 	SaveCheckBox(ui->streamDelayPreserve, "Output", "DelayPreserve");


### PR DESCRIPTION
### Description
Add ability to save screenshots to the OS clipboard.

HDR images will be converted to SDR.

Skip Linux because the image is sometimes corrupt when tested on Ubuntu.

### Motivation and Context
Useful for working with programs that accept images from the clipboard.

### How Has This Been Tested?
- [x] Windows: Clipboard is not used when setting is disabled
- [x] Windows, HDR: Verified clipboard matches file and is correct
- [x] Windows, SDR: Verified clipboard is SDR tonemapped compared to JXR file and both are correct
- [x] Mac: Clipboard is not used when setting is disabled
- [x] Mac, SDR: Verified clipboard matches file and is correct
- [x] Mac, HDR: Verified clipboard is correct, and SDR file hasn't regressed
- [x] Linux: Setting is not visible
- [x] Linux: Screenshot to file still works

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.