### PR TITLE
UI: Save last used output resolution to scene collection

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -359,6 +359,7 @@ private:
 	std::string patronJson;
 
 	std::atomic<obs_scene_t *> currentScene = nullptr;
+	std::optional<std::pair<uint32_t, uint32_t>> lastOutputResolution;
 
 	void UpdateMultiviewProjectorMenu();
 


### PR DESCRIPTION
### Description

Saves the last used output resolution to the scene collections.

### Motivation and Context

Useful for supporting changes for #9910 to avoid wrong migrations. Suggested by @Warchamp7 

### How Has This Been Tested?

Ensured it's now saved and there are no leaks.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
