### PR TITLE
vlc-video: Fix play_pause to respect boolean

### DIFF
--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -821,9 +821,11 @@ static void vlcs_play_pause(void *data, bool pause)
 {
 	struct vlc_source *c = data;
 
-	if (pause)
+	libvlc_state_t state = libvlc_media_player_get_state_(c->media_player);
+
+	if (pause && state == libvlc_Playing)
 		libvlc_media_list_player_pause_(c->media_list_player);
-	else
+	else if (!pause && state == libvlc_Paused)
 		libvlc_media_list_player_play_(c->media_list_player);
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This fixes the behaviour of the media_play_pause of the VLC Video Source, to bring it in line with the media source and the documentation.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

`libvlc_media_list_player_pause_` acts as a pause toggle, unpausing the video if it is currently paused. As such, calling `media_play_pause(vlc_source, true)` would unpause the video if currently paused, effectively ignoring the value of the bool.
This fixes it by checking for the state before calling the libvlc functions.

There is a very slight technical breaking change here : `media_play_pause` is now a no-op when called on a source that is in a state other than playing or paused.
Previously, when calling `media_play_pause` on a video in a state other than playing or paused, the libvlc functions were called, but as far as I can see the only effect were changes in the UI buttons (and not on the actual source playback), so I don't think it should affect much. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 22.04
The python script attached below allows sending play or pause requests to a specified source. Using it, I checked that the behaviour was consistent.
[vlc_pause_test.zip](https://github.com/obsproject/obs-studio/files/13772911/vlc_pause_test.zip)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
