### PR TITLE
mac-virtualcam: Correct device timer firing rate

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
+++ b/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
@@ -141,7 +141,7 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
 
         _timer!.schedule(
             deadline: .now(),
-            repeating: Double(1 / OBSCameraFrameRate),
+            repeating: 1.0 / Double(OBSCameraFrameRate),
             leeway: .seconds(0)
         )
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Resolves the conversion to a Double in `OBSCameraDeviceSource`, such that the virtual camera device timer fires correctly every `1/60` seconds, instead of trying to fire every `0` seconds.

### Motivation and Context
Resolves https://github.com/obsproject/obs-studio/issues/9760. CPU use was very high with the new virtual camera extension at idle and while active because of the amount of polling the device timer was doing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my machine. Reduced camera extension process CPU use by roughly 10x.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
