### PR TITLE
obs-ffmpeg: Initialize stopping member variable to false

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -465,6 +465,7 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 	/* write headers and start capture */
 	os_atomic_set_bool(&stream->active, true);
 	os_atomic_set_bool(&stream->capturing, true);
+	os_atomic_set_bool(&stream->stopping, false);
 	stream->total_bytes = 0;
 	obs_output_begin_data_capture(stream->output, 0);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If an output has already stopped, but its StopRecording function was called again, then ffmpeg_mux_stop would be called and set stopping to true. On the next output start, OBS would output 1 frame, see that stopping is true, and then stop the output.

This was most easily observed using an Output Timer to record prior to 93f5b45be8c8b91199c52cf7a0ab59d8c3a08760.

Initialize stopping to false with the other state flags to ensure that the output has a clean starting state.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Discovered while reviewing #9813 and investigating #6558.

Prior to 93f5b45be8c8b91199c52cf7a0ab59d8c3a08760 (#9813), you could run into this by following these Steps To Reproduce:
1. Set an Output Timer for recording. Use something like 5-10 seconds (short enough to make repeatedly running easy, long enough to distinguish it from a recording that immediately stopped).
2. Start recording.
3. Wait for the Output Timer to stop the recording.
4. Repeat Steps 2 and 3 several times until you get a recording that is only 1 frame.

You'll end up with a log snippet like this:
```
14:16:04.230: Starting recording due to OutputTimer
[...]
14:16:04.296: ==== Recording Start ===============================================
14:16:04.297: [ffmpeg muxer: 'adv_file_output'] Writing file 'C:/Videos/2023-11-20 14-16-04.mp4'...
14:16:05.489: [ffmpeg muxer: 'adv_file_output'] Output of file 'C:/Videos/2023-11-20 14-16-04.mp4' stopped
14:16:05.490: Output 'adv_file_output': stopping
14:16:05.490: Output 'adv_file_output': Total frames output: 1
14:16:05.490: Output 'adv_file_output': Total drawn frames: 36
14:16:05.503: ==== Recording Stop ================================================
14:16:14.282: Stopping recording due to OutputTimer timeout
14:16:14.282: Stopping recording due to OutputTimer timeout
14:16:14.283: Stopping recording due to OutputTimer timeout
14:16:14.283: Stopping recording due to OutputTimer timeout
14:16:14.283: Stopping recording due to OutputTimer timeout
```
See the key line:
```
14:16:05.490: Output 'adv_file_output': Total frames output: 1
```

If you look further up, the previous recording session should look something like this:
```
14:15:58.540: Stopping recording due to OutputTimer timeout
14:15:58.550: Stopping recording due to OutputTimer timeout
14:15:58.559: [ffmpeg muxer: 'adv_file_output'] Output of file 'C:/Videos/2023-11-20 14-15-48.mp4' stopped
14:15:58.559: Output 'adv_file_output': stopping
14:15:58.559: Output 'adv_file_output': Total frames output: 264
14:15:58.559: Output 'adv_file_output': Total drawn frames: 300
14:15:58.566: Stopping recording due to OutputTimer timeout
14:15:58.579: Stopping recording due to OutputTimer timeout
14:15:58.590: ==== Recording Stop ================================================
```
The key here is the "Stopping recording due to OutputTimer timeout" after "Output 'adv_file_output': stopping".

What seems to occur is that the output is stopped, but then the Output Timer calls [`OutputTimer::EventStopRecording()`](https://github.com/obsproject/obs-studio/blob/cfd8d4c993ba2b6d61541b66a8d08ed436de824d/UI/frontend-plugins/frontend-tools/output-timer.cpp#L245), which then calls `obs_frontend_recording_stop()`, which invokes `StopRecording`.
https://github.com/obsproject/obs-studio/blob/cfd8d4c993ba2b6d61541b66a8d08ed436de824d/UI/api-interface.cpp#L302-L305

Since the output has already actually stopped, the `stopping` member variable should be `false`. However, the calls to stop the output set `stopping` to `true`, and this is not cleared by the output's stopping process because the output has already stopped.
https://github.com/obsproject/obs-studio/blob/cfd8d4c993ba2b6d61541b66a8d08ed436de824d/plugins/obs-ffmpeg/obs-ffmpeg-mux.c#L535-L544

This may also fix a number of other "output recording does not stop" or "can not record after a while" issues that were actually caused by a bad output stop or teardown process.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11. Despite seeing "Stopping recording due to OutputTimer timeout" after "Output 'adv_file_output': stopping", subsequent OutputTimer invoked recording sessions do not stop early.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
