### PR TITLE
cmake: Align Product Name and Bundle Name on macOS

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -175,12 +175,14 @@ build() {
       if [[ ${GITHUB_EVENT_NAME} == push && ${GITHUB_REF_NAME} =~ [0-9]+.[0-9]+.[0-9]+(-(rc|beta).+)? ]] {
         run_xcodebuild ${archive_args}
         run_xcodebuild ${export_args}
+
+        mv "OBS Studio.app" OBS.app
       } else {
         run_xcodebuild ${build_args}
 
         rm -rf OBS.app
         mkdir OBS.app
-        ditto UI/${config}/OBS.app OBS.app
+        ditto "UI/${config}/OBS Studio.app" OBS.app
       }
       popd
       ;;

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -50,7 +50,7 @@ function(set_target_properties_obs target)
     if(target STREQUAL obs-studio)
       set_target_properties(
         ${target}
-        PROPERTIES OUTPUT_NAME OBS
+        PROPERTIES OUTPUT_NAME "OBS Studio"
                    MACOSX_BUNDLE TRUE
                    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/cmake/macos/Info.plist.in"
                    XCODE_EMBED_FRAMEWORKS_REMOVE_HEADERS_ON_COPY YES
@@ -62,7 +62,7 @@ function(set_target_properties_obs target)
       set_target_xcode_properties(
         ${target}
         PROPERTIES PRODUCT_BUNDLE_IDENTIFIER com.obsproject.obs-studio
-                   PRODUCT_NAME OBS
+                   PRODUCT_NAME "OBS Studio"
                    ASSETCATALOG_COMPILER_APPICON_NAME AppIcon
                    CURRENT_PROJECT_VERSION ${OBS_BUILD_NUMBER}
                    MARKETING_VERSION ${OBS_VERSION_CANONICAL}
@@ -75,6 +75,7 @@ function(set_target_properties_obs target)
                    INFOPLIST_KEY_NSHumanReadableCopyright "(c) 2012-${CURRENT_YEAR} Lain Bailey"
                    INFOPLIST_KEY_NSCameraUsageDescription "OBS needs to access the camera to enable camera sources to work."
                    INFOPLIST_KEY_NSMicrophoneUsageDescription "OBS needs to access the microphone to enable audio input.")
+
       # cmake-format: on
 
       get_property(obs_dependencies GLOBAL PROPERTY _OBS_DEPENDENCIES)


### PR DESCRIPTION
### Description
Changes the `PRODUCT_NAME` property to "OBS Studio" to ensure `CFBundleName` in the app bundle's `Info.plist` has the value used in OBS Studio 29.

### Motivation and Context
The `CFBundleName` is used on macOS for the menu bar, Dock, LaunchPad, and task switcher. The changes to have Xcode manage the property list file automatically requires the `PRODUCT_NAME` to be set correctly for this.

Fixes https://github.com/obsproject/obs-studio/issues/9871.

### How Has This Been Tested?
Tested on macOS 14.1.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
