### PR TITLE
libobs: Fix PTS incrementation when FPS divisor is enabled

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1398,7 +1398,8 @@ static void receive_video(void *param, struct video_data *frame)
 	enc_frame.pts = encoder->cur_pts;
 
 	if (do_encode(encoder, &enc_frame))
-		encoder->cur_pts += encoder->timebase_num;
+		encoder->cur_pts +=
+			encoder->timebase_num * encoder->frame_rate_divisor;
 
 wait_for_audio:
 	profile_end(receive_video_name);


### PR DESCRIPTION
### Description
When using a PTS divisor, OBS would still increment the PTS by only the original `fps_den` value, not considering that PTS values should be multiplied by the divisor.

For example, `60/1` increases like `0,1,2,3`. `60000/1001` increases like `0,1001,2002,3003`.

Without this fix, `60/1` main OBS framerate with a divisor of `2` produces `0,1,2,3`, while the correct pattern would be `0,2,4,6`.

### Motivation and Context
Was testing the ffmpeg nvenc encoder with the new FPS dividing feature of encoders and discovered this bug.

Bug appeared as `Encoding queue duration surpassed 5 seconds, terminating encoder` after 10 seconds of encode, even though no such encoder congestion was happening.

### How Has This Been Tested?
Tested with a fractional of `60 / 1` and encoder divisor of `2` and the issue no longer appears.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
