### PR TITLE
UI: Save invalid transition source data in safe mode

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1779,6 +1779,10 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 		obs_data_array_push_back(transitions, sourceData);
 	}
 
+	for (const OBSDataAutoRelease &transition : safeModeTransitions) {
+		obs_data_array_push_back(transitions, transition);
+	}
+
 	return transitions;
 }
 
@@ -1787,6 +1791,7 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 {
 	size_t count = obs_data_array_count(transitions);
 
+	safeModeTransitions.clear();
 	for (size_t i = 0; i < count; i++) {
 		OBSDataAutoRelease item = obs_data_array_item(transitions, i);
 		const char *name = obs_data_get_string(item, "name");
@@ -1806,6 +1811,8 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitions,
 				ui->transitions->count() - 1);
 			if (cb)
 				cb(private_data, source);
+		} else if (safe_mode || disable_3p_plugins) {
+			safeModeTransitions.push_back(std::move(item));
 		}
 	}
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -235,6 +235,7 @@ private:
 	QStringList oldExtraDockNames;
 
 	OBSDataAutoRelease safeModeModuleData;
+	std::vector<OBSDataAutoRelease> safeModeTransitions;
 
 	bool loaded = false;
 	long disableSaving = 1;


### PR DESCRIPTION
### Description

Saves transitions that failed creating the source properly in separate array if safe mode is enabled.

There may be a better way of doing this, hence a draft.

### Motivation and Context

Fixes #9963 

### How Has This Been Tested?

Verified transitions are not removed from JSON anymore.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
