### PR TITLE
win-wasapi: Remove 'BETA' from Application Audio Capture name

### DIFF
--- a/plugins/win-wasapi/data/locale/en-US.ini
+++ b/plugins/win-wasapi/data/locale/en-US.ini
@@ -1,6 +1,6 @@
 AudioInput="Audio Input Capture"
 AudioOutput="Audio Output Capture"
-ApplicationAudioCapture="Application Audio Capture (BETA)"
+ApplicationAudioCapture="Application Audio Capture"
 Device="Device"
 Default="Default"
 UseDeviceTiming="Use Device Timestamps"


### PR DESCRIPTION
### Description

Removes the "BETA" from the Application Audio Capture name.

### Motivation and Context

With #9672 merged and hopefully finally fixing #8064 it's probably time to remove the "BETA" label.

We can wait with this until we receive more feedback during the final release candidate phase.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
