### PR TITLE
UI: Add crash handling options per thread

### DIFF
--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -90,6 +90,19 @@ void base_set_crash_handler(void (*handler)(const char *, va_list, void *),
 	crash_handler = handler;
 }
 
+static _Thread_local int thread_crash_handling = CRASH_SAVE_FILE |
+						 CRASH_SHOW_USER;
+
+void base_set_thread_crash_handling(int crash)
+{
+	thread_crash_handling = crash;
+}
+
+int base_get_thread_crash_handling()
+{
+	return thread_crash_handling;
+}
+
 OBS_NORETURN void bcrash(const char *format, ...)
 {
 	va_list args;

--- a/libobs/util/base.h
+++ b/libobs/util/base.h
@@ -76,6 +76,12 @@ EXPORT void base_set_crash_handler(void (*handler)(const char *, va_list,
 						   void *),
 				   void *param);
 
+#define CRASH_SAVE_FILE (1 << 0)
+#define CRASH_SHOW_USER (1 << 1)
+#define CRASH_KILL_THREAD (1 << 2)
+EXPORT void base_set_thread_crash_handling(int crash);
+EXPORT int base_get_thread_crash_handling();
+
 EXPORT void blogva(int log_level, const char *format, va_list args);
 
 #if !defined(_MSC_VER) && !defined(SWIG)


### PR DESCRIPTION
### Description
Add crash handling options per thread
Allows threads to not kill obs on unhandled exception
When only the thread is killed:
![image](https://github.com/obsproject/obs-studio/assets/5457024/120378dd-ec33-4aa0-803b-1a671564c2c6)
When the process is killed:
![image](https://github.com/obsproject/obs-studio/assets/5457024/9262df8c-228e-4552-aa8b-332ff62e77f5)

### Motivation and Context
Threads created in the obs process have an option to not kill obs process on unhandled exceptions.
For example for the BrowserManagerThread, that way the user can end stream on their own terms and don't end it by closing the crash popup

### How Has This Been Tested?
On windows 64

### Types of changes
 - Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
