### PR TITLE
linux-pipewire: Add locks to unsafe pipewire functions

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1286,14 +1286,20 @@ obs_pipewire_connect_stream(obs_pipewire *obs_pw, obs_source_t *source,
 
 void obs_pipewire_stream_show(obs_pipewire_stream *obs_pw_stream)
 {
-	if (obs_pw_stream->stream)
+	if (obs_pw_stream->stream) {
+		pw_thread_loop_lock(obs_pw_stream->obs_pw->thread_loop);
 		pw_stream_set_active(obs_pw_stream->stream, true);
+		pw_thread_loop_unlock(obs_pw_stream->obs_pw->thread_loop);
+	}
 }
 
 void obs_pipewire_stream_hide(obs_pipewire_stream *obs_pw_stream)
 {
-	if (obs_pw_stream->stream)
+	if (obs_pw_stream->stream) {
+		pw_thread_loop_lock(obs_pw_stream->obs_pw->thread_loop);
 		pw_stream_set_active(obs_pw_stream->stream, false);
+		pw_thread_loop_unlock(obs_pw_stream->obs_pw->thread_loop);
+	}
 }
 
 uint32_t obs_pipewire_stream_get_width(obs_pipewire_stream *obs_pw_stream)
@@ -1433,9 +1439,11 @@ void obs_pipewire_stream_destroy(obs_pipewire_stream *obs_pw_stream)
 	g_clear_pointer(&obs_pw_stream->texture, gs_texture_destroy);
 	obs_leave_graphics();
 
+	pw_thread_loop_lock(obs_pw_stream->obs_pw->thread_loop);
 	if (obs_pw_stream->stream)
 		pw_stream_disconnect(obs_pw_stream->stream);
 	g_clear_pointer(&obs_pw_stream->stream, pw_stream_destroy);
+	pw_thread_loop_unlock(obs_pw_stream->obs_pw->thread_loop);
 
 	clear_format_info(obs_pw_stream);
 	bfree(obs_pw_stream);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
These functions log that they should be used with the thread lock held, so lets hold the lock before calling them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Maybe it fixes the errors we see related to obs_pw being invalid.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
adding a bunch of pipewire sources and removing a bunch and restarting obs and nothing seems impacted.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) (maybe)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable) 
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
