### PR TITLE
output-timer: Fixed buttons so that stopping a timer does not stop stream/recording

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -53,12 +53,14 @@ void OutputTimer::StreamingTimerButton()
 	if (!obs_frontend_streaming_active()) {
 		blog(LOG_INFO, "Starting stream due to OutputTimer");
 		obs_frontend_streaming_start();
-	} else if (streamingAlreadyActive) {
+	} else if (streamingAlreadyActive ||
+		   !this->streamingTimer->isActive()) {
 		StreamTimerStart();
 		streamingAlreadyActive = false;
 	} else if (obs_frontend_streaming_active()) {
-		blog(LOG_INFO, "Stopping stream due to OutputTimer");
-		obs_frontend_streaming_stop();
+		stoppingStreamTimer = true;
+		StreamTimerStop();
+		stoppingStreamTimer = false;
 	}
 }
 
@@ -67,12 +69,14 @@ void OutputTimer::RecordingTimerButton()
 	if (!obs_frontend_recording_active()) {
 		blog(LOG_INFO, "Starting recording due to OutputTimer");
 		obs_frontend_recording_start();
-	} else if (recordingAlreadyActive) {
+	} else if (recordingAlreadyActive ||
+		   !this->recordingTimer->isActive()) {
 		RecordTimerStart();
 		recordingAlreadyActive = false;
 	} else if (obs_frontend_recording_active()) {
-		blog(LOG_INFO, "Stopping recording due to OutputTimer");
-		obs_frontend_recording_stop();
+		stoppingRecordingTimer = true;
+		RecordTimerStop();
+		stoppingRecordingTimer = false;
 	}
 }
 
@@ -235,14 +239,18 @@ void OutputTimer::ShowHideDialog()
 
 void OutputTimer::EventStopStreaming()
 {
-	blog(LOG_INFO, "Stopping stream due to OutputTimer timeout");
-	obs_frontend_streaming_stop();
+	if (!stoppingStreamTimer) {
+		blog(LOG_INFO, "Stopping stream due to OutputTimer timeout");
+		obs_frontend_streaming_stop();
+	}
 }
 
 void OutputTimer::EventStopRecording()
 {
-	blog(LOG_INFO, "Stopping recording due to OutputTimer timeout");
-	obs_frontend_recording_stop();
+	if (!stoppingRecordingTimer) {
+		blog(LOG_INFO, "Stopping recording due to OutputTimer timeout");
+		obs_frontend_recording_stop();
+	}
 }
 
 static void SaveOutputTimer(obs_data_t *save_data, bool saving, void *)

--- a/UI/frontend-plugins/frontend-tools/output-timer.hpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.hpp
@@ -34,6 +34,8 @@ public slots:
 private:
 	bool streamingAlreadyActive = false;
 	bool recordingAlreadyActive = false;
+	bool stoppingStreamTimer = false;
+	bool stoppingRecordingTimer = false;
 
 	QTimer *streamingTimer;
 	QTimer *recordingTimer;


### PR DESCRIPTION
### Description

I made it so that stopping a stream/recording timer does not cause the stream/recording to stop.

This was done by adding two member variables to the OutputTimer class and by then referencing them appropriately at the correct places.

### Motivation and Context
Multiple users including myself have had this happen while streaming when we set our timer and decide either that we want to stream longer or just set the timer incorrectly and need to change it.

https://obsproject.com/forum/threads/how-to-cancel-or-change-the-output-timer-once-started.137102/

https://github.com/obsproject/obs-studio/issues/10026

### How Has This Been Tested?
I compiled and ran it and did the following tests:

1. Start the stream timer, make sure it starts the stream as before
2. Stop the stream timer, make sure it doesn't stop the stream and still stops the timer
3. Restart the timer and make sure it actually stops the stream when the time runs out

I did the same for the recording timer.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
