### PR TITLE
obs-ffmpeg: Add B-Frames option for VA-API

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -752,6 +752,8 @@ static bool vaapi_device_modified(obs_properties_t *ppts, obs_property_t *p,
 	if (vaapi_device_rc_supported(profile, va_dpy, VA_RC_CQP, device))
 		obs_property_list_add_string(rc_p, "CQP", "CQP");
 
+	set_visible(ppts, "bf", vaapi_device_bframe_supported(profile, va_dpy));
+
 fail:
 	vaapi_close_device(&drm_fd, va_dpy);
 	return true;
@@ -941,6 +943,9 @@ static obs_properties_t *vaapi_properties_internal(bool hevc)
 				   obs_module_text("KeyframeIntervalSec"), 0,
 				   20, 1);
 	obs_property_int_set_suffix(p, " s");
+
+	obs_properties_add_int(props, "bf", obs_module_text("BFrames"), 0, 4,
+			       1);
 
 	obs_properties_add_text(props, "ffmpeg_opts",
 				obs_module_text("FFmpegOpts"),

--- a/plugins/obs-ffmpeg/vaapi-utils.h
+++ b/plugins/obs-ffmpeg/vaapi-utils.h
@@ -14,6 +14,7 @@ void vaapi_close_device(int *fd, VADisplay dpy);
 
 bool vaapi_device_rc_supported(VAProfile profile, VADisplay dpy, uint32_t rc,
 			       const char *device_path);
+bool vaapi_device_bframe_supported(VAProfile profile, VADisplay dpy);
 
 bool vaapi_display_h264_supported(VADisplay dpy, const char *device_path);
 bool vaapi_device_h264_supported(const char *device_path);


### PR DESCRIPTION
The option is already there, but it wasn't available from UI.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add B-Frames option for VA-API
![2023-10-20_11:40:46](https://github.com/obsproject/obs-studio/assets/522831/87168aa1-3b56-4e5a-9d8b-2eada0927c85)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The option was already there, but it was needed to edit configuration file to enable B-frames. This makes it available from UI.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested with mesa driver.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
