### PR TITLE
libobs: Use macOS specific APIs to report free disk space

### DIFF
--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -358,6 +358,31 @@ uint64_t os_get_sys_free_size(void)
     return vmstat.free_count * vm_page_size;
 }
 
+int64_t os_get_free_space(const char *path)
+{
+    if (path) {
+        NSURL *fileURL = [NSURL fileURLWithPath:@(path)];
+
+        NSDictionary *values = [fileURL resourceValuesForKeys:@[NSURLVolumeAvailableCapacityForOpportunisticUsageKey]
+                                                        error:nil];
+
+        NSNumber *availableSpace = values[NSURLVolumeAvailableCapacityForOpportunisticUsageKey];
+
+        if (availableSpace) {
+            return availableSpace.longValue;
+        }
+    }
+
+    return 0;
+}
+
+uint64_t os_get_free_disk_space(const char *dir)
+{
+    int64_t free_space = os_get_free_space(dir);
+
+    return (uint64_t) free_space;
+}
+
 static uint64_t total_memory = 0;
 static bool total_memory_initialized = false;
 

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -571,6 +571,7 @@ void os_closedir(os_dir_t *dir)
 	}
 }
 
+#ifndef __APPLE__
 int64_t os_get_free_space(const char *path)
 {
 	struct statvfs info;
@@ -581,6 +582,7 @@ int64_t os_get_free_space(const char *path)
 
 	return ret;
 }
+#endif
 
 struct posix_glob_info {
 	struct os_glob_info base;
@@ -1136,6 +1138,7 @@ uint64_t os_get_sys_total_size(void)
 }
 #endif
 
+#ifndef __APPLE__
 uint64_t os_get_free_disk_space(const char *dir)
 {
 	struct statvfs info;
@@ -1144,6 +1147,7 @@ uint64_t os_get_free_disk_space(const char *dir)
 
 	return (uint64_t)info.f_frsize * (uint64_t)info.f_bavail;
 }
+#endif
 
 char *os_generate_uuid(void)
 {


### PR DESCRIPTION
### Description
Implements macOS-specific API functions for libobs to report free disk space.

### Motivation and Context
APFS has the concept of "purgeable disk space" which is used by the OS for caches, ephemeral data and volume snapshots, which will be made available to users if they write data to disk.

As such the disk space available to users can be larger than what is actually used on the volume. macOS makes a distinction between available volume data for different types of data, for OBS it makes sense to use "Opportunistic Usage" which is defined as "nonessential resources".

This aligns the amount of free disk space with what is reported in Finder, Disk Utility, and other native applications.

Fixes https://github.com/obsproject/obs-studio/issues/9810.

### How Has This Been Tested?
Tested on macOS 14.1.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
