### PR TITLE
UI: Use C++11 ranged-for instead of Q_FOREACH

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10882,9 +10882,11 @@ void OBSBasic::CheckDiskSpaceRemaining()
 
 void OBSBasic::ResetStatsHotkey()
 {
-	QList<OBSBasicStats *> list = findChildren<OBSBasicStats *>();
+	const QList<OBSBasicStats *> list = findChildren<OBSBasicStats *>();
 
-	foreach(OBSBasicStats * s, list) s->Reset();
+	for (OBSBasicStats *s : list) {
+		s->Reset();
+	}
 }
 
 void OBSBasic::on_OBSBasic_customContextMenuRequested(const QPoint &pos)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Qt has been porting uses of Q_FOREACH/foreach to C++11's ranged-for. Let's do the same.

References:
 * https://bugreports.qt.io/browse/QTBUG-115796
 * https://doc.qt.io/qt-6/foreach-keyword.html
 * https://codereview.qt-project.org/q/Q_FOREACH
 * https://en.cppreference.com/w/cpp/language/range-for

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We target C++17. Q_FOREACH was previously suggested to be deprecated/replaced for Qt 6. While that did not happen, Qt's efforts to replace Q_FOREACH/foreach indicate that its days may be numbered.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and ran OBS on Windows 11. Invoked the Reset Stats hotkey a few times.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
