### PR TITLE
obs-ffmpeg: Remove Windows 7/Ubuntu 20.04 NVENC fallback

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -41,10 +41,6 @@ struct nvenc_encoder {
 	int64_t dts_offset; // Revert when FFmpeg fixes b-frame DTS calculation
 };
 
-#ifdef __linux__
-extern bool ubuntu_20_04_nvenc_fallback;
-#endif
-
 #define ENCODER_NAME_H264 "NVIDIA NVENC H.264 (FFmpeg)"
 static const char *h264_nvenc_getname(void *unused)
 {
@@ -128,12 +124,6 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 		rc = "CBR";
 	}
 
-#ifdef __linux__
-	bool use_old_nvenc = ubuntu_20_04_nvenc_fallback;
-#else
-#define use_old_nvenc false
-#endif
-
 	info.format = voi->format;
 	info.colorspace = voi->colorspace;
 	info.range = voi->range;
@@ -143,8 +133,8 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 	av_opt_set_int(enc->ffve.context->priv_data, "cbr", false, 0);
 	av_opt_set(enc->ffve.context->priv_data, "profile", profile, 0);
 
-	if (use_old_nvenc || (obs_data_has_user_value(settings, "preset") &&
-			      !obs_data_has_user_value(settings, "preset2"))) {
+	if (obs_data_has_user_value(settings, "preset") &&
+	    !obs_data_has_user_value(settings, "preset2")) {
 
 		if (astrcmpi(preset, "mq") == 0) {
 			preset = "hq";
@@ -505,12 +495,6 @@ obs_properties_t *nvenc_properties_internal(enum codec_type codec, bool ffmpeg)
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *p;
 
-#ifdef __linux__
-	bool use_old_nvenc = ubuntu_20_04_nvenc_fallback;
-#else
-#define use_old_nvenc false
-#endif
-
 	p = obs_properties_add_list(props, "rate_control",
 				    obs_module_text("RateControl"),
 				    OBS_COMBO_TYPE_LIST,
@@ -539,60 +523,47 @@ obs_properties_t *nvenc_properties_internal(enum codec_type codec, bool ffmpeg)
 				   10, 1);
 	obs_property_int_set_suffix(p, " s");
 
-	p = obs_properties_add_list(props, use_old_nvenc ? "preset" : "preset2",
-				    obs_module_text("Preset"),
+	p = obs_properties_add_list(props, "preset2", obs_module_text("Preset"),
 				    OBS_COMBO_TYPE_LIST,
 				    OBS_COMBO_FORMAT_STRING);
 
 #define add_preset(val)                                                        \
 	obs_property_list_add_string(p, obs_module_text("NVENC.Preset2." val), \
 				     val)
-	if (use_old_nvenc) {
-		add_preset("mq");
-		add_preset("hq");
-		add_preset("default");
-		add_preset("hp");
-		add_preset("ll");
-		add_preset("llhq");
-		add_preset("llhp");
-	} else {
-		add_preset("p1");
-		add_preset("p2");
-		add_preset("p3");
-		add_preset("p4");
-		add_preset("p5");
-		add_preset("p6");
-		add_preset("p7");
-	}
+
+	add_preset("p1");
+	add_preset("p2");
+	add_preset("p3");
+	add_preset("p4");
+	add_preset("p5");
+	add_preset("p6");
+	add_preset("p7");
 #undef add_preset
 
-	if (!use_old_nvenc) {
-		p = obs_properties_add_list(props, "tune",
-					    obs_module_text("Tuning"),
-					    OBS_COMBO_TYPE_LIST,
-					    OBS_COMBO_FORMAT_STRING);
+	p = obs_properties_add_list(props, "tune", obs_module_text("Tuning"),
+				    OBS_COMBO_TYPE_LIST,
+				    OBS_COMBO_FORMAT_STRING);
 
 #define add_tune(val)                                                         \
 	obs_property_list_add_string(p, obs_module_text("NVENC.Tuning." val), \
 				     val)
-		add_tune("hq");
-		add_tune("ll");
-		add_tune("ull");
+	add_tune("hq");
+	add_tune("ll");
+	add_tune("ull");
 #undef add_tune
 
-		p = obs_properties_add_list(props, "multipass",
-					    obs_module_text("NVENC.Multipass"),
-					    OBS_COMBO_TYPE_LIST,
-					    OBS_COMBO_FORMAT_STRING);
+	p = obs_properties_add_list(props, "multipass",
+				    obs_module_text("NVENC.Multipass"),
+				    OBS_COMBO_TYPE_LIST,
+				    OBS_COMBO_FORMAT_STRING);
 
 #define add_multipass(val)            \
 	obs_property_list_add_string( \
 		p, obs_module_text("NVENC.Multipass." val), val)
-		add_multipass("disabled");
-		add_multipass("qres");
-		add_multipass("fullres");
+	add_multipass("disabled");
+	add_multipass("qres");
+	add_multipass("fullres");
 #undef add_multipass
-	}
 
 	p = obs_properties_add_list(props, "profile",
 				    obs_module_text("Profile"),

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -369,23 +369,7 @@ bool obs_module_load(void)
 		blog(LOG_INFO, "NVENC supported");
 
 #ifdef _WIN32
-		if (get_win_ver_int() > 0x0601) {
-			obs_nvenc_load(h264, hevc, av1);
-		} else {
-			// if on Win 7, new nvenc isn't available so there's
-			// no nvenc encoder for the user to select, expose
-			// the old encoder directly
-			if (h264) {
-				h264_nvenc_encoder_info.caps &=
-					~OBS_ENCODER_CAP_INTERNAL;
-			}
-#ifdef ENABLE_HEVC
-			if (hevc) {
-				hevc_nvenc_encoder_info.caps &=
-					~OBS_ENCODER_CAP_INTERNAL;
-			}
-#endif
-		}
+		obs_nvenc_load(h264, hevc, av1);
 #endif
 		if (h264)
 			obs_register_encoder(&h264_nvenc_encoder_info);

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -1,4 +1,3 @@
-#include <util/dstr.h>
 #include <obs-module.h>
 #include <util/platform.h>
 #include <libavutil/avutil.h>
@@ -241,34 +240,6 @@ extern bool load_nvenc_lib(void);
 extern uint32_t get_nvenc_ver();
 #endif
 
-/* please remove this annoying garbage and the associated garbage in
- * obs-ffmpeg-nvenc.c when ubuntu 20.04 is finally gone for good. */
-
-#ifdef __linux__
-bool ubuntu_20_04_nvenc_fallback = false;
-
-static void do_nvenc_check_for_ubuntu_20_04(void)
-{
-	FILE *fp;
-	char *line = NULL;
-	size_t linecap = 0;
-
-	fp = fopen("/etc/os-release", "r");
-	if (!fp) {
-		return;
-	}
-
-	while (getline(&line, &linecap, fp) != -1) {
-		if (strncmp(line, "VERSION_CODENAME=focal", 22) == 0) {
-			ubuntu_20_04_nvenc_fallback = true;
-		}
-	}
-
-	fclose(fp);
-	free(line);
-}
-#endif
-
 static bool nvenc_codec_exists(const char *name, const char *fallback)
 {
 	const AVCodec *nvenc = avcodec_find_encoder_by_name(name);
@@ -396,11 +367,6 @@ bool obs_module_load(void)
 	bool av1 = false;
 	if (nvenc_supported(&h264, &hevc, &av1)) {
 		blog(LOG_INFO, "NVENC supported");
-
-#ifdef __linux__
-		/* why are we here? just to suffer? */
-		do_nvenc_check_for_ubuntu_20_04();
-#endif
 
 #ifdef _WIN32
 		if (get_win_ver_int() > 0x0601) {


### PR DESCRIPTION
### Description

Removes fallbacks that were necessary for Ubuntu 20.04 and Windows 7, which are no longer supported.

### Motivation and Context

Dead code cleanup.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
