### PR TITLE
libobs,obs-filters: Use common straight alpha math

### DIFF
--- a/libobs/data/area.effect
+++ b/libobs/data/area.effect
@@ -117,13 +117,6 @@ float4 PSDrawAreaRGBAMultiplyTonemap(FragData frag_in) : TARGET
 	return rgba;
 }
 
-float4 PSDrawAreaRGBADivide(FragData frag_in) : TARGET
-{
-	float4 rgba = DrawArea(frag_in);
-	rgba.rgb *= max(1. / rgba.a, 0.);
-	return rgba;
-}
-
 float4 DrawAreaUpscale(FragData frag_in)
 {
 	float2 uv = frag_in.uv;
@@ -217,15 +210,6 @@ technique DrawMultiplyTonemap
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawAreaRGBAMultiplyTonemap(frag_in);
-	}
-}
-
-technique DrawAlphaDivide
-{
-	pass
-	{
-		vertex_shader = VSDefault(vert_in);
-		pixel_shader  = PSDrawAreaRGBADivide(frag_in);
 	}
 }
 

--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -163,13 +163,6 @@ float4 PSDrawBicubicRGBAMultiplyTonemap(FragData f_in, bool undistort) : TARGET
 	return rgba;
 }
 
-float4 PSDrawBicubicRGBADivide(FragData f_in) : TARGET
-{
-	float4 rgba = DrawBicubic(f_in, false);
-	rgba.rgb *= max(1. / rgba.a, 0.);
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -203,15 +196,6 @@ technique DrawMultiplyTonemap
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawBicubicRGBAMultiplyTonemap(f_in, false);
-	}
-}
-
-technique DrawAlphaDivide
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader = PSDrawBicubicRGBADivide(f_in);
 	}
 }
 

--- a/libobs/data/bilinear_lowres_scale.effect
+++ b/libobs/data/bilinear_lowres_scale.effect
@@ -86,13 +86,6 @@ float4 PSDrawLowresBilinearRGBAMultiplyTonemap(VertData f_in) : TARGET
 	return rgba;
 }
 
