### PR TITLE
UI: Use std::shared_ptr instead of QSharedPointer

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -23,7 +23,7 @@ using namespace std;
 // Padding on top and bottom of vertical meters
 #define METER_PADDING 1
 
-QWeakPointer<VolumeMeterTimer> VolumeMeter::updateTimer;
+std::weak_ptr<VolumeMeterTimer> VolumeMeter::updateTimer;
 
 static inline Qt::CheckState GetCheckState(bool muted, bool unassigned)
 {
@@ -870,9 +870,9 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter,
 	channels = (int)audio_output_get_channels(obs_get_audio());
 
 	doLayout();
-	updateTimerRef = updateTimer.toStrongRef();
+	updateTimerRef = updateTimer.lock();
 	if (!updateTimerRef) {
-		updateTimerRef = QSharedPointer<VolumeMeterTimer>::create();
+		updateTimerRef = std::make_shared<VolumeMeterTimer>();
 		updateTimerRef->setTimerType(Qt::PreciseTimer);
 		updateTimerRef->start(16);
 		updateTimer = updateTimerRef;

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -3,7 +3,6 @@
 #include <obs.hpp>
 #include <QWidget>
 #include <QPaintEvent>
-#include <QSharedPointer>
 #include <QTimer>
 #include <QMutex>
 #include <QList>
@@ -96,8 +95,8 @@ class VolumeMeter : public QWidget {
 
 private:
 	obs_volmeter_t *obs_volmeter;
-	static QWeakPointer<VolumeMeterTimer> updateTimer;
-	QSharedPointer<VolumeMeterTimer> updateTimerRef;
+	static std::weak_ptr<VolumeMeterTimer> updateTimer;
+	std::shared_ptr<VolumeMeterTimer> updateTimerRef;
 
 	inline void resetLevels();
 	inline void doLayout();

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10487,7 +10487,7 @@ void OBSBasic::AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area,
 #endif
 
 	extraDockNames.push_back(dock->objectName());
-	extraDocks.push_back(QSharedPointer<QDockWidget>(dock));
+	extraDocks.push_back(std::shared_ptr<QDockWidget>(dock));
 }
 
 void OBSBasic::RemoveDockWidget(const QString &name)
@@ -10495,7 +10495,7 @@ void OBSBasic::RemoveDockWidget(const QString &name)
 	if (extraDockNames.contains(name)) {
 		int idx = extraDockNames.indexOf(name);
 		extraDockNames.removeAt(idx);
-		extraDocks[idx].clear();
+		extraDocks[idx].reset();
 		extraDocks.removeAt(idx);
 	} else if (extraCustomDockNames.contains(name)) {
 		int idx = extraCustomDockNames.indexOf(name);

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -564,7 +564,7 @@ private:
 	void UpdatePreviewProgramIndicators();
 
 	QStringList extraDockNames;
-	QList<QSharedPointer<QDockWidget>> extraDocks;
+	QList<std::shared_ptr<QDockWidget>> extraDocks;
 
 	QStringList extraCustomDockNames;
 	QList<QPointer<QDockWidget>> extraCustomDocks;
@@ -572,7 +572,7 @@ private:
 #ifdef BROWSER_AVAILABLE
 	QPointer<QAction> extraBrowserMenuDocksSeparator;
 
-	QList<QSharedPointer<QDockWidget>> extraBrowserDocks;
+	QList<std::shared_ptr<QDockWidget>> extraBrowserDocks;
 	QStringList extraBrowserDockNames;
 	QStringList extraBrowserDockTargets;
 

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -174,7 +174,7 @@ void ExtraBrowsersModel::UpdateItem(Item &item)
 
 	OBSBasic *main = OBSBasic::Get();
 	BrowserDock *dock = reinterpret_cast<BrowserDock *>(
-		main->extraBrowserDocks[idx].data());
+		main->extraBrowserDocks[idx].get());
 	dock->setWindowTitle(item.title);
 	dock->setObjectName(item.title + OBJ_NAME_SUFFIX);
 
@@ -498,7 +498,7 @@ void OBSBasic::SaveExtraBrowserDocks()
 {
 	Json::array array;
 	for (int i = 0; i < extraBrowserDocks.size(); i++) {
-		QDockWidget *dock = extraBrowserDocks[i].data();
+		QDockWidget *dock = extraBrowserDocks[i].get();
 		QString title = extraBrowserDockNames[i];
 		QString url = extraBrowserDockTargets[i];
 		QString uuid = dock->property("uuid").toString();
@@ -571,7 +571,7 @@ void OBSBasic::AddExtraBrowserDock(const QString &title, const QString &url,
 	}
 
 	AddDockWidget(dock, Qt::RightDockWidgetArea, true);
-	extraBrowserDocks.push_back(QSharedPointer<QDockWidget>(dock));
+	extraBrowserDocks.push_back(std::shared_ptr<QDockWidget>(dock));
 	extraBrowserDockNames.push_back(title);
 	extraBrowserDockTargets.push_back(url);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Use std::shared_ptr instead of QSharedPointer

Also use std::weak_ptr instead of QWeakPointer as needed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Qt has been porting QSharedPointer and QWeakPointer to std::shared_ptr and std::weak_ptr respectively. QSharedPointer is apparently 2x slower than std::shared_ptr.

References:
 * https://bugreports.qt.io/browse/QTBUG-109570
 * https://codereview.qt-project.org/c/qt/qtbase/+/359678
 * https://codereview.qt-project.org/c/qt/qtgrpc/+/447780
 * https://codereview.qt-project.org/c/qt/qtbase/+/450134
 * https://codereview.qt-project.org/c/qt/qttools/+/450776
 * https://codereview.qt-project.org/c/qt/qttools/+/450777
 * https://codereview.qt-project.org/q/QSharedPointer


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and ran OBS on Windows 11. Created, opened, closed, and removed some Custom Browser Docks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
