### PR TITLE
obs-scripting: Fix memory leak in returned char *

### DIFF
--- a/shared/obs-scripting/obslua/obslua.i
+++ b/shared/obs-scripting/obslua/obslua.i
@@ -52,6 +52,19 @@ static inline void wrap_blog(int log_level, const char *message)
  * %newobject obs_module_get_config_path; */
 %typemap(newfree) char * "bfree($1);";
 
+%newobject obs_frontend_get_current_scene_collection;
+%newobject obs_frontend_get_current_profile;
+%newobject obs_frontend_get_current_record_output_path;
+%newobject obs_frontend_get_last_recording;
+%newobject obs_frontend_get_last_screenshot;
+%newobject obs_frontend_get_last_replay;
+%newobject os_quick_read_utf8_file;
+%newobject os_get_config_path_ptr;
+%newobject os_get_program_data_path_ptr;
+%newobject os_get_abs_path_ptr;
+%newobject os_generate_formatted_filename;
+%newobject os_generate_uuid;
+
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;

--- a/shared/obs-scripting/obspython/obspython.i
+++ b/shared/obs-scripting/obspython/obspython.i
@@ -64,6 +64,19 @@ static inline void wrap_blog(int log_level, const char *message)
  * %newobject obs_module_get_config_path; */
 %typemap(newfree) char * "bfree($1);";
 
+%newobject obs_frontend_get_current_scene_collection;
+%newobject obs_frontend_get_current_profile;
+%newobject obs_frontend_get_current_record_output_path;
+%newobject obs_frontend_get_last_recording;
+%newobject obs_frontend_get_last_screenshot;
+%newobject obs_frontend_get_last_replay;
+%newobject os_quick_read_utf8_file;
+%newobject os_get_config_path_ptr;
+%newobject os_get_program_data_path_ptr;
+%newobject os_get_abs_path_ptr;
+%newobject os_generate_formatted_filename;
+%newobject os_generate_uuid;
+
 %ignore blog;
 %ignore blogva;
 %ignore bcrash;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Uses the %newfree typemap to automatically free `char *` in returned values.

I have learned that `obs_frontend_get_current_scene_collection` and `obs_frontend_get_current_profile` are defined in deps\obs-scripting\obs-scripting-python-frontend.c and its lua variant, and not in obspython.i, but they are defined there only to free the string as well (but longer, but is also why they don't leak memory). I would like to delete those, but it seems that `obs-frontend-api.h` is not included when swig compiles. I would like to know what I'm supposed to do regarding those.

Also note that apparently, obs_frontend_get_current_profile_path was overlooked(?) and is not in the scripting modules, but i included it among the functions i declared wth the typemap.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Penwywern brought these to my attention

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
First built master and used these two scripts (please remove the .txt extension).
[test_newobject.py.txt](https://github.com/obsproject/obs-studio/files/13603719/test_newobject.py.txt)
[test_newobject.lua.txt](https://github.com/obsproject/obs-studio/files/13603721/test_newobject.lua.txt)
These simply execute the functions while checking `bnum_allocs` before and after each function to see if the function leaks memory.

Script log showed:
![image](https://github.com/obsproject/obs-studio/assets/65320293/5be0063c-f1c2-4cfe-9f19-c11543afa2a6)
![image](https://github.com/obsproject/obs-studio/assets/65320293/472a4c78-d01a-41cc-ac85-fa0509d1b2e9)

Then applied my change:
![image](https://github.com/obsproject/obs-studio/assets/65320293/417b7632-5b6b-4089-9a1a-4d0ec3da0658)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
