### PR TITLE
CI: Add support for dependency revisions to Linux CI builds

### DIFF
--- a/.github/scripts/utils.zsh/setup_linux
+++ b/.github/scripts/utils.zsh/setup_linux
@@ -28,9 +28,9 @@ local deps_baseurl
 local deps_label
 local deps_hash
 
-IFS=';' read -r deps_version deps_baseurl deps_label deps_hash <<< \
+IFS=';' read -r deps_version deps_baseurl deps_label deps_hash deps_revision <<< \
   "$(jq -r --arg target "${target}" \
-    '.dependencies["cef"] | {version, baseUrl, "label", "hash": .hashes[$target]} | join(";")' \
+    '.dependencies["cef"] | {version, baseUrl, "label", "hash": .hashes[$target], "revision": .revision[$target]} | join(";")' \
     ${buildspec_file})"
 
 if (( ! deps_version )) {
@@ -40,7 +40,7 @@ if (( ! deps_version )) {
 log_group 'Setting up pre-built Chromium Embedded Framework...'
 
 pushd ${project_root}/.deps
-local _filename="cef_binary_${deps_version}_${target//-/_}.tar.xz"
+local _filename="cef_binary_${deps_version}_${target//-/_}${deps_revision:+"_v${deps_revision}"}.tar.xz"
 local _url=${deps_baseurl}/${_filename}
 local _target="cef_binary_${deps_version}_${target//-/_}"
 typeset -g CEF_VERSION=${deps_version}


### PR DESCRIPTION
### Description
Adds support for revisions in buildspec file for Linux CI builds.

### Motivation and Context
Updating dependencies without increasing the version number requires a revision suffix to the file name (as hashes will change).

This support is already implemented in CMake for Windows and macOS but was missing support for Linux builds, which is added with this PR.

### How Has This Been Tested?
Tested on Ubuntu 23.04 with added revision to buildspec and without.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
