### PR TITLE
obs-ffmpeg: Readd OBS_ENCODER_CAP_DYN_BITRATE to AMF texture encoders

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1506,7 +1506,8 @@ static void register_avc()
 	amf_encoder_info.get_defaults = amf_defaults;
 	amf_encoder_info.get_properties = amf_avc_properties;
 	amf_encoder_info.get_extra_data = amf_extra_data;
-	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE;
+	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE |
+				OBS_ENCODER_CAP_DYN_BITRATE;
 
 	obs_register_encoder(&amf_encoder_info);
 
@@ -1859,7 +1860,8 @@ static void register_hevc()
 	amf_encoder_info.get_defaults = amf_defaults;
 	amf_encoder_info.get_properties = amf_hevc_properties;
 	amf_encoder_info.get_extra_data = amf_extra_data;
-	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE;
+	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE |
+				OBS_ENCODER_CAP_DYN_BITRATE;
 
 	obs_register_encoder(&amf_encoder_info);
 
@@ -2184,7 +2186,8 @@ static void register_av1()
 	amf_encoder_info.get_defaults = amf_av1_defaults;
 	amf_encoder_info.get_properties = amf_av1_properties;
 	amf_encoder_info.get_extra_data = amf_extra_data;
-	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE;
+	amf_encoder_info.caps = OBS_ENCODER_CAP_PASS_TEXTURE |
+				OBS_ENCODER_CAP_DYN_BITRATE;
 
 	obs_register_encoder(&amf_encoder_info);
 


### PR DESCRIPTION
### Description

Re-enable dynamic bitrate on texture-amf. This was left out of #8991 for some reason.

### Motivation and Context

After reconfiguration was fixed the flag wasn't added back.

Fixes #9667
Fixes #8548

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
 
### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
