### PR TITLE
libobs,obs-filters: Fix NAN when tonemapping

### DIFF
--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -45,6 +45,7 @@ float3 rec2020_to_rec709(float3 v)
 float3 reinhard(float3 rgb)
 {
 	rgb /= rgb + float3(1., 1., 1.);
+	rgb = saturate(rgb);
 	rgb = pow(rgb, float3(1. / 2.4, 1. / 2.4, 1. / 2.4));
 	rgb = srgb_nonlinear_to_linear(rgb);
 	return rgb;

--- a/plugins/obs-filters/data/color.effect
+++ b/plugins/obs-filters/data/color.effect
@@ -37,6 +37,7 @@ float3 rec2020_to_rec709(float3 v)
 float3 reinhard(float3 rgb)
 {
 	rgb /= rgb + float3(1., 1., 1.);
+	rgb = saturate(rgb);
 	rgb = pow(rgb, float3(1. / 2.4, 1. / 2.4, 1. / 2.4));
 	rgb = srgb_nonlinear_to_linear(rgb);
 	return rgb;


### PR DESCRIPTION
### Description
Can happen when colors are wider than Rec. 2020.

### Motivation and Context
Don't want black pixels where colors should be.

### How Has This Been Tested?
Both shader paths looked buggy before and look fine after. Also verified Windows OpenGL runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.