### PR TITLE
libobs: Prevent audio doubling

### DIFF
--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -149,8 +149,6 @@ static void buffer_audio(void *data, AudioQueueRef aq, AudioQueueBufferRef buf)
 	UNUSED_PARAMETER(aq);
 }
 
-extern bool devices_match(const char *id1, const char *id2);
-
 static bool audio_monitor_init(struct audio_monitor *monitor,
 			       obs_source_t *source)
 {

--- a/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
+++ b/libobs/audio-monitoring/pulse/pulseaudio-wrapper.h
@@ -35,8 +35,6 @@ struct enum_cb {
 
 void get_default_id(char **id);
 
-bool devices_match(const char *id1, const char *id2);
-
 /**
  * Initialize the pulseaudio mainloop and increase the reference count
  */

--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -403,8 +403,6 @@ static inline void audio_monitor_free(struct audio_monitor *monitor)
 	da_free(monitor->buf);
 }
 
-extern bool devices_match(const char *id1, const char *id2);
-
 static bool audio_monitor_init(struct audio_monitor *monitor,
 			       obs_source_t *source)
 {

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -388,6 +388,10 @@ struct obs_core_audio {
 
 	pthread_mutex_t task_mutex;
 	struct circlebuf tasks;
+
+	volatile long duplicate_audio_device_refs;
+	bool user_ignore_duplicate_audio;
+	bool ignore_duplicate_audio;
 };
 
 /* user sources, output channels, and displays */
@@ -664,6 +668,7 @@ enum audio_action_type {
 	AUDIO_ACTION_MUTE,
 	AUDIO_ACTION_PTT,
 	AUDIO_ACTION_PTM,
+	AUDIO_ACTION_IGNORE,
 };
 
 struct audio_action {
@@ -772,6 +777,7 @@ struct obs_source {
 	int64_t sync_offset;
 	int64_t last_sync_offset;
 	float balance;
+	bool output_devices_match;
 
 	/* async video data */
 	gs_texture_t *async_textures[MAX_AV_PLANES];
@@ -898,6 +904,8 @@ extern void obs_transition_load(obs_source_t *source, obs_data_t *data);
 struct audio_monitor *audio_monitor_create(obs_source_t *source);
 void audio_monitor_reset(struct audio_monitor *monitor);
 extern void audio_monitor_destroy(struct audio_monitor *monitor);
+extern bool devices_match(const char *id1, const char *id2);
+extern void update_audio_output_dup_refs(obs_source_t *source);
 
 extern obs_source_t *
 obs_source_create_set_last_ver(const char *id, const char *name,

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3033,6 +3033,13 @@ void obs_reset_audio_monitoring(void)
 	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
 }
 
+static bool update_audio_monitor_dup_refs(void *data, obs_source_t *source)
+{
+	UNUSED_PARAMETER(data);
+	update_audio_output_dup_refs(source);
+	return true;
+}
+
 bool obs_set_audio_monitoring_device(const char *name, const char *id)
 {
 	if (!name || !id || !*name || !*id)
@@ -3057,6 +3064,8 @@ bool obs_set_audio_monitoring_device(const char *name, const char *id)
 	obs_reset_audio_monitoring();
 
 	pthread_mutex_unlock(&obs->audio.monitoring_mutex);
+
+	obs_enum_sources(update_audio_monitor_dup_refs, NULL);
 	return true;
 }
 


### PR DESCRIPTION
### Description
If a source has output & monitor enabled and there is an audio output source active that has the same audio output device as the monitor, the audio would be doubled in the final output.

### Motivation and Context
Suggestion from @Warchamp7, as he says this should be implemented before #1253 is merged.

### How Has This Been Tested?
Created audio source and set the monitoring to output and monitor. Then added a audio output source the used the same device as the monitor. Then I recorded a video to make sure there was no audio doubling.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
