### PR TITLE
rtmp-services: Add IRLToolkit Frankfurt ingest

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 239,
+    "version": 240,
     "files": [
         {
             "name": "services.json",
-            "version": 239
+            "version": 240
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2383,6 +2383,10 @@
                     "url": "rtmps://stream.ams.irl.run/ingest"
                 },
                 {
+                    "name": "Frankfurt, DE",
+                    "url": "rtmps://stream.fra.irl.run/ingest"
+                },
+                {
                     "name": "Singapore",
                     "url": "rtmps://stream.sin.irl.run/ingest"
                 },


### PR DESCRIPTION
### Description
Add new Frankfurt, Germany ingest to the IRLToolkit service

### Motivation and Context
For a complete list of ingest locations

### How Has This Been Tested?
JSON decoder doesn't error out

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
