### PR TITLE
Rename `circlebuf` to `deque`

### DIFF
--- a/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.hpp
+++ b/UI/frontend-plugins/frontend-tools/captions-mssapi-stream.hpp
@@ -6,18 +6,18 @@
 #include <mutex>
 #include <vector>
 #include <obs.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/windows/WinHandle.hpp>
 
 #include <fstream>
 
-class CircleBuf {
-	circlebuf buf = {};
+class Deque {
+	deque buf = {};
 
 public:
-	inline ~CircleBuf() { circlebuf_free(&buf); }
-	inline operator circlebuf *() { return &buf; }
-	inline circlebuf *operator->() { return &buf; }
+	inline ~Deque() { deque_free(&buf); }
+	inline operator deque *() { return &buf; }
+	inline deque *operator->() { return &buf; }
 };
 
 class mssapi_captions;
@@ -36,7 +36,7 @@ class CaptionStream : public ISpAudio {
 	std::vector<int16_t> temp_buf;
 	WAVEFORMATEX format = {};
 
-	CircleBuf buf;
+	Deque buf;
 	ULONG wait_size = 0;
 	DWORD samplerate = 0;
 	ULARGE_INTEGER pos = {};

--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -239,7 +239,7 @@ void mp_decode_clear_packets(struct mp_decode *d)
 
 	while (d->packets.size) {
 		AVPacket *pkt;
-		circlebuf_pop_front(&d->packets, &pkt, sizeof(pkt));
+		deque_pop_front(&d->packets, &pkt, sizeof(pkt));
 		mp_media_free_packet(d->m, pkt);
 	}
 }
@@ -247,7 +247,7 @@ void mp_decode_clear_packets(struct mp_decode *d)
 void mp_decode_free(struct mp_decode *d)
 {
 	mp_decode_clear_packets(d);
-	circlebuf_free(&d->packets);
+	deque_free(&d->packets);
 
 	av_packet_free(&d->pkt);
 	av_packet_free(&d->orig_pkt);
@@ -274,7 +274,7 @@ void mp_decode_free(struct mp_decode *d)
 
 void mp_decode_push_packet(struct mp_decode *decode, AVPacket *packet)
 {
-	circlebuf_push_back(&decode->packets, &packet, sizeof(packet));
+	deque_push_back(&decode->packets, &packet, sizeof(packet));
 }
 
 static inline int64_t get_estimated_duration(struct mp_decode *d,
@@ -376,8 +376,8 @@ bool mp_decode_next(struct mp_decode *d)
 				}
 			} else {
 				mp_media_free_packet(d->m, d->orig_pkt);
-				circlebuf_pop_front(&d->packets, &d->orig_pkt,
-						    sizeof(d->orig_pkt));
+				deque_pop_front(&d->packets, &d->orig_pkt,
+						sizeof(d->orig_pkt));
 				av_packet_ref(d->pkt, d->orig_pkt);
 				d->packet_pending = true;
 			}

--- a/deps/media-playback/media-playback/decode.h
+++ b/deps/media-playback/media-playback/decode.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-#include <util/circlebuf.h>
+#include <util/deque.h>
 
 #ifdef _MSC_VER
 #pragma warning(push)
@@ -69,7 +69,7 @@ struct mp_decode {
 	AVPacket *orig_pkt;
 	AVPacket *pkt;
 	bool packet_pending;
-	struct circlebuf packets;
+	struct deque packets;
 };
 
 extern bool mp_decode_init(struct mp_media *media, enum AVMediaType type,

--- a/docs/sphinx/reference-libobs-util-circlebuf.rst
+++ b/docs/sphinx/reference-libobs-util-circlebuf.rst
@@ -4,6 +4,8 @@ Circular Buffers
 A circular buffer that will automatically increase in size as necessary
 as data is pushed to the front or back.
 
+.. deprecated:: 3X.0
+
 .. code:: cpp
 
    #include <util/circlebuf.h>

--- a/docs/sphinx/reference-libobs-util-deque.rst
+++ b/docs/sphinx/reference-libobs-util-deque.rst
@@ -1,0 +1,158 @@
+Double-Ended Queue
+==================
+
+A double-ended queue (deque) that will automatically increase in size as necessary
+as data is pushed to the front or back.
+
+.. code:: cpp
+
+   #include <util/deque.h>
+
+
+Deque Structure (struct deque)
+--------------------------------------------
+
+.. struct:: deque
+.. member:: void   *deque.data
+.. member:: size_t deque.size
+.. member:: size_t deque.start_pos
+.. member:: size_t deque.end_pos
+.. member:: size_t deque.capacity
+
+
+Deque Inline Functions
+--------------------------------
+
+.. function:: void deque_init(struct deque *dq)
+
+   Initializes a deque (just zeroes out the entire structure).
+
+   :param dq: The deque
+
+---------------------
+
+.. function:: void deque_free(struct deque *dq)
+
+   Frees a deque.
+
+   :param dq: The deque
+
+---------------------
+
+.. function:: void deque_reserve(struct deque *dq, size_t capacity)
+
+   Reserves a specific amount of buffer space to ensure minimum
+   upsizing.
+
+   :param dq:       The deque
+   :param capacity: The new capacity, in bytes
+
+---------------------
+
+.. function:: void deque_upsize(struct deque *dq, size_t size)
+
+   Sets the current active (not just reserved) size.  Any new data is
+   zeroed.
+
+   :param dq:       The deque
+   :param size:     The new size, in bytes
+
+---------------------
+
+.. function:: void deque_place(struct deque *dq, size_t position, const void *data, size_t size)
+
+   Places data at a specific positional index (relative to the starting
+   point) within the deque.
+
+   :param dq:       The deque
+   :param position: Positional index relative to starting point
+   :param data:     Data to insert
+   :param size:     Size of data to insert
+
+---------------------
+
+.. function:: void deque_push_back(struct deque *dq, const void *data, size_t size)
+
+   Pushes data to the end of the deque.
+
+   :param dq:       The deque
+   :param data:     Data
+   :param size:     Size of data
+
+---------------------
+
+.. function:: void deque_push_front(struct deque *dq, const void *data, size_t size)
+
+   Pushes data to the front of the deque.
+
+   :param dq:       The deque
+   :param data:     Data
+   :param size:     Size of data
+
+---------------------
+
+.. function:: void deque_push_back_zero(struct deque *dq, size_t size)
+
+   Pushes zeroed data to the end of the deque.
+
+   :param dq:       The deque
+   :param size:     Size
+
+---------------------
+
+.. function:: void deque_push_front_zero(struct deque *dq, size_t size)
+
+   Pushes zeroed data to the front of the deque.
+
+   :param dq:       The deque
+   :param size:     Size
+
+---------------------
+
+.. function:: void deque_peek_front(struct deque *dq, void *data, size_t size)
+
+   Peeks data at the front of the deque.
+
+   :param dq:       The deque
+   :param data:     Buffer to store data in
+   :param size:     Size of data to retrieve
+
+---------------------
+
+.. function:: void deque_peek_back(struct deque *dq, void *data, size_t size)
+
+   Peeks data at the back of the deque.
+
+   :param dq:       The deque
+   :param data:     Buffer to store data in
+   :param size:     Size of data to retrieve
+
+---------------------
+
+.. function:: void deque_pop_front(struct deque *dq, void *data, size_t size)
+
+   Pops data from the front of the deque.
+
+   :param dq:       The deque
+   :param data:     Buffer to store data in, or *NULL*
+   :param size:     Size of data to retrieve
+
+---------------------
+
+.. function:: void deque_pop_back(struct deque *dq, void *data, size_t size)
+
+   Pops data from the back of the deque.
+
+   :param dq:       The deque
+   :param data:     Buffer to store data in, or *NULL*
+   :param size:     Size of data to retrieve
+
+---------------------
+
+.. function:: void *deque_data(struct deque *dq, size_t idx)
+
+   Gets a direct pointer to data at a specific positional index within
+   the deque, relative to the starting point.
+
+   :param dq:       The deque
+   :param idx:      Byte index relative to the starting point

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -114,6 +114,7 @@ target_sources(
           util/crc32.h
           util/curl/curl-helper.h
           util/darray.h
+          util/deque.h
           util/dstr.c
           util/dstr.h
           util/file-serializer.c
@@ -343,6 +344,7 @@ set(public_headers
     util/config-file.h
     util/crc32.h
     util/darray.h
+    util/deque.h
     util/dstr.h
     util/dstr.hpp
     util/file-serializer.h

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -4,7 +4,7 @@
 #include <CoreAudio/CoreAudio.h>
 
 #include "../../media-io/audio-resampler.h"
-#include "../../util/circlebuf.h"
+#include "../../util/deque.h"
 #include "../../util/threading.h"
 #include "../../util/platform.h"
 #include "../../obs-internal.h"
@@ -18,8 +18,8 @@ struct audio_monitor {
 	AudioQueueBufferRef buffers[3];
 
 	pthread_mutex_t mutex;
-	struct circlebuf empty_buffers;
-	struct circlebuf new_data;
+	struct deque empty_buffers;
+	struct deque new_data;
 	audio_resampler_t *resampler;
 	size_t buffer_size;
 	size_t wait_size;
@@ -39,9 +39,9 @@ static inline bool fill_buffer(struct audio_monitor *monitor)
 		return false;
 	}
 
-	circlebuf_pop_front(&monitor->empty_buffers, &buf, sizeof(buf));
-	circlebuf_pop_front(&monitor->new_data, buf->mAudioData,
-			    monitor->buffer_size);
+	deque_pop_front(&monitor->empty_buffers, &buf, sizeof(buf));
+	deque_pop_front(&monitor->new_data, buf->mAudioData,
+			monitor->buffer_size);
 
 	buf->mAudioDataByteSize = (UInt32)monitor->buffer_size;
 
@@ -59,7 +59,7 @@ static void on_audio_pause(void *data, calldata_t *calldata)
 	UNUSED_PARAMETER(calldata);
 	struct audio_monitor *monitor = data;
 	pthread_mutex_lock(&monitor->mutex);
-	circlebuf_free(&monitor->new_data);
+	deque_free(&monitor->new_data);
 	pthread_mutex_unlock(&monitor->mutex);
 }
 
@@ -108,7 +108,7 @@ static void on_audio_playback(void *param, obs_source_t *source,
 	}
 
 	pthread_mutex_lock(&monitor->mutex);
-	circlebuf_push_back(&monitor->new_data, resample_data[0], bytes);
+	deque_push_back(&monitor->new_data, resample_data[0], bytes);
 
 	if (monitor->new_data.size >= monitor->wait_size) {
 		monitor->wait_size = 0;
@@ -133,7 +133,7 @@ static void buffer_audio(void *data, AudioQueueRef aq, AudioQueueBufferRef buf)
 	struct audio_monitor *monitor = data;
 
 	pthread_mutex_lock(&monitor->mutex);
-	circlebuf_push_back(&monitor->empty_buffers, &buf, sizeof(buf));
+	deque_push_back(&monitor->empty_buffers, &buf, sizeof(buf));
 	while (monitor->empty_buffers.size > 0) {
 		if (!fill_buffer(monitor)) {
 			break;
@@ -231,9 +231,8 @@ static bool audio_monitor_init(struct audio_monitor *monitor,
 			return false;
 		}
 
-		circlebuf_push_back(&monitor->empty_buffers,
-				    &monitor->buffers[i],
-				    sizeof(monitor->buffers[i]));
+		deque_push_back(&monitor->empty_buffers, &monitor->buffers[i],
+				sizeof(monitor->buffers[i]));
 	}
 
 	if (pthread_mutex_init(&monitor->mutex, NULL) != 0) {
@@ -287,8 +286,8 @@ static void audio_monitor_free(struct audio_monitor *monitor)
 	}
 
 	audio_resampler_destroy(monitor->resampler);
-	circlebuf_free(&monitor->empty_buffers);
-	circlebuf_free(&monitor->new_data);
+	deque_free(&monitor->empty_buffers);
+	deque_free(&monitor->new_data);
 	pthread_mutex_destroy(&monitor->mutex);
 }
 

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -185,6 +185,7 @@ target_sources(
           util/config-file.h
           util/crc32.c
           util/crc32.h
+          util/deque.h
           util/dstr.c
           util/dstr.h
           util/file-serializer.c

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -20,7 +20,7 @@
 
 #include "../util/threading.h"
 #include "../util/darray.h"
-#include "../util/circlebuf.h"
+#include "../util/deque.h"
 #include "../util/platform.h"
 #include "../util/profiler.h"
 #include "../util/util_uint64.h"

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -19,7 +19,7 @@
 
 #include "util/c99defs.h"
 #include "util/darray.h"
-#include "util/circlebuf.h"
+#include "util/deque.h"
 #include "util/dstr.h"
 #include "util/threading.h"
 #include "util/platform.h"
@@ -281,8 +281,8 @@ struct obs_core_video_mix {
 	bool texture_converted;
 	bool using_nv12_tex;
 	bool using_p010_tex;
-	struct circlebuf vframe_info_buffer;
-	struct circlebuf vframe_info_buffer_gpu;
+	struct deque vframe_info_buffer;
+	struct deque vframe_info_buffer_gpu;
 	gs_stagesurf_t *mapped_surfaces[NUM_CHANNELS];
 	int cur_texture;
 	volatile long raw_active;
@@ -291,8 +291,8 @@ struct obs_core_video_mix {
 	bool raw_was_active;
 	bool was_active;
 	pthread_mutex_t gpu_encoder_mutex;
-	struct circlebuf gpu_encoder_queue;
-	struct circlebuf gpu_encoder_avail_queue;
+	struct deque gpu_encoder_queue;
+	struct deque gpu_encoder_avail_queue;
 	DARRAY(obs_encoder_t *) gpu_encoders;
 	os_sem_t *gpu_encode_semaphore;
 	os_event_t *gpu_encode_inactive;
@@ -359,7 +359,7 @@ struct obs_core_video {
 	float hdr_nominal_peak_level;
 
 	pthread_mutex_t task_mutex;
-	struct circlebuf tasks;
+	struct deque tasks;
 
 	pthread_mutex_t mixes_mutex;
 	DARRAY(struct obs_core_video_mix *) mixes;
@@ -375,7 +375,7 @@ struct obs_core_audio {
 	DARRAY(struct obs_source *) root_nodes;
 
 	uint64_t buffered_ts;
-	struct circlebuf buffered_timestamps;
+	struct deque buffered_timestamps;
 	uint64_t buffering_wait_ticks;
 	int total_buffering_ticks;
 	int max_buffering_ticks;
@@ -387,7 +387,7 @@ struct obs_core_audio {
 	char *monitoring_device_id;
 
 	pthread_mutex_t task_mutex;
-	struct circlebuf tasks;
+	struct deque tasks;
 };
 
 /* user sources, output channels, and displays */
@@ -768,7 +768,7 @@ struct obs_source {
 	struct obs_source *next_audio_source;
 	struct obs_source **prev_next_audio_source;
 	uint64_t audio_ts;
-	struct circlebuf audio_input_buf[MAX_AUDIO_CHANNELS];
+	struct deque audio_input_buf[MAX_AUDIO_CHANNELS];
 	size_t last_audio_input_buf_size;
 	DARRAY(struct audio_action) audio_actions;
 	float *audio_output_buf[MAX_AUDIO_MIXES][MAX_AUDIO_CHANNELS];
@@ -1136,7 +1136,7 @@ struct obs_output {
 
 	struct pause_data pause;
 
-	struct circlebuf audio_buffer[MAX_AUDIO_MIXES][MAX_AV_PLANES];
+	struct deque audio_buffer[MAX_AUDIO_MIXES][MAX_AV_PLANES];
 	uint64_t audio_start_ts;
 	uint64_t video_start_ts;
 	size_t audio_size;
@@ -1157,13 +1157,13 @@ struct obs_output {
 	struct caption_text *caption_head;
 	struct caption_text *caption_tail;
 
-	struct circlebuf caption_data;
+	struct deque caption_data;
 
 	bool valid;
 
 	uint64_t active_delay_ns;
 	encoded_callback_t delay_callback;
-	struct circlebuf delay_data; /* struct delay_data */
+	struct deque delay_data; /* struct delay_data */
 	pthread_mutex_t delay_mutex;
 	uint32_t delay_sec;
 	uint32_t delay_flags;
@@ -1270,7 +1270,7 @@ struct obs_encoder {
 
 	int64_t cur_pts;
 
-	struct circlebuf audio_input_buffer[MAX_AV_PLANES];
+	struct deque audio_input_buffer[MAX_AV_PLANES];
 	uint8_t *audio_output_buffer[MAX_AV_PLANES];
 
 	/* if a video encoder is paired with an audio encoder, make it start

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -487,9 +487,9 @@ static inline bool queue_frame(struct obs_core_video_mix *video,
 		(video->gpu_encoder_queue.size && vframe_info->count > 1);
 
 	if (duplicate) {
-		struct obs_tex_frame *tf = circlebuf_data(
-			&video->gpu_encoder_queue,
-			video->gpu_encoder_queue.size - sizeof(*tf));
+		struct obs_tex_frame *tf =
+			deque_data(&video->gpu_encoder_queue,
+				   video->gpu_encoder_queue.size - sizeof(*tf));
 
 		/* texture-based encoding is stopping */
 		if (!tf) {
@@ -502,7 +502,7 @@ static inline bool queue_frame(struct obs_core_video_mix *video,
 	}
 
 	struct obs_tex_frame tf;
-	circlebuf_pop_front(&video->gpu_encoder_avail_queue, &tf, sizeof(tf));
+	deque_pop_front(&video->gpu_encoder_avail_queue, &tf, sizeof(tf));
 
 	if (tf.released) {
 		gs_texture_acquire_sync(tf.tex, tf.lock_key, GS_WAIT_INFINITE);
@@ -531,7 +531,7 @@ static inline bool queue_frame(struct obs_core_video_mix *video,
 	tf.released = true;
 	tf.handle = gs_texture_get_shared_handle(tf.tex);
 	gs_texture_release_sync(tf.tex, ++tf.lock_key);
-	circlebuf_push_back(&video->gpu_encoder_queue, &tf, sizeof(tf));
+	deque_push_back(&video->gpu_encoder_queue, &tf, sizeof(tf));
 
 	os_sem_post(video->gpu_encode_semaphore);
 
@@ -560,8 +560,8 @@ static void output_gpu_encoders(struct obs_core_video_mix *video,
 		goto end;
 
 	struct obs_vframe_info vframe_info;
-	circlebuf_pop_front(&video->vframe_info_buffer_gpu, &vframe_info,
-			    sizeof(vframe_info));
+	deque_pop_front(&video->vframe_info_buffer_gpu, &vframe_info,
+			sizeof(vframe_info));
 
 	pthread_mutex_lock(&video->gpu_encoder_mutex);
 	encode_gpu(video, raw_active, &vframe_info);
@@ -915,11 +915,11 @@ static inline void video_sleep(struct obs_core_video *video, uint64_t *p_time,
 		bool gpu_active = video->gpu_was_active;
 
 		if (raw_active)
-			circlebuf_push_back(&video->vframe_info_buffer,
-					    &vframe_info, sizeof(vframe_info));
+			deque_push_back(&video->vframe_info_buffer,
+					&vframe_info, sizeof(vframe_info));
 		if (gpu_active)
-			circlebuf_push_back(&video->vframe_info_buffer_gpu,
-					    &vframe_info, sizeof(vframe_info));
+			deque_push_back(&video->vframe_info_buffer_gpu,
+					&vframe_info, sizeof(vframe_info));
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }
@@ -967,8 +967,8 @@ static inline void output_frame(struct obs_core_video_mix *video)
 
 	if (raw_active && frame_ready) {
 		struct obs_vframe_info vframe_info;
-		circlebuf_pop_front(&video->vframe_info_buffer, &vframe_info,
-				    sizeof(vframe_info));
+		deque_pop_front(&video->vframe_info_buffer, &vframe_info,
+				sizeof(vframe_info));
 
 		frame.timestamp = vframe_info.timestamp;
 		profile_start(output_frame_output_video_data_name);
@@ -1004,20 +1004,20 @@ static void clear_base_frame_data(struct obs_core_video_mix *video)
 {
 	video->texture_rendered = false;
 	video->texture_converted = false;
-	circlebuf_free(&video->vframe_info_buffer);
+	deque_free(&video->vframe_info_buffer);
 	video->cur_texture = 0;
 }
 
 static void clear_raw_frame_data(struct obs_core_video_mix *video)
 {
 	memset(video->textures_copied, 0, sizeof(video->textures_copied));
-	circlebuf_free(&video->vframe_info_buffer);
+	deque_free(&video->vframe_info_buffer);
 }
 
 #ifdef _WIN32
 static void clear_gpu_frame_data(struct obs_core_video_mix *video)
 {
-	circlebuf_free(&video->vframe_info_buffer_gpu);
+	deque_free(&video->vframe_info_buffer_gpu);
 }
 #endif
 
@@ -1032,7 +1032,7 @@ static void execute_graphics_tasks(void)
 		pthread_mutex_lock(&video->task_mutex);
 		if (video->tasks.size) {
 			struct obs_task_info info;
-			circlebuf_pop_front(&video->tasks, &info, sizeof(info));
+			deque_pop_front(&video->tasks, &info, sizeof(info));
 			info.task(info.param);
 		}
 		tasks_remaining = !!video->tasks.size;

--- a/libobs/util/circlebuf.h
+++ b/libobs/util/circlebuf.h
@@ -29,7 +29,7 @@ extern "C" {
 
 /* Dynamic circular buffer */
 
-struct circlebuf {
+OBS_DEPRECATED struct circlebuf {
 	void *data;
 	size_t size;
 
@@ -38,19 +38,19 @@ struct circlebuf {
 	size_t capacity;
 };
 
-static inline void circlebuf_init(struct circlebuf *cb)
+OBS_DEPRECATED static inline void circlebuf_init(struct circlebuf *cb)
 {
 	memset(cb, 0, sizeof(struct circlebuf));
 }
 
-static inline void circlebuf_free(struct circlebuf *cb)
+OBS_DEPRECATED static inline void circlebuf_free(struct circlebuf *cb)
 {
 	bfree(cb->data);
 	memset(cb, 0, sizeof(struct circlebuf));
 }
 
-static inline void circlebuf_reorder_data(struct circlebuf *cb,
-					  size_t new_capacity)
+OBS_DEPRECATED static inline void circlebuf_reorder_data(struct circlebuf *cb,
+							 size_t new_capacity)
 {
 	size_t difference;
 	uint8_t *data;
@@ -64,7 +64,8 @@ static inline void circlebuf_reorder_data(struct circlebuf *cb,
 	cb->start_pos += difference;
 }
 
-static inline void circlebuf_ensure_capacity(struct circlebuf *cb)
+OBS_DEPRECATED static inline void
+circlebuf_ensure_capacity(struct circlebuf *cb)
 {
 	size_t new_capacity;
 	if (cb->size <= cb->capacity)
@@ -79,7 +80,8 @@ static inline void circlebuf_ensure_capacity(struct circlebuf *cb)
 	cb->capacity = new_capacity;
 }
 
-static inline void circlebuf_reserve(struct circlebuf *cb, size_t capacity)
+OBS_DEPRECATED static inline void circlebuf_reserve(struct circlebuf *cb,
+						    size_t capacity)
 {
 	if (capacity <= cb->capacity)
 		return;
@@ -89,7 +91,8 @@ static inline void circlebuf_reserve(struct circlebuf *cb, size_t capacity)
 	cb->capacity = capacity;
 }
 
-static inline void circlebuf_upsize(struct circlebuf *cb, size_t size)
+OBS_DEPRECATED static inline void circlebuf_upsize(struct circlebuf *cb,
+						   size_t size)
 {
 	size_t add_size = size - cb->size;
 	size_t new_end_pos = cb->end_pos + add_size;
@@ -117,8 +120,9 @@ static inline void circlebuf_upsize(struct circlebuf *cb, size_t size)
 }
 
 /** Overwrites data at a specific point in the buffer (relative).  */
-static inline void circlebuf_place(struct circlebuf *cb, size_t position,
-				   const void *data, size_t size)
+OBS_DEPRECATED static inline void circlebuf_place(struct circlebuf *cb,
+						  size_t position,
+						  const void *data, size_t size)
 {
 	size_t end_point = position + size;
 	size_t data_end_pos;
@@ -142,8 +146,8 @@ static inline void circlebuf_place(struct circlebuf *cb, size_t position,
 	}
 }
 
-static inline void circlebuf_push_back(struct circlebuf *cb, const void *data,
-				       size_t size)
+OBS_DEPRECATED static inline void
+circlebuf_push_back(struct circlebuf *cb, const void *data, size_t size)
 {
 	size_t new_end_pos = cb->end_pos + size;
 
@@ -167,8 +171,8 @@ static inline void circlebuf_push_back(struct circlebuf *cb, const void *data,
 	cb->end_pos = new_end_pos;
 }
 
-static inline void circlebuf_push_front(struct circlebuf *cb, const void *data,
-					size_t size)
+OBS_DEPRECATED static inline void
+circlebuf_push_front(struct circlebuf *cb, const void *data, size_t size)
 {
 	cb->size += size;
 	circlebuf_ensure_capacity(cb);
@@ -193,7 +197,8 @@ static inline void circlebuf_push_front(struct circlebuf *cb, const void *data,
 	}
 }
 
-static inline void circlebuf_push_back_zero(struct circlebuf *cb, size_t size)
+OBS_DEPRECATED static inline void circlebuf_push_back_zero(struct circlebuf *cb,
+							   size_t size)
 {
 	size_t new_end_pos = cb->end_pos + size;
 
@@ -216,7 +221,8 @@ static inline void circlebuf_push_back_zero(struct circlebuf *cb, size_t size)
 	cb->end_pos = new_end_pos;
 }
 
-static inline void circlebuf_push_front_zero(struct circlebuf *cb, size_t size)
+OBS_DEPRECATED static inline void
+circlebuf_push_front_zero(struct circlebuf *cb, size_t size)
 {
 	cb->size += size;
 	circlebuf_ensure_capacity(cb);
@@ -240,8 +246,8 @@ static inline void circlebuf_push_front_zero(struct circlebuf *cb, size_t size)
 	}
 }
 
-static inline void circlebuf_peek_front(struct circlebuf *cb, void *data,
-					size_t size)
+OBS_DEPRECATED static inline void circlebuf_peek_front(struct circlebuf *cb,
+						       void *data, size_t size)
 {
 	assert(size <= cb->size);
 
@@ -259,8 +265,8 @@ static inline void circlebuf_peek_front(struct circlebuf *cb, void *data,
 	}
 }
 
-static inline void circlebuf_peek_back(struct circlebuf *cb, void *data,
-				       size_t size)
+OBS_DEPRECATED static inline void circlebuf_peek_back(struct circlebuf *cb,
+						      void *data, size_t size)
 {
 	assert(size <= cb->size);
 
@@ -282,8 +288,8 @@ static inline void circlebuf_peek_back(struct circlebuf *cb, void *data,
 	}
 }
 
-static inline void circlebuf_pop_front(struct circlebuf *cb, void *data,
-				       size_t size)
+OBS_DEPRECATED static inline void circlebuf_pop_front(struct circlebuf *cb,
+						      void *data, size_t size)
 {
 	circlebuf_peek_front(cb, data, size);
 
@@ -298,8 +304,8 @@ static inline void circlebuf_pop_front(struct circlebuf *cb, void *data,
 		cb->start_pos -= cb->capacity;
 }
 
-static inline void circlebuf_pop_back(struct circlebuf *cb, void *data,
-				      size_t size)
+OBS_DEPRECATED static inline void circlebuf_pop_back(struct circlebuf *cb,
+						     void *data, size_t size)
 {
 	circlebuf_peek_back(cb, data, size);
 
@@ -315,7 +321,8 @@ static inline void circlebuf_pop_back(struct circlebuf *cb, void *data,
 		cb->end_pos -= size;
 }
 
-static inline void *circlebuf_data(struct circlebuf *cb, size_t idx)
+OBS_DEPRECATED static inline void *circlebuf_data(struct circlebuf *cb,
+						  size_t idx)
 {
 	uint8_t *ptr = (uint8_t *)cb->data;
 	size_t offset = cb->start_pos + idx;

--- a/libobs/util/deque.h
+++ b/libobs/util/deque.h
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2023 Lain Bailey <lain@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include "c99defs.h"
+#include <string.h>
+#include <stdlib.h>
+#include <assert.h>
+
+#include "bmem.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Double-ended Queue */
+
+struct deque {
+	void *data;
+	size_t size;
+
+	size_t start_pos;
+	size_t end_pos;
+	size_t capacity;
+};
+
+static inline void deque_init(struct deque *dq)
+{
+	memset(dq, 0, sizeof(struct deque));
+}
+
+static inline void deque_free(struct deque *dq)
+{
+	bfree(dq->data);
+	memset(dq, 0, sizeof(struct deque));
+}
+
+static inline void deque_reorder_data(struct deque *dq, size_t new_capacity)
+{
+	size_t difference;
+	uint8_t *data;
+
+	if (!dq->size || !dq->start_pos || dq->end_pos > dq->start_pos)
+		return;
+
+	difference = new_capacity - dq->capacity;
+	data = (uint8_t *)dq->data + dq->start_pos;
+	memmove(data + difference, data, dq->capacity - dq->start_pos);
+	dq->start_pos += difference;
+}
+
+static inline void deque_ensure_capacity(struct deque *dq)
+{
+	size_t new_capacity;
+	if (dq->size <= dq->capacity)
+		return;
+
+	new_capacity = dq->capacity * 2;
+	if (dq->size > new_capacity)
+		new_capacity = dq->size;
+
+	dq->data = brealloc(dq->data, new_capacity);
+	deque_reorder_data(dq, new_capacity);
+	dq->capacity = new_capacity;
+}
+
+static inline void deque_reserve(struct deque *dq, size_t capacity)
+{
+	if (capacity <= dq->capacity)
+		return;
+
+	dq->data = brealloc(dq->data, capacity);
+	deque_reorder_data(dq, capacity);
+	dq->capacity = capacity;
+}
+
+static inline void deque_upsize(struct deque *dq, size_t size)
+{
+	size_t add_size = size - dq->size;
+	size_t new_end_pos = dq->end_pos + add_size;
+
+	if (size <= dq->size)
+		return;
+
+	dq->size = size;
+	deque_ensure_capacity(dq);
+
+	if (new_end_pos > dq->capacity) {
+		size_t back_size = dq->capacity - dq->end_pos;
+		size_t loop_size = add_size - back_size;
+
+		if (back_size)
+			memset((uint8_t *)dq->data + dq->end_pos, 0, back_size);
+
+		memset(dq->data, 0, loop_size);
+		new_end_pos -= dq->capacity;
+	} else {
+		memset((uint8_t *)dq->data + dq->end_pos, 0, add_size);
+	}
+
+	dq->end_pos = new_end_pos;
+}
+
+/** Overwrites data at a specific point in the buffer (relative).  */
+static inline void deque_place(struct deque *dq, size_t position,
+			       const void *data, size_t size)
+{
+	size_t end_point = position + size;
+	size_t data_end_pos;
+
+	if (end_point > dq->size)
+		deque_upsize(dq, end_point);
+
+	position += dq->start_pos;
+	if (position >= dq->capacity)
+		position -= dq->capacity;
+
+	data_end_pos = position + size;
+	if (data_end_pos > dq->capacity) {
+		size_t back_size = data_end_pos - dq->capacity;
+		size_t loop_size = size - back_size;
+
+		memcpy((uint8_t *)dq->data + position, data, loop_size);
+		memcpy(dq->data, (uint8_t *)data + loop_size, back_size);
+	} else {
+		memcpy((uint8_t *)dq->data + position, data, size);
+	}
+}
+
+static inline void deque_push_back(struct deque *dq, const void *data,
+				   size_t size)
+{
+	size_t new_end_pos = dq->end_pos + size;
+
+	dq->size += size;
+	deque_ensure_capacity(dq);
+
+	if (new_end_pos > dq->capacity) {
+		size_t back_size = dq->capacity - dq->end_pos;
+		size_t loop_size = size - back_size;
+
+		if (back_size)
+			memcpy((uint8_t *)dq->data + dq->end_pos, data,
+			       back_size);
+		memcpy(dq->data, (uint8_t *)data + back_size, loop_size);
+
+		new_end_pos -= dq->capacity;
+	} else {
+		memcpy((uint8_t *)dq->data + dq->end_pos, data, size);
+	}
+
+	dq->end_pos = new_end_pos;
+}
+
+static inline void deque_push_front(struct deque *dq, const void *data,
+				    size_t size)
+{
+	dq->size += size;
+	deque_ensure_capacity(dq);
+
+	if (dq->size == size) {
+		dq->start_pos = 0;
+		dq->end_pos = size;
+		memcpy((uint8_t *)dq->data, data, size);
+
+	} else if (dq->start_pos < size) {
+		size_t back_size = size - dq->start_pos;
+
+		if (dq->start_pos)
+			memcpy(dq->data, (uint8_t *)data + back_size,
+			       dq->start_pos);
+
+		dq->start_pos = dq->capacity - back_size;
+		memcpy((uint8_t *)dq->data + dq->start_pos, data, back_size);
+	} else {
+		dq->start_pos -= size;
+		memcpy((uint8_t *)dq->data + dq->start_pos, data, size);
+	}
+}
+
+static inline void deque_push_back_zero(struct deque *dq, size_t size)
+{
+	size_t new_end_pos = dq->end_pos + size;
+
+	dq->size += size;
+	deque_ensure_capacity(dq);
+
+	if (new_end_pos > dq->capacity) {
+		size_t back_size = dq->capacity - dq->end_pos;
+		size_t loop_size = size - back_size;
+
+		if (back_size)
+			memset((uint8_t *)dq->data + dq->end_pos, 0, back_size);
+		memset(dq->data, 0, loop_size);
+
+		new_end_pos -= dq->capacity;
+	} else {
+		memset((uint8_t *)dq->data + dq->end_pos, 0, size);
+	}
+
+	dq->end_pos = new_end_pos;
+}
+
+static inline void deque_push_front_zero(struct deque *dq, size_t size)
+{
+	dq->size += size;
+	deque_ensure_capacity(dq);
+
+	if (dq->size == size) {
+		dq->start_pos = 0;
+		dq->end_pos = size;
+		memset((uint8_t *)dq->data, 0, size);
+
+	} else if (dq->start_pos < size) {
+		size_t back_size = size - dq->start_pos;
+
+		if (dq->start_pos)
+			memset(dq->data, 0, dq->start_pos);
+
+		dq->start_pos = dq->capacity - back_size;
+		memset((uint8_t *)dq->data + dq->start_pos, 0, back_size);
+	} else {
+		dq->start_pos -= size;
+		memset((uint8_t *)dq->data + dq->start_pos, 0, size);
+	}
+}
+
+static inline void deque_peek_front(struct deque *dq, void *data, size_t size)
+{
+	assert(size <= dq->size);
+
+	if (data) {
+		size_t start_size = dq->capacity - dq->start_pos;
+
+		if (start_size < size) {
+			memcpy(data, (uint8_t *)dq->data + dq->start_pos,
+			       start_size);
+			memcpy((uint8_t *)data + start_size, dq->data,
+			       size - start_size);
+		} else {
+			memcpy(data, (uint8_t *)dq->data + dq->start_pos, size);
+		}
+	}
+}
+
+static inline void deque_peek_back(struct deque *dq, void *data, size_t size)
+{
+	assert(size <= dq->size);
+
+	if (data) {
+		size_t back_size = (dq->end_pos ? dq->end_pos : dq->capacity);
+
+		if (back_size < size) {
+			size_t front_size = size - back_size;
+			size_t new_end_pos = dq->capacity - front_size;
+
+			memcpy((uint8_t *)data + (size - back_size), dq->data,
+			       back_size);
+			memcpy(data, (uint8_t *)dq->data + new_end_pos,
+			       front_size);
+		} else {
+			memcpy(data, (uint8_t *)dq->data + dq->end_pos - size,
+			       size);
+		}
+	}
+}
+
+static inline void deque_pop_front(struct deque *dq, void *data, size_t size)
+{
+	deque_peek_front(dq, data, size);
+
+	dq->size -= size;
+	if (!dq->size) {
+		dq->start_pos = dq->end_pos = 0;
+		return;
+	}
+
+	dq->start_pos += size;
+	if (dq->start_pos >= dq->capacity)
+		dq->start_pos -= dq->capacity;
+}
+
+static inline void deque_pop_back(struct deque *dq, void *data, size_t size)
+{
+	deque_peek_back(dq, data, size);
+
+	dq->size -= size;
+	if (!dq->size) {
+		dq->start_pos = dq->end_pos = 0;
+		return;
+	}
+
+	if (dq->end_pos <= size)
+		dq->end_pos = dq->capacity - (size - dq->end_pos);
+	else
+		dq->end_pos -= size;
+}
+
+static inline void *deque_data(struct deque *dq, size_t idx)
+{
+	uint8_t *ptr = (uint8_t *)dq->data;
+	size_t offset = dq->start_pos + idx;
+
+	if (idx >= dq->size)
+		return NULL;
+
+	if (offset >= dq->capacity)
+		offset -= dq->capacity;
+
+	return ptr + offset;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include <util/base.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/darray.h>
 #include <util/dstr.h>
 #include <obs-module.h>

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include <obs-module.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/threading.h>
 #include <util/dstr.h>
 #include <util/darray.h>
@@ -568,7 +568,7 @@ static void close_audio(struct ffmpeg_data *data)
 {
 	for (int idx = 0; idx < data->num_audio_streams; idx++) {
 		for (size_t i = 0; i < MAX_AV_PLANES; i++)
-			circlebuf_free(&data->excess_frames[idx][i]);
+			deque_free(&data->excess_frames[idx][i]);
 
 		if (data->samples[idx][0])
 			av_freep(&data->samples[idx][0]);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -2,7 +2,7 @@
 
 #include <obs-module.h>
 #include <obs-hotkey.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/darray.h>
 #include <util/dstr.h>
 #include <util/pipe.h>
@@ -49,7 +49,7 @@ struct ffmpeg_muxer {
 	/* these are accessed both by replay buffer and by HLS */
 	pthread_t mux_thread;
 	bool mux_thread_joinable;
-	struct circlebuf packets;
+	struct deque packets;
 
 	/* HLS only */
 	int keyint_sec;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -73,7 +73,7 @@ struct ffmpeg_data {
 
 	/* audio_tracks is a bitmask storing the indices of the mixes */
 	int audio_tracks;
-	struct circlebuf excess_frames[MAX_AUDIO_MIXES][MAX_AV_PLANES];
+	struct deque excess_frames[MAX_AUDIO_MIXES][MAX_AV_PLANES];
 	uint8_t *samples[MAX_AUDIO_MIXES][MAX_AV_PLANES];
 	AVFrame *aframe[MAX_AUDIO_MIXES];
 

--- a/plugins/obs-filters/eq-filter.c
+++ b/plugins/obs-filters/eq-filter.c
@@ -1,5 +1,5 @@
 #include <media-io/audio-math.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/darray.h>
 #include <obs-module.h>
 

--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -5,7 +5,7 @@
 #include <obs-module.h>
 #include <media-io/audio-math.h>
 #include <util/platform.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/threading.h>
 
 /* -------------------------------------------------------- */

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -1,7 +1,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/threading.h>
 #include <obs-module.h>
 
@@ -88,9 +88,9 @@ struct noise_suppress_data {
 	size_t frames;
 	size_t channels;
 
-	struct circlebuf info_buffer;
-	struct circlebuf input_buffers[MAX_PREPROC_CHANNELS];
-	struct circlebuf output_buffers[MAX_PREPROC_CHANNELS];
+	struct deque info_buffer;
+	struct deque input_buffers[MAX_PREPROC_CHANNELS];
+	struct deque output_buffers[MAX_PREPROC_CHANNELS];
 
 	bool use_rnnoise;
 	bool use_nvafx;
@@ -197,8 +197,8 @@ static void noise_suppress_destroy(void *data)
 			}
 		}
 #endif
-		circlebuf_free(&ng->input_buffers[i]);
-		circlebuf_free(&ng->output_buffers[i]);
+		deque_free(&ng->input_buffers[i]);
+		deque_free(&ng->output_buffers[i]);
 	}
 
 #ifdef LIBSPEEXDSP_ENABLED
@@ -231,7 +231,7 @@ static void noise_suppress_destroy(void *data)
 #endif
 
 	bfree(ng->copy_buffers[0]);
-	circlebuf_free(&ng->info_buffer);
+	deque_free(&ng->info_buffer);
 	da_free(ng->output_data);
 	bfree(ng);
 }
@@ -402,8 +402,8 @@ static inline void alloc_channel(struct noise_suppress_data *ng,
 #ifdef LIBRNNOISE_ENABLED
 	ng->rnn_states[channel] = rnnoise_create(NULL);
 #endif
-	circlebuf_reserve(&ng->input_buffers[channel], frames * sizeof(float));
-	circlebuf_reserve(&ng->output_buffers[channel], frames * sizeof(float));
+	deque_reserve(&ng->input_buffers[channel], frames * sizeof(float));
+	deque_reserve(&ng->output_buffers[channel], frames * sizeof(float));
 }
 
 static inline enum speaker_layout convert_speaker_layout(uint8_t channels)
@@ -1015,10 +1015,10 @@ static inline void process_nvafx(struct noise_suppress_data *ng)
 
 static inline void process(struct noise_suppress_data *ng)
 {
-	/* Pop from input circlebuf */
+	/* Pop from input deque */
 	for (size_t i = 0; i < ng->channels; i++)
-		circlebuf_pop_front(&ng->input_buffers[i], ng->copy_buffers[i],
-				    ng->frames * sizeof(float));
+		deque_pop_front(&ng->input_buffers[i], ng->copy_buffers[i],
+				ng->frames * sizeof(float));
 
 	if (ng->use_rnnoise) {
 		process_rnnoise(ng);
@@ -1030,10 +1030,10 @@ static inline void process(struct noise_suppress_data *ng)
 		process_speexdsp(ng);
 	}
 
-	/* Push to output circlebuf */
+	/* Push to output deque */
 	for (size_t i = 0; i < ng->channels; i++)
-		circlebuf_push_back(&ng->output_buffers[i], ng->copy_buffers[i],
-				    ng->frames * sizeof(float));
+		deque_push_back(&ng->output_buffers[i], ng->copy_buffers[i],
+				ng->frames * sizeof(float));
 }
 
 struct ng_audio_info {
@@ -1041,19 +1041,19 @@ struct ng_audio_info {
 	uint64_t timestamp;
 };
 
-static inline void clear_circlebuf(struct circlebuf *buf)
+static inline void clear_deque(struct deque *buf)
 {
-	circlebuf_pop_front(buf, NULL, buf->size);
+	deque_pop_front(buf, NULL, buf->size);
 }
 
 static void reset_data(struct noise_suppress_data *ng)
 {
 	for (size_t i = 0; i < ng->channels; i++) {
-		clear_circlebuf(&ng->input_buffers[i]);
-		clear_circlebuf(&ng->output_buffers[i]);
+		clear_deque(&ng->input_buffers[i]);
+		clear_deque(&ng->output_buffers[i]);
 	}
 
-	clear_circlebuf(&ng->info_buffer);
+	clear_deque(&ng->info_buffer);
 }
 
 static struct obs_audio_data *
@@ -1091,44 +1091,44 @@ noise_suppress_filter_audio(void *data, struct obs_audio_data *audio)
 	ng->last_timestamp = audio->timestamp;
 
 	/* -----------------------------------------------
-	 * push audio packet info (timestamp/frame count) to info circlebuf */
+	 * push audio packet info (timestamp/frame count) to info deque */
 	info.frames = audio->frames;
 	info.timestamp = audio->timestamp;
-	circlebuf_push_back(&ng->info_buffer, &info, sizeof(info));
+	deque_push_back(&ng->info_buffer, &info, sizeof(info));
 
 	/* -----------------------------------------------
-	 * push back current audio data to input circlebuf */
+	 * push back current audio data to input deque */
 	for (size_t i = 0; i < ng->channels; i++)
-		circlebuf_push_back(&ng->input_buffers[i], audio->data[i],
-				    audio->frames * sizeof(float));
+		deque_push_back(&ng->input_buffers[i], audio->data[i],
+				audio->frames * sizeof(float));
 
 	/* -----------------------------------------------
-	 * pop/process each 10ms segments, push back to output circlebuf */
+	 * pop/process each 10ms segments, push back to output deque */
 	while (ng->input_buffers[0].size >= segment_size)
 		process(ng);
 
 	/* -----------------------------------------------
-	 * peek front of info circlebuf, check to see if we have enough to
+	 * peek front of info deque, check to see if we have enough to
 	 * pop the expected packet size, if not, return null */
 	memset(&info, 0, sizeof(info));
-	circlebuf_peek_front(&ng->info_buffer, &info, sizeof(info));
+	deque_peek_front(&ng->info_buffer, &info, sizeof(info));
 	out_size = info.frames * sizeof(float);
 
 	if (ng->output_buffers[0].size < out_size)
 		return NULL;
 
 	/* -----------------------------------------------
-	 * if there's enough audio data buffered in the output circlebuf,
+	 * if there's enough audio data buffered in the output deque,
 	 * pop and return a packet */
-	circlebuf_pop_front(&ng->info_buffer, NULL, sizeof(info));
+	deque_pop_front(&ng->info_buffer, NULL, sizeof(info));
 	da_resize(ng->output_data, out_size * ng->channels);
 
 	for (size_t i = 0; i < ng->channels; i++) {
 		ng->output_audio.data[i] =
 			(uint8_t *)&ng->output_data.array[i * out_size];
 
-		circlebuf_pop_front(&ng->output_buffers[i],
-				    ng->output_audio.data[i], out_size);
+		deque_pop_front(&ng->output_buffers[i],
+				ng->output_audio.data[i], out_size);
 	}
 
 	ng->output_audio.frames = info.frames;

--- a/plugins/obs-outputs/ftl-stream.c
+++ b/plugins/obs-outputs/ftl-stream.c
@@ -18,7 +18,7 @@
 #include <obs-module.h>
 #include <obs-avc.h>
 #include <util/platform.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/dstr.h>
 #include <util/threading.h>
 #include <inttypes.h>
@@ -64,7 +64,7 @@ struct ftl_stream {
 	obs_output_t *output;
 
 	pthread_mutex_t packets_mutex;
-	struct circlebuf packets;
+	struct deque packets;
 	bool sent_headers;
 	int64_t frames_sent;
 
@@ -134,7 +134,7 @@ static inline void free_packets(struct ftl_stream *stream)
 
 	while (stream->packets.size) {
 		struct encoder_packet packet;
-		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+		deque_pop_front(&stream->packets, &packet, sizeof(packet));
 		obs_encoder_packet_release(&packet);
 	}
 	pthread_mutex_unlock(&stream->packets_mutex);
@@ -205,7 +205,7 @@ static void ftl_stream_destroy(void *data)
 		os_event_destroy(stream->stop_event);
 		os_sem_destroy(stream->send_sem);
 		pthread_mutex_destroy(&stream->packets_mutex);
-		circlebuf_free(&stream->packets);
+		deque_free(&stream->packets);
 		bfree(stream);
 	}
 }
@@ -276,8 +276,8 @@ static inline bool get_next_packet(struct ftl_stream *stream,
 
 	pthread_mutex_lock(&stream->packets_mutex);
 	if (stream->packets.size) {
-		circlebuf_pop_front(&stream->packets, packet,
-				    sizeof(struct encoder_packet));
+		deque_pop_front(&stream->packets, packet,
+				sizeof(struct encoder_packet));
 		new_packet = true;
 	}
 	pthread_mutex_unlock(&stream->packets_mutex);
@@ -658,8 +658,8 @@ static bool ftl_stream_start(void *data)
 static inline bool add_packet(struct ftl_stream *stream,
 			      struct encoder_packet *packet)
 {
-	circlebuf_push_back(&stream->packets, packet,
-			    sizeof(struct encoder_packet));
+	deque_push_back(&stream->packets, packet,
+			sizeof(struct encoder_packet));
 	return true;
 }
 
@@ -673,7 +673,7 @@ static void drop_frames(struct ftl_stream *stream, const char *name,
 {
 	UNUSED_PARAMETER(pframes);
 
-	struct circlebuf new_buf = {0};
+	struct deque new_buf = {0};
 	int num_frames_dropped = 0;
 
 #ifdef _DEBUG
@@ -682,16 +682,16 @@ static void drop_frames(struct ftl_stream *stream, const char *name,
 	UNUSED_PARAMETER(name);
 #endif
 
-	circlebuf_reserve(&new_buf, sizeof(struct encoder_packet) * 8);
+	deque_reserve(&new_buf, sizeof(struct encoder_packet) * 8);
 
 	while (stream->packets.size) {
 		struct encoder_packet packet;
-		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+		deque_pop_front(&stream->packets, &packet, sizeof(packet));
 
 		/* do not drop audio data or video keyframes */
 		if (packet.type == OBS_ENCODER_AUDIO ||
 		    packet.drop_priority >= highest_priority) {
-			circlebuf_push_back(&new_buf, &packet, sizeof(packet));
+			deque_push_back(&new_buf, &packet, sizeof(packet));
 
 		} else {
 			num_frames_dropped++;
@@ -699,7 +699,7 @@ static void drop_frames(struct ftl_stream *stream, const char *name,
 		}
 	}
 
-	circlebuf_free(&stream->packets);
+	deque_free(&stream->packets);
 	stream->packets = new_buf;
 
 	if (stream->min_priority < highest_priority)
@@ -721,7 +721,7 @@ static bool find_first_video_packet(struct ftl_stream *stream,
 
 	for (size_t i = 0; i < count; i++) {
 		struct encoder_packet *cur =
-			circlebuf_data(&stream->packets, i * sizeof(*first));
+			deque_data(&stream->packets, i * sizeof(*first));
 		if (cur->type == OBS_ENCODER_VIDEO && !cur->keyframe) {
 			*first = *cur;
 			return true;

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -72,7 +72,7 @@ static inline void free_packets(struct rtmp_stream *stream)
 
 	while (stream->packets.size) {
 		struct encoder_packet packet;
-		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+		deque_pop_front(&stream->packets, &packet, sizeof(packet));
 		obs_encoder_packet_release(&packet);
 	}
 	pthread_mutex_unlock(&stream->packets_mutex);
@@ -130,11 +130,11 @@ static void rtmp_stream_destroy(void *data)
 	os_event_destroy(stream->stop_event);
 	os_sem_destroy(stream->send_sem);
 	pthread_mutex_destroy(&stream->packets_mutex);
-	circlebuf_free(&stream->packets);
+	deque_free(&stream->packets);
 #ifdef TEST_FRAMEDROPS
-	circlebuf_free(&stream->droptest_info);
+	deque_free(&stream->droptest_info);
 #endif
-	circlebuf_free(&stream->dbr_frames);
+	deque_free(&stream->dbr_frames);
 	pthread_mutex_destroy(&stream->dbr_mutex);
 
 	os_event_destroy(stream->buffer_space_available_event);
@@ -241,8 +241,8 @@ static inline bool get_next_packet(struct rtmp_stream *stream,
 
 	pthread_mutex_lock(&stream->packets_mutex);
 	if (stream->packets.size) {
-		circlebuf_pop_front(&stream->packets, packet,
-				    sizeof(struct encoder_packet));
+		deque_pop_front(&stream->packets, packet,
+				sizeof(struct encoder_packet));
 		new_packet = true;
 	}
 	pthread_mutex_unlock(&stream->packets_mutex);
@@ -326,12 +326,11 @@ static void droptest_cap_data_rate(struct rtmp_stream *stream, size_t size)
 	info.ts = ts;
 	info.size = size;
 
-	circlebuf_push_back(&stream->droptest_info, &info, sizeof(info));
+	deque_push_back(&stream->droptest_info, &info, sizeof(info));
 	stream->droptest_size += size;
 
 	if (stream->droptest_info.size) {
-		circlebuf_peek_front(&stream->droptest_info, &info,
-				     sizeof(info));
+		deque_peek_front(&stream->droptest_info, &info, sizeof(info));
 
 		if (stream->droptest_size > stream->droptest_max) {
 			uint64_t elapsed = ts - info.ts;
@@ -342,8 +341,8 @@ static void droptest_cap_data_rate(struct rtmp_stream *stream, size_t size)
 			}
 
 			while (stream->droptest_size > stream->droptest_max) {
-				circlebuf_pop_front(&stream->droptest_info,
-						    &info, sizeof(info));
+				deque_pop_front(&stream->droptest_info, &info,
+						sizeof(info));
 				stream->droptest_size -= info.size;
 			}
 		}
@@ -585,8 +584,8 @@ static void dbr_add_frame(struct rtmp_stream *stream, struct dbr_frame *back)
 	struct dbr_frame front;
 	uint64_t dur;
 
-	circlebuf_push_back(&stream->dbr_frames, back, sizeof(*back));
-	circlebuf_peek_front(&stream->dbr_frames, &front, sizeof(front));
+	deque_push_back(&stream->dbr_frames, back, sizeof(*back));
+	deque_peek_front(&stream->dbr_frames, &front, sizeof(front));
 
 	stream->dbr_data_size += back->size;
 
@@ -594,7 +593,7 @@ static void dbr_add_frame(struct rtmp_stream *stream, struct dbr_frame *back)
 
 	if (dur >= MAX_ESTIMATE_DURATION_MS) {
 		stream->dbr_data_size -= front.size;
-		circlebuf_pop_front(&stream->dbr_frames, NULL, sizeof(front));
+		deque_pop_front(&stream->dbr_frames, NULL, sizeof(front));
 	}
 
 	stream->dbr_est_bitrate =
@@ -1287,7 +1286,7 @@ static bool init_connect(struct rtmp_stream *stream)
 	const char *codec = obs_encoder_get_codec(venc);
 	stream->video_codec = to_video_type(codec);
 
-	circlebuf_free(&stream->dbr_frames);
+	deque_free(&stream->dbr_frames);
 	stream->audio_bitrate = (long)obs_data_get_int(asettings, "bitrate");
 	stream->dbr_data_size = 0;
 	stream->dbr_orig_bitrate = (long)obs_data_get_int(vsettings, "bitrate");
@@ -1415,8 +1414,8 @@ static bool rtmp_stream_start(void *data)
 static inline bool add_packet(struct rtmp_stream *stream,
 			      struct encoder_packet *packet)
 {
-	circlebuf_push_back(&stream->packets, packet,
-			    sizeof(struct encoder_packet));
+	deque_push_back(&stream->packets, packet,
+			sizeof(struct encoder_packet));
 	return true;
 }
 
@@ -1430,7 +1429,7 @@ static void drop_frames(struct rtmp_stream *stream, const char *name,
 {
 	UNUSED_PARAMETER(pframes);
 
-	struct circlebuf new_buf = {0};
+	struct deque new_buf = {0};
 	int num_frames_dropped = 0;
 
 #ifdef _DEBUG
@@ -1439,16 +1438,16 @@ static void drop_frames(struct rtmp_stream *stream, const char *name,
 	UNUSED_PARAMETER(name);
 #endif
 
-	circlebuf_reserve(&new_buf, sizeof(struct encoder_packet) * 8);
+	deque_reserve(&new_buf, sizeof(struct encoder_packet) * 8);
 
 	while (stream->packets.size) {
 		struct encoder_packet packet;
-		circlebuf_pop_front(&stream->packets, &packet, sizeof(packet));
+		deque_pop_front(&stream->packets, &packet, sizeof(packet));
 
 		/* do not drop audio data or video keyframes */
 		if (packet.type == OBS_ENCODER_AUDIO ||
 		    packet.drop_priority >= highest_priority) {
-			circlebuf_push_back(&new_buf, &packet, sizeof(packet));
+			deque_push_back(&new_buf, &packet, sizeof(packet));
 
 		} else {
 			num_frames_dropped++;
@@ -1456,7 +1455,7 @@ static void drop_frames(struct rtmp_stream *stream, const char *name,
 		}
 	}
 
-	circlebuf_free(&stream->packets);
+	deque_free(&stream->packets);
 	stream->packets = new_buf;
 
 	if (stream->min_priority < highest_priority)
@@ -1478,7 +1477,7 @@ static bool find_first_video_packet(struct rtmp_stream *stream,
 
 	for (size_t i = 0; i < count; i++) {
 		struct encoder_packet *cur =
-			circlebuf_data(&stream->packets, i * sizeof(*first));
+			deque_data(&stream->packets, i * sizeof(*first));
 		if (cur->type == OBS_ENCODER_VIDEO && !cur->keyframe) {
 			*first = *cur;
 			return true;
@@ -1497,8 +1496,8 @@ static bool dbr_bitrate_lowered(struct rtmp_stream *stream)
 	if (stream->dbr_est_bitrate &&
 	    stream->dbr_est_bitrate < stream->dbr_cur_bitrate) {
 		stream->dbr_data_size = 0;
-		circlebuf_pop_front(&stream->dbr_frames, NULL,
-				    stream->dbr_frames.size);
+		deque_pop_front(&stream->dbr_frames, NULL,
+				stream->dbr_frames.size);
 		est_bitrate = stream->dbr_est_bitrate / 100 * 100;
 		if (est_bitrate < 50) {
 			est_bitrate = 50;

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -1,6 +1,6 @@
 #include <obs-module.h>
 #include <util/platform.h>
-#include <util/circlebuf.h>
+#include <util/deque.h>
 #include <util/dstr.h>
 #include <util/threading.h>
 #include <inttypes.h>
@@ -57,7 +57,7 @@ struct rtmp_stream {
 	obs_output_t *output;
 
 	pthread_mutex_t packets_mutex;
-	struct circlebuf packets;
+	struct deque packets;
 	bool sent_headers;
 
 	bool got_first_video;
@@ -96,14 +96,14 @@ struct rtmp_stream {
 	int dropped_frames;
 
 #ifdef TEST_FRAMEDROPS
-	struct circlebuf droptest_info;
+	struct deque droptest_info;
 	uint64_t droptest_last_key_check;
 	size_t droptest_max;
 	size_t droptest_size;
 #endif
 
 	pthread_mutex_t dbr_mutex;
-	struct circlebuf dbr_frames;
+	struct deque dbr_frames;
 	size_t dbr_data_size;
 	uint64_t dbr_inc_timeout;
 	long audio_bitrate;


### PR DESCRIPTION
### Description

Renames "circlebuf" to "deque" because its interface and behaviour is more like a [double-ended queue](https://en.wikipedia.org/wiki/Double-ended_queue) rather than what most people would understand to be a [circular buffer](https://en.wikipedia.org/wiki/Circular_buffer).

### Motivation and Context

 If it walks like a deque, looks like a deque, and quacks like a deque, then it's probably a deque.

(Also this naming has confused me several times over the years so I have a personal grudge against it :P)

### How Has This Been Tested?

OBS compiles!

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
