### PR TITLE
libobs: Use UUIDs for all contexts

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -382,6 +382,15 @@ Libobs Objects
 
 ---------------------
 
+.. function:: obs_output_t *obs_get_output_by_uuid(const char *uuid)
+
+   Gets an output by its UUID.
+
+   Increments the output reference counter, use
+   :c:func:`obs_output_release()` to release it when complete.
+
+---------------------
+
 .. function:: obs_encoder_t *obs_get_encoder_by_name(const char *name)
 
    Gets an encoder by its name.
@@ -391,9 +400,27 @@ Libobs Objects
 
 ---------------------
 
+.. function:: obs_encoder_t *obs_get_encoder_by_uuid(const char *uuid)
+
+   Gets an encoder by its UUID.
+
+   Increments the encoder reference counter, use
+   :c:func:`obs_encoder_release()` to release it when complete.
+
+---------------------
+
 .. function:: obs_service_t *obs_get_service_by_name(const char *name)
 
    Gets an service by its name.
+
+   Increments the service reference counter, use
+   :c:func:`obs_service_release()` to release it when complete.
+
+---------------------
+
+.. function:: obs_service_t *obs_get_service_by_uuid(const char *uuid)
+
+   Gets an service by its UUID.
 
    Increments the service reference counter, use
    :c:func:`obs_service_release()` to release it when complete.

--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -378,6 +378,12 @@ General Encoder Functions
 
 ---------------------
 
+.. function:: const char *obs_encoder_get_uuid(const obs_encoder_t *encoder)
+
+   :return: The UUID of the encoder
+
+---------------------
+
 .. function:: const char *obs_encoder_get_codec(const obs_encoder_t *encoder)
               const char *obs_get_encoder_codec(const char *id)
 

--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -397,6 +397,12 @@ General Output Functions
 
 ---------------------
 
+.. function:: const char *obs_output_get_uuid(const obs_output_t *output)
+
+   :return: The UUID of the output
+
+---------------------
+
 .. function:: const char *obs_output_get_id(const obs_output_t *output)
 
    :return: The output's type identifier string

--- a/docs/sphinx/reference-services.rst
+++ b/docs/sphinx/reference-services.rst
@@ -287,6 +287,12 @@ General Service Functions
 
 ---------------------
 
+.. function:: const char *obs_service_get_uuid(const obs_service_t *service)
+
+   :return: The UUID of the service
+
+---------------------
+
 .. function:: obs_data_t *obs_service_defaults(const char *id)
 
    :return: An incremented reference to the service's default settings.

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -431,6 +431,13 @@ void obs_encoder_set_name(obs_encoder_t *encoder, const char *name)
 		obs_context_data_setname(&encoder->context, name);
 }
 
+const char *obs_encoder_get_uuid(const obs_encoder_t *encoder)
+{
+	return obs_encoder_valid(encoder, "obs_encoder_get_uuid")
+		       ? encoder->context.uuid
+		       : NULL;
+}
+
 static inline obs_data_t *get_defaults(const struct obs_encoder_info *info)
 {
 	obs_data_t *settings = obs_data_create();

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -316,6 +316,13 @@ const char *obs_output_get_name(const obs_output_t *output)
 		       : NULL;
 }
 
+const char *obs_output_get_uuid(const obs_output_t *output)
+{
+	return obs_output_valid(output, "obs_output_get_uuid")
+		       ? output->context.uuid
+		       : NULL;
+}
+
 bool obs_output_actual_start(obs_output_t *output)
 {
 	bool success = false;

--- a/libobs/obs-service.c
+++ b/libobs/obs-service.c
@@ -123,6 +123,13 @@ const char *obs_service_get_name(const obs_service_t *service)
 		       : NULL;
 }
 
+const char *obs_service_get_uuid(const obs_service_t *service)
+{
+	return obs_service_valid(service, "obs_service_get_uuid")
+		       ? service->context.uuid
+		       : NULL;
+}
+
 static inline obs_data_t *get_defaults(const struct obs_service_info *info)
 {
 	obs_data_t *settings = obs_data_create();

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -722,11 +722,20 @@ EXPORT obs_source_t *obs_get_transition_by_uuid(const char *uuid);
 /** Gets an output by its name. */
 EXPORT obs_output_t *obs_get_output_by_name(const char *name);
 
+/** Gets an output by its UUID. */
+EXPORT obs_output_t *obs_get_output_by_uuid(const char *uuid);
+
 /** Gets an encoder by its name. */
 EXPORT obs_encoder_t *obs_get_encoder_by_name(const char *name);
 
+/** Gets an output by its UUID. */
+EXPORT obs_encoder_t *obs_get_encoder_by_uuid(const char *uuid);
+
 /** Gets an service by its name. */
 EXPORT obs_service_t *obs_get_service_by_name(const char *name);
+
+/** Gets a service by its UUID. */
+EXPORT obs_service_t *obs_get_service_by_uuid(const char *uuid);
 
 enum obs_base_effect {
 	OBS_EFFECT_DEFAULT,         /**< RGB/YUV */
@@ -2059,6 +2068,7 @@ EXPORT bool obs_weak_output_references_output(obs_weak_output_t *weak,
 					      obs_output_t *output);
 
 EXPORT const char *obs_output_get_name(const obs_output_t *output);
+EXPORT const char *obs_output_get_uuid(const obs_output_t *output);
 
 /** Starts the output. */
 EXPORT bool obs_output_start(obs_output_t *output);
@@ -2417,6 +2427,7 @@ EXPORT bool obs_weak_encoder_references_encoder(obs_weak_encoder_t *weak,
 
 EXPORT void obs_encoder_set_name(obs_encoder_t *encoder, const char *name);
 EXPORT const char *obs_encoder_get_name(const obs_encoder_t *encoder);
+EXPORT const char *obs_encoder_get_uuid(const obs_encoder_t *encoder);
 
 /** Returns the codec of an encoder by the id */
 EXPORT const char *obs_get_encoder_codec(const char *id);
@@ -2605,6 +2616,7 @@ EXPORT bool obs_weak_service_references_service(obs_weak_service_t *weak,
 						obs_service_t *service);
 
 EXPORT const char *obs_service_get_name(const obs_service_t *service);
+EXPORT const char *obs_service_get_uuid(const obs_service_t *service);
 
 /** Gets the default settings for a service */
 EXPORT obs_data_t *obs_service_defaults(const char *id);


### PR DESCRIPTION
### Description
This adds uuids to outputs, encoders and services.

### Motivation and Context
This will help me in the output wrapper PR (#8918), so I can store/find outputs by their uuid. UUIDs are a better way of looking up contexts, as the uuid never changes and is always unique.

These are currently not using hash tables. As there are far less of these than sources, lookup times shouldn't be impacted.

### How Has This Been Tested?
Retrieved UUID from virtual camera output and also found that output by that UUID. Haven't tested with encoders or services but the code is basically the same, so they should also work.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
