### PR TITLE
CI: Update build workflow to use Xcode 15.1 on macOS

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -81,7 +81,7 @@ jobs:
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
           print '::group::Enable Xcode 14.3.1 and AppleScript'
-          sudo xcode-select --switch /Applications/Xcode_14.3.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_15.1.app/Contents/Developer
           sudo sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db \
             "INSERT OR REPLACE INTO access VALUES('kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552);"
           sudo sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db \


### PR DESCRIPTION
### Description
Updates Xcode selection for GitHub Actions builds to Xcode 15.1.

### Motivation and Context
Ensure that OBS Studio builds on GitHub Actions have the same build environment available as local builds.

### How Has This Been Tested?
Requires test on actual CI infrastructure.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
