### PR TITLE
UI: Fix transform of sources in groups

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -520,6 +520,8 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 							 &invGroupTransform);
 			matrix4_inv(&invGroupTransform, &invGroupTransform);
 			obs_sceneitem_defer_group_resize_begin(stretchGroup);
+		} else {
+			stretchGroup = nullptr;
 		}
 	}
 }


### PR DESCRIPTION
### Description
Clear stretchGroup if the group is meant to be ignored.

### Motivation and Context
Group resize is not deferred until adjustments are completed by a mouseReleaseEvent in certain cases, resulting in unexpected movement of sources that are part of a group as they are resized or stretched beyond group bounds.

Related/Resolved Issue: https://github.com/obsproject/obs-studio/issues/9754

The bug can be described/reproduced as follow:

1. The user selects within a group in the sources dock
2. The user moves their mouse over the selected source such that the cursor would change.
   - This results in a cursor update and a call to `GetStrechHandle()`
   - as the source is part of a group, `stretchGroup` will be set to the group of the source

3. The user clicks on the canvas without touching a stretch/rotation handle
   - A `mouseReleaseEvent` is fired
   - `obs_sceneitem_defer_group_resize_end()` is called on the group as `stretchGroup` is still defined from earlier
   - the `defer_group_resize` member of the group will become negative
   - The deferal check in `resize_group()` (obs-scene.c) will always pass now
4. When scaling or rotating the source close to the group bounds, the group bounds will now dynamically update causing the source in to fly off the canvas.


### How Has This Been Tested?
I tested this by reproducing the steps outlined above and experiencing the expected behavior
This is unlikely to affect any other areas of the code.

OS: Arch Linux
Kernel: x86_64 Linux 6.5.9-arch2-1
CPU: AMD Ryzen 7 2700X Eight-Core @ 16x 3.7GHz
GPU: NVIDIA GeForce RTX 3070

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
