### PR TITLE
cmake: Expand generator exps in libobs pkgconfig

### DIFF
--- a/cmake/Modules/CompilerConfig.cmake
+++ b/cmake/Modules/CompilerConfig.cmake
@@ -163,8 +163,9 @@ else()
     check_c_compiler_flag("-fopenmp-simd" C_COMPILER_SUPPORTS_OPENMP_SIMD)
     check_cxx_compiler_flag("-fopenmp-simd" CXX_COMPILER_SUPPORTS_OPENMP_SIMD)
     set(ARCH_SIMD_FLAGS
-        -DSIMDE_ENABLE_OPENMP "$<$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:C_COMPILER_SUPPORTS_OPENMP_SIMD>>:-fopenmp-simd>"
-        "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:CXX_COMPILER_SUPPORTS_OPENMP_SIMD>>:-fopenmp-simd>")
+        -DSIMDE_ENABLE_OPENMP
+        "$<$<OR:$<AND:$<COMPILE_LANGUAGE:C>,$<BOOL:C_COMPILER_SUPPORTS_OPENMP_SIMD>>,$<AND:$<COMPILE_LANGUAGE:CXX>,$<BOOL:CXX_COMPILER_SUPPORTS_OPENMP_SIMD>>>:-fopenmp-simd>"
+    )
   endif()
 endif()
 

--- a/cmake/Modules/ObsHelpers_Linux.cmake
+++ b/cmake/Modules/ObsHelpers_Linux.cmake
@@ -58,7 +58,12 @@ function(export_target_pkgconf target)
     set(_TARGET_OPTIONS "")
   endif()
 
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/${target}.pc.in" "${target}.pc" @ONLY)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/${target}.pc.in"
+                 "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/${target}.pc.in2" @ONLY)
+  file(
+    GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc"
+    INPUT "${CMAKE_CURRENT_SOURCE_DIR}/pkgconfig/${target}.pc.in2")
 
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${target}.pc" DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endfunction()


### PR DESCRIPTION



<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Expand generator exps in libobs pkgconfig

Non-x86 platforms use a generator expression to add a -fopenmp flag so make sure to render this expression while writing out any pkgconfig file

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Should fix #7972 and #7990 where the generator expression gets inserted into libobs.pc

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've added this patch into the Nix build on my ARM64 Linux machine, and tried to compile some plugins against the libobs.pc output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
