### PR TITLE
mac-virtualcam: Reduce excessive polling for new sample buffers

### DIFF
--- a/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
+++ b/plugins/mac-virtualcam/src/camera-extension/OBSCameraDeviceSource.swift
@@ -23,7 +23,8 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
     private var _streamingCounter: UInt32 = 0
     private var _streamingSinkCounter: UInt32 = 0
 
-    private var _timer: DispatchSourceTimer?
+    private var _placeholderTimer: DispatchSourceTimer?
+    private var _consumeBufferTimer: DispatchSourceTimer?
 
     private let _timerQueue = DispatchQueue(
         label: "timerQueue",
@@ -137,15 +138,15 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
 
         _streamingCounter += 1
 
-        _timer = DispatchSource.makeTimerSource(flags: .strict, queue: _timerQueue)
+        _placeholderTimer = DispatchSource.makeTimerSource(flags: .strict, queue: _timerQueue)
 
-        _timer!.schedule(
+        _placeholderTimer!.schedule(
             deadline: .now(),
             repeating: 1.0 / Double(OBSCameraFrameRate),
             leeway: .seconds(0)
         )
 
-        _timer!.setEventHandler {
+        _placeholderTimer!.setEventHandler {
             if self.sinkStarted {
                 return
             }
@@ -217,9 +218,9 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
                 }
             }
         }
-        _timer!.setCancelHandler {}
+        _placeholderTimer!.setCancelHandler {}
 
-        _timer!.resume()
+        _placeholderTimer!.resume()
     }
 
     func stopStreaming() {
@@ -228,9 +229,9 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
         } else {
             _streamingCounter = 0
 
-            if let timer = _timer {
+            if let timer = _placeholderTimer {
                 timer.cancel()
-                _timer = nil
+                _placeholderTimer = nil
             }
         }
     }
@@ -267,22 +268,41 @@ class OBSCameraDeviceSource: NSObject, CMIOExtensionDeviceSource {
 
                 self._streamSink.stream.notifyScheduledOutputChanged(output)
             }
-            self.consumeBuffer(client)
         }
     }
 
     func startStreamingSink(client: CMIOExtensionClient) {
         _streamingSinkCounter += 1
         self.sinkStarted = true
-        consumeBuffer(client)
+
+        _consumeBufferTimer = DispatchSource.makeTimerSource(flags: .strict, queue: _timerQueue)
+
+        _consumeBufferTimer!.schedule(
+            deadline: .now(),
+            repeating: 1.0 / (Double(OBSCameraFrameRate) * 3.0),
+            leeway: .seconds(0)
+        )
+
+        _consumeBufferTimer!.setEventHandler {
+            self.consumeBuffer(client)
+        }
+
+        _consumeBufferTimer!.setCancelHandler {}
+
+        _consumeBufferTimer!.resume()
     }
 
     func stopStreamingSink() {
         self.sinkStarted = false
+
         if _streamingCounter > 1 {
             _streamingSinkCounter -= 1
         } else {
             _streamingSinkCounter = 0
+            if let timer = _consumeBufferTimer {
+                timer.cancel()
+                _consumeBufferTimer = nil
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The function that [consumes sample buffers](https://developer.apple.com/documentation/coremediaio/cmioextensionstream/3915931-consumesamplebuffer) in the virtual camera's sink stream appears to be non-blocking. Since the completion handler in OBS calls the parent function directly, this causes the completion handler to be called very frequently, predominantly with a `nil` `CMSampleBuffer`. This PR is one attempt at addressing the amount of calls, modifying the callback to call `consumeBuffer` in tandem with the virtual camera's framerate, via ~~`DispatchQueue`'s `asyncAfter` method~~ a second `DispatchSourceTimer`.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The background CPU usage from the excessive amount of calls to `consumeBuffer` adds up, with various Mac OBS users noting an increase in CPU use of the new virtual camera, and `com.apple.cmio.registerassistantservice`'s usage in particular. See https://github.com/obsproject/obs-studio/issues/9864, etc.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my M1 Max MacBook Pro running 14.1.2. Prior to the change, on my machine, `consumeBuffer` was being called between 20,000 and 30,000 times per second, with `com.apple.cmio.registerassistantservice` CPU use around 50%. With the change, the function is called nearer to the prescribed framerate, with `com.apple.cmio.registerassistantservice` CPU usage between ~~0-1%~~ 2-3%. Visually, I monitored the virtual camera output and did not note any significant increase in dropped frames/decreased framerate.

### Other
Documentation is thin on the ground for the best particular way to handle video streams moving from one process to another via CMIO and sink streams. Idiomatically, there may be a better way to handle this. I thought about CFNotifications when frames are prepared on the OBS end, or more precise timer shenanigans. I'm totally fine if this PR is just tracking for a better solution. Since I was tinkering around already, I merely figured I may as well submit this PR, as it does at least do the job.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
