### PR TITLE
Add functions to generate properties from frontend api

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -3,6 +3,7 @@
 #include "qt-wrappers.hpp"
 #include "window-basic-main.hpp"
 #include "window-basic-main-outputs.hpp"
+#include "properties-view.hpp"
 
 #include <functional>
 
@@ -745,6 +746,36 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			[undo](const std::string &data) { undo(data.c_str()); },
 			[redo](const std::string &data) { redo(data.c_str()); },
 			undo_data, redo_data, repeatable);
+	}
+
+	void *obs_frontend_generate_properties_by_obj(
+		obs_data_t *settings, void *obj, const reload_cb reload,
+		const update_cb update, const visual_update_cb visual_update,
+		bool deferrable) override
+	{
+		OBSPropertiesView *view = new OBSPropertiesView(
+			settings, obj, (PropertiesReloadCallback)reload,
+			(PropertiesUpdateCallback)update,
+			(PropertiesVisualUpdateCb)visual_update);
+
+		view->SetDeferrable(deferrable);
+
+		return view;
+	}
+
+	void *obs_frontend_generate_properties_by_type(
+		obs_data_t *settings, const char *type, const reload_cb reload,
+		const update_cb update, const visual_update_cb visual_update,
+		bool deferrable) override
+	{
+		OBSPropertiesView *view = new OBSPropertiesView(
+			settings, type, (PropertiesReloadCallback)reload,
+			(PropertiesUpdateCallback)update,
+			(PropertiesVisualUpdateCb)visual_update);
+
+		view->SetDeferrable(deferrable);
+
+		return view;
 	}
 
 	void on_load(obs_data_t *settings) override

--- a/UI/frontend-plugins/aja-output-ui/AJAOutputUI.h
+++ b/UI/frontend-plugins/aja-output-ui/AJAOutputUI.h
@@ -3,7 +3,6 @@
 #include <QDialog>
 
 #include "ui_output.h"
