### PR TITLE
UI: Fix typo in Virtual Camera logging functions

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -301,7 +301,7 @@ inline BasicOutputHandler::BasicOutputHandler(OBSBasic *main_) : main(main_)
 	}
 }
 
-extern void log_cvam_changed(const VCamConfig &config, bool starting);
+extern void log_vcam_changed(const VCamConfig &config, bool starting);
 
 bool BasicOutputHandler::StartVirtualCam()
 {
@@ -346,7 +346,7 @@ bool BasicOutputHandler::StartVirtualCam()
 		DestroyVirtualCamView();
 	}
 
-	log_cvam_changed(main->vcamConfig, true);
+	log_vcam_changed(main->vcamConfig, true);
 
 	return success;
 }

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -8199,7 +8199,7 @@ void OBSBasic::VCamConfigButtonClicked()
 	dialog.exec();
 }
 
-void log_cvam_changed(const VCamConfig &config, bool starting)
+void log_vcam_changed(const VCamConfig &config, bool starting)
 {
 	const char *action = starting ? "Starting" : "Changing";
 
@@ -8228,7 +8228,7 @@ void OBSBasic::UpdateVirtualCamConfig(const VCamConfig &config)
 	vcamConfig = config;
 
 	outputHandler->UpdateVirtualCamOutputSource();
-	log_cvam_changed(config, false);
+	log_vcam_changed(config, false);
 }
 
 void OBSBasic::RestartVirtualCam(const VCamConfig &config)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
cvam -> vcam

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want function names to be easily understood and not cause confusion. Noticed while evaluating commits for inclusion in the release/30.0 branch.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built locally on Windows 11 to confirm the rename did not introduce build errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
