### PR TITLE
obs-scripting: Add Python 3.11 support for Windows and macOS

### DIFF
--- a/deps/obs-scripting/obs-scripting-python-import.c
+++ b/deps/obs-scripting/obs-scripting-python-import.c
@@ -39,7 +39,7 @@
 #endif
 
 #define PY_MAJOR_VERSION_MAX 3
-#define PY_MINOR_VERSION_MAX 11
+#define PY_MINOR_VERSION_MAX 12
 
 bool import_python(const char *python_path, python_version_t *python_version)
 {

--- a/deps/obs-scripting/obspython/CMakeLists.txt
+++ b/deps/obs-scripting/obspython/CMakeLists.txt
@@ -14,7 +14,7 @@ if(POLICY CMP0094)
   cmake_policy(SET CMP0094 NEW)
 endif()
 
-find_package(Python 3.8...<3.11 REQUIRED Interpreter Development)
+find_package(Python 3.8...<3.12 REQUIRED Interpreter Development)
 find_package(SWIG 4 REQUIRED)
 
 include(UseSWIG)


### PR DESCRIPTION
### Description
Adds necessary forward definitions of Python symbols for Python 3.11, enabling Python 3.11 support for Windows and macOS.

### Motivation and Context
Python 3.11 is the first version with official ARM64 support on Windows and is also the current stable version of Python.

### How Has This Been Tested?
Compiled and run OBS with Python 3.11 on Windows 11 and macOS 14.1, used a Python test script to check API functionality with all 17 tests passing.

Also confirmed that the loaded Python version in the frontend was reported as Python 3.11.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
