### PR TITLE
mac-capture: Don't crash when migrating unknown display IDs

### DIFF
--- a/plugins/mac-capture/window-utils.h
+++ b/plugins/mac-capture/window-utils.h
@@ -31,3 +31,8 @@ void window_defaults(obs_data_t *settings);
 void add_window_properties(obs_properties_t *props);
 
 void show_window_properties(obs_properties_t *props, bool show);
+
+/** Get the display ID of a display and simultaneously migrate pre-30.0 display IDs to 30.0 UUIDs.
+ - Parameter settings: Pointer to `obs_data_t` object containing `display` int and/or `display_uuid` string
+ - Returns: `CGDirectDisplayID` of the display the user selected. May be 0 if the display cannot be found. */
+CGDirectDisplayID get_display_migrate_settings(obs_data_t *settings);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The current code assumes that a display UUID can be created with the stored ID, but that's not always the case, e.g. when the user doesn't have the display connected. As such, we need to null check this, and fall back to the invalid ID (0) when the ID cannot be migrated.

The current code also only migrates on source creation, which yields weird behaviour where if the user opens properties and then cancels it would still show the first display, but only for the session. This is why the code was factored out of the creation function and now is always used when an ID needs to be acquired from OBS Data settings, including when the source is updated.

The deprecated display capture still doesn't like when the display doesn't exist (it returns false/NULL on creation leading to the source basically being "dead" and the user not able to do anything with it but delete it), but this is the same on 29.1 and I'm not too worried about that source anyways.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Got reports of crashes in mac-capture when the UUID gets created.
This can be reproduced easily by (first removing "display_uuid" if it exists and then) setting the "display" setting in the scene collection json to a number higher than the number of connected displays.

Fixes #9606

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Tested that with a variety of different settings (existing "display", nonexistent "display", existing "display_uuid", nonexistent "display_uuid", and combinations of the keys) that previous behavior is restored, where when the display isn't found, nothing is shown but the properties let you select one of the available displays.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
