### PR TITLE
libobs: Add more files to list of public headers

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -261,21 +261,40 @@ target_compile_definitions(libobs PUBLIC HAVE_OBSCONFIG_H)
 set(public_headers
     # cmake-format: sortable
     callback/calldata.h
+    callback/decl.h
     callback/proc.h
     callback/signal.h
+    graphics/axisang.h
+    graphics/bounds.h
+    graphics/effect-parser.h
+    graphics/effect.h
     graphics/graphics.h
+    graphics/image-file.h
     graphics/input.h
+    graphics/libnsgif/libnsgif.h
     graphics/math-defs.h
+    graphics/math-extra.h
+    graphics/matrix3.h
+    graphics/matrix4.h
+    graphics/plane.h
+    graphics/quat.h
+    graphics/shader-parser.h
     graphics/srgb.h
     graphics/vec2.h
     graphics/vec3.h
     graphics/vec4.h
     media-io/audio-io.h
+    media-io/audio-math.h
+    media-io/audio-resampler.h
+    media-io/format-conversion.h
     media-io/frame-rate.h
     media-io/media-io-defs.h
+    media-io/media-remux.h
     media-io/video-frame.h
     media-io/video-io.h
+    media-io/video-scaler.h
     obs-audio-controls.h
+    obs-avc.h
     obs-config.h
     obs-data.h
     obs-defs.h
@@ -283,9 +302,10 @@ set(public_headers
     obs-hotkey.h
     obs-hotkeys.h
     obs-interaction.h
-    obs-internal.h
     obs-missing-files.h
     obs-module.h
+    obs-nal.h
+    obs-nix-platform.h
     obs-output.h
     obs-properties.h
     obs-service.h
@@ -293,16 +313,28 @@ set(public_headers
     obs-ui.h
     obs.h
     obs.hpp
+    util/AlignedNew.hpp
+    util/apple/cfstring-utils.h
+    util/array-serializer.h
     util/base.h
+    util/bitstream.h
     util/bmem.h
     util/c99defs.h
+    util/cf-lexer.h
+    util/cf-parser.h
     util/circlebuf.h
     util/config-file.h
+    util/crc32.h
     util/darray.h
     util/dstr.h
+    util/dstr.hpp
+    util/file-serializer.h
+    util/lexer.h
+    util/pipe.h
     util/platform.h
     util/profiler.h
     util/profiler.hpp
+    util/serializer.h
     util/simde/check.h
     util/simde/debug-trap.h
     util/simde/hedley.h
@@ -318,10 +350,23 @@ set(public_headers
     util/simde/x86/sse.h
     util/simde/x86/sse2.h
     util/sse-intrin.h
+    util/task.h
     util/text-lookup.h
+    util/threading-posix.h
+    util/threading-windows.h
     util/threading.h
+    util/uthash.h
     util/util.hpp
-    util/util_uint64.h)
+    util/util_uint128.h
+    util/util_uint64.h
+    util/windows/ComPtr.hpp
+    util/windows/CoTaskMemPtr.hpp
+    util/windows/device-enum.h
+    util/windows/HRError.hpp
+    util/windows/win-registry.h
+    util/windows/win-version.h
+    util/windows/window-helpers.h
+    util/windows/WinHandle.hpp)
 
 if(ENABLE_HEVC)
   list(APPEND public_headers obs-hevc.h)


### PR DESCRIPTION
### Description
Adds more files to list of public header files to fix build errors for 3rd party plugins.

### Motivation and Context
`libobs` does not provide a bespoke set of public headers for consumers of the library - instead the internal structure of the library is exposed unchanged via its internal headers to consumers.

This requires all headers that export symbols to be included as well as all headers included by those, and also all headers providing functionality via static inline functions.

As these are distributed over almost all headers of `libobs` (there are no bespoke "export headers" that only contain symbols and inline functions needed for consumers), this unfortunately also requires providing a majority of the header files.

This change probably "overcorrects" the issue, but given that 3rd party plugins currently get full access to `libobs` internal API (there is no distinction between the required runtime modules and 3rd party plugins from an architectural point of view) we have no other choice for the time being.

### How Has This Been Tested?
Checked the includes of all header files and their recursive includes as well.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
