### PR TITLE
UI: Delete sentinel in aboutToQuit signal

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1437,6 +1437,9 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 #endif
 
 	setDesktopFileName("com.obsproject.Studio");
+
+	connect(this, &QCoreApplication::aboutToQuit, this,
+		&OBSApp::AppCleanup);
 }
 
 OBSApp::~OBSApp()
@@ -3270,6 +3273,11 @@ void OBSApp::ProcessSigInt(void)
 #endif
 }
 
+void OBSApp::AppCleanup()
+{
+	delete_safe_mode_sentinel();
+}
+
 int main(int argc, char *argv[])
 {
 #ifndef _WIN32
@@ -3476,7 +3484,6 @@ int main(int argc, char *argv[])
 	log_blocked_dlls();
 #endif
 
-	delete_safe_mode_sentinel();
 	blog(LOG_INFO, "Number of memory leaks: %ld", bnum_allocs());
 	base_set_log_handler(nullptr, nullptr);
 

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -134,6 +134,9 @@ private:
 	QSocketNotifier *snInt = nullptr;
 #endif
 
+private slots:
+	void AppCleanup();
+
 public:
 	OBSApp(int &argc, char **argv, profiler_name_store_t *store);
 	~OBSApp();


### PR DESCRIPTION
### Description

Moves safe mode sentinel deletion to `aboutToQuit` signal handler.

### Motivation and Context

Based on [Qt documentation recommendations](https://doc.qt.io/qt-6/qcoreapplication.html#exec) cleanup should take place at the `aboutToQuit()` signal rather than `main()` as it's not guaranteed to execute when the Windows session ends.

We ought to move other cleanup there as well (e.g. libobs shutdown, `~OBSBasic`/`~OBSApp` cleanup), but this'll do for now.

Fixes #9877

### How Has This Been Tested?

Has been tested to validate safe mode sentinel still gets deleted on regular shutdown as well as on Windows session termination (in a VM only).

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
