### PR TITLE
win-capture: Fix Vulkan race condition

### DIFF
--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -1796,7 +1796,6 @@ OBS_CreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *cinfo,
 	if ((res == VK_SUCCESS) && (count > 0)) {
 		struct vk_swap_data *swap_data = alloc_swap_data(ac);
 		if (swap_data) {
-			init_swap_data(swap_data, data, sc);
 			swap_data->swap_images = vk_alloc(
 				ac, count * sizeof(VkImage), _Alignof(VkImage),
 				VK_SYSTEM_ALLOCATION_SCOPE_OBJECT);
@@ -1816,6 +1815,7 @@ OBS_CreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR *cinfo,
 			swap_data->shtex_info = NULL;
 			swap_data->d3d11_tex = NULL;
 			swap_data->captured = false;
+			init_swap_data(swap_data, data, sc);
 		}
 	}
 


### PR DESCRIPTION
This race condition is caused when one thread creates a swap chain, which calls OBS_CreateSwapchainKHR, at the same time another thread calls OBS_CreateImageView.

OBS_CreateSwapchainKHR allocates swap data, publishes this into the data->swaps linked list, then initializes it. Meanwhile, OBS_CreateImageView is iterating the swaps linked list, to see if the image matches any swap chain images. Due to the order in OBS_CreateSwapchainKHR, there's no guarantee this data is initialized so it often ends up running out of bounds on the swap_images array.

The fix is simply to defer the swap data publish to after init.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The issue is that we have one thread (our window thread) creating a swap chain, which calls OBS_CreateSwapchainKHR, at the same time another thread (the main thread) is calling OBS_CreateImageView.
OBS_CreateSwapchainKHR allocates swap data, publishes this into the data->swaps linked list, then initializes it. Meanwhile, OBS_CreateImageView is iterating the swaps linked list, to see if the image matches any swap chain images. Unfortunately, due to the order in OBS_CreateSwapchainKHR, there's no guarantee this data is initialized, so often ends up running out of bounds on the swap_images array.
The fix is simply to defer the swap data publish to after initialization

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We need to be able to consistently capture an in-development Vulkan project.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested against our Vulkan project.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
