### PR TITLE
linux-v4l2: Expand packed values to 4 bytes

### DIFF
--- a/plugins/linux-v4l2/v4l2-helpers.c
+++ b/plugins/linux-v4l2/v4l2-helpers.c
@@ -192,7 +192,7 @@ int_fast32_t v4l2_get_input_caps(int_fast32_t dev, int input, uint32_t *caps)
 	return 0;
 }
 
-int_fast32_t v4l2_set_format(int_fast32_t dev, int *resolution,
+int_fast32_t v4l2_set_format(int_fast32_t dev, int64_t *resolution,
 			     int *pixelformat, int *bytesperline)
 {
 	bool set = false;
@@ -229,7 +229,7 @@ int_fast32_t v4l2_set_format(int_fast32_t dev, int *resolution,
 	return 0;
 }
 
-int_fast32_t v4l2_set_framerate(int_fast32_t dev, int *framerate)
+int_fast32_t v4l2_set_framerate(int_fast32_t dev, int64_t *framerate)
 {
 	bool set = false;
 	int num, denom;

--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -75,8 +75,8 @@ struct v4l2_data {
 	int pixfmt;
 	int standard;
 	int dv_timing;
-	int resolution;
-	int framerate;
+	int64_t resolution;
+	int64_t framerate;
 	int color_range;
 
 	/* internal data */
@@ -591,7 +591,8 @@ static void v4l2_resolution_list(int dev, uint_fast32_t pixelformat,
 		blog(LOG_INFO, "Stepwise and Continuous framesizes "
 			       "are currently hardcoded");
 
-		for (const int *packed = v4l2_framesizes; *packed; ++packed) {
+		for (const int64_t *packed = v4l2_framesizes; *packed;
+		     ++packed) {
 			int width;
 			int height;
 			v4l2_unpack_tuple(&width, &height, *packed);
@@ -643,7 +644,8 @@ static void v4l2_framerate_list(int dev, uint_fast32_t pixelformat,
 		blog(LOG_INFO, "Stepwise and Continuous framerates "
 			       "are currently hardcoded");
 
-		for (const int *packed = v4l2_framerates; *packed; ++packed) {
+		for (const int64_t *packed = v4l2_framerates; *packed;
+		     ++packed) {
 			int num;
 			int denom;
 			v4l2_unpack_tuple(&num, &denom, *packed);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Expand packed values to 4 bytes, and wrap up static values with a macro.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
These days you might capture card a 175Hz monitor with a framerate defined as 10000000/57143 that doesnt fit in a short, as reported by a user. And reporting a negative FPS in that case isnt very helpful.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
My logitech webcam still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
