### PR TITLE
cmake: Force PDB generation on Windows for MSVC builds in all configs

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -23,6 +23,15 @@ if(CMAKE_VERSION VERSION_EQUAL 3.24.0)
   set(THREADS_HAVE_PTHREAD_ARG FALSE)
 endif()
 
+# CMake 3.25 changed the way symbol generation is handled on Windows
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.25.0)
+  if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT ProgramDatabase)
+  else()
+    set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded)
+  endif()
+endif()
+
 message(DEBUG "Current Windows API version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")
 if(CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM)
   message(DEBUG "Maximum Windows API version: ${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION_MAXIMUM}")
@@ -47,13 +56,19 @@ add_compile_options(
   "$<$<COMPILE_LANG_AND_ID:C,MSVC>:${_obs_msvc_c_options}>"
   "$<$<COMPILE_LANG_AND_ID:CXX,MSVC>:${_obs_msvc_cpp_options}>"
   "$<$<COMPILE_LANG_AND_ID:C,Clang>:${_obs_clang_c_options}>"
-  "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>")
+  "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>"
+  $<$<NOT:$<CONFIG:Debug>>:/Gy>)
 
 add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_WARNINGS $<$<CONFIG:DEBUG>:DEBUG>
                         $<$<CONFIG:DEBUG>:_DEBUG>)
 
-add_link_options("$<$<NOT:$<CONFIG:Debug>>:/OPT\:REF>" "$<$<CONFIG:Debug>:/INCREMENTAL\:NO>"
-                 "$<$<CONFIG:RelWithDebInfo>:/INCREMENTAL\:NO>" "$<$<CONFIG:RelWithDebInfo>:/OPT\:ICF>" /Brepro)
+# cmake-format: off
+add_link_options($<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
+                 $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
+                 $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
+                 /DEBUG
+                 /Brepro)
+# cmake-format: on
 
 if(CMAKE_COMPILE_WARNING_AS_ERROR)
   add_link_options(/WX)

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -251,14 +251,14 @@ function(_target_install_obs target)
     POST_BUILD
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
     COMMAND "${CMAKE_COMMAND}" -E copy ${target_file} "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
-    COMMAND "${CMAKE_COMMAND}" -E $<IF:$<CONFIG:Debug,RelWithDebInfo>,copy,true> ${target_pdb_file}
+    COMMAND "${CMAKE_COMMAND}" -E $<IF:$<CONFIG:Debug,RelWithDebInfo,Release>,copy,true> ${target_pdb_file}
             "${OBS_OUTPUT_DIR}/$<CONFIG>/${_TIO_DESTINATION}"
     COMMENT "${comment}"
     VERBATIM)
 
   install(
     FILES ${target_pdb_file}
-    CONFIGURATIONS RelWithDebInfo Debug
+    CONFIGURATIONS RelWithDebInfo Debug Release
     DESTINATION "${_TIO_DESTINATION}"
     COMPONENT Runtime
     OPTIONAL)
@@ -272,7 +272,7 @@ function(target_export target)
 
   install(
     FILES "$<TARGET_PDB_FILE:${target}>"
-    CONFIGURATIONS RelWithDebInfo Debug
+    CONFIGURATIONS RelWithDebInfo Debug Release
     DESTINATION "${OBS_EXECUTABLE_DESTINATION}"
     COMPONENT Development
     OPTIONAL)


### PR DESCRIPTION
### Description
Adds necessary compiler and linker flags to mimic MSVC's default settings which always generate PDBs regardless of optimisation and never use incremental linking.

### Motivation and Context
CMake 3.25 changed the way PDB generation is handled by only enabling it for Debug and RelWithDebInfo builds, which prohibits generation of fully optimized builds with associated symbols (which is MSVC's default).

If configuring with CMake 3.25 or above, enable this globally for builds using MSVC and fall back to embedded debug information for anything else (which would probably be clang-cl).

The necessary linker flag `/DEBUG` also needs to be added manually to the "Release" configuration, as CMake removes it by default.

With these changes, users get the benefit of optimised builds while we retain the ability to symbolicate crashes locally with the shipped PDBs.

### How Has This Been Tested?
Tested with CMake 3.27 and Visual Studio 17 2022, building in "Release" configuration" all PDBs are correctly generated and copied.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
