### PR TITLE
plugins: Remove old macOS version ifdefs

### DIFF
--- a/plugins/mac-avcapture/av-capture.mm
+++ b/plugins/mac-avcapture/av-capture.mm
@@ -2038,11 +2038,9 @@ static obs_properties_t *av_capture_properties(void *data)
 
     NSMutableArray *device_types = [NSMutableArray
         arrayWithObjects:AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeExternalUnknown, nil];
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (__builtin_available(macOS 13.0, *)) {
         [device_types addObject:AVCaptureDeviceTypeDeskViewCamera];
     }
-#endif
     AVCaptureDeviceDiscoverySession *video_discovery =
         [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:device_types mediaType:AVMediaTypeVideo
                                                                 position:AVCaptureDevicePositionUnspecified];

--- a/plugins/mac-capture/mac-sck-common.h
+++ b/plugins/mac-capture/mac-sck-common.h
@@ -1,7 +1,6 @@
 #include <AvailabilityMacros.h>
 #include <Cocoa/Cocoa.h>
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300  // __MAC_12_3
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
 
@@ -85,4 +84,3 @@ void screen_stream_video_update(struct screen_capture *sc, CMSampleBufferRef sam
 void screen_stream_audio_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer);
 
 #pragma clang diagnostic pop
-#endif

--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -18,14 +18,11 @@ bool is_screen_capture_available(void)
     if (self.sc != NULL) {
         if (type == SCStreamOutputTypeScreen && !self.sc->audio_only) {
             screen_stream_video_update(self.sc, sampleBuffer);
-        }
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
-        else if (@available(macOS 13.0, *)) {
+        } else if (@available(macOS 13.0, *)) {
             if (type == SCStreamOutputTypeAudio) {
                 screen_stream_audio_update(self.sc, sampleBuffer);
             }
         }
-#endif
     }
 }
 
@@ -33,11 +30,9 @@ bool is_screen_capture_available(void)
 {
     NSString *errorMessage;
     switch (error.code) {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         case SCStreamErrorUserStopped:
             errorMessage = @"User stopped stream.";
             break;
-#endif
         case SCStreamErrorNoCaptureSource:
             errorMessage = @"Stream stopped as no capture source was not found.";
             break;

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -185,11 +185,9 @@ static bool init_screen_stream(struct screen_capture *sc)
     [sc->stream_properties setPixelFormat:l10r_type];
 
     if (@available(macOS 13.0, *)) {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
         [sc->stream_properties setCapturesAudio:YES];
         [sc->stream_properties setExcludesCurrentProcessAudio:YES];
         [sc->stream_properties setChannelCount:2];
-#endif
     } else {
         if (sc->capture_type != ScreenCaptureWindowStream) {
             sc->disp = NULL;
@@ -216,7 +214,6 @@ static bool init_screen_stream(struct screen_capture *sc)
         return !did_add_output;
     }
 
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
     if (@available(macOS 13.0, *)) {
         did_add_output = [sc->disp addStreamOutput:sc->capture_delegate type:SCStreamOutputTypeAudio
                                 sampleHandlerQueue:nil
@@ -228,7 +225,6 @@ static bool init_screen_stream(struct screen_capture *sc)
             return !did_add_output;
         }
     }
-#endif
     os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
     os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
 

--- a/plugins/mac-capture/plugin-main.c
+++ b/plugins/mac-capture/plugin-main.c
@@ -16,7 +16,6 @@ extern bool is_screen_capture_available() WEAK_IMPORT_ATTRIBUTE;
 
 bool obs_module_load(void)
 {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300 // __MAC_12_3
 	if (is_screen_capture_available()) {
 		extern struct obs_source_info sck_video_capture_info;
 		obs_register_source(&sck_video_capture_info);
@@ -31,7 +30,6 @@ bool obs_module_load(void)
 			obs_register_source(&sck_audio_capture_info);
 		}
 	}
-#endif
 	obs_register_source(&display_capture_info);
 	obs_register_source(&window_capture_info);
 	obs_register_source(&coreaudio_input_capture_info);

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -141,12 +141,10 @@ static CFStringRef obs_to_vt_profile(CMVideoCodecType codec_type,
 		}
 		if (strcmp(profile, "main10") == 0)
 			return kVTProfileLevel_HEVC_Main10_AutoLevel;
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120300 // macOS 12.3
 		if (__builtin_available(macOS 12.3, *)) {
 			if (strcmp(profile, "main42210") == 0)
 				return kVTProfileLevel_HEVC_Main42210_AutoLevel;
 		}
-#endif // macOS 12.3
 		return kVTProfileLevel_HEVC_Main_AutoLevel;
 #else
 		(void)format;
@@ -300,7 +298,6 @@ static OSStatus session_set_bitrate(VTCompressionSessionRef session,
 		can_limit_bitrate = true;
 
 		if (__builtin_available(macOS 13.0, *)) {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130000
 			if (is_apple_silicon) {
 				compressionPropertyKey =
 					kVTCompressionPropertyKey_ConstantBitRate;
@@ -310,11 +307,6 @@ static OSStatus session_set_bitrate(VTCompressionSessionRef session,
 				       "CBR support for VideoToolbox encoder requires Apple Silicon. "
 				       "Will use ABR instead.");
 			}
-#else
-			VT_LOG(LOG_WARNING,
-			       "CBR support for VideoToolbox not available in this build of OBS. "
-			       "Will use ABR instead.");
-#endif
 		} else {
 			VT_LOG(LOG_WARNING,
 			       "CBR support for VideoToolbox encoder requires macOS 13 or newer. "


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
8dd20dfd335dd07d2f1678c9cdf67894e09beab4 introduced an explicit check for the available macOS SDK, meaning that we can be sure that the macOS 13.1 SDK is available. As such, we do not require ifdef guards for the availability of functions that are older than 13.1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't like dead code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14, compiled and run.
Made a basic test with the effected sources/encoder to make sure I didn't majorly screw anything up.
Functionality should be the same as before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
