### PR TITLE
libobs: Send item_remove signal after detaching item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2327,8 +2327,8 @@ static void obs_sceneitem_remove_internal(obs_sceneitem_t *item)
 
 	set_visibility(item, false);
 
-	signal_item_remove(item);
 	detach_sceneitem(item);
+	signal_item_remove(item);
 
 	obs_sceneitem_set_transition(item, true, NULL);
 	obs_sceneitem_set_transition(item, false, NULL);


### PR DESCRIPTION
### Description

Swaps order to send `item_remove` signal *after* it has actually been removed from the list of scene items

### Motivation and Context

The documentation states

> Called when a scene item has been removed from the scene.

However, as the signal is emitted *before* the removal actually takes place using any enumerations such as `obs_scene_enum_items` in the callback will still produce the "removed" item. This PR changes the order for this to be in line with the documentation.

### How Has This Been Tested?

Has been tested with my ROI WIP UI which suffered from an issue due to the callback triggering an immediate refresh of its internal list of scene items, which would still include the removed item.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
