### PR TITLE
win-wasapi: Use provided timestamp for process capture and handle flags

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -249,8 +249,6 @@ class WASAPISource {
 	audio_format format;
 	uint32_t sampleRate;
 
-	uint64_t framesProcessed = 0;
-
 	static DWORD WINAPI ReconnectThread(LPVOID param);
 	static DWORD WINAPI CaptureThread(LPVOID param);
 
@@ -1145,10 +1143,7 @@ bool WASAPISource::ProcessCaptureData()
 		data.samples_per_sec = sampleRate;
 		data.format = format;
 		if (sourceType == SourceType::ProcessOutput) {
-			data.timestamp = util_mul_div64(framesProcessed,
-							UINT64_C(1000000000),
-							sampleRate);
-			framesProcessed += frames;
+			data.timestamp = ts * 100;
 		} else {
 			data.timestamp = useDeviceTiming ? ts * 100
 							 : os_gettime_ns();


### PR DESCRIPTION
### Description

Changes process audio capture to use the OS-provided timestamp instead of calculating our own. In tests this seems to resolve audio issues reported by various users (also see: https://github.com/stream-labs/obs-studio/pull/543).

Additionally adds some logging and handling for flags that may be set by `IAudioClient::GetBuffer()`:
- `AUDCLNT_BUFFERFLAGS_TIMESTAMP_ERROR` is treated as failure, buffer is free'd and capture reset
- `AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY` is logged to debug, but ignored as it probably won't cause issues with libobs's audio data processing
- `AUDCLNT_BUFFERFLAGS_SILENT` now replaces the buffer with all zeroes to avoid processing potentially stale or garbage data (also logged to debug as it can get very spammy)

### Motivation and Context

Hopefully helps with #8064 (not closing that one quite yet).

### How Has This Been Tested?

A user with extremely reliable reproduction of the audio issue reported no problems during a test recording.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
