### PR TITLE
mac-virtualcam: Check result of finished extension installation

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
+++ b/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
@@ -4,5 +4,6 @@ Error.SystemExtension.CameraUnavailable="Could not find virtual camera.\n\nPleas
 Error.SystemExtension.CameraNotStarted="Unable to start virtual camera.\n\nPlease try again."
 Error.SystemExtension.InstallationError="An error has occured while installing the virtual camera:"
 Error.SystemExtension.WrongLocation="OBS cannot install the virtual camera if it's not in \"/Applications\". Please move OBS to the \"/Applications\" directory."
+Error.SystemExtension.CompleteAfterReboot="The installation of the virtual camera will complete after a system reboot."
 Error.DAL.NotInstalled="The virtual camera could not be installed or updated.\n\nPlease try again and enter the name and password of an administrator when prompted."
 Error.DAL.NotUninstalled="Could not remove the legacy virtual camera.\n\nPlease try again and enter the name and password of an administrator when prompted."

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -96,8 +96,17 @@ struct virtualcam_data {
 
 - (void)request:(nonnull OSSystemExtensionRequest *)request didFinishWithResult:(OSSystemExtensionRequestResult)result
 {
-    self.installed = YES;
-    blog(LOG_INFO, "macOS Camera Extension activated successfully.");
+    switch (result) {
+        case OSSystemExtensionRequestCompleted:
+            self.installed = YES;
+            blog(LOG_INFO, "macOS Camera Extension activated successfully.");
+            break;
+        case OSSystemExtensionRequestWillCompleteAfterReboot:
+            self.lastErrorMessage =
+                [NSString stringWithUTF8String:obs_module_text("Error.SystemExtension.CompleteAfterReboot")];
+            blog(LOG_INFO, "macOS Camera Extension will activate after reboot.");
+            break;
+    }
 }
 
 - (void)requestNeedsUserApproval:(nonnull OSSystemExtensionRequest *)request


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a switch to distinguish between the possible results that could occur. While we expect to received RequestCompleted for our camera extension (RequestWillCompleteAfterReboot is usually more of a network extension thing), we can't be sure that this always is what we receive unless we check it.

I may have overdone it a bit by adding the locale string but if we're adding this handling we may as well also tell the user about it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
@PatTheMav suggested this in #9638 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.
Tested that the virtualcam still works as before because we always receive `OSSystemExtensionRequestCompleted`.
Tested the `OSSystemExtensionRequestWillCompleteAfterReboot` code path by flipping the switch cases, I'm not sure we can get actually get this case in reality (at least currently. who knows what happens in the future with these things).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
