### PR TITLE
obs-outputs: Switch RTMP color metadata order

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -918,8 +918,6 @@ static inline bool send_headers(struct rtmp_stream *stream)
 
 	if (!send_audio_header(stream, i++, &next))
 		return false;
-	if (!send_video_header(stream))
-		return false;
 
 	// send metadata only if HDR
 	video_t *video = obs_get_video();
@@ -928,6 +926,9 @@ static inline bool send_headers(struct rtmp_stream *stream)
 	if (colorspace == VIDEO_CS_2100_PQ || colorspace == VIDEO_CS_2100_HLG)
 		if (!send_video_metadata(stream)) // Y2023 spec
 			return false;
+
+	if (!send_video_header(stream))
+		return false;
 
 	while (next) {
 		if (!send_audio_header(stream, i++, &next))


### PR DESCRIPTION
Sends color metadata before the video header for RTMP streams. Only applicable to HDR RTMP streams. Ensures the server sees the correctly configured color metadata first, in cases where the decoder config in the video header has incorrect or missing color information. Mitigates a bug that users with outdated AMD drivers may encounter.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sends color metadata before the video header for RTMP streams. Only applicable to HDR RTMP streams. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We noticed in previous testing of HDR HEVC livestreaming over RTMP with AMD RX 7900 XTX, that the decoder config in the video header was missing color metadata. This has since been fixed with the latest drivers. This PR sends the correctly configured container-level HDR color metadata first before sending the video header, mitigating potentially incorrect behaviour for users who have not yet updated their drivers. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested HDR HEVC livestreaming over RTMP to YouTube with:
* AMD RX 7900 XTX (both before and after updating drivers to the latest available versions as of Dec 15 2023)
* Intel Arc A750
* Nvidia RTX 4090

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
