### PR TITLE
libobs: Fix rendering stats not being logged on output stop

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2641,7 +2641,7 @@ static void obs_output_end_data_capture_internal(obs_output_t *output,
 
 	os_atomic_set_bool(&output->data_active, false);
 
-	if (output->video)
+	if (flag_video(output))
 		log_frame_info(output);
 
 	if (data_capture_ending(output))


### PR DESCRIPTION
### Description

As of fb57eff212fbe5e777cf559288bc70bf67d9c428 `output->video` will be `NULL` for encoded outputs, so check if the output has the video flag set instead to determine whether or not to print frame stats.

### Motivation and Context

Fixes #9704

### How Has This Been Tested?

@Penwy confirmed that this change fixes it.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
