### PR TITLE
UI: Add transition management APIs

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -110,6 +110,20 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		}
 	}
 
+	void obs_frontend_add_transition(obs_source_t *transition) override
+	{
+		QMetaObject::invokeMethod(main, "AddTransitionInstance",
+					  Q_ARG(OBSSource,
+						OBSSource(transition)));
+	}
+
+	void obs_frontend_remove_transition(obs_source_t *transition) override
+	{
+		QMetaObject::invokeMethod(main, "RemoveTransitionInstance",
+					  Q_ARG(OBSSource,
+						OBSSource(transition)));
+	}
+
 	void obs_frontend_get_transitions(
 		struct obs_frontend_source_list *sources) override
 	{

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -112,6 +112,18 @@ void obs_frontend_set_current_scene(obs_source_t *scene)
 		c->obs_frontend_set_current_scene(scene);
 }
 
+void obs_frontend_add_transition(obs_source_t *transition)
+{
+	if (callbacks_valid())
+		c->obs_frontend_add_transition(transition);
+}
+
+void obs_frontend_remove_transition(obs_source_t *transition)
+{
+	if (callbacks_valid())
+		c->obs_frontend_remove_transition(transition);
+}
+
 void obs_frontend_get_transitions(struct obs_frontend_source_list *sources)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -107,6 +107,8 @@ EXPORT void obs_frontend_get_scenes(struct obs_frontend_source_list *sources);
 EXPORT obs_source_t *obs_frontend_get_current_scene(void);
 EXPORT void obs_frontend_set_current_scene(obs_source_t *scene);
 
+EXPORT void obs_frontend_add_transition(obs_source_t *transition);
+EXPORT void obs_frontend_remove_transition(obs_source_t *transition);
 EXPORT void
 obs_frontend_get_transitions(struct obs_frontend_source_list *sources);
 EXPORT obs_source_t *obs_frontend_get_current_transition(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -16,6 +16,9 @@ struct obs_frontend_callbacks {
 	virtual obs_source_t *obs_frontend_get_current_scene(void) = 0;
 	virtual void obs_frontend_set_current_scene(obs_source_t *scene) = 0;
 
+	virtual void obs_frontend_add_transition(obs_source_t *transition) = 0;
+	virtual void
+	obs_frontend_remove_transition(obs_source_t *transition) = 0;
 	virtual void obs_frontend_get_transitions(
 		struct obs_frontend_source_list *sources) = 0;
 	virtual obs_source_t *obs_frontend_get_current_transition(void) = 0;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -461,6 +461,7 @@ private:
 
 	void InitDefaultTransitions();
 	void InitTransition(obs_source_t *transition);
+	void DeinitTransition(obs_source_t *transition);
 	obs_source_t *FindTransition(const char *name);
 	OBSSource GetCurrentTransition();
 	obs_data_array_t *SaveTransitions();
@@ -719,6 +720,8 @@ public slots:
 	void SaveProjectDeferred();
 	void SaveProject();
 
+	void AddTransitionInstance(OBSSource transition);
+	void RemoveTransitionInstance(OBSSource transition);
 	void SetTransition(OBSSource transition);
 	void OverrideTransition(OBSSource transition);
 	void TransitionToScene(OBSScene scene, bool force = false);
@@ -767,6 +770,7 @@ private slots:
 
 	void AddTransition(const char *id);
 	void RenameTransition(OBSSource transition);
+	void TransitionWasRenamed(OBSSource transition);
 	void TransitionClicked();
 	void TransitionStopped();
 	void TransitionFullyStopped();

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -309,6 +309,24 @@ Functions
 
 ---------------------------------------
 
+.. function:: void obs_frontend_add_transition(obs_source_t *transition)
+
+   :param transition: The transition to add to the frontend's transition list.
+                      This source should be created with
+                      :c:func:`obs_source_create_private()` to ensure behavior is
+                      consistent with the transitions created by a user.
+                      The transition can be safely renamed with
+                      :c:func:`obs_source_set_name()`
+
+---------------------------------------
+
+.. function:: void obs_frontend_remove_transition(obs_source_t *transition)
+
+   :param transition: The transition that should be removed from the frontend's
+                      transition list
+
+---------------------------------------
+
 .. function:: void obs_frontend_get_transitions(struct obs_frontend_source_list *sources)
 
    :param sources: Pointer to a :c:type:`obs_frontend_source_list`


### PR DESCRIPTION
### Description
This PR provides two new APIs for managing transitions in the frontend. This allows plugins to create and delete new instances of transitions on behalf of the user, as well as the ability to properly rename existing transitions.

### Motivation and Context
I am working on a plugin to programmatically manage OBS on behalf of the user, and I noticed that this feature I needed was absent from the frontend API. Note that this does not provide functions for managing quick transitions as that is outside of the scope for what I needed.

I did make a couple of decisions that might not sit right with everyone and I'm open to changing them in light of any substantial objections:

1. I provided the ability to rename transitions by registering a callback for the "rename" signal rather than providing an API call specifically for renaming. I felt that this was more appropriate, however this does slightly conflict with the other decision I made.
2. The rename and add-transition behaviors automatically update the name of the source to be unique, similarly to how copying and pasting sources in the UI does with a simple brute force scan of existing sources and appending a number to the name. I'm on the fence about whether this belongs in the API or if it should fall on the API consumer to not provide duplicated names. Since it's the frontend API, I'm leaning more towards having it protect itself from bad state, however the behavior might cause some surprises, especially when it comes to using `obs_source_set_name` since the name you set might be immediately overwritten. This does also open up a fun side effect, you can now successfully rename the non-configurable transitions from a plugin and have it reflect in the UI. I consider doing that to be invoking undefined behavior though.

### How Has This Been Tested?
I have only tested this manually with a debug plugin that called the functions with a series of hardcoded parameters on Windows 10 22H2

### Types of changes
 - New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
