### PR TITLE
cmake: Explicitly fail if macOS SDK is too old

### DIFF
--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -15,6 +15,20 @@ if(NOT CMAKE_OSX_ARCHITECTURES)
 endif()
 set_property(CACHE CMAKE_OSX_ARCHITECTURES PROPERTY STRINGS arm64 x86_64)
 
+# Make sure the macOS SDK is recent enough for OBS
+set(OBS_MACOS_MINIMUM_SDK "13.1") # Keep in sync with Xcode
+set(OBS_MACOS_MINIMUM_XCODE "14.2") # Keep in sync with SDK
+message(DEBUG "macOS SDK Path: ${CMAKE_OSX_SYSROOT}")
+string(REGEX MATCH ".+/MacOSX.platform/Developer/SDKs/MacOSX([0-9]+\.[0-9])+\.sdk$" _ ${CMAKE_OSX_SYSROOT})
+set(OBS_MACOS_CURRENT_SDK ${CMAKE_MATCH_1})
+message(DEBUG "macOS SDK version: ${OBS_MACOS_CURRENT_SDK}")
+if(OBS_MACOS_CURRENT_SDK VERSION_LESS OBS_MACOS_MINIMUM_SDK)
+  message(
+    FATAL_ERROR
+      "Your macOS SDK version (${OBS_MACOS_CURRENT_SDK}) is too low. The macOS ${OBS_MACOS_MINIMUM_SDK} SDK (Xcode ${OBS_MACOS_MINIMUM_XCODE}) is required to build OBS."
+  )
+endif()
+
 if(XCODE)
   # Enable dSYM generator for release builds
   string(APPEND CMAKE_C_FLAGS_RELEASE " -g")


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a check to explicitly make sure that the macOS SDK being used is recent enough to build OBS. OBS code currently has ifdefs for older SDKs in some but not all places and relies on some frameworks existing that do not exist on older versions, this should clarify what we require.
This commit sets the minimum SDK to 13.0. This can be increased in the future if required.

I've put this code in `compilerconfig.cmake` because it feels to me like it makes the most sense, but am not really sure about that. Happy to change this if desired.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The ifdef situation is a bit unclear. We have 12.3 ifdefs in some places, but then not others, same with 13.0.
The [wiki](https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Mac#prerequisites) specifies Xcode 14.2 (which has the macOS 13.1 SDK) as the minimum, so let's use that explicitly.

This should also enable future cleanups of ifdefs that check for versions lower than our minimum, which still exist in some places.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14 with Xcode 15.0 and macOS 14.0 SDK
Generated the project to confirm it still works.
Manually increased the minimum to 14.1 and had it fail with:
> CMake Error at cmake/macos/compilerconfig.cmake:24 (message):
  Your macOS SDK version (14.0) is too low.  The macOS 14.1 SDK is required
  to build OBS.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
