### PR TITLE
obs-ffmpeg: Add FFmpeg VAAPI AV1 encoder 

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -114,8 +114,11 @@ static uint16_t get_max_luminance(const AVStream *stream)
 {
 	uint32_t max_luminance = 0;
 
-	for (int i = 0; i < stream->nb_side_data; i++) {
-		const AVPacketSideData *const sd = &stream->side_data[i];
+
+	AVCodecParameters *cpar = stream->codecpar;
+
+	for (int i = 0; i < cpar->nb_coded_side_data; i++) {
+		const AVPacketSideData *const sd = &cpar->coded_side_data[i];
 		switch (sd->type) {
 		case AV_PKT_DATA_MASTERING_DISPLAY_METADATA: {
 			const AVMasteringDisplayMetadata *mastering =

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -504,7 +504,7 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	}
 
 	if (!m->is_local_file && !d->got_first_keyframe) {
-		if (!f->key_frame)
+		if (!f->flags & AV_FRAME_FLAG_KEY)
 			return;
 
 		d->got_first_keyframe = true;

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -724,7 +724,7 @@ static void *ffmpeg_mux_io_thread(void *data)
 	// ffmpeg, then we flush the chunk. next_seek_position is the actual
 	// offset we should seek to when we write the chunk.
 	uint64_t current_seek_position = 0;
-	uint64_t next_seek_position;
+	uint64_t next_seek_position = 0;
 
 	for (;;) {
 		// Wait for ffmpeg to write data to the buffer

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -498,9 +498,11 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 			av_content_light_metadata_alloc(&content_size);
 		content->MaxCLL = max_luminance;
 		content->MaxFALL = max_luminance;
-		av_stream_add_side_data(ffm->video_stream,
+		AVCodecParameters *cpar = ffm->video_stream->codecpar;
+		av_packet_side_data_add(&cpar->coded_side_data,
+					&cpar->nb_coded_side_data,
 					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
-					(uint8_t *)content, content_size);
+					(uint8_t *)content, content_size, 0);
 
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
@@ -516,10 +518,11 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 		mastering->max_luminance = av_make_q(max_luminance, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
-		av_stream_add_side_data(ffm->video_stream,
+		av_packet_side_data_add(&cpar->coded_side_data,
+					&cpar->nb_coded_side_data,
 					AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
 					(uint8_t *)mastering,
-					sizeof(*mastering));
+					sizeof(*mastering), 0);
 	}
 
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -213,9 +213,11 @@ static bool create_video_stream(struct ffmpeg_data *data)
 			av_content_light_metadata_alloc(&content_size);
 		content->MaxCLL = hdr_nominal_peak_level;
 		content->MaxFALL = hdr_nominal_peak_level;
-		av_stream_add_side_data(data->video,
+		AVCodecParameters *cpar = data->video->codecpar;
+		av_packet_side_data_add(&cpar->coded_side_data,
+					&cpar->nb_coded_side_data,
 					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
-					(uint8_t *)content, content_size);
+					(uint8_t *)content, content_size, 0);
 
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
@@ -231,10 +233,11 @@ static bool create_video_stream(struct ffmpeg_data *data)
 		mastering->max_luminance = av_make_q(hdr_nominal_peak_level, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
-		av_stream_add_side_data(data->video,
+		av_packet_side_data_add(&cpar->coded_side_data,
+					&cpar->nb_coded_side_data,
 					AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
 					(uint8_t *)mastering,
-					sizeof(*mastering));
+					sizeof(*mastering), 0);
 	}
 
 	closest_format = data->config.format;

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -47,6 +47,7 @@ extern struct obs_encoder_info aom_av1_encoder_info;
 
 #ifdef LIBAVUTIL_VAAPI_AVAILABLE
 extern struct obs_encoder_info h264_vaapi_encoder_info;
+extern struct obs_encoder_info av1_vaapi_encoder_info;
 #ifdef ENABLE_HEVC
 extern struct obs_encoder_info hevc_vaapi_encoder_info;
 #endif
@@ -337,6 +338,19 @@ static bool h264_vaapi_supported(void)
 	 * that support H264. */
 	return vaapi_get_h264_default_device() != NULL;
 }
+
+static bool av1_vaapi_supported(void)
+{
+	const AVCodec *vaenc = avcodec_find_encoder_by_name("av1_vaapi");
+
+	if (!vaenc)
+		return false;
+
+	/* NOTE: If default device is NULL, it means there is no device
+	 * that support AV1. */
+	return vaapi_get_av1_default_device() != NULL;
+}
+
 #ifdef ENABLE_HEVC
 static bool hevc_vaapi_supported(void)
 {
@@ -445,6 +459,13 @@ bool obs_module_load(void)
 		obs_register_encoder(&h264_vaapi_encoder_info);
 	} else {
 		blog(LOG_INFO, "FFmpeg VAAPI H264 encoding not supported");
+	}
+
+	if (av1_vaapi_supported()) {
+		blog(LOG_INFO, "FFmpeg VAAPI AV1 encoding supported");
+		obs_register_encoder(&av1_vaapi_encoder_info);
+	} else {
+		blog(LOG_INFO, "FFmpeg VAAPI AV1 encoding not supported");
 	}
 
 #ifdef ENABLE_HEVC

--- a/plugins/obs-ffmpeg/vaapi-utils.c
+++ b/plugins/obs-ffmpeg/vaapi-utils.c
@@ -7,6 +7,7 @@
 #include <util/bmem.h>
 #include <util/dstr.h>
 
+#include <va/va.h>
 #include <va/va_drm.h>
 #include <va/va_str.h>
 
@@ -259,6 +260,61 @@ const char *vaapi_get_h264_default_device()
 	}
 
 	return default_h264_device;
+}
+
+bool vaapi_display_av1_supported(VADisplay dpy, const char *device_path)
+{
+	bool ret = false;
+
+	CHECK_PROFILE(ret, VAProfileAV1Profile0, dpy, device_path);
+
+	if (!ret) {
+		CHECK_PROFILE_LP(ret, VAProfileAV1Profile0, dpy, device_path);
+	}
+
+	return ret;
+}
+
+bool vaapi_device_av1_supported(const char *device_path)
+{
+	bool ret = false;
+	VADisplay va_dpy;
+
+	int drm_fd = -1;
+
+	va_dpy = vaapi_open_device(&drm_fd, device_path,
+				   "vaapi_device_av1_supported");
+	if (!va_dpy)
+		return false;
+
+	ret = vaapi_display_av1_supported(va_dpy, device_path);
+
+	vaapi_close_device(&drm_fd, va_dpy);
+
+	return ret;
+}
+
+const char *vaapi_get_av1_default_device()
+{
+	static const char *default_av1_device = NULL;
+
+	if (!default_av1_device) {
+		bool ret = false;
+		char path[32] = "/dev/dri/renderD1";
+		for (int i = 28;; i++) {
+			sprintf(path, "/dev/dri/renderD1%d", i);
+			if (access(path, F_OK) != 0)
+				break;
+
+			ret = vaapi_device_av1_supported(path);
+			if (ret) {
+				default_av1_device = strdup(path);
+				break;
+			}
+		}
+	}
+
+	return default_av1_device;
 }
 
 #ifdef ENABLE_HEVC

--- a/plugins/obs-ffmpeg/vaapi-utils.h
+++ b/plugins/obs-ffmpeg/vaapi-utils.h
@@ -19,6 +19,10 @@ bool vaapi_display_h264_supported(VADisplay dpy, const char *device_path);
 bool vaapi_device_h264_supported(const char *device_path);
 const char *vaapi_get_h264_default_device(void);
 
+bool vaapi_display_av1_supported(VADisplay dpy, const char *device_path);
+bool vaapi_device_av1_supported(const char *device_path);
+const char *vaapi_get_av1_default_device(void);
+
 #ifdef ENABLE_HEVC
 bool vaapi_display_hevc_supported(VADisplay dpy, const char *device_path);
 bool vaapi_device_hevc_supported(const char *device_path);


### PR DESCRIPTION
### Description
This include refactors, update to current FFmpeg master (https://github.com/FFmpeg/FFmpeg/commit/e5f774268a06c637df5edb3dffa237caf6e678ea) and the new FFmpeg vaapi av1 decoder. (see commits and their descriptions)

### Motivation and Context
This allows to use the upcoming ffmpeg 6.1 `av1_vaapi` encoder (https://github.com/FFmpeg/FFmpeg/commit/3be81e3b449febfb04596f3f187aae27f18d02f7) for GPU accelerated av1 encoding using vaapi.

### How Has This Been Tested?
**This does not work** yet, when trying to be used `ffmpeg_mux_get_extra_data` fails crashing obs.
I think the issue is that I do not parse the headers from the av1 bitstream, I've tried copying what `obs-ffmpeg-av1.c` does and forward the `extradata` field or `AV_PKT_DATA_NEW_EXTRADATA` `sidedata` however theses are not present and by looking at ffmpeg's source I don't think they are touched at all by `av1_vaapi`, so I think parsing them from the bitstream is the only option, it is likely the keyframe flag also need to be fixed.
Help happily wanted, I have not touched av1 bitstream before.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
