### PR TITLE
libobs: Fix crop to bounding box not being duplicated with item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1740,6 +1740,8 @@ static inline void duplicate_item_data(struct obs_scene_item *dst,
 	dst->bounds_type = src->bounds_type;
 	dst->bounds_align = src->bounds_align;
 	dst->bounds = src->bounds;
+	dst->crop_to_bounds = src->crop_to_bounds;
+	dst->bounds_crop = src->bounds_crop;
 
 	if (src->show_transition) {
 		obs_source_t *transition = obs_source_duplicate(


### PR DESCRIPTION
### Description

Fixes bounding box crop information not being duplicated when a scene item is duplicated (e.g. when duplicating scenes).

### Motivation and Context

Fix bug.

### How Has This Been Tested?

Duplicated scene, no longer an issue.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
