### PR TITLE
libobs/util: Remove unused struct member from text-lookup

### DIFF
--- a/libobs/util/text-lookup.c
+++ b/libobs/util/text-lookup.c
@@ -39,7 +39,6 @@ static inline void text_item_destroy(struct text_item *item)
 /* ------------------------------------------------------------------------- */
 
 struct text_lookup {
-	struct dstr language;
 	struct text_item *items;
 };
 
@@ -263,8 +262,6 @@ void text_lookup_destroy(lookup_t *lookup)
 			HASH_DELETE(hh, lookup->items, item);
 			text_item_destroy(item);
 		}
-
-		dstr_free(&lookup->language);
 		bfree(lookup);
 	}
 }


### PR DESCRIPTION
### Description

Removes an unused dstr from this struct.

### Motivation and Context

Stumbled over it while working on some text-lookup related experiments.

### How Has This Been Tested?

Still compiled

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
