### PR TITLE
libobs: Add obs_view_enum_video_info and deprecate obs_view_get_video_info

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -895,6 +895,14 @@ Views
 
 .. function:: bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)
 
-   Gets the video settings currently in use for this view context.
+   Gets the video settings of the first matching mix currently in use for this view context.
 
    :return: *false* if no video
+
+   .. deprecated:: 3X.X
+
+---------------------
+
+.. function:: void obs_view_enum_video_info(obs_view_t *view, bool (*enum_proc)(void *, struct obs_video_info *), void *param)
+
+   Enumerates all the video info of all mixes that use the specified mix.

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -217,3 +217,21 @@ bool obs_view_get_video_info(obs_view_t *view, struct obs_video_info *ovi)
 
 	return false;
 }
+
+void obs_view_enum_video_info(obs_view_t *view,
+			      bool (*enum_proc)(void *,
+						struct obs_video_info *),
+			      void *param)
+{
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+
+	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
+		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
+		if (mix->view != view)
+			continue;
+		if (!enum_proc(param, &mix->ovi))
+			break;
+	}
+
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -952,8 +952,8 @@ EXPORT video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi);
 EXPORT void obs_view_remove(obs_view_t *view);
 
 /** Gets the video settings currently in use for this view context, returns false if no video */
-EXPORT bool obs_view_get_video_info(obs_view_t *view,
-				    struct obs_video_info *ovi);
+OBS_DEPRECATED EXPORT bool obs_view_get_video_info(obs_view_t *view,
+						   struct obs_video_info *ovi);
 
 /** Enumerate the video info of all mixes using the specified view context */
 EXPORT void obs_view_enum_video_info(obs_view_t *view,

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -955,6 +955,12 @@ EXPORT void obs_view_remove(obs_view_t *view);
 EXPORT bool obs_view_get_video_info(obs_view_t *view,
 				    struct obs_video_info *ovi);
 
+/** Enumerate the video info of all mixes using the specified view context */
+EXPORT void obs_view_enum_video_info(obs_view_t *view,
+				     bool (*enum_proc)(void *,
+						       struct obs_video_info *),
+				     void *param);
+
 /* ------------------------------------------------------------------------- */
 /* Display context */
 


### PR DESCRIPTION
### Description

- Deprecates `obs_view_get_video_info()`
- Adds `obs_view_enum_video_info()`

### Motivation and Context

Existing function will only return info for first mix using the view, but multiple mixes can use it. Note that these are not used internally at the moment, but for the sake of correctness this feels good to do.

### How Has This Been Tested?

N/A

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
