### PR TITLE
mac-capture: Fix ScreenCaptureKit deadlock when using invalid display ID

### DIFF
--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -108,6 +108,13 @@ static bool init_screen_stream(struct screen_capture *sc)
         case ScreenCaptureDisplayStream: {
             SCDisplay *target_display = get_target_display();
 
+            if (!target_display) {
+                MACCAP_ERR("init_screen_stream: Invalid target display ID:  %u\n", sc->display);
+
+                os_sem_post(sc->shareable_content_available);
+                return false;
+            }
+
             if (sc->hide_obs) {
                 SCRunningApplication *obsApp = nil;
                 NSString *mainBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];


### PR DESCRIPTION
### Description
Adds a check for an invalid <nil> display ID to bail out early and avoid non-deterministic deadlocks caused by ReplayKit failing internally.

### Motivation and Context
In some scenarios ScreenCaptureKit will not call our completion handler when an internal ReplayKit error occurred. This seems to be more common when a <nil> display id is provided as the content filter for ScreenCaptureKit.

The issue was reported to Apple as FB13455947, but it is good practice for us to check for an invalid display ID before even attempting to start a capture stream.

Fixes https://github.com/obsproject/obs-studio/issues/9923

### How Has This Been Tested?
Tested on macOS 14.1.2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
