### PR TITLE
libobs: Mark data path modification functions as deprecated

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1273,13 +1273,15 @@ char *obs_find_data_file(const char *file)
 	return NULL;
 }
 
-void obs_add_data_path(const char *path)
+// TODO: Remove after deprecation grace period
+OBS_DEPRECATED void obs_add_data_path(const char *path)
 {
 	struct dstr *new_path = da_push_back_new(core_module_paths);
 	dstr_init_copy(new_path, path);
 }
 
-bool obs_remove_data_path(const char *path)
+// TODO: Remove after deprecation grace period
+OBS_DEPRECATED bool obs_remove_data_path(const char *path)
 {
 	for (size_t i = 0; i < core_module_paths.num; ++i) {
 		int result = dstr_cmp(&core_module_paths.array[i], path);


### PR DESCRIPTION
### Description
Marks `obs_add_data_path` and `obs_remove_data_path` as deprecated.

### Motivation and Context
Change was suggested by @Lain-B  in https://github.com/obsproject/obs-studio/pull/8179.

### How Has This Been Tested?
Successfully compiled without deprecation warnings on macOS 14.1.2.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
