### PR TITLE
Revert "UI: Add workaround for Qt tooltip stylesheet bug"

### DIFF
--- a/UI/obs-proxy-style.cpp
+++ b/UI/obs-proxy-style.cpp
@@ -90,17 +90,3 @@ int OBSProxyStyle::styleHint(StyleHint hint, const QStyleOption *option,
 
 	return QProxyStyle::styleHint(hint, option, widget, returnData);
 }
-
-#ifdef QT_TOOLTIP_WORKAROUND_NEEDED
-void OBSProxyStyle::polish(QWidget *widget)
-{
-	QProxyStyle::polish(widget);
-
-	// QTBUG-115511 workaround to make tooltip label QSS work again
-	if (widget->inherits("QTipLabel")) {
-		QPalette palette = widget->palette();
-		palette.setResolveMask(0);
-		widget->setPalette(palette);
-	}
-}
-#endif

--- a/UI/obs-proxy-style.hpp
+++ b/UI/obs-proxy-style.hpp
@@ -2,19 +2,11 @@
 
 #include <QProxyStyle>
 
-#if defined(_WIN32) && QT_VERSION == QT_VERSION_CHECK(6, 5, 2)
-#define QT_TOOLTIP_WORKAROUND_NEEDED
-#endif
-
 class OBSProxyStyle : public QProxyStyle {
 public:
 	int styleHint(StyleHint hint, const QStyleOption *option,
 		      const QWidget *widget,
 		      QStyleHintReturn *returnData) const override;
-
-#ifdef QT_TOOLTIP_WORKAROUND_NEEDED
-	void polish(QWidget *widget) override;
-#endif
 };
 
 class OBSContextBarProxyStyle : public OBSProxyStyle {


### PR DESCRIPTION
### Description

This reverts commit d97950445e57a62459f4d5de2a6c8d43b5f61c66.

### Motivation and Context

No longer required as this was fixed in Qt 6.5.3.

### How Has This Been Tested?

Hasn't, but should be fine now.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
