### PR TITLE
mac-virtualcam: Always replace camera extension; Treat extension installation cancellation as error 

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -68,15 +68,7 @@ struct virtualcam_data {
                   actionForReplacingExtension:(nonnull OSSystemExtensionProperties *)existing
                                 withExtension:(nonnull OSSystemExtensionProperties *)ext
 {
-    NSString *extVersion = [NSString stringWithFormat:@"%@.%@", [ext bundleShortVersion], [ext bundleVersion]];
-    NSString *existingVersion =
-        [NSString stringWithFormat:@"%@.%@", [existing bundleShortVersion], [existing bundleVersion]];
-
-    if ([extVersion compare:existingVersion options:NSNumericSearch] == NSOrderedDescending) {
-        return OSSystemExtensionReplacementActionReplace;
-    } else {
-        return OSSystemExtensionReplacementActionCancel;
-    }
+    return OSSystemExtensionReplacementActionReplace;
 }
 
 - (void)request:(nonnull OSSystemExtensionRequest *)request didFailWithError:(nonnull NSError *)error

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -77,10 +77,6 @@ struct virtualcam_data {
     int severity;
 
     switch (error.code) {
-        case OSSystemExtensionErrorRequestCanceled:
-            errorMessage = @"macOS Camera Extension installation request cancelled.";
-            severity = LOG_INFO;
-            break;
         case OSSystemExtensionErrorUnsupportedParentBundleLocation:
             self.lastErrorMessage =
                 [NSString stringWithUTF8String:obs_module_text("Error.SystemExtension.WrongLocation")];
@@ -95,7 +91,7 @@ struct virtualcam_data {
             break;
     }
 
-    blog(severity, "mac-camera-extension error: %s", errorMessage.UTF8String);
+    blog(severity, "mac-camera-extension: %s", errorMessage.UTF8String);
 }
 
 - (void)request:(nonnull OSSystemExtensionRequest *)request didFinishWithResult:(OSSystemExtensionRequestResult)result


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->


Current code assumes that a newer version of the extension is always better. However that's not true - when the user installs an old version of OBS, we should also install the old version of the camera extension to have a version compatible with the installed OBS.
For normal users this method is only called when the versions in the Info.plist do not match. In system extensions developer mode it's called every time an installation is requested (meaning on every start), which is probably desired as well; and by never returning "ReplacementActionCancel" we can now always treat "ErrorRequestCanceled" as an error and not something that we requested to happen.

OSSystemExtensionErrorRequestCanceled is called when the activation delegate returns OSSystemExtensionReplacementActionCancel on request actionForReplacingExtension withExtension. As per above we no longer request cancellation, so we can be sure that receiving a "cancelled" error is an actual error and not something that is supposed to happen.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #9636

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Installed OBS 30.0 Beta 3 and allowed the virtualcam extension. Replaced OBS with my own build (which has a lower build number). Whereas before it would cancel the installation, it now replaces the extension.
Activated system extension developer mode and started OBS. Saw that the log reports that the installation request was cancelled, but the virtual camera still works.

Before, the first scenario would cancel the request.
The cancellation would result in an unintended error message on virtualcam start and prevent the virtualcam from starting.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
