### PR TITLE
obs-webrtc: Add support for audio-only and video-only outputs

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -83,12 +83,12 @@ void WHIPOutput::Data(struct encoder_packet *packet)
 		return;
 	}
 
-	if (packet->type == OBS_ENCODER_AUDIO) {
+	if (audio_track && packet->type == OBS_ENCODER_AUDIO) {
 		int64_t duration = packet->dts_usec - last_audio_timestamp;
 		Send(packet->data, packet->size, duration, audio_track,
 		     audio_sr_reporter);
 		last_audio_timestamp = packet->dts_usec;
-	} else if (packet->type == OBS_ENCODER_VIDEO) {
+	} else if (video_track && packet->type == OBS_ENCODER_VIDEO) {
 		int64_t duration = packet->dts_usec - last_video_timestamp;
 		Send(packet->data, packet->size, duration, video_track,
 		     video_sr_reporter);
@@ -99,6 +99,12 @@ void WHIPOutput::Data(struct encoder_packet *packet)
 void WHIPOutput::ConfigureAudioTrack(std::string media_stream_id,
 				     std::string cname)
 {
+	if (!obs_output_get_audio_encoder(output, 0)) {
+		do_log(LOG_DEBUG,
+		       "Not configuring audio track: Audio encoder not assigned");
+		return;
+	}
+
 	auto media_stream_track_id = std::string(media_stream_id + "-audio");
 
 	uint32_t ssrc = base_ssrc;
@@ -127,6 +133,12 @@ void WHIPOutput::ConfigureAudioTrack(std::string media_stream_id,
 void WHIPOutput::ConfigureVideoTrack(std::string media_stream_id,
 				     std::string cname)
 {
+	if (!obs_output_get_video_encoder(output)) {
+		do_log(LOG_DEBUG,
+		       "Not configuring video track: Video encoder not assigned");
+		return;
+	}
+
 	auto media_stream_track_id = std::string(media_stream_id + "-video");
 
 	// More predictable SSRC values between audio and video
@@ -536,10 +548,11 @@ void WHIPOutput::Send(void *data, uintptr_t size, uint64_t duration,
 
 void register_whip_output()
 {
-	struct obs_output_info info = {};
+	const uint32_t base_flags = OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE;
 
+	struct obs_output_info info = {};
 	info.id = "whip_output";
-	info.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE;
+	info.flags = OBS_OUTPUT_AV | base_flags;
 	info.get_name = [](void *) -> const char * {
 		return obs_module_text("Output.Name");
 	};
@@ -575,5 +588,13 @@ void register_whip_output()
 	info.encoded_audio_codecs = "opus";
 	info.protocols = "WHIP";
 
+	obs_register_output(&info);
+
+	info.id = "whip_output_video";
+	info.flags = OBS_OUTPUT_VIDEO | base_flags;
+	obs_register_output(&info);
+
+	info.id = "whip_output_audio";
+	info.flags = OBS_OUTPUT_AUDIO | base_flags;
 	obs_register_output(&info);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds the `whip_output_audio` and `whip_output_video` output kinds, which selectively advertise only video or only audio support.

To use these types, it is effectively the same as with the AV version. Just create the output, assign your video or audio encoder, and you're good.

### Motivation and Context
It's not uncommon in WebRTC systems to have video-only or audio-only streams. The WHIP protocol supports this, so this will allow plugins which do custom things with WHIP to access this functionality.

### How Has This Been Tested?
Code compiles on Ubuntu 22.04

I've been using this patch for many months in production privately, and I think it can benefit more than just myself.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
