### PR TITLE
UI: Use XDG_VIDEOS_DIR instead of HOME if set

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -203,7 +203,11 @@ bool GetDataFilePath(const char *data, string &output)
 
 string GetDefaultVideoSavePath()
 {
-	return string(getenv("HOME"));
+	const char *videoPath = getenv("XDG_VIDEOS_DIR");
+	if (!videoPath || videoPath[0] == '\0')
+		return getenv("HOME");
+
+	return videoPath;
 }
 
 vector<string> GetPreferredLocales()


### PR DESCRIPTION
### Description

Updates `GetDefaultVideoSavePath()` to check `XDG_VIDEOS_DIR` on *nix instead of dumping things into`$HOME`

### Motivation and Context

Want to not clutter `$HOME` by default.

### How Has This Been Tested?

Has not been tested yet.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
