### PR TITLE
UI: Fix YouTubeAppDock causing hidden browser docks to automatically play audio on macOS

### DIFF
--- a/UI/window-dock-youtube-app.cpp
+++ b/UI/window-dock-youtube-app.cpp
@@ -36,6 +36,7 @@ YouTubeAppDock::YouTubeAppDock(const QString &title)
 	  dockBrowser(nullptr),
 	  cookieManager(nullptr)
 {
+	cef->init_browser();
 	OBSBasic::InitBrowserPanelSafeBlock();
 	AddYouTubeAppDock();
 }


### PR DESCRIPTION
### Description
Explicitly initialises CEF when a YouTubeAppDock is created to fix a premature trigger of a `QEventLoop` before the main event loop has even been started.

This avoids all other browser docks' browser instances from being automatically created, their associated websites being loaded, and their video and audio output automatically playing even though no docks are hidden.

### Motivation and Context

> [!IMPORTANT]
> Given that user-created browser docks do _not_ use `InitBrowserPanelSafeBlock` but instead initialise CEF directly on the main event loop, this should not lead to worse UX, but merely makes the YouTubeAppDock behave like normal browser docks.

> [!NOTE]
> When used before the primary event loop has been started, this function will lead to unknown side-effects. After that, the function does have the same side-effects mentioned by Qt in relation to `QDialog::exec()`, thus its note "Avoid using this function" applies.

#### Current State
Logically the current UI code runs through the following steps:

* Create user-defined browser docks from settings
  * Only create Dock Widgets, but do not initialise a CEF instance or browser instances yet
* Create a YouTubeAppDock
  * Check for a running CEF instance
  * If a running CEF instance is found, create a cookie manager
  * If _no_ running CEF instance is found, call `InitBrowserPanelSafeBlock` to create one
    * Call `init_browser` to create a new CEF instance (the function is blocking)
    * Create a new thread that will wait for the CEF instance to be created
    * Spin up a local `QEventLoop` to handle UI events
    * Wait for the thread to finish
    * The thread will stop the local `QEventLoop` once finished
    * Finally create a cookie manager
* Restore the dock state

#### The Problem
This leads to an issue outside of Windows (where CEF runs its own event loop on a separate thread):

* The local event loop created by `InitBrowserPanelSafeBlock` runs _before_ the main event loop exists (because `OBSInit()` will do a **whole** lot of other things before `QApplication::exec()` will be called).
* This leads to Qt initialising the entire program, prematurely going through the entire Widget initialisation
* Because the state of the browser docks has not been restored, Qt treats them as "uninitialised" and thus sets them to `visible`.
* Once this short-lived loop is ended (because CEF is initialised) the dock states will be restored - hidden docks will thus be set to "not `visible`".
* However the prior run of the event loop already scheduled a call to each dock's `showEvent` method on the event loop, which initialises CEF (if not available yet) and loads the associated web page
* If a user has any site with autoplaying video with audio set up in their dock, the associated audio will be audible, seemingly coming from "nowhere"
* So when `QApplication::exec()` finally spins up the _actual_ main event loop, all docks will be loaded, their sites initialised, audio will be played, but the docks will also already be set to be hidden

#### The Fix
To fix this, a premature run of the local `QEventLoop` needs to be prevented. Given the highly interconnected nature of the code (Widget creation is tightly coupled to browser initialisation, the entire code is written in a synchronous fashion and not written with the asynchronous nature of an application event loop in mind) there is no _good_ way to fix this (the good way would be to untangle all these steps and schedule each callback on the main event loop).

### How Has This Been Tested?
Tested on macOS 14 with a hidden browser dock containing an autoplaying video with sound and YouTube selected as current service:

* The dock is _not_ loaded automatically, no audio is heard playing
* The YouTubeAppDock is visible on application launch if it was not manually-closed before
* The YouTubeAppDock is _not_ visible on application launch if it was closed manually before
* The YouTubeAppDock correctly appears when YouTube is selected as a service _after_ closing the settings dialog
* The YouTubeAppDock is correctly removed when another service is selected as a service _after_ closing the settings dialog

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
