### PR TITLE
UI: Add HotkeyBlocker class

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -585,6 +585,7 @@ void ColorSourceToolbar::on_choose_clicked()
 	options |= QColorDialog::DontUseNativeDialog;
 #endif
 
+	HotkeyBlocker hb;
 	QColor newColor = QColorDialog::getColor(color, this, desc, options);
 	if (!newColor.isValid()) {
 		return;
@@ -658,6 +659,7 @@ void TextSourceToolbar::on_selectFont_clicked()
 	options = QFontDialog::DontUseNativeDialog;
 #endif
 
+	HotkeyBlocker hb;
 	font = QFontDialog::getFont(
 		&success, font, this,
 		QTStr("Basic.PropertiesWindow.SelectFont.WindowTitle"),
@@ -711,6 +713,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 	options |= QColorDialog::DontUseNativeDialog;
 #endif
 
+	HotkeyBlocker hb;
 	QColor newColor = QColorDialog::getColor(color, this, desc, options);
 	if (!newColor.isValid()) {
 		return;

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -295,3 +295,9 @@ extern bool restart_safe;
 extern "C" void install_dll_blocklist_hook(void);
 extern "C" void log_blocked_dlls(void);
 #endif
+
+class HotkeyBlocker {
+public:
+	inline HotkeyBlocker() { App()->DisableHotkeys(); }
+	inline ~HotkeyBlocker() { App()->UpdateHotkeyFocusSetting(); }
+};

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -1922,6 +1922,7 @@ bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 	options |= QColorDialog::DontUseNativeDialog;
 #endif
 
+	HotkeyBlocker hb;
 	color = QColorDialog::getColor(color, view, QT_UTF8(desc), options);
 
 #ifdef __APPLE__
@@ -1975,6 +1976,8 @@ bool WidgetInfo::FontChanged(const char *setting)
 #ifndef _WIN32
 	options = QFontDialog::DontUseNativeDialog;
 #endif
+
+	HotkeyBlocker hb;
 
 	if (!font_obj) {
 		QFont initial;

--- a/shared/qt/wrappers/qt-wrappers.cpp
+++ b/shared/qt/wrappers/qt-wrappers.cpp
@@ -332,6 +332,7 @@ void setThemeID(QWidget *widget, const QString &themeID)
 
 QString SelectDirectory(QWidget *parent, QString title, QString path)
 {
+	HotkeyBlocker hb;
 	QString dir = QFileDialog::getExistingDirectory(
 		parent, title, path,
 		QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
@@ -342,6 +343,7 @@ QString SelectDirectory(QWidget *parent, QString title, QString path)
 QString SaveFile(QWidget *parent, QString title, QString path,
 		 QString extensions)
 {
+	HotkeyBlocker hb;
 	QString file =
 		QFileDialog::getSaveFileName(parent, title, path, extensions);
 
@@ -351,6 +353,7 @@ QString SaveFile(QWidget *parent, QString title, QString path,
 QString OpenFile(QWidget *parent, QString title, QString path,
 		 QString extensions)
 {
+	HotkeyBlocker hb;
 	QString file =
 		QFileDialog::getOpenFileName(parent, title, path, extensions);
 
@@ -360,6 +363,7 @@ QString OpenFile(QWidget *parent, QString title, QString path,
 QStringList OpenFiles(QWidget *parent, QString title, QString path,
 		      QString extensions)
 {
+	HotkeyBlocker hb;
 	QStringList files =
 		QFileDialog::getOpenFileNames(parent, title, path, extensions);
 


### PR DESCRIPTION
### Description
This adds a HotkeyBlocker class that is similar to SignalBlocker. It is used when selection dialogs are opened and because they are modal, hotkeys shouldn't be able to be used.

### Motivation and Context
Simpler alternative to #8725 

Fixes #7824

### How Has This Been Tested?
Opened file dialog from image context bar widget and made sure hotkeys were disabled when browsing and re-enabled when it was closed.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
