### PR TITLE
libobs: Fix memory leak when migrating from legacy scene item data

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2042,13 +2042,17 @@ static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item,
 	/* Check if legacy keys exists, migrate if necessary */
 	dstr_printf(&legacy, "libobs.show_scene_item.%s", name);
 	hotkey_array = obs_data_get_array(hotkey_data, legacy.array);
-	if (hotkey_array)
+	if (hotkey_array) {
 		obs_data_set_array(hotkey_data, show.array, hotkey_array);
+		obs_data_array_release(hotkey_array);
+	}
 
 	dstr_printf(&legacy, "libobs.hide_scene_item.%s", name);
 	hotkey_array = obs_data_get_array(hotkey_data, legacy.array);
-	if (hotkey_array)
+	if (hotkey_array) {
 		obs_data_set_array(hotkey_data, hide.array, hotkey_array);
+		obs_data_array_release(hotkey_array);
+	}
 
 	item->toggle_visibility = obs_hotkey_pair_register_source(
 		scene->source, show.array, show_desc.array, hide.array,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds `obs_data_array_release` when a legacy scene item data structure is detected.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Before the commit 763dddbbaf, hotkeys to show and hide scene items are distinguished by source name instead of ID. When migrating from the legacy data structure, the pointer to the data was not released.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

Steps to reproduce and test:

1. Prepare an old scene collection file.
   Ensure there is a key starting from `libobs.hide_scene_item.` and followed by source names instead of numbers.
2. Run OBS.
3. Exit OBS.
4. Check there is no memory leaks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
