### PR TITLE
Add support for FFmpeg 6.1

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -114,8 +114,14 @@ static uint16_t get_max_luminance(const AVStream *stream)
 {
 	uint32_t max_luminance = 0;
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 31, 102)
 	for (int i = 0; i < stream->nb_side_data; i++) {
 		const AVPacketSideData *const sd = &stream->side_data[i];
+#else
+	for (int i = 0; i < stream->codecpar->nb_coded_side_data; i++) {
+		const AVPacketSideData *const sd =
+			&stream->codecpar->coded_side_data[i];
+#endif
 		switch (sd->type) {
 		case AV_PKT_DATA_MASTERING_DISPLAY_METADATA: {
 			const AVMasteringDisplayMetadata *mastering =

--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -504,7 +504,12 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	}
 
 	if (!m->is_local_file && !d->got_first_keyframe) {
+
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(58, 29, 100)
 		if (!f->key_frame)
+#else
+		if (!(f->flags & AV_FRAME_FLAG_KEY))
+#endif
 			return;
 
 		d->got_first_keyframe = true;

--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -91,6 +91,7 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 			return false;
 		}
 
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 31, 102)
 #if FF_API_BUFFER_SIZE_T
 		int content_size;
 #else
@@ -125,6 +126,7 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 				       mastering_size);
 			}
 		}
+#endif
 
 		ret = avcodec_parameters_copy(out_stream->codecpar,
 					      in_stream->codecpar);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -168,9 +168,17 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 			av_content_light_metadata_alloc(&content_size);
 		content->MaxCLL = hdr_nominal_peak_level;
 		content->MaxFALL = hdr_nominal_peak_level;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 31, 102)
 		av_stream_add_side_data(data->video,
 					AV_PKT_DATA_CONTENT_LIGHT_LEVEL,
 					(uint8_t *)content, content_size);
+#else
+		av_packet_side_data_add(
+			&data->video->codecpar->coded_side_data,
+			&data->video->codecpar->nb_coded_side_data,
+			AV_PKT_DATA_CONTENT_LIGHT_LEVEL, (uint8_t *)content,
+			content_size, 0);
+#endif
 
 		AVMasteringDisplayMetadata *const mastering =
 			av_mastering_display_metadata_alloc();
@@ -186,10 +194,18 @@ static bool create_video_stream(struct ffmpeg_output *stream,
 		mastering->max_luminance = av_make_q(hdr_nominal_peak_level, 1);
 		mastering->has_primaries = 1;
 		mastering->has_luminance = 1;
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(60, 31, 102)
 		av_stream_add_side_data(data->video,
 					AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
 					(uint8_t *)mastering,
 					sizeof(*mastering));
+#else
+		av_packet_side_data_add(
+			&data->video->codecpar->coded_side_data,
+			&data->video->codecpar->nb_coded_side_data,
+			AV_PKT_DATA_MASTERING_DISPLAY_METADATA,
+			(uint8_t *)mastering, sizeof(*mastering), 0);
+#endif
 	}
 	context = avcodec_alloc_context3(NULL);
 	context->codec_type = codec->type;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Deprecated FFmpeg API usage (deprecated by FFmpeg 6.1) are updated to use the [newer API as detailed here.](https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges).

~~Note that one of the commits removes code that uses the deprecated API without replacement code. This is because the metadata being copied by the removed code is handled by the latter usage of `avcodec_parameters_copy()` which copies over the metadata that is now included in `AVCodecParameters` since FFmpeg 6.1.~~

The code that is no longer necessary since FFmpeg 6.1 is now in a `#if` block. See the previous comment for details.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
On ArchLinux, the AUR package obs-studio-git fails to build due to usage of deprecated FFmpeg functions causing build fails (as the deprecation warnings are treated as errors). Currently, ArchLinux uses FFmpeg 6.1. This PR introduces changes that fix the usage of the FFmpeg API to follow the new changes that were made for FFmpeg 6.1.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I patched the PKGBUILD (file used to build ArchLinux packages) to use the new changes and built and installed obs-studio on my machine. I tested recording the screen and obs-studio was able to record and stop without issue, and reported no memory leaks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) (addresses https://github.com/obsproject/obs-studio/issues/9841 )
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Note that these changes would probably fail to build with any version of FFmpeg less than version 6.1.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

Not sure if documentation is required for this change, so it is left unchecked for now.