### PR TITLE
mac-capture: If window is not found, look for a matching one

### DIFF
--- a/plugins/mac-capture/mac-sck-common.h
+++ b/plugins/mac-capture/mac-sck-common.h
@@ -65,6 +65,7 @@ struct screen_capture {
     ScreenCaptureAudioStreamType audio_capture_type;
     CGDirectDisplayID display;
     CGWindowID window;
+    NSString *window_title;
     NSString *application_id;
 };
 

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -74,7 +74,7 @@ static void sck_video_capture_destroy(void *data)
     bfree(sc);
 }
 
-static bool init_screen_stream(struct screen_capture *sc)
+static bool init_screen_stream(struct screen_capture *sc, obs_data_t *settings)
 {
     SCContentFilter *content_filter;
     if (sc->capture_failed) {
@@ -141,6 +141,16 @@ static bool init_screen_stream(struct screen_capture *sc)
                         break;
                     }
                 }
+                // If no window with a matching ID exists, look for one with a matching title and owning application
+                if (target_window == NULL) {
+                    for (SCWindow *window in sc->shareable_content.windows) {
+                        if ([window.title isEqualToString:sc->window_title] &&
+                            [window.owningApplication.bundleIdentifier isEqualToString:sc->application_id]) {
+                            target_window = window;
+                            break;
+                        }
+                    }
+                }
             } else {
                 target_window = [sc->shareable_content.windows objectAtIndex:0];
                 sc->window = target_window.windowID;
@@ -150,6 +160,11 @@ static bool init_screen_stream(struct screen_capture *sc)
             if (target_window) {
                 [sc->stream_properties setWidth:(size_t) target_window.frame.size.width];
                 [sc->stream_properties setHeight:(size_t) target_window.frame.size.height];
+                sc->window_title = [target_window.title retain];
+                sc->application_id = [target_window.owningApplication.bundleIdentifier retain];
+                obs_data_set_int(settings, "window", target_window.windowID);
+                obs_data_set_string(settings, "window_title", sc->window_title.UTF8String);
+                obs_data_set_string(settings, "application", sc->application_id.UTF8String);
             }
 
         } break;
@@ -259,6 +274,7 @@ static void *sck_video_capture_create(obs_data_t *settings, obs_source_t *source
     sc->show_empty_names = obs_data_get_bool(settings, "show_empty_names");
     sc->show_hidden_windows = obs_data_get_bool(settings, "show_hidden_windows");
     sc->window = (CGWindowID) obs_data_get_int(settings, "window");
+    sc->window_title = [[NSString alloc] initWithUTF8String:obs_data_get_string(settings, "window_title")];
     sc->capture_type = (unsigned int) obs_data_get_int(settings, "type");
     sc->audio_only = false;
 
@@ -277,7 +293,7 @@ static void *sck_video_capture_create(obs_data_t *settings, obs_source_t *source
     sc->application_id = [[NSString alloc] initWithUTF8String:obs_data_get_string(settings, "application")];
     pthread_mutex_init(&sc->mutex, NULL);
 
-    if (!init_screen_stream(sc))
+    if (!init_screen_stream(sc, settings))
         goto fail;
 
     return sc;
@@ -383,6 +399,7 @@ static void sck_video_capture_defaults(obs_data_t *settings)
     obs_data_set_default_string(settings, "application", NULL);
     obs_data_set_default_int(settings, "type", ScreenCaptureDisplayStream);
     obs_data_set_default_int(settings, "window", kCGNullWindowID);
+    obs_data_set_default_string(settings, "window_title", NULL);
     obs_data_set_default_bool(settings, "show_cursor", true);
     obs_data_set_default_bool(settings, "hide_obs", false);
     obs_data_set_default_bool(settings, "show_empty_names", false);
@@ -403,6 +420,8 @@ static void sck_video_capture_update(void *data, obs_data_t *settings)
 
     CGDirectDisplayID display = get_display_migrate_settings(settings);
 
+    const char *window_title = obs_data_get_string(settings, "window_title");
+    sc->window_title = [[NSString alloc] initWithUTF8String:window_title];
     NSString *application_id = [[NSString alloc] initWithUTF8String:obs_data_get_string(settings, "application")];
     bool show_cursor = obs_data_get_bool(settings, "show_cursor");
     bool hide_obs = obs_data_get_bool(settings, "hide_obs");
@@ -444,7 +463,7 @@ static void sck_video_capture_update(void *data, obs_data_t *settings)
     sc->hide_obs = hide_obs;
     sc->show_empty_names = show_empty_names;
     sc->show_hidden_windows = show_hidden_windows;
-    init_screen_stream(sc);
+    init_screen_stream(sc, settings);
 
     obs_leave_graphics();
 }
@@ -533,7 +552,9 @@ static bool reactivate_capture(obs_properties_t *props __unused, obs_property_t 
     obs_enter_graphics();
     destroy_screen_stream(sc);
     sc->capture_failed = false;
-    init_screen_stream(sc);
+    obs_data_t *settings = obs_source_get_settings(sc->source);
+    init_screen_stream(sc, settings);
+    obs_data_release(settings);
     obs_leave_graphics();
     obs_property_set_enabled(property, false);
     return true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
If a macOS Screen Capture is started in windowed mode, and the target window does not exist, try to find one with a matching title and application bundle ID.

### Motivation and Context
I use a window capture for speedrun splits. Prior to this change, I had to reconfigure my window capture every time I started runs, due to OBS not automatically recognizing the window. This patch matches the behavior of the deprecated macOS Window Capture source (except it still does not watch for the window to be opened if it is closed when the capture starts).

### How Has This Been Tested?
I tested on my local machine, an M1 MBP running macOS 14.0. I verified it correctly finds a matching window, and falls back gracefully to the old behavior if no matching window is found. I also checked to make sure it does not break the behavior of the display capture or application capture.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
