### PR TITLE
build-aux: Use Mbed TLS for libdatachannel

### DIFF
--- a/build-aux/modules/10-mbedtls.json
+++ b/build-aux/modules/10-mbedtls.json
@@ -19,6 +19,13 @@
             "url": "https://github.com/ARMmbed/mbedtls.git",
             "commit": "1873d3bfc2da771672bd8e7e8f41f57e0af77f33",
             "tag": "v3.4.0"
+        },
+        {
+            "type": "shell",
+            "commands": [
+                "echo '#define MBEDTLS_SSL_DTLS_SRTP' >> include/mbedtls/mbedtls_config.h"
+            ]
         }
+
     ]
 }

--- a/build-aux/modules/50-libdatachannel.json
+++ b/build-aux/modules/50-libdatachannel.json
@@ -7,6 +7,7 @@
         "-DNO_TESTS=ON",
         "-DNO_WEBSOCKET=ON",
         "-DUSE_NICE=ON",
+        "-DUSE_MBEDTLS=ON",
         "-DPREFER_SYSTEM_LIB=ON"
     ],
     "sources": [


### PR DESCRIPTION
### Description
Switch to Mbed TLS for libdatachannel in flatpak

### Motivation and Context
Resolves #9846 WHIP now works in flatpak

This also matches how libdatachannel is used on other platforms (mac OS)

### How Has This Been Tested?
Locally when I use WHIP it works

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