-#include "../../UI/properties-view.hpp"
 
 namespace aja {
 class CardManager;
@@ -12,20 +11,16 @@ class CardManager;
 class AJAOutputUI : public QDialog {
 	Q_OBJECT
 private:
-	OBSPropertiesView *propertiesView;
-	OBSPropertiesView *previewPropertiesView;
-	OBSPropertiesView *miscPropertiesView;
+	QWidget *propertiesView;
+	QWidget *previewPropertiesView;
+	QWidget *miscPropertiesView;
 	aja::CardManager *cardManager;
 public slots:
 	void on_outputButton_clicked();
-	void PropertiesChanged();
 	void OutputStateChanged(bool);
 
 	void on_previewOutputButton_clicked();
-	void PreviewPropertiesChanged();
 	void PreviewOutputStateChanged(bool);
-
-	void MiscPropertiesChanged();
 
 public:
 	std::unique_ptr<Ui_Output> ui;
@@ -35,7 +30,6 @@ public:
 	aja::CardManager *GetCardManager();
 
 	void ShowHideDialog();
-	void SaveSettings(const char *filename, obs_data_t *settings);
 	void SetupPropertiesView();
 	void SetupPreviewPropertiesView();
 	void SetupMiscPropertiesView();

--- a/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/aja-output-ui/CMakeLists.txt
@@ -35,21 +35,8 @@ target_sources(
           "${CMAKE_SOURCE_DIR}/plugins/aja/aja-vpid-data.hpp"
           "${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.cpp"
           "${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp"
           "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp")
+          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp")
 
 target_sources(aja-output-ui PRIVATE forms/output.ui)
 

--- a/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
+++ b/UI/frontend-plugins/aja-output-ui/cmake/legacy.cmake
@@ -46,21 +46,8 @@ target_sources(
           ${CMAKE_SOURCE_DIR}/plugins/aja/aja-vpid-data.hpp
           ${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.cpp
           ${CMAKE_SOURCE_DIR}/plugins/aja/aja-widget-io.hpp
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
-          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
-          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp
           ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp
-          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp)
+          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp)
 
 target_link_libraries(aja-output-ui PRIVATE OBS::libobs OBS::frontend-api Qt::Widgets AJA::LibAJANTV2)
 

--- a/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
+++ b/UI/frontend-plugins/decklink-output-ui/CMakeLists.txt
@@ -15,26 +15,8 @@ add_library(OBS::decklink-output-ui ALIAS decklink-output-ui)
 target_sources(decklink-output-ui PRIVATE forms/output.ui)
 
 target_sources(
-  decklink-output-ui
-  PRIVATE DecklinkOutputUI.cpp
-          DecklinkOutputUI.h
-          decklink-ui-main.cpp
-          decklink-ui-main.h
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp")
+  decklink-output-ui PRIVATE DecklinkOutputUI.cpp DecklinkOutputUI.h decklink-ui-main.cpp decklink-ui-main.h
+                             "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp" "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp")
 
 target_link_libraries(decklink-output-ui PRIVATE OBS::libobs OBS::frontend-api Qt::Widgets)
 

--- a/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
+++ b/UI/frontend-plugins/decklink-output-ui/DecklinkOutputUI.h
@@ -3,21 +3,19 @@
 #include <QDialog>
 
 #include "ui_output.h"
-#include "../../UI/properties-view.hpp"
+#include <obs.hpp>
 
 class DecklinkOutputUI : public QDialog {
 	Q_OBJECT
 private:
-	OBSPropertiesView *propertiesView;
-	OBSPropertiesView *previewPropertiesView;
+	QWidget *propertiesView;
+	QWidget *previewPropertiesView;
 
 public slots:
 	void on_outputButton_clicked();
-	void PropertiesChanged();
 	void OutputStateChanged(bool);
 
 	void on_previewOutputButton_clicked();
-	void PreviewPropertiesChanged();
 	void PreviewOutputStateChanged(bool);
 
 public:
@@ -27,8 +25,5 @@ public:
 	void ShowHideDialog();
 
 	void SetupPropertiesView();
-	void SaveSettings();
-
 	void SetupPreviewPropertiesView();
-	void SavePreviewSettings();
 };

--- a/UI/frontend-plugins/decklink-output-ui/cmake/legacy.cmake
+++ b/UI/frontend-plugins/decklink-output-ui/cmake/legacy.cmake
@@ -23,26 +23,8 @@ endif()
 target_sources(decklink-output-ui PRIVATE forms/output.ui)
 
 target_sources(
-  decklink-output-ui
-  PRIVATE DecklinkOutputUI.cpp
-          DecklinkOutputUI.h
-          decklink-ui-main.cpp
-          decklink-ui-main.h
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
-          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
-          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp
-          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp
-          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp)
+  decklink-output-ui PRIVATE DecklinkOutputUI.cpp DecklinkOutputUI.h decklink-ui-main.cpp decklink-ui-main.h
+                             ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp)
 
 target_link_libraries(decklink-output-ui PRIVATE OBS::libobs OBS::frontend-api Qt::Widgets)
 

--- a/UI/frontend-plugins/frontend-tools/CMakeLists.txt
+++ b/UI/frontend-plugins/frontend-tools/CMakeLists.txt
@@ -15,23 +15,10 @@ target_sources(
           output-timer.hpp
           tool-helpers.hpp
           output-timer.cpp
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/double-slider.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp"
-          "${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp"
+          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp"
           "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp"
-          "${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp")
+          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp"
+          "${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp")
 
 target_sources(frontend-tools PRIVATE forms/auto-scene-switcher.ui forms/captions.ui forms/output-timer.ui
                                       forms/scripts.ui)

