### PR TITLE
Open dropped svg in browser source

### DIFF
--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -23,7 +23,7 @@ static const char *imageExtensions[] = {"bmp", "gif", "jpeg", "jpg",
 #endif
 					"png", "tga", "webp", nullptr};
 
-static const char *htmlExtensions[] = {"htm", "html", nullptr};
+static const char *htmlExtensions[] = {"htm", "html", "svg", nullptr};
 
 static const char *mediaExtensions[] = {
 	"3ga",   "669",   "a52",   "aac",  "ac3",  "adt",  "adts", "aif",


### PR DESCRIPTION
Browser source supports even pdf files, but is showing controls.
Would it be good idea to add pdf extension too?