### PR TITLE
linux-pipewire: Load glad symbols on start

### DIFF
--- a/plugins/linux-pipewire/linux-pipewire.c
+++ b/plugins/linux-pipewire/linux-pipewire.c
@@ -21,6 +21,7 @@
 
 #include <obs-module.h>
 #include <obs-nix-platform.h>
+#include <glad/glad.h>
 
 #include <pipewire/pipewire.h>
 #include "screencast-portal.h"
@@ -34,6 +35,10 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 bool obs_module_load(void)
 {
+	obs_enter_graphics();
+	gladLoadGL();
+	obs_leave_graphics();
+
 	pw_init(NULL, NULL);
 
 	screencast_portal_load();


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
After the cmake 3.0 rebuild glad was transitioned to a static library. This lead to the glad symbols being uninitialized and crashes when they are used in some cases.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

fixes shm capture for compositors that dont support dmabuf.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Loading with software gl no longer crashes when calling glBindTexture.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
