### PR TITLE
UI: Fix compile error due to use of strlen in constexpr

### DIFF
--- a/UI/update/win-update.cpp
+++ b/UI/update/win-update.cpp
@@ -57,8 +57,9 @@ try {
 	constexpr uint64_t currentVersion = (uint64_t)LIBOBS_API_VER << 16ULL |
 					    OBS_RELEASE_CANDIDATE << 8ULL |
 					    OBS_BETA;
-	constexpr bool isPreRelease = currentVersion & 0xffff ||
-				      strlen(OBS_COMMIT);
+	constexpr bool isPreRelease =
+		currentVersion & 0xffff ||
+		std::char_traits<char>::length(OBS_COMMIT);
 
 	json manifestContents = json::parse(manifest_data);
 	Manifest manifest = manifestContents.get<Manifest>();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
On Windows in VS2022 I was getting a compile error due to the usage of `strlen` in a `constexpr`.
`C:\Repos\github\obs-studio\UI\update\win-update.cpp(60,30): error C2131: expression did not evaluate to a constant`

I asked about this in the OBS developer Discord chat but it seems like the original author of this code was not experiencing a compile error.

It is unclear to me exactly why I am experiencing the compile error and the original author of the code is not. I checked to see if the string whose length was being checked (`OBS_COMMIT`) was defined in my build, which it is, although it was set to empty string by default. In my debugging I tried manually setting OBS_COMMIT to a non-empty string and still got the same compile error.

However, it seems like the right thing to do here is use one of the workarounds suggested in Raymond Chen's blog post below:

https://devblogs.microsoft.com/oldnewthing/20221114-00/?p=107393

In this PR I opted to go with `std::char_traits<char>::length` for no reason other than it seems to work and it was the first in the list of workarounds suggested in the above blog post.

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was getting a compile error when building OBS on Windows 10, with VS 2022 (17.7.4). Tested with Windows SDK versions 10.0.20348.0 and 10.0.22621.0.

I followed the suggested best practices to build OBS with the CMake presets, and my Visual Studio 2022 is fully up to date (17.7.4).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that the compile error went away, and tested the "Help -> Check For Updates" on Windows. No problems were found.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
