### PR TITLE
build-aux: Use fallback-x11 instead of x11

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -6,7 +6,7 @@
     "command": "obs",
     "finish-args": [
         "--socket=wayland",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=all",
         "--share=network",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->


### Description
Fixes a warning when compiling/building the obs flatpak
fallback-x11 only enables x11 if the application doesn't use wayland, and instead falls back to x11. If the app uses wayland then the x11 socket is never made available I am assuming.

### Motivation and Context
removes a warning

### How Has This Been Tested?
Testing is unnecessary because it just uses the same behavior but removes a build time warning

### Types of changes
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