--- a/UI/frontend-plugins/frontend-tools/cmake/legacy.cmake
+++ b/UI/frontend-plugins/frontend-tools/cmake/legacy.cmake
@@ -27,23 +27,10 @@ target_sources(
           output-timer.hpp
           tool-helpers.hpp
           output-timer.cpp
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.cpp
-          ${CMAKE_SOURCE_DIR}/UI/double-slider.hpp
-          ${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.cpp
-          ${CMAKE_SOURCE_DIR}/UI/horizontal-scroll-area.hpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.cpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.hpp
-          ${CMAKE_SOURCE_DIR}/UI/properties-view.moc.hpp
-          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp
-          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/spinbox-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.cpp
-          ${CMAKE_SOURCE_DIR}/UI/slider-ignorewheel.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.hpp
-          ${CMAKE_SOURCE_DIR}/UI/vertical-scroll-area.cpp
+          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp
           ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.cpp
-          ${CMAKE_SOURCE_DIR}/UI/plain-text-edit.hpp)
+          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.cpp
+          ${CMAKE_SOURCE_DIR}/UI/qt-wrappers.hpp)
 
 target_compile_features(frontend-tools PRIVATE cxx_std_17)
 

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -1,6 +1,5 @@
 #include "obs-module.h"
 #include "scripts.hpp"
-#include "../../properties-view.hpp"
 #include "../../qt-wrappers.hpp"
 #include "../../plain-text-edit.hpp"
 
@@ -529,11 +528,9 @@ void ScriptsTool::on_scripts_currentRowChanged(int row)
 
 	OBSDataAutoRelease settings = obs_script_get_settings(script);
 
-	OBSPropertiesView *view = new OBSPropertiesView(
-		settings.Get(), script,
-		(PropertiesReloadCallback)obs_script_get_properties, nullptr,
-		(PropertiesVisualUpdateCb)obs_script_update);
-	view->SetDeferrable(false);
+	QWidget *view = (QWidget *)obs_frontend_generate_properties_by_obj(
+		settings.Get(), script, (reload_cb)obs_script_get_properties,
+		nullptr, (visual_update_cb)obs_script_update, false);
 
 	propertiesView = view;
 

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -631,3 +631,26 @@ void obs_frontend_add_undo_redo_action(const char *name,
 		c->obs_frontend_add_undo_redo_action(
 			name, undo, redo, undo_data, redo_data, repeatable);
 }
+
+void *obs_frontend_generate_properties_by_obj(
+	obs_data_t *settings, void *obj, const reload_cb reload,
+	const update_cb update, const visual_update_cb visual_update,
+	bool deferrable)
+{
+	return !!callbacks_valid() ? c->obs_frontend_generate_properties_by_obj(
+					     settings, obj, reload, update,
+					     visual_update, deferrable)
+				   : nullptr;
+}
+
+void *obs_frontend_generate_properties_by_type(
+	obs_data_t *settings, const char *type, const reload_cb reload,
+	const update_cb update, const visual_update_cb visual_update,
+	bool deferrable)
+{
+	return !!callbacks_valid()
+		       ? c->obs_frontend_generate_properties_by_type(
+				 settings, type, reload, update, visual_update,
+				 deferrable)
+		       : nullptr;
+}

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -252,6 +252,19 @@ EXPORT void obs_frontend_add_undo_redo_action(
 	const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 	const char *undo_data, const char *redo_data, bool repeatable);
 
+typedef obs_properties_t *(*reload_cb)(void *obj);
+typedef void (*update_cb)(void *obj, obs_data_t *old_settings,
+			  obs_data_t *new_settings);
+typedef void (*visual_update_cb)(void *obj, obs_data_t *settings);
+EXPORT void *obs_frontend_generate_properties_by_obj(
+	obs_data_t *settings, void *obj, const reload_cb reload,
+	const update_cb update, const visual_update_cb visual_update,
+	bool deferrable);
+EXPORT void *obs_frontend_generate_properties_by_type(
+	obs_data_t *settings, const char *type, const reload_cb reload,
+	const update_cb update, const visual_update_cb visual_update,
+	bool deferrable);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -167,6 +167,15 @@ struct obs_frontend_callbacks {
 						       const char *undo_data,
 						       const char *redo_data,
 						       bool repeatable) = 0;
