### PR TITLE
rtmp-services: Add "Vault - by CommanderRoot" to ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 241,
+    "version": 242,
     "files": [
         {
             "name": "services.json",
-            "version": 241
+            "version": 242
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2633,6 +2633,35 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Vault - by CommanderRoot",
+            "common": false,
+            "more_info_link": "https://vault.root-space.eu/",
+            "stream_key_link": "https://vault.root-space.eu/recordings",
+            "servers": [
+                {
+                    "name": "EU - Central",
+                    "url": "rtmp://ingest-eu-central.vault.root-space.eu/app"
+                },
+                {
+                    "name": "US - West",
+                    "url": "rtmp://ingest-us-west.vault.root-space.eu/app"
+                }
+            ],
+            "protocol": "RTMP",
+            "supported video codecs": [
+                "h264"
+            ],
+            "supported audio codecs": [
+                "aac"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 7800,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Adding "Vault - by CommanderRoot" to OBS-Studio's ingest list

### Motivation and Context
My Vault is a backup service but also allows the forwarding / re-streaming to other services. Adding it as a direct option in OBS Studio makes it easier for my users to setup ingesting into my service. Since Twitch removed the restriction on simulcasting there has been an increased interest in streaming to multiple streaming services at the same time.

### How Has This Been Tested?
- [x] JSON validation: Ensured that the JSON files are well-formed and adhered to the required format for OBS-Studio's ingest list.
- [x] Copy JSON files to %APPDATA%\obs-studio\plugin_config\rtmp-services: Manually copied the JSON files to the appropriate location where OBS-Studio reads ingest settings.
- [x] Checked settings: Verified that "Vault - by CommanderRoot" appears in the updated ingest list within OBS-Studio's settings.
- [x] Connection testing: Attempted to connect to the servers provided by "Vault - by CommanderRoot" to ensure successful streaming functionality.
- [x] According to [Service Submission Guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines)

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
