### PR TITLE
Preparations for Camera portal, part 3

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1237,6 +1237,7 @@ obs_pipewire_stream *obs_pipewire_connect_stream(
 	obs_pw_stream = bzalloc(sizeof(obs_pipewire_stream));
 	obs_pw_stream->obs_pw = obs_pw;
 	obs_pw_stream->source = source;
+	obs_pw_stream->cursor.visible = connect_info->screencast.cursor_visible;
 
 	init_format_info(obs_pw_stream);
 

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1222,16 +1222,17 @@ void obs_pipewire_destroy(obs_pipewire *obs_pw)
 	bfree(obs_pw);
 }
 
-obs_pipewire_stream *
-obs_pipewire_connect_stream(obs_pipewire *obs_pw, obs_source_t *source,
-			    int pipewire_node, const char *stream_name,
-			    struct pw_properties *stream_properties)
+obs_pipewire_stream *obs_pipewire_connect_stream(
+	obs_pipewire *obs_pw, obs_source_t *source, int pipewire_node,
+	const struct obs_pipwire_connect_stream_info *connect_info)
 {
 	struct spa_pod_builder pod_builder;
 	const struct spa_pod **params = NULL;
 	obs_pipewire_stream *obs_pw_stream;
 	uint32_t n_params;
 	uint8_t params_buffer[4096];
+
+	assert(connect_info != NULL);
 
 	obs_pw_stream = bzalloc(sizeof(obs_pipewire_stream));
 	obs_pw_stream->obs_pw = obs_pw;
@@ -1248,8 +1249,9 @@ obs_pipewire_connect_stream(obs_pipewire *obs_pw, obs_source_t *source,
 	blog(LOG_DEBUG, "[pipewire] registered event %p", obs_pw_stream->reneg);
 
 	/* Stream */
-	obs_pw_stream->stream =
-		pw_stream_new(obs_pw->core, stream_name, stream_properties);
+	obs_pw_stream->stream = pw_stream_new(obs_pw->core,
+					      connect_info->stream_name,
+					      connect_info->stream_properties);
 	pw_stream_add_listener(obs_pw_stream->stream,
 			       &obs_pw_stream->stream_listener, &stream_events,
 			       obs_pw_stream);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -31,6 +31,9 @@ typedef struct _obs_pipewire_stream obs_pipewire_stream;
 struct obs_pipwire_connect_stream_info {
 	const char *stream_name;
 	struct pw_properties *stream_properties;
+	struct {
+		bool cursor_visible;
+	} screencast;
 };
 
 obs_pipewire *obs_pipewire_create(int pipewire_fd);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -36,13 +36,13 @@ obs_pipewire_connect_stream(obs_pipewire *obs_pw, obs_source_t *source,
 			    int pipewire_node, const char *stream_name,
 			    struct pw_properties *stream_properties);
 
-void obs_pipewire_stream_show(obs_pipewire_stream *obs_pw);
-void obs_pipewire_stream_hide(obs_pipewire_stream *obs_pw);
-uint32_t obs_pipewire_stream_get_width(obs_pipewire_stream *obs_pw);
-uint32_t obs_pipewire_stream_get_height(obs_pipewire_stream *obs_pw);
-void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw,
+void obs_pipewire_stream_show(obs_pipewire_stream *obs_pw_stream);
+void obs_pipewire_stream_hide(obs_pipewire_stream *obs_pw_stream);
+uint32_t obs_pipewire_stream_get_width(obs_pipewire_stream *obs_pw_stream);
+uint32_t obs_pipewire_stream_get_height(obs_pipewire_stream *obs_pw_stream);
+void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream,
 				      gs_effect_t *effect);
 
-void obs_pipewire_stream_set_cursor_visible(obs_pipewire_stream *obs_pw,
+void obs_pipewire_stream_set_cursor_visible(obs_pipewire_stream *obs_pw_stream,
 					    bool cursor_visible);
 void obs_pipewire_stream_destroy(obs_pipewire_stream *obs_pw_stream);

--- a/plugins/linux-pipewire/pipewire.h
+++ b/plugins/linux-pipewire/pipewire.h
@@ -28,13 +28,17 @@
 typedef struct _obs_pipewire obs_pipewire;
 typedef struct _obs_pipewire_stream obs_pipewire_stream;
 
+struct obs_pipwire_connect_stream_info {
+	const char *stream_name;
+	struct pw_properties *stream_properties;
+};
+
 obs_pipewire *obs_pipewire_create(int pipewire_fd);
 void obs_pipewire_destroy(obs_pipewire *obs_pw);
 
-obs_pipewire_stream *
-obs_pipewire_connect_stream(obs_pipewire *obs_pw, obs_source_t *source,
-			    int pipewire_node, const char *stream_name,
-			    struct pw_properties *stream_properties);
+obs_pipewire_stream *obs_pipewire_connect_stream(
+	obs_pipewire *obs_pw, obs_source_t *source, int pipewire_node,
+	const struct obs_pipwire_connect_stream_info *connect_info);
 
 void obs_pipewire_stream_show(obs_pipewire_stream *obs_pw_stream);
 void obs_pipewire_stream_hide(obs_pipewire_stream *obs_pw_stream);

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -158,6 +158,7 @@ static const char *capture_type_to_string(enum portal_capture_type capture_type)
 static void on_pipewire_remote_opened_cb(GObject *source, GAsyncResult *res,
 					 void *user_data)
 {
+	struct obs_pipwire_connect_stream_info connect_info;
 	struct screencast_portal_capture *capture;
 	g_autoptr(GUnixFDList) fd_list = NULL;
 	g_autoptr(GVariant) result = NULL;
@@ -192,12 +193,16 @@ static void on_pipewire_remote_opened_cb(GObject *source, GAsyncResult *res,
 	if (!capture->obs_pw)
 		return;
 
+	connect_info = (struct obs_pipwire_connect_stream_info){
+		.stream_name = "OBS Studio",
+		.stream_properties = pw_properties_new(
+			PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY,
+			"Capture", PW_KEY_MEDIA_ROLE, "Screen", NULL),
+	};
+
 	capture->obs_pw_stream = obs_pipewire_connect_stream(
 		capture->obs_pw, capture->source, capture->pipewire_node,
-		"OBS Studio",
-		pw_properties_new(PW_KEY_MEDIA_TYPE, "Video",
-				  PW_KEY_MEDIA_CATEGORY, "Capture",
-				  PW_KEY_MEDIA_ROLE, "Screen", NULL));
+		&connect_info);
 	obs_pipewire_stream_set_cursor_visible(capture->obs_pw_stream,
 					       capture->cursor_visible);
 }

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -198,13 +198,15 @@ static void on_pipewire_remote_opened_cb(GObject *source, GAsyncResult *res,
 		.stream_properties = pw_properties_new(
 			PW_KEY_MEDIA_TYPE, "Video", PW_KEY_MEDIA_CATEGORY,
 			"Capture", PW_KEY_MEDIA_ROLE, "Screen", NULL),
+		.screencast =
+			{
+				.cursor_visible = capture->cursor_visible,
+			},
 	};
 
 	capture->obs_pw_stream = obs_pipewire_connect_stream(
 		capture->obs_pw, capture->source, capture->pipewire_node,
 		&connect_info);
-	obs_pipewire_stream_set_cursor_visible(capture->obs_pw_stream,
-					       capture->cursor_visible);
 }
 
 static void open_pipewire_remote(struct screencast_portal_capture *capture)


### PR DESCRIPTION
### Description

Massage the function to connect PipeWire streams to receive construction info through a small struct embedded, instead of directly from the function arguments.

### Motivation and Context

This is a tangential cleanup split out from https://github.com/obsproject/obs-studio/pull/9771 to help reviewers.

### How Has This Been Tested?

 - Run OBS Studio on Linux / Wayland, add a screen or window capture
 - Notice it continues to work normally

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
 - Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
