### PR TITLE
win-wasapi: Log source name on initialization

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -999,8 +999,9 @@ void WASAPISource::Initialize()
 		}
 	}
 
-	blog(LOG_INFO, "WASAPI: Device '%s' [%" PRIu32 " Hz] initialized",
-	     device_name.c_str(), sampleRate);
+	blog(LOG_INFO,
+	     "WASAPI: Device '%s' [%" PRIu32 " Hz] initialized (source: %s)",
+	     device_name.c_str(), sampleRate, obs_source_get_name(source));
 
 	if (sourceType == SourceType::ProcessOutput && !hooked) {
 		hooked = true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Log the source name when a WASAPI device is initialized.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This was brought up in the ideas section of the community discord and I agree that it will help when troubleshooting.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked the log: https://obsproject.com/logs/VfuT59quYb99nOos

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
