### PR TITLE
libobs: Export SIMDe headers unconditionally for plugin development

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -303,6 +303,20 @@ set(public_headers
     util/platform.h
     util/profiler.h
     util/profiler.hpp
+    util/simde/check.h
+    util/simde/debug-trap.h
+    util/simde/hedley.h
+    util/simde/simde-align.h
+    util/simde/simde-arch.h
+    util/simde/simde-common.h
+    util/simde/simde-constify.h
+    util/simde/simde-detect-clang.h
+    util/simde/simde-diagnostic.h
+    util/simde/simde-features.h
+    util/simde/simde-math.h
+    util/simde/x86/mmx.h
+    util/simde/x86/sse.h
+    util/simde/x86/sse2.h
     util/sse-intrin.h
     util/text-lookup.h
     util/threading.h
@@ -311,26 +325,6 @@ set(public_headers
 
 if(ENABLE_HEVC)
   list(APPEND public_headers obs-hevc.h)
-endif()
-
-if(ARCH_SIMD_FLAGS)
-  set(public_headers
-      # cmake-format: sortable
-      ${public_headers}
-      util/simde/check.h
-      util/simde/debug-trap.h
-      util/simde/hedley.h
-      util/simde/simde-align.h
-      util/simde/simde-arch.h
-      util/simde/simde-common.h
-      util/simde/simde-constify.h
-      util/simde/simde-detect-clang.h
-      util/simde/simde-diagnostic.h
-      util/simde/simde-features.h
-      util/simde/simde-math.h
-      util/simde/x86/mmx.h
-      util/simde/x86/sse.h
-      util/simde/x86/sse2.h)
 endif()
 
 # cmake-format: off


### PR DESCRIPTION
### Description
Changes `libobs` export to include SIMDe headers by default.

### Motivation and Context
Fixes https://github.com/obsproject/obs-plugintemplate/issues/95.

### How Has This Been Tested?
Checked import of `libobs` Framework with new settings and confirmed SIMDe headers were correctly copied over.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
