### PR TITLE
UI: Add --config-dir option to set config path

### DIFF
--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -268,7 +268,6 @@ static inline int GetProfilePath(char *path, size_t size, const char *file)
 	return window->GetProfilePath(path, size, file);
 }
 
-extern bool portable_mode;
 extern bool steam;
 extern bool safe_mode;
 extern bool disable_3p_plugins;

--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -300,7 +300,7 @@ RunOnceMutex CheckIfAlreadyRunning(bool &already_running)
 {
 	string name;
 
-	if (!portable_mode) {
+	if (!App()->IsPortableMode()) {
 		name = "OBSStudioCore";
 	} else {
 		char path[500];

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -182,7 +182,7 @@ static void AddExtraModulePaths()
 				    data_path_with_module_suffix.c_str());
 	}
 
-	if (portable_mode)
+	if (App()->IsPortableMode())
 		return;
 
 	char base_module_dir[512];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

This patch adds a new option `--config-dir <path>` to allow the config path used by OBS to be set on run. This new functionality can be seen as a generalization of portable mode, and the patch accordingly reimplements the portable mode option in terms of the config path option.

When the `--config-dir` option is specified, OBS now acts as if it is portable mode -- that is to say, checks against the now removed `portable_mode` flag are now done against `opt_config_path` being empty or not.

***Note:*** This change is non-breaking as `--portable` has not been removed but has instead been updated to work in terms of the `opt_config_path` string.

### Motivation and Context

The two key motivations for this patch are as follows:

1. Portable mode is unsupported on macOS. This patch does not change this behaviour, and `--portable` will still be hidden when running on macOS with `--help`, but `--config-dir` can be used on macOS without issue, enabling creators of portable OBS packages (e.g. for specific events) to target macOS with ease.
2. Running multiple instances of different portable OBS packages normally requires duplicating the program data for each portable instance. This patch allows the same instance to be run with different `--config-dir` values, avoiding duplication of identical data.

### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
* Tested on macOS Sonoma 14.0 with various config paths being passed on the command line, as well as no config path being passed and seeing that the default non-portable-mode config path is used.
* Additionally tested on Windows 11 with various configurations of the `--portable` and `--config-dir` flags.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
