### PR TITLE
frontend-tools: Fix multiple signal-slot connections on output timer

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -32,6 +32,15 @@ OutputTimer::OutputTimer(QWidget *parent)
 
 	recordingTimer = new QTimer(this);
 	recordingTimerDisplay = new QTimer(this);
+
+	QObject::connect(streamingTimer, &QTimer::timeout, this,
+			 &OutputTimer::EventStopStreaming);
+	QObject::connect(streamingTimerDisplay, &QTimer::timeout, this,
+			 &OutputTimer::UpdateStreamTimerDisplay);
+	QObject::connect(recordingTimer, &QTimer::timeout, this,
+			 &OutputTimer::EventStopRecording);
+	QObject::connect(recordingTimerDisplay, &QTimer::timeout, this,
+			 &OutputTimer::UpdateRecordTimerDisplay);
 }
 
 void OutputTimer::closeEvent(QCloseEvent *)
@@ -86,12 +95,6 @@ void OutputTimer::StreamTimerStart()
 	streamingTimer->setInterval(total);
 	streamingTimer->setSingleShot(true);
 
-	QObject::connect(streamingTimer, &QTimer::timeout, this,
-			 &OutputTimer::EventStopStreaming);
-
-	QObject::connect(streamingTimerDisplay, &QTimer::timeout, this,
-			 &OutputTimer::UpdateStreamTimerDisplay);
-
 	streamingTimer->start();
 	streamingTimerDisplay->start(1000);
 	ui->outputTimerStream->setText(obs_module_text("Stop"));
@@ -119,12 +122,6 @@ void OutputTimer::RecordTimerStart()
 
 	recordingTimer->setInterval(total);
 	recordingTimer->setSingleShot(true);
-
-	QObject::connect(recordingTimer, &QTimer::timeout, this,
-			 &OutputTimer::EventStopRecording);
-
-	QObject::connect(recordingTimerDisplay, &QTimer::timeout, this,
-			 &OutputTimer::UpdateRecordTimerDisplay);
 
 	recordingTimer->start();
 	recordingTimerDisplay->start(1000);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This will fix the output timer bug from issue #6558. If you use the output timer too many times in a run of the program, issues start happening where on every other run of the output timer, the video will stop prematurely and generate a tiny video recording file. 

Every time the start button is pressed it makes a new connection to the QTimers, increasing the amount of connections and signals being sent to the QTimers by 1 each time the start button is clicked.

This fix moves the connections to the QTimers to the function that creates them, so that the connection is only established once.

### Motivation and Context
Fixes #6558.

### How Has This Been Tested?
I used the output timer to record multiple 5 seconds videos consecutively with the issue not happening.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.