### PR TITLE
libobs, mac-capture, mac-avcapture: Replace Master enums with Main

### DIFF
--- a/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
+++ b/libobs/audio-monitoring/osx/coreaudio-enum-devices.c
@@ -21,7 +21,7 @@ static bool obs_enum_audio_monitoring_device(obs_enum_audio_device_cb cb,
 
 	AudioObjectPropertyAddress addr = {kAudioDevicePropertyStreams,
 					   kAudioDevicePropertyScopeOutput,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	/* Check if the device is capable of audio output. */
 	AudioObjectGetPropertyDataSize(id, &addr, 0, NULL, &size);
@@ -69,7 +69,7 @@ static void enum_audio_devices(obs_enum_audio_device_cb cb, void *data,
 {
 	AudioObjectPropertyAddress addr = {kAudioHardwarePropertyDevices,
 					   kAudioObjectPropertyScopeGlobal,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	UInt32 size = 0;
 	UInt32 count;
@@ -116,7 +116,7 @@ static void get_default_id(char **p_id)
 	AudioObjectPropertyAddress addr = {
 		kAudioHardwarePropertyDefaultSystemOutputDevice,
 		kAudioObjectPropertyScopeGlobal,
-		kAudioObjectPropertyElementMaster};
+		kAudioObjectPropertyElementMain};
 
 	if (*p_id)
 		return;

--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -2175,7 +2175,7 @@ bool obs_module_load(void)
     // From WWDC video 2014 #508 at 5:34
     // https://developer.apple.com/videos/wwdc/2014/#508
     CMIOObjectPropertyAddress prop = {kCMIOHardwarePropertyAllowScreenCaptureDevices, kCMIOObjectPropertyScopeGlobal,
-                                      kCMIOObjectPropertyElementMaster};
+                                      kCMIOObjectPropertyElementMain};
     UInt32 allow = 1;
     CMIOObjectSetPropertyData(kCMIOObjectSystemObject, &prop, 0, NULL, sizeof(allow), &allow);
 

--- a/plugins/mac-capture/audio-device-enum.c
+++ b/plugins/mac-capture/audio-device-enum.c
@@ -44,7 +44,7 @@ static bool coreaudio_enum_device(enum_device_proc_t proc, void *param,
 
 	AudioObjectPropertyAddress addr = {kAudioDevicePropertyStreams,
 					   kAudioDevicePropertyScopeInput,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	/* check to see if it's a mac input device */
 	AudioObjectGetPropertyDataSize(id, &addr, 0, NULL, &size);
@@ -77,7 +77,7 @@ static void enum_devices(enum_device_proc_t proc, void *param)
 {
 	AudioObjectPropertyAddress addr = {kAudioHardwarePropertyDevices,
 					   kAudioObjectPropertyScopeGlobal,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	UInt32 size = 0;
 	UInt32 count;
@@ -142,7 +142,7 @@ bool coreaudio_get_device_id(CFStringRef uid, AudioDeviceID *id)
 	AudioObjectPropertyAddress propertyAddress = {
 		kAudioHardwarePropertyDeviceForUID,
 		kAudioObjectPropertyScopeGlobal,
-		kAudioObjectPropertyElementMaster};
+		kAudioObjectPropertyElementMain};
 
 	AudioValueTranslation translation = {&uid, sizeof(CFStringRef), id,
 					     sizeof(AudioDeviceID)};

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -82,7 +82,7 @@ static bool find_device_id_by_uid(struct coreaudio_data *ca)
 
 	AudioObjectPropertyAddress addr = {
 		.mScope = kAudioObjectPropertyScopeGlobal,
-		.mElement = kAudioObjectPropertyElementMaster};
+		.mElement = kAudioObjectPropertyElementMain};
 
 	if (!ca->device_uid)
 		ca->device_uid = bstrdup("default");
@@ -283,7 +283,7 @@ static bool coreaudio_init_buffer(struct coreaudio_data *ca)
 	AudioObjectPropertyAddress addr = {
 		kAudioDevicePropertyStreamConfiguration,
 		kAudioDevicePropertyScopeInput,
-		kAudioObjectPropertyElementMaster};
+		kAudioObjectPropertyElementMain};
 
 	stat = AudioObjectGetPropertyDataSize(ca->device_id, &addr, 0, NULL,
 					      &buf_size);
@@ -431,7 +431,7 @@ static OSStatus add_listener(struct coreaudio_data *ca, UInt32 property)
 {
 	AudioObjectPropertyAddress addr = {property,
 					   kAudioObjectPropertyScopeGlobal,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	return AudioObjectAddPropertyListener(ca->device_id, &addr,
 					      notification_callback, ca);
@@ -457,7 +457,7 @@ static bool coreaudio_init_hooks(struct coreaudio_data *ca)
 		AudioObjectPropertyAddress addr = {
 			PROPERTY_DEFAULT_DEVICE,
 			kAudioObjectPropertyScopeGlobal,
-			kAudioObjectPropertyElementMaster};
+			kAudioObjectPropertyElementMain};
 
 		stat = AudioObjectAddPropertyListener(kAudioObjectSystemObject,
 						      &addr,
@@ -484,7 +484,7 @@ static void coreaudio_remove_hooks(struct coreaudio_data *ca)
 
 	AudioObjectPropertyAddress addr = {kAudioDevicePropertyDeviceIsAlive,
 					   kAudioObjectPropertyScopeGlobal,
-					   kAudioObjectPropertyElementMaster};
+					   kAudioObjectPropertyElementMain};
 
 	AudioObjectRemovePropertyListener(ca->device_id, &addr,
 					  notification_callback, ca);
@@ -513,7 +513,7 @@ static bool coreaudio_get_device_name(struct coreaudio_data *ca)
 	const AudioObjectPropertyAddress addr = {
 		kAudioDevicePropertyDeviceNameCFString,
 		kAudioObjectPropertyScopeInput,
-		kAudioObjectPropertyElementMaster};
+		kAudioObjectPropertyElementMain};
 
 	OSStatus stat = AudioObjectGetPropertyData(ca->device_id, &addr, 0,
 						   NULL, &size, &cf_name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replaces enum values `kAudioObjectPropertyElementMaster` and `kCMIOObjectPropertyElementMaster` with their `Main` counterparts.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The `Master` versions are deprecated since macOS 12. This doesn't currently complain as our deployment target is 11, but it also doesn't hurt to use the new versions (which are the same values anyways) as we soft-require (and soon hard-require, see #9698) the macOS 13.1 SDK.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14
Compiled and run. The resulting code is the same as `Master` and `Main` have the same values in both the AudioObject and CMIO cases.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
