### PR TITLE
libobs/util, libobs/media-io: Fix link error including header files from C++

### DIFF
--- a/libobs/media-io/video-frame.h
+++ b/libobs/media-io/video-frame.h
@@ -20,6 +20,10 @@
 #include "../util/bmem.h"
 #include "video-io.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct video_frame {
 	uint8_t *data[MAX_AV_PLANES];
 	uint32_t linesize[MAX_AV_PLANES];
@@ -58,3 +62,7 @@ static inline void video_frame_destroy(struct video_frame *frame)
 EXPORT void video_frame_copy(struct video_frame *dst,
 			     const struct video_frame *src,
 			     enum video_format format, uint32_t height);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libobs/util/array-serializer.h
+++ b/libobs/util/array-serializer.h
@@ -19,6 +19,10 @@
 #include "serializer.h"
 #include "darray.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct array_output_data {
 	DARRAY(uint8_t) bytes;
 };
@@ -26,3 +30,7 @@ struct array_output_data {
 EXPORT void array_output_serializer_init(struct serializer *s,
 					 struct array_output_data *data);
 EXPORT void array_output_serializer_free(struct array_output_data *data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libobs/util/crc32.h
+++ b/libobs/util/crc32.h
@@ -18,4 +18,12 @@
 
 #include "c99defs.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 EXPORT uint32_t calc_crc32(uint32_t crc, const void *buf, size_t size);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libobs/util/file-serializer.h
+++ b/libobs/util/file-serializer.h
@@ -18,6 +18,10 @@
 
 #include "serializer.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 EXPORT bool file_input_serializer_init(struct serializer *s, const char *path);
 EXPORT void file_input_serializer_free(struct serializer *s);
 
@@ -26,3 +30,7 @@ EXPORT bool file_output_serializer_init_safe(struct serializer *s,
 					     const char *path,
 					     const char *temp_ext);
 EXPORT void file_output_serializer_free(struct serializer *s);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds `extern "C" {}` to the header files under `libobs/util/` that contain extern functions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I realized it causes a link error when I include a header file `util/crc32.h` and use the function from a C++ source code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 37

In a C++ source code for an external building plugin, included `util/crc32.h` and called `calc_crc32` from a function, and build it. Then, confirmed the linker shows no error.


CI will test this won't break existing code.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
