### PR TITLE
cmake: Allow finding the CEF wrapper without a build folder on Linux

### DIFF
--- a/cmake/finders/FindCEF.cmake
+++ b/cmake/finders/FindCEF.cmake
@@ -154,7 +154,8 @@ elseif(CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
     CEF_LIBRARY_WRAPPER_RELEASE
     NAMES cef_dll_wrapper.a libcef_dll_wrapper.a
     NO_DEFAULT_PATH
-    PATHS "${CEF_ROOT_DIR}/build/libcef_dll" "${CEF_ROOT_DIR}/build/libcef_dll_wrapper"
+    PATHS "${CEF_ROOT_DIR}/libcef_dll_wrapper" "${CEF_ROOT_DIR}/build/libcef_dll"
+          "${CEF_ROOT_DIR}/build/libcef_dll_wrapper"
     DOC "Chromium Embedded Framework static library wrapper.")
 endif()
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This modify the CEF finder of CMake 3.0 framework, to restore a behavior that was supported with 2.0.

The Flatpak (and also my CEF AUR packages), do not generate/use a build folder to provide the wrapper.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I don't see a real reason to drop this behavior.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Makes Flatpak on CMake 3.0 with #9787 (with other fixes e.g. fix GIO finder, disabling AJA) build.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
 - If you have a shorter commit name idea, feel free to suggest it.
- [x] I have included updates to all appropriate documentation.
