### PR TITLE
libobs: Fix disk space reporting for attached network drives on macOS

### DIFF
--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -363,10 +363,21 @@ int64_t os_get_free_space(const char *path)
     if (path) {
         NSURL *fileURL = [NSURL fileURLWithPath:@(path)];
 
-        NSDictionary *values = [fileURL resourceValuesForKeys:@[NSURLVolumeAvailableCapacityForOpportunisticUsageKey]
-                                                        error:nil];
+        NSDictionary *values = [fileURL resourceValuesForKeys:@[NSURLVolumeIsLocalKey] error:nil];
 
-        NSNumber *availableSpace = values[NSURLVolumeAvailableCapacityForOpportunisticUsageKey];
+        BOOL isLocalVolume = [values[NSURLVolumeIsLocalKey] boolValue];
+
+        NSURLResourceKey volumeKey;
+
+        if (isLocalVolume) {
+            volumeKey = NSURLVolumeAvailableCapacityForOpportunisticUsageKey;
+        } else {
+            volumeKey = NSURLVolumeAvailableCapacityKey;
+        }
+
+        values = [fileURL resourceValuesForKeys:@[volumeKey] error:nil];
+
+        NSNumber *availableSpace = values[volumeKey];
 
         if (availableSpace) {
             return availableSpace.longValue;


### PR DESCRIPTION
### Description
Changes available disk space calculation on macOS to use more generic available disk space volume resource for non-local volumes.

### Motivation and Context
While the NSURLVolumeAvailableCapacityForOpportunisticUsageKey resource correctly reports available disk space for local volumes (regardless of actual file system used), it does not report actual values for attached network drives.

The NSURLVolumeAvailableCapacityKey resource will still report available disk space as expected, so use this value for non-local volumes instead.

This change should have no drawbacks for users: On local volumes and those with support for purgeable disk space, the correct amount of available disk space is reported. For remote volumes, purgeable disk space is not supported in disk space calculations anyway (the feature is not exposed via SMB) so the more generic value is more accurate for users.

### How Has This Been Tested?
Tested on macOS 14.1.2, got correct results for:

* Internal volumes (APFS)
* Attached volumes via USB (FAT32, HFS+)
* Attached volumes via SMB (BTRFS, APFS)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
