### PR TITLE
rtmp-services: Update OnlyFans streaming service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 234,
+    "version": 235,
     "files": [
         {
             "name": "services.json",
-            "version": 234
+            "version": 235
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1526,13 +1526,18 @@
         },
         {
             "name": "OnlyFans.com",
+            "stream_key_link": "https://onlyfans.com/my/settings/other",
             "servers": [
                 {
-                    "name": "USA",
+                    "name": "CloudBeta",
+                    "url": "rtmp://cloudbetastreaming.onlyfans.com/live"
+                },
+                {
+                    "name": "Backup (USA)",
                     "url": "rtmp://route0.onlyfans.com/live"
                 },
                 {
-                    "name": "Europe",
+                    "name": "Backup (Europe)",
                     "url": "rtmp://route0-dc2.onlyfans.com/live"
                 }
             ],


### PR DESCRIPTION
### Description
Update OnlyFans streaming service urls 

### Motivation and Context
We have changed the our main url for streaming. Added it as a new entity. The old one has been renamed as an alternative.

### How Has This Been Tested?
Not tested. Since it was not possible to build the project on macOS 12.5 (a lot of build errors)

### Types of changes
Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
