### PR TITLE
obs-webrtc: Allow non-CBR rate control with WHIP

### DIFF
--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -33,7 +33,6 @@ void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 	// For now, ensure maximum compatibility with webrtc peers
 	if (video_settings) {
 		obs_data_set_int(video_settings, "bf", 0);
-		obs_data_set_string(video_settings, "rate_control", "CBR");
 		obs_data_set_bool(video_settings, "repeat_headers", true);
 	}
 }


### PR DESCRIPTION
### Description
Currently, the WHIP implementation in OBS forces the rate control mode to CBR. However, nothing about WHIP requires CBR (and many things using WHIP use VBR), and there's no specific upstream service to care about it (WHIP is a protocol, not a service, despite being exposed as a "service" in OBS), so there's no obvious reason to force this. After discussion in #9753 and in Discord, the consensus is that we should stop forcing the rate control method for WHIP and honor the user's requested rate control method.

### Motivation and Context
Allow WHIP functionality to work more like much of the world is using it by not arbitrarily limiting the user's choices when there doesn't seem to be a benefit to having that limitation.

Fixes #9753 

### How Has This Been Tested?
Using a test WHIP server, configured OBS for all four combinations of [CBR,VBR] and [x264, NVENC H.264] and verified that the output bitrate from OBS matched the requested rate control mode (steady at 5000kbit for CBR modes; varying from under 100kbit to 5000kbit  for VBR modes, depending on whether the test video stream had active movement or not).

Only tested on Windows, but since the only change is not forcing a rate control mode before initializing the encoder, should work fine on Mac & Linux as long as rate control modes worked on those platforms to start with.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (no changes)
