### PR TITLE
obs-filters: Remove LTCG linker flag for SpeexDSP builds on Windows

### DIFF
--- a/plugins/obs-filters/cmake/speexdsp.cmake
+++ b/plugins/obs-filters/cmake/speexdsp.cmake
@@ -6,8 +6,7 @@ if(ENABLE_SPEEXDSP)
   target_sources(obs-filters PRIVATE noise-suppress-filter.c)
   target_link_libraries(obs-filters PRIVATE SpeexDSP::Libspeexdsp)
   target_compile_definitions(obs-filters PRIVATE LIBSPEEXDSP_ENABLED)
-  target_link_options(obs-filters PRIVATE $<$<PLATFORM_ID:Windows>:/LTCG> $<$<PLATFORM_ID:Windows>:/IGNORE:4098>
-                      $<$<PLATFORM_ID:Windows>:/IGNORE:4099>)
+  target_link_options(obs-filters PRIVATE $<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:Debug>>:/NODEFAULTLIB:MSVCRT>)
 
   target_enable_feature(obs-filters "SpeexDSP noise suppression" HAS_NOISEREDUCTION)
 else()


### PR DESCRIPTION
### Description
Remove `/LTCG` linker flag for SpeexDSP implementation on Windows.

### Motivation and Context
Flag was added in CMake 2.0 update and is incompatible with incremental linking enabled by default for Debug configuration (MSVC default) in recent compiler flag update.

The original error that necessitates adding LTCG is not present with current obs-deps anymore, so remove it and disable the hard-coded default library directive instead.

### How Has This Been Tested?
Built OBS Studio on Windows 11 with Debug configuration on current master.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
