### PR TITLE
libobs: Pair video encoder with all audio encoders

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1246,9 +1246,7 @@ struct obs_encoder {
 
 	/* if a video encoder is paired with an audio encoder, make it start
 	 * up at the specific timestamp.  if this is the audio encoder,
-	 * wait_for_video makes it wait until it's ready to sync up with
-	 * video */
-	bool wait_for_video;
+	 * it waits until it's ready to sync up with video */
 	bool first_received;
 	struct obs_encoder *paired_encoder;
 	int64_t offset_usec;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1248,7 +1248,7 @@ struct obs_encoder {
 	 * up at the specific timestamp.  if this is the audio encoder,
 	 * it waits until it's ready to sync up with video */
 	bool first_received;
-	struct obs_encoder *paired_encoder;
+	DARRAY(struct obs_encoder *) paired_encoders;
 	int64_t offset_usec;
 	uint64_t first_raw_ts;
 	uint64_t start_ts;

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2402,8 +2402,6 @@ static inline void pair_encoders(obs_output_t *output)
 
 		if (!audio->active && !video->active &&
 		    !video->paired_encoder && !audio->paired_encoder) {
-
-			audio->wait_for_video = true;
 			audio->paired_encoder = video;
 			video->paired_encoder = audio;
 		}

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2376,39 +2376,32 @@ static inline bool initialize_video_encoders(obs_output_t *output)
 	return true;
 }
 
-static inline obs_encoder_t *find_inactive_audio_encoder(obs_output_t *output)
-{
-	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		struct obs_encoder *audio = output->audio_encoders[i];
-
-		if (audio && !audio->active && !audio->paired_encoder)
-			return audio;
-	}
-
-	return NULL;
-}
-
 static inline void pair_encoders(obs_output_t *output)
 {
 	size_t first_venc_idx;
 	if (!get_first_video_encoder_index(output, &first_venc_idx))
 		return;
 	struct obs_encoder *video = output->video_encoders[first_venc_idx];
-	struct obs_encoder *audio = find_inactive_audio_encoder(output);
 
-	if (video && audio) {
-		pthread_mutex_lock(&audio->init_mutex);
-		pthread_mutex_lock(&video->init_mutex);
-
-		if (!audio->active && !video->active &&
-		    !video->paired_encoder && !audio->paired_encoder) {
-			audio->paired_encoder = video;
-			video->paired_encoder = audio;
-		}
-
+	pthread_mutex_lock(&video->init_mutex);
+	if (video->active) {
 		pthread_mutex_unlock(&video->init_mutex);
+		return;
+	}
+
+	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+		struct obs_encoder *audio = output->audio_encoders[i];
+		if (!audio)
+			continue;
+
+		pthread_mutex_lock(&audio->init_mutex);
+		if (!audio->active && !audio->paired_encoders.num) {
+			da_push_back(video->paired_encoders, &audio);
+			da_push_back(audio->paired_encoders, &video);
+		}
 		pthread_mutex_unlock(&audio->init_mutex);
 	}
+	pthread_mutex_unlock(&video->init_mutex);
 }
 
 bool obs_output_initialize_encoders(obs_output_t *output, uint32_t flags)


### PR DESCRIPTION
### Description

Change encoder pairing to sync video encoder to all audio encoders and vice-versa.

Also removes unused `wait_for_video` bool.

### Motivation and Context

Fixes longstanding issue where first audio track in multi-track recordings is offset from the other audio tracks.

Fixes #4530

| **Before** | **After** |
| - | - |
| ![before](https://github.com/obsproject/obs-studio/assets/3123295/1d9f6109-0942-4748-b3ab-bc40ba878477) | ![after](https://github.com/obsproject/obs-studio/assets/3123295/41a3b631-ea2d-4111-9d8a-6abe8cdd2f47) |

### How Has This Been Tested?

Made some test recordings and confirmed no longer broken.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
