### PR TITLE
UI: Add missing NULL check for skipUpdateVer

### DIFF
--- a/UI/update/win-update.cpp
+++ b/UI/update/win-update.cpp
@@ -265,7 +265,8 @@ try {
 
 	const char *skipUpdateVer = config_get_string(
 		GetGlobalConfig(), "General", "SkipUpdateVersion");
-	if (!manualUpdate && updateVer == skipUpdateVer && !repairMode)
+	if (!manualUpdate && !repairMode && skipUpdateVer &&
+	    updateVer == skipUpdateVer)
 		return;
 
 	/* ----------------------------------- *


### PR DESCRIPTION
### Description

Adds a missing check as `config_get_string()` actually returns `NULL` if the key does not exist.

Other config or data functions return valid values even if not set, e.g. `config_get_int()` returns `0` or `obs_data_get_string()` returns `""`, and I missed that `config_get_string()` doesn't when changing this from a number to a string.

### Motivation and Context

Fixes #9719

### How Has This Been Tested?

Verified OBS no longer crashes if `SkipUpdateVersion` config key does not exist.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