+
+	virtual void *obs_frontend_generate_properties_by_obj(
+		obs_data_t *settings, void *obj, const reload_cb reload,
+		const update_cb update, const visual_update_cb visual_update,
+		bool deferrable) = 0;
+	virtual void *obs_frontend_generate_properties_by_type(
+		obs_data_t *settings, const char *type, const reload_cb reload,
+		const update_cb update, const visual_update_cb visual_update,
+		bool deferrable) = 0;
 };
 
 EXPORT void

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -228,6 +228,25 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj,
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_,
+				     PropertiesReloadCallback reloadCallback,
+				     PropertiesUpdateCallback callback_,
+				     PropertiesVisualUpdateCb visUpdateCb_,
+				     int minSize_)
+	: VScrollArea(nullptr),
+	  properties(nullptr, obs_properties_destroy),
+	  settings(settings_),
+	  type(type_),
+	  reloadCallback(reloadCallback),
+	  callback(callback_),
+	  visUpdateCb(visUpdateCb_),
+	  minSize(minSize_)
+{
+	setFrameShape(QFrame::NoFrame);
+	QMetaObject::invokeMethod(this, "ReloadProperties",
+				  Qt::QueuedConnection);
+}
+
+OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_,
 				     PropertiesReloadCallback reloadCallback_,
 				     int minSize_)
 	: VScrollArea(nullptr),

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -168,6 +168,11 @@ public:
 			  int minSize = 0);
 	OBSPropertiesView(OBSData settings, const char *type,
 			  PropertiesReloadCallback reloadCallback,
+			  PropertiesUpdateCallback callback,
+			  PropertiesVisualUpdateCb cb = nullptr,
+			  int minSize = 0);
+	OBSPropertiesView(OBSData settings, const char *type,
+			  PropertiesReloadCallback reloadCallback,
 			  int minSize = 0);
 
 #define obj_constructor(type)                                              \

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -932,3 +932,33 @@ Functions
                       This uses the undo action from the first and the redo action from the last action.
 
    .. versionadded:: 29.1
+
+---------------------------------------
+
+.. function:: void *obs_frontend_generate_properties_by_obj(obs_data_t *settings, void *obj, const reload_cb reload, const update_cb update, const visual_update_cb visual_update, bool deferrable)
+
+   Generates properties view widget by object.
+
+   :param settings: Settings of the properties
+   :param obj: Pointer of object setting up properties (source, output, etc.)
+   :param reload: Callback for when the properties are reloaded
+   :param update: Callback for when the properties are updated
+   :param visual_update: Callback for when the properties are visually updated
+   :param deferrable: Set whether the properties are deferrable
+
+   :return: The QWidget of the properties
+
+---------------------------------------
+
+.. function:: void *obs_frontend_generate_properties_by_type(obs_data_t *settings, const char *type, const reload_cb reload, const update_cb update, const visual_update_cb visual_update, bool deferrable)
+
+   Generates properties view widget by ID of object.
+
+   :param settings: Settings of the properties
+   :param type: ID of object (source, output, etc.)
+   :param reload: Callback for when the properties are reloaded
+   :param update: Callback for when the properties are updated
+   :param visual_update: Callback for when the properties are visually updated
+   :param deferrable: Set whether the properties are deferrable
+
+   :return: The QWidget of the properties


### PR DESCRIPTION
### Description
Adds functions to the frontend api to generate a properties widget. This is useful so frontend plugins no longer have to link to UI files.

### Motivation and Context
Got sick of dealing with cmake files in frontend plugins.

### How Has This Been Tested?
Tested with script properties. Still need to be tested with Decklink and AJA plugins.

### Types of changes
- New feature (non-breaking change which adds functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
