### PR TITLE
obs-scripting: Fix Sparkle delta updates by disabling bytecode caching

### DIFF
--- a/deps/obs-scripting/obs-scripting-python.c
+++ b/deps/obs-scripting/obs-scripting-python.c
@@ -1706,6 +1706,11 @@ bool obs_scripting_load_python(const char *python_path)
 	PySys_SetArgv(argc, argv);
 	PRAGMA_WARN_POP
 
+#ifdef __APPLE__
+	PyRun_SimpleString("import sys");
+	PyRun_SimpleString("sys.dont_write_bytecode = True");
+#endif
+
 #ifdef DEBUG_PYTHON_STARTUP
 	/* ---------------------------------------------- */
 	/* Debug logging to file if startup is failing    */


### PR DESCRIPTION
### Description
Restores delta patching functionality on macOS for users with correctly configured Python framework for scripting.

### Motivation and Context
Python automatically creates bytecode caches which end up inside the application bundle of OBS Studio on macOS. These directories will lead to a hash mismatch when Sparkle attempts to apply a delta update (to ensure that the patch can be applied).

> [!NOTE]
>
> This issue will occur even without any active scripts - just having a valid Python framework configured will make the scripting library create a Python environment and import the `obspython` module.

### How Has This Been Tested?
Tested on macOS 14 by launching the application with Python 3.10 enabled and checked the contents of the app bundle. Also removed the automatically created cache directory on an unfixed bundle and confirmed that Sparkle delta updates were applied correctly then.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
