### PR TITLE
libobs-d3d11: Use OS D3DCompiler_47.dll

### DIFF
--- a/libobs-d3d11/CMakeLists.txt
+++ b/libobs-d3d11/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_definitions(
   libobs-d3d11 PRIVATE "$<$<BOOL:${GPU_PRIORITY_VAL}>:USE_GPU_PRIORITY>"
                        "$<IF:$<BOOL:${GPU_PRIORITY_VAL}>,GPU_PRIORITY_VAL=${GPU_PRIORITY_VAL},GPU_PRIORITY_VAL=0>")
 
-target_link_libraries(libobs-d3d11 PRIVATE OBS::libobs d3d9 d3d11 dxgi shcore)
+target_link_libraries(libobs-d3d11 PRIVATE OBS::libobs d3d9 d3d11 d3dcompiler dxgi shcore)
 
 target_enable_feature(libobs "Direct3D 11 renderer")
 

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -26,6 +26,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <d3dcompiler.h>
 
 void gs_vertex_shader::GetBuffersExpected(
 	const vector<D3D11_INPUT_ELEMENT_DESC> &inputs)
@@ -243,13 +244,13 @@ void gs_shader::Compile(const char *shaderString, const char *file,
 		streampos len = cacheFile.tellg();
 		cacheFile.seekg(0, ios::beg);
 
-		device->d3dCreateBlob(len, shader);
+		D3DCreateBlob(len, shader);
 		cacheFile.read((char *)(*shader)->GetBufferPointer(), len);
 	} else {
-		hr = device->d3dCompile(shaderString, strlen(shaderString),
-					file, NULL, NULL, "main", target,
-					D3D10_SHADER_OPTIMIZATION_LEVEL3, 0,
-					shader, errorsBlob.Assign());
+		hr = D3DCompile(shaderString, strlen(shaderString), file, NULL,
+				NULL, "main", target,
+				D3D10_SHADER_OPTIMIZATION_LEVEL3, 0, shader,
+				errorsBlob.Assign());
 		if (FAILED(hr)) {
 			if (errorsBlob != NULL && errorsBlob->GetBufferSize())
 				throw ShaderError(errorsBlob, hr);
@@ -267,12 +268,8 @@ void gs_shader::Compile(const char *shaderString, const char *file,
 #ifdef DISASSEMBLE_SHADERS
 	ComPtr<ID3D10Blob> asmBlob;
 
-	if (!device->d3dDisassemble)
-		return;
-
-	hr = device->d3dDisassemble((*shader)->GetBufferPointer(),
-				    (*shader)->GetBufferSize(), 0, nullptr,
-				    &asmBlob);
+	hr = D3DDisassemble((*shader)->GetBufferPointer(),
+			    (*shader)->GetBufferSize(), 0, nullptr, &asmBlob);
 
 	if (SUCCEEDED(hr) && !!asmBlob && asmBlob->GetBufferSize()) {
 		blog(LOG_INFO, "=============================================");

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -281,41 +281,6 @@ gs_swap_chain::~gs_swap_chain()
 		CloseHandle(hWaitable);
 }
 
-void gs_device::InitCompiler()
-{
-	char d3dcompiler[40] = {};
-	int ver = 49;
-
-	while (ver > 30) {
-		snprintf(d3dcompiler, sizeof(d3dcompiler),
-			 "D3DCompiler_%02d.dll", ver);
-
-		HMODULE module = LoadLibraryA(d3dcompiler);
-		if (module) {
-			d3dCompile = (pD3DCompile)GetProcAddress(module,
-								 "D3DCompile");
-			d3dCreateBlob = (pD3DCreateBlob)GetProcAddress(
-				module, "D3DCreateBlob");
-
-#ifdef DISASSEMBLE_SHADERS
-			d3dDisassemble = (pD3DDisassemble)GetProcAddress(
-				module, "D3DDisassemble");
-#endif
-			if (d3dCompile && d3dCreateBlob) {
-				return;
-			}
-
-			FreeLibrary(module);
-		}
-
-		ver--;
-	}
-
-	throw "Could not find any D3DCompiler libraries. Make sure you've "
-	      "installed the <a href=\"https://obsproject.com/go/dxwebsetup\">"
-	      "DirectX components</a> that OBS Studio requires.";
-}
-
 void gs_device::InitFactory()
 {
 	HRESULT hr = CreateDXGIFactory1(IID_PPV_ARGS(&factory));
@@ -994,7 +959,6 @@ gs_device::gs_device(uint32_t adapterIdx)
 		curSamplers[i] = NULL;
 	}
 
-	InitCompiler();
 	InitFactory();
 	InitAdapter(adapterIdx);
 	InitDevice(adapterIdx);

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -1055,12 +1055,6 @@ struct gs_device {
 	ID3D11BlendState *curBlendState = nullptr;
 	D3D11_PRIMITIVE_TOPOLOGY curToplogy;
 
-	pD3DCompile d3dCompile = nullptr;
-	pD3DCreateBlob d3dCreateBlob = nullptr;
-#ifdef DISASSEMBLE_SHADERS
-	pD3DDisassemble d3dDisassemble = nullptr;
-#endif
-
 	gs_rect viewport;
 
 	vector<mat4float> projStack;
@@ -1074,7 +1068,6 @@ struct gs_device {
 
 	vector<std::pair<HMONITOR, gs_monitor_color_info>> monitor_to_hdr;
 
-	void InitCompiler();
 	void InitFactory();
 	void InitAdapter(uint32_t adapterIdx);
 	void InitDevice(uint32_t adapterIdx);


### PR DESCRIPTION
### Description
OBS needs Windows 10 minimum these days, so the DLL will be there.

### Motivation and Context
Less code is better.

### How Has This Been Tested?
Able to run OBS with empty shader cache, with and without DISASSEMBLE_SHADERS defined.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.