### PR TITLE
cmake: Disable /INCREMENTAL unconditionally

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -65,7 +65,7 @@ add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO
 # cmake-format: off
 add_link_options($<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
                  $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
-                 $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
+                 /INCREMENTAL:NO
                  /DEBUG
                  /Brepro)
 # cmake-format: on


### PR DESCRIPTION
### Description

Disables `/INCREMENTAL` unconditionally.

### Motivation and Context

Debug builds fail after #9816 as it enabled `/INCREMENTAL` for Debug builds, however that currently does not work due to speexdsp.

Since we've never had incremental builds for Debug just disable it again. We can revisit later why we had disabled it in the first place, and if that's something we should fix elsewhere.

### How Has This Been Tested?

Built in Debug.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