-float4 PSDrawLowresBilinearRGBADivide(VertData f_in) : TARGET
-{
-	float4 rgba = DrawLowresBilinear(f_in);
-	rgba.rgb *= max(1. / rgba.a, 0.);
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -126,14 +119,5 @@ technique DrawMultiplyTonemap
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawLowresBilinearRGBAMultiplyTonemap(f_in);
-	}
-}
-
-technique DrawAlphaDivide
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLowresBilinearRGBADivide(f_in);
 	}
 }

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -31,14 +31,14 @@ float4 PSDrawBare(VertInOut vert_in) : TARGET
 float4 PSDrawAlphaDivide(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb = (rgba.a > 0.) ? (rgba.rgb / rgba.a) : float3(0., 0., 0.);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	return rgba;
 }
 
 float4 PSDrawAlphaDivideTonemap(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb = (rgba.a > 0.) ? (rgba.rgb / rgba.a) : float3(0., 0., 0.);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba.rgb = rec709_to_rec2020(rgba.rgb);
 	rgba.rgb = reinhard(rgba.rgb);
 	rgba.rgb = rec2020_to_rec709(rgba.rgb);
@@ -48,8 +48,7 @@ float4 PSDrawAlphaDivideTonemap(VertInOut vert_in) : TARGET
 float4 PSDrawAlphaDivideR10L(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
-	rgba.rgb = (rgba.a > 0.) ? (rgba.rgb / rgba.a) : float3(0., 0., 0.);
-	rgba.rgb *= multiplier;
+	rgba.rgb *= (rgba.a > 0.) ? (multiplier / rgba.a) : 0.;
 	rgba.rgb = rec709_to_rec2020(rgba.rgb);
 	rgba.rgb = linear_to_st2084(rgba.rgb);
 	uint3 rgb1023 = uint3(mad(rgba.rgb, 1023., .5));

--- a/libobs/data/lanczos_scale.effect
+++ b/libobs/data/lanczos_scale.effect
@@ -219,13 +219,6 @@ float4 PSDrawLanczosRGBAMultiplyTonemap(FragData f_in, bool undistort) : TARGET
 	return rgba;
 }
 
-float4 PSDrawLanczosRGBADivide(FragData f_in) : TARGET
-{
-	float4 rgba = DrawLanczos(f_in, false);
-	rgba.rgb *= max(1. / rgba.a, 0.);
-	return rgba;
-}
-
 technique Draw
 {
 	pass
@@ -259,15 +252,6 @@ technique DrawMultiplyTonemap
 	{
 		vertex_shader = VSDefault(v_in);
 		pixel_shader  = PSDrawLanczosRGBAMultiplyTonemap(f_in, false);
-	}
-}
-
-technique DrawAlphaDivide
-{
-	pass
-	{
-		vertex_shader = VSDefault(v_in);
-		pixel_shader  = PSDrawLanczosRGBADivide(f_in);
 	}
 }
 

--- a/plugins/obs-filters/data/blend_add_filter.effect
+++ b/plugins/obs-filters/data/blend_add_filter.effect
@@ -35,7 +35,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 PSAddImageRGBA(VertDataOut v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 
 	float3 targetRGB = target.Sample(textureSampler, v_in.uv2).rgb;

--- a/plugins/obs-filters/data/blend_mul_filter.effect
+++ b/plugins/obs-filters/data/blend_mul_filter.effect
@@ -35,7 +35,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 PSMuliplyImageRGBA(VertDataOut v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 
 	float3 targetRGB = target.Sample(textureSampler, v_in.uv2).rgb;

--- a/plugins/obs-filters/data/blend_sub_filter.effect
+++ b/plugins/obs-filters/data/blend_sub_filter.effect
@@ -35,7 +35,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 PSSubtractImageRGBA(VertDataOut v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 
 	float3 targetRGB = target.Sample(textureSampler, v_in.uv2).rgb;

--- a/plugins/obs-filters/data/chroma_key_filter.effect
+++ b/plugins/obs-filters/data/chroma_key_filter.effect
@@ -85,7 +85,7 @@ float4 ProcessChromaKey(float4 rgba, VertData v_in)
 float4 PSChromaKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	return ProcessChromaKey(rgba, v_in);
 }
 

--- a/plugins/obs-filters/data/chroma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/chroma_key_filter_v2.effect
@@ -95,7 +95,7 @@ float4 ProcessChromaKey(float4 rgba, VertData v_in)
 float4 PSChromaKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba = ProcessChromaKey(rgba, v_in);
 	rgba.rgb *= rgba.a;
 	return rgba;

--- a/plugins/obs-filters/data/color_correction_filter.effect
+++ b/plugins/obs-filters/data/color_correction_filter.effect
@@ -47,7 +47,7 @@ float4 PSColorFilterRGBA(VertData vert_in) : TARGET
 {
 	/* Grab the current pixel to perform operations on. */
 	float4 currentPixel = image.Sample(textureSampler, vert_in.uv);
-	currentPixel.rgb = max(float3(0.0, 0.0, 0.0), currentPixel.rgb / currentPixel.a);
+	currentPixel.rgb *= (currentPixel.a > 0.) ? (1. / currentPixel.a) : 0.;
 
 	/* Always address the gamma first. */
 	currentPixel.rgb = pow(currentPixel.rgb, float3(gamma, gamma, gamma));

--- a/plugins/obs-filters/data/color_grade_filter.effect
+++ b/plugins/obs-filters/data/color_grade_filter.effect
@@ -47,7 +47,7 @@ float3 srgb_linear_to_nonlinear(float3 v)
 float4 LUT1D(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
-	textureColor.rgb = max(float3(0.0, 0.0, 0.0), textureColor.rgb / textureColor.a);
+	textureColor.rgb *= (textureColor.a > 0.) ? (1. / textureColor.a) : 0.;
 	float3 nonlinear = srgb_linear_to_nonlinear(textureColor.rgb);
 
 	if (nonlinear.r >= domain_min.r && nonlinear.r <= domain_max.r) {
@@ -85,7 +85,7 @@ float4 LUT3D(VertDataOut v_in) : TARGET
 float4 LUTAlpha3D(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
-	textureColor.rgb = max(float3(0.0, 0.0, 0.0), textureColor.rgb / textureColor.a);
+	textureColor.rgb *= (textureColor.a > 0.) ? (1. / textureColor.a) : 0.;
 	float3 nonlinear = srgb_linear_to_nonlinear(textureColor.rgb);
 
 	float3 clut_uvw = nonlinear * clut_scale + clut_offset;
@@ -98,7 +98,7 @@ float4 LUTAlpha3D(VertDataOut v_in) : TARGET
 float4 LUTAmount3D(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
-	textureColor.rgb = max(float3(0.0, 0.0, 0.0), textureColor.rgb / textureColor.a);
+	textureColor.rgb *= (textureColor.a > 0.) ? (1. / textureColor.a) : 0.;
 	float3 nonlinear = srgb_linear_to_nonlinear(textureColor.rgb);
 
 	float3 clut_uvw = nonlinear * clut_scale + clut_offset;
@@ -112,7 +112,7 @@ float4 LUTAmount3D(VertDataOut v_in) : TARGET
 float4 LUTDomain3D(VertDataOut v_in) : TARGET
 {
 	float4 textureColor = image.Sample(textureSampler, v_in.uv);
-	textureColor.rgb = max(float3(0.0, 0.0, 0.0), textureColor.rgb / textureColor.a);
+	textureColor.rgb *= (textureColor.a > 0.) ? (1. / textureColor.a) : 0.;
 	float3 nonlinear = srgb_linear_to_nonlinear(textureColor.rgb);
 
 	float r = nonlinear.r;

--- a/plugins/obs-filters/data/color_key_filter.effect
+++ b/plugins/obs-filters/data/color_key_filter.effect
@@ -50,7 +50,7 @@ float4 ProcessColorKey(float4 rgba, VertData v_in)
 float4 PSColorKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 	return ProcessColorKey(rgba, v_in);
 }

--- a/plugins/obs-filters/data/color_key_filter_v2.effect
+++ b/plugins/obs-filters/data/color_key_filter_v2.effect
@@ -60,7 +60,7 @@ float4 ProcessColorKey(float4 rgba, VertData v_in)
 float4 PSColorKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba.a *= opacity;
 	rgba = ProcessColorKey(rgba, v_in);
 	rgba.rgb *= rgba.a;

--- a/plugins/obs-filters/data/luma_key_filter.effect
+++ b/plugins/obs-filters/data/luma_key_filter.effect
@@ -28,7 +28,7 @@ VertData VSDefault(VertData v_in)
 float4 PSALumaKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 
 	float4 lumaCoef = float4(0.2989, 0.5870, 0.1140, 0.0);
 

--- a/plugins/obs-filters/data/luma_key_filter_v2.effect
+++ b/plugins/obs-filters/data/luma_key_filter_v2.effect
@@ -28,7 +28,7 @@ VertData VSDefault(VertData v_in)
 float4 PSALumaKeyRGBA(VertData v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 
 	float3 lumaCoef = float3(0.2126, 0.7152, 0.0722);
 

--- a/plugins/obs-filters/data/mask_alpha_filter.effect
+++ b/plugins/obs-filters/data/mask_alpha_filter.effect
@@ -35,7 +35,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 PSAlphaMaskRGBA(VertDataOut v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);

--- a/plugins/obs-filters/data/mask_color_filter.effect
+++ b/plugins/obs-filters/data/mask_color_filter.effect
@@ -35,7 +35,7 @@ VertDataOut VSDefault(VertDataIn v_in)
 float4 PSColorMaskRGBA(VertDataOut v_in) : TARGET
 {
 	float4 rgba = image.Sample(textureSampler, v_in.uv);
-	rgba.rgb = max(float3(0.0, 0.0, 0.0), rgba.rgb / rgba.a);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
 	rgba *= color;
 
 	float4 targetRGB = target.Sample(textureSampler, v_in.uv2);


### PR DESCRIPTION
### Description
This pattern uses fewer instructions and also avoids using max, which does not work on infinity.

Also remove unreferenced techniques from scale filters.

### Motivation and Context
Clean up my past badness.

### How Has This Been Tested?
- [x] DeckLink (three paths)
- [x] Blend add
- [x] Blend multiply
- [x] Blend subtract
- [x] Chroma key
- [x] Chroma key v2
- [x] Color correction
- [x] Color grade (four paths)
- [x] Color key
- [x] Color key v2
- [x] Luma key
- [x] Luma key v2
- [x] Mask alpha
- [x] Mask color
- [x] Windows and Mac
- [x] Area
- [x] Bicubic
- [x] Bilinear lowres
- [x] Lanczos

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.