### PR TITLE
win-wasapi: Use wasapi resampler when capturing processes & set  hnsBufferDuration to 0.

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -789,8 +789,12 @@ ComPtr<IAudioClient> WASAPISource::InitClient(
 	DWORD flags = AUDCLNT_STREAMFLAGS_EVENTCALLBACK;
 	if (type != SourceType::Input)
 		flags |= AUDCLNT_STREAMFLAGS_LOOPBACK;
-	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, flags,
-				 BUFFER_TIME_100NS, 0, pFormat, nullptr);
+	if (type == SourceType::ProcessOutput)
+		flags |= AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM |
+			 AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY;
+
+	res = client->Initialize(AUDCLNT_SHAREMODE_SHARED, flags, 0, 0, pFormat,
+				 nullptr);
 	if (FAILED(res))
 		throw HRError("Failed to initialize audio client", res);
 


### PR DESCRIPTION
### Description
After a while, cracks and distortions are heard when trying to capture application audio.
See: https://github.com/obsproject/obs-studio/issues/8064
As a potentially mitigating factor, we let wasapi deal with resampling and channel mixing by enabling some AUDCLNT_STREAMFLAGS.
The sdk specifies also that: `For a shared-mode stream that uses event-driven buffering, the caller must set both hnsPeriodicity and hnsBufferDuration to 0.`
hnsBufferDuration was non-zero so we set it to 0.

**Sidenote:**
Windows sdk sample is clearly wrong and doesn't follow its own SDK. :upside_down_face:
Firstly, it passes AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM as hnsPeriodicity;
secondly, it sets a non-zero hnsBufferDuration although the code uses
AUDCLNT_SHAREMODE_SHARED & AUDCLNT_STREAMFLAGS_EVENTCALLBACK
(which imply event-driven buffering in shared mode).

[1] https://github.com/microsoft/Windows-classic-samples/blob/ac06e54a15e9a62443e400fffff190fb978ea586/Samples/ApplicationLoopback/cpp/LoopbackCapture.cpp#L105-L110

**Help needed**
This patch is in need of testers.
Test builds are available from CI (see the checks tab):
https://github.com/obsproject/obs-studio/suites/17918463445/artifacts/1029474840
If you're hit by the bug in #8064 , please test & report your results as a comment to this PR.

### Motivation and Context
Try to fix a bug.

### How Has This Been Tested?
A few people are reporting it seems to fix the issue for them.
But we need more testing; hence this PR to allow test builds to be more easily distributed.


### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
