### PR TITLE
libobs: Fix hotkeys with groups and duplicate sceneitems

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1692,14 +1692,24 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 	dst->hide_transition_duration = src->hide_transition_duration;
 
 	if (duplicate_hotkeys && !dst_scene->source->context.private) {
+		struct dstr show = {0};
+		struct dstr hide = {0};
 		obs_data_array_t *data0 = NULL;
 		obs_data_array_t *data1 = NULL;
 
 		obs_hotkey_pair_save(src->toggle_visibility, &data0, &data1);
 		obs_hotkey_pair_load(dst->toggle_visibility, data0, data1);
 
+		/* Fix scene item ID */
+		dstr_printf(&show, "libobs.show_scene_item.%" PRIi64, dst->id);
+		dstr_printf(&hide, "libobs.hide_scene_item.%" PRIi64, dst->id);
+		obs_hotkey_pair_set_names(dst->toggle_visibility, show.array,
+					  hide.array);
+
 		obs_data_array_release(data0);
 		obs_data_array_release(data1);
+		dstr_free(&show);
+		dstr_free(&hide);
 	}
 
 	obs_sceneitem_set_crop(dst, &src->crop);
@@ -2012,20 +2022,33 @@ static bool hotkey_hide_sceneitem(void *data, obs_hotkey_pair_id id,
 static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item,
 			 const char *name)
 {
+	struct obs_data_array *hotkey_array;
+	obs_data_t *hotkey_data = scene->source->context.hotkey_data;
+
 	struct dstr show = {0};
 	struct dstr hide = {0};
+	struct dstr legacy = {0};
 	struct dstr show_desc = {0};
 	struct dstr hide_desc = {0};
 
-	dstr_copy(&show, "libobs.show_scene_item.%1");
-	dstr_replace(&show, "%1", name);
-	dstr_copy(&hide, "libobs.hide_scene_item.%1");
-	dstr_replace(&hide, "%1", name);
+	dstr_printf(&show, "libobs.show_scene_item.%" PRIi64, item->id);
+	dstr_printf(&hide, "libobs.hide_scene_item.%" PRIi64, item->id);
 
 	dstr_copy(&show_desc, obs->hotkeys.sceneitem_show);
 	dstr_replace(&show_desc, "%1", name);
 	dstr_copy(&hide_desc, obs->hotkeys.sceneitem_hide);
 	dstr_replace(&hide_desc, "%1", name);
+
+	/* Check if legacy keys exists, migrate if necessary */
+	dstr_printf(&legacy, "libobs.show_scene_item.%s", name);
+	hotkey_array = obs_data_get_array(hotkey_data, legacy.array);
+	if (hotkey_array)
+		obs_data_set_array(hotkey_data, show.array, hotkey_array);
+
+	dstr_printf(&legacy, "libobs.hide_scene_item.%s", name);
+	hotkey_array = obs_data_get_array(hotkey_data, legacy.array);
+	if (hotkey_array)
+		obs_data_set_array(hotkey_data, hide.array, hotkey_array);
 
 	item->toggle_visibility = obs_hotkey_pair_register_source(
 		scene->source, show.array, show_desc.array, hide.array,
@@ -2034,6 +2057,7 @@ static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item,
 
 	dstr_free(&show);
 	dstr_free(&hide);
+	dstr_free(&legacy);
 	dstr_free(&show_desc);
 	dstr_free(&hide_desc);
 }
@@ -2041,18 +2065,8 @@ static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item,
 static void sceneitem_rename_hotkey(const obs_sceneitem_t *scene_item,
 				    const char *new_name)
 {
-	struct dstr show = {0};
-	struct dstr hide = {0};
 	struct dstr show_desc = {0};
 	struct dstr hide_desc = {0};
-
-	dstr_copy(&show, "libobs.show_scene_item.%1");
-	dstr_replace(&show, "%1", new_name);
-	dstr_copy(&hide, "libobs.hide_scene_item.%1");
-	dstr_replace(&hide, "%1", new_name);
-
-	obs_hotkey_pair_set_names(scene_item->toggle_visibility, show.array,
-				  hide.array);
 
 	dstr_copy(&show_desc, obs->hotkeys.sceneitem_show);
 	dstr_replace(&show_desc, "%1", new_name);
@@ -2062,8 +2076,6 @@ static void sceneitem_rename_hotkey(const obs_sceneitem_t *scene_item,
 	obs_hotkey_pair_set_descriptions(scene_item->toggle_visibility,
 					 show_desc.array, hide_desc.array);
 
-	dstr_free(&show);
-	dstr_free(&hide);
 	dstr_free(&show_desc);
 	dstr_free(&hide_desc);
 }


### PR DESCRIPTION
### Description

Use the locally unique ID of a scene item for its hotkey(s) rather than the name, which will conflict when multiple sceneitems for the same source exist.

Also addresses the following issues:
- IDs and counter were not restored before creating hotkeys, which needs to be the case for ID-based hotkeys to work
- Moving items into and out of groups did not move their hotkeys to the group/scene so they would get lost
- Adds migration for old name-based hotkeys to new ID-based ones

### Motivation and Context

Fixes #9639

### How Has This Been Tested?

Verified hotkeys are now saved and loaded correctly.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
