### PR TITLE
frontend-tools: Remove unused startAtLaunch variable

### DIFF
--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.cpp
@@ -49,7 +49,6 @@ struct SwitcherData {
 	OBSWeakSource nonMatchingScene;
 	int interval = DEFAULT_INTERVAL;
 	bool switchIfNotMatching = false;
-	bool startAtLaunch = false;
 
 	void Thread();
 	void Start();
@@ -257,15 +256,6 @@ void SceneSwitcher::on_remove_clicked()
 	}
 
 	delete item;
-}
-
-void SceneSwitcher::on_startAtLaunch_toggled(bool value)
-{
-	if (loading)
-		return;
-
-	lock_guard<mutex> lock(switcher->m);
-	switcher->startAtLaunch = value;
 }
 
 void SceneSwitcher::UpdateNonMatchingScene(const QString &name)

--- a/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
+++ b/UI/frontend-plugins/frontend-tools/auto-scene-switcher.hpp
@@ -35,7 +35,6 @@ public slots:
 	void on_remove_clicked();
 	void on_noMatchDontSwitch_clicked();
 	void on_noMatchSwitch_clicked();
-	void on_startAtLaunch_toggled(bool value);
 	void on_noMatchSwitchScene_currentTextChanged(const QString &text);
 	void on_checkInterval_valueChanged(int value);
 	void on_toggleStartButton_clicked();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Remove a variable `startAtLaunch` and function `on_startAtLaunch_toggled`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

`startAtLaunch` was there from the initial commit 39592ff5eb for the scene switcher. However, it was not used at that time and is still not used.

The automatic scene switcher is automatically started if it was enabled at previous time. I think the variable `startAtLaunch` is unnecessary.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

Checked there are no files containing `startAtLaunch` by git-grep.

Checked major functionalities on Automatic Scene Switcher are working.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
