### PR TITLE
CI: Fix Steam upload (again)

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -78,9 +78,9 @@ runs:
       shell: zsh --no-rcs --errexit --pipefail {0}
       env:
         GH_TOKEN: ${{ inputs.workflowSecret }}
-        windows_custom_asset: ${{ steps.asset-info.outputs.windowsAssetUrl }}
-        macos_apple_custom_asset: ${{ steps.asset-info.outputs.macos_appleAssetUrl }}
-        macos_intel_custom_asset: ${{ steps.asset-info.outputs.macos_intelAssetUrl }}
+        windows_custom_asset: ${{ inputs.customAssetWindows }}
+        macos_apple_custom_asset: ${{ inputs.customAssetMacOSApple }}
+        macos_intel_custom_asset: ${{ inputs.customAssetMacOSIntel }}
       run: |
         : Download Assets 📥
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
@@ -92,27 +92,23 @@ runs:
         case ${GITHUB_EVENT_NAME} {
           release)
             gh release download ${{ inputs.tagName }} \
-              --pattern '*macOS*.dmg' \
-              --pattern '*Windows*' \
+              --pattern '*.dmg' \
               --pattern '*.zip' \
               --clobber
 
-            IFS=';' read -r description is_prerelease <<< \
-              "$(gh release view ${{ inputs.tagName }} --json tagName,isPrerelease --jq 'join(";")')"
+            IFS=';' read -r is_prerelease description <<< \
+              "$(gh release view ${{ inputs.tagName }} --json isPrerelease,tagName --jq 'join(";")')"
             ;;
           workflow_dispatch)
             if [[ '${{ inputs.tagName }}' =~ [0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)*$ ]] {
               gh release download ${{ inputs.tagName }} \
-                --pattern '*macOS*.dmg' \
-                --pattern '*Windows*' \
+                --pattern '*.dmg' \
                 --pattern '*.zip' \
                 --clobber
 
               description='${{ inputs.tagName }}'
               read -r is_prerelease <<< \
                 "$(gh release view ${{ inputs.tagName }} --json isPrerelease --jq '.isPrerelease')"
-              asset_names=(gh release view ${{ inputs.tagName }} --json assets \
-                --jq '.assets[] | select(.name|test(".*(macos|Full-x64|windows).*")) | .name')
 
               local -A custom_assets=(
                 windows "Windows x64;${windows_custom_asset}"


### PR DESCRIPTION
### Description

Fixes the steam upload action once again.

- `gh release view --json` outputs keys in alphabetical order, regardless of the order of speciifed tags, so this never worked
- `gh release download --pattern` is case-sensitive
- `asset_names` was never used
- Custom asset URLs were assigned from outputs that don't exist rather than the inputs?

### Motivation and Context

I hate it here.

### How Has This Been Tested?

Tested at least the dispatch: https://github.com/derrod/obs-studio/actions/runs/6466954279/job/17556017624

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
