### PR TITLE
Add support for Lua plugin creators to create subcategories for Sources

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6130,6 +6130,8 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 	bool foundDeprecated = false;
 	size_t idx = 0;
 
+	std::map<const char *, Custom_Subcategory_info> customSubcategory_MAP;
+
 	QMenu *popup = new QMenu(QTStr("Add"), this);
 	QMenu *deprecated = new QMenu(QTStr("Deprecated"), popup);
 
@@ -6169,11 +6171,48 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 		const char *name = obs_source_get_display_name(type);
 		uint32_t caps = obs_get_source_output_flags(type);
 
+		const char *subcategoryName =
+			obs_source_get_subcategory_name(type);
+
+		if (subcategoryName != NULL) {
+
+			if (strcmp(subcategoryName, "Deprecated") == 0) {
+				/* This allows plugin creators to put
+				*  their Sources into Deprecated as well */
+				addSource(deprecated, unversioned_type, name);
+				foundDeprecated = true;
+			} else {
+				// If it doesn't already exist
+				if (customSubcategory_MAP.count(
+					    subcategoryName) == 0) {
+					Custom_Subcategory_info
+						custSubcategory_info;
+
+					QMenu *SubcategoryMenu = new QMenu(
+						QTStr(subcategoryName));
+
+					custSubcategory_info.m_QMenu_ref =
+						SubcategoryMenu;
+
+					customSubcategory_MAP[subcategoryName] =
+						custSubcategory_info;
+				}
+
+				QMenu *submenu =
+					customSubcategory_MAP[subcategoryName]
+						.m_QMenu_ref;
+
+				addSource(submenu, unversioned_type, name);
+			}
+		}
+
 		if ((caps & OBS_SOURCE_CAP_DISABLED) != 0)
 			continue;
 
 		if ((caps & OBS_SOURCE_DEPRECATED) == 0) {
-			addSource(popup, unversioned_type, name);
+			if (subcategoryName == NULL) {
+				addSource(popup, unversioned_type, name);
+			};
 		} else {
 			addSource(deprecated, unversioned_type, name);
 			foundDeprecated = true;
@@ -6189,6 +6228,16 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 	connect(addGroup, &QAction::triggered,
 		[this]() { AddSource("group"); });
 	popup->addAction(addGroup);
+
+	// Custom Subcategories
+	if (customSubcategory_MAP.size() >= 1) {
+		popup->addSeparator();
+
+		for (const auto &entry : customSubcategory_MAP) {
+			QMenu *submenu = entry.second.m_QMenu_ref;
+			popup->addMenu(submenu);
+		}
+	}
 
 	if (!foundDeprecated) {
 		delete deprecated;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1281,3 +1281,10 @@ public:
 protected:
 	virtual bool eventFilter(QObject *editor, QEvent *event) override;
 };
+
+#ifndef CUSTOM_SUBCATEGORY_MAP
+#define CUSTOM_SUBCATEGORY_MAP
+struct Custom_Subcategory_info {
+	QMenu *m_QMenu_ref;
+};
+#endif

--- a/deps/obs-scripting/obs-scripting-lua-source.c
+++ b/deps/obs-scripting/obs-scripting-lua-source.c
@@ -599,6 +599,11 @@ static int obs_lua_register_source(lua_State *script)
 
 	info.id = v->id;
 	info.type = (enum obs_source_type)get_table_int(script, -1, "type");
+	info.subcategory = get_table_string(script, -1, "subcategory");
+
+	if (info.subcategory[0] == '\0') {
+		info.subcategory = NULL;
+	}
 
 	info.output_flags = get_table_int(script, -1, "output_flags");
 

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -47,6 +47,10 @@ Source Definition Structure (obs_source_info)
    - **OBS_SOURCE_TYPE_FILTER**     - Filter
    - **OBS_SOURCE_TYPE_TRANSITION** - Transition
 
+.. member:: const char *obs_source_info.subcategory
+
+   Subcategory string for the Source to be put in at in the Popup UI.
+
 .. member:: uint32_t obs_source_info.output_flags
 
    Source output capability flags (required).
@@ -966,6 +970,12 @@ General Source Functions
 
    Gets/sets the hidden property that determines whether it should be hidden from the user.
    Used when the source is still alive but should not be referenced.
+
+---------------------
+
+.. function:: const char *obs_source_get_subcategory_name(const char *id)
+
+   Gets the subcategory string from :c:member:`obs_source_info.subcategory`.
 
 ---------------------
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -956,6 +956,12 @@ obs_properties_t *obs_source_properties(const obs_source_t *source)
 	return NULL;
 }
 
+const char *obs_source_get_subcategory_name(const char *id)
+{
+	const struct obs_source_info *info = get_source_info(id);
+	return info ? info->subcategory : NULL;
+}
+
 uint32_t obs_source_get_output_flags(const obs_source_t *source)
 {
 	return obs_source_valid(source, "obs_source_get_output_flags")

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -234,6 +234,9 @@ struct obs_source_info {
 	/** Source output flags */
 	uint32_t output_flags;
 
+	/** Custom Subcategory string for the popup GUI */
+	const char *subcategory;
+
 	/**
 	 * Get the translated name of the source type
 	 *

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1060,6 +1060,9 @@ EXPORT void obs_source_set_hidden(obs_source_t *source, bool hidden);
 /** Returns the current 'hidden' state on the source */
 EXPORT bool obs_source_is_hidden(obs_source_t *source);
 
+/** Returns the custom subcategory name of a source */
+EXPORT const char *obs_source_get_subcategory_name(const char *id);
+
 /** Returns capability flags of a source */
 EXPORT uint32_t obs_source_get_output_flags(const obs_source_t *source);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add support for Lua plugin creators to create subcategories for Sources. These categories always get added after "Group".

<img src="https://github.com/obsproject/obs-studio/assets/12023782/c6403c45-2e7e-4446-ae8a-c2a7ce1efa11" height=350px>

Plugins can now include this ``source_def.subcategory = "Test"`` a new property that can get passed to ``obs_register_source``.

This creates sub categories, and you can even put it inside Deprecated.

<img src="https://github.com/obsproject/obs-studio/assets/12023782/5ea2cff8-1b90-4f65-9e1a-ee45df615902" height=45px>


Here's an example .lua plugin to test this new feature: https://pastebin.com/gc2AeJfu


### Motivation and Context
This implements my own feature request after asking in the Discord, how I can put Plugin Sources into a Subcategory. Being told that I can't or being misunderstood.

This motivated me to add this feature.

I didn't like the idea that there's nothing that a Plugin Developer can do, **to not mix the original Sources with the custom-made sources**. Plugin Developers should have the freedom to decide how their Source should show up, which is also a good nice QoL for the user using the Plugin.

And other organization reasons.
<img src="https://github.com/obsproject/obs-studio/assets/12023782/89d97445-f3b6-45c7-b37b-16e785ed4b53" height=300px>

So I wanted to add subcategories. Just don't ask whether one can put add subcategories in a subcategories.


### How Has This Been Tested?
Tested several cases like
``source_def.subcategory = nil``
``source_def.subcategory = "Test"``

and if it's not references at all
I had to check for ``\0`` and make it return ``NULL``

There's only one issue. The subcategories don't refresh if you refresh the plugin, everything else does refresh.
That's something with the Lua OBS C implementation script that I didn't figure out so far. Help is appreciated.

There's a test script above as well.


### Types of changes
* New Feature
* Small change in the Documentation

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
