### PR TITLE
libobs: Fix obs_view_remove only resetting the first matching mix

### DIFF
--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -192,9 +192,10 @@ void obs_view_remove(obs_view_t *view)
 		return;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
-	size_t idx = find_mix_for_view(view);
-	if (idx != DARRAY_INVALID)
-		obs->video.mixes.array[idx]->view = NULL;
+	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
+		if (obs->video.mixes.array[i]->view == view)
+			obs->video.mixes.array[i]->view = NULL;
+	}
 	set_main_mix();
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 }


### PR DESCRIPTION
### Description

Multiple mixes can share a view (as demonstrated with the GPU scaling feature), so we should reset the view for *all* mixes, not just the first one that uses it.

### Motivation and Context

Fix bugs.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
