### PR TITLE
build-aux: Work around oneVPL search path for Flatpak QSV

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -18,7 +18,8 @@
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.a11y.Bus",
         "--system-talk-name=org.freedesktop.Avahi",
-        "--env=VST_PATH=/app/extensions/Plugins/vst"
+        "--env=VST_PATH=/app/extensions/Plugins/vst",
+        "--env=ONEVPL_SEARCH_PATH=/app/lib"
     ],
     "add-extensions": {
         "com.obsproject.Studio.Plugin": {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

With an Intel GPU, the QuickSync encoders fail to start in the Flatpak build:

```
info: [qsv encoder: 'advanced_video_recording'] debug info:
error: Failed to initialize MFX

 Specified object not found. /run/build/obs/plugins/obs-qsv11/common_utils_linux.cpp 140

 Specified object not found. /run/build/obs/plugins/obs-qsv11/QSV_Encoder_Internal.cpp 156
warning: [qsv encoder: 'msdk_impl'] Specified object/item/sync point not found. (MFX_ERR_NOT_FOUND)
warning: [qsv encoder: 'advanced_video_recording'] qsv failed to load
```

Tracing this back points to the `MFXCreateSession` call [in common_utils_linux.cpp](https://github.com/obsproject/obs-studio/blob/0e5007794836c31bebd46fb492776f38f84f0441/plugins/obs-qsv11/common_utils_linux.cpp#L137), implemented on `libvpl`'s side in [mfx_dispatcher_vpl.cpp](https://github.com/intel/libvpl/blob/79ef61b11790c70941cfa4d167b5d20d3a4e9744/libvpl/src/mfx_dispatcher_vpl.cpp#L132). Next, `CreateSession` fails in [mfx_dispatcher_vpl_loader.cpp](https://github.com/intel/libvpl/blob/79ef61b11790c70941cfa4d167b5d20d3a4e9744/libvpl/src/mfx_dispatcher_vpl_loader.cpp#L1551) due to `m_implInfoList` being empty. That list is populated by [`QueryLibraryCaps`](https://github.com/intel/libvpl/blob/79ef61b11790c70941cfa4d167b5d20d3a4e9744/libvpl/src/mfx_dispatcher_vpl_loader.cpp#L889), which in turn requires `m_libInfoList` to be populated. This happens [in `BuildListOfCandidateLibs`](https://github.com/intel/libvpl/blob/79ef61b11790c70941cfa4d167b5d20d3a4e9744/libvpl/src/mfx_dispatcher_vpl_loader.cpp#L428), which ultimately checks the following paths for the libraries, in from highest to lowest priority:

1. `ONEVPL_PRIORITY_PATH` environment variable
2. `LD_LIBRARY_PATH` environment variable
3. `/usr/lib/x86_64-linux-gnu`
4.  `/lib`
5. `/usr/lib`
6. `/lib64`
7. `/usr/lib64`
8. `ONEVPL_SEARCH_PATH` environment variable
9. `/opt/intel/mediasdk/lib`
10. `/opt/intel/mediasdk/lib64`

Thus, setting `ONEVPL_SEARCH_PATH=/app/lib` (where the libraries are actually installed in the Flatpak) resolves the issue. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes https://github.com/obsproject/obs-studio/issues/9930 (why is this closed?) as well as the off-topic comments of https://github.com/obsproject/obs-studio/issues/9324 and https://github.com/obsproject/obs-studio/issues/9825.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on the current release by appending `ONEVPL_SEARCH_PATH=/app/lib` to the environment variables via [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal) with the QuickSync H.264 encoder in recording mode. The `MFX_ERR_NOT_FOUND` error is gone and the encoder starts successfully, producing valid recordings with different settings. My laptop takes a day to build OBS from source, will test this specific commit as soon as I can (update: tested and working).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
