### PR TITLE
mac-capture: Update capture to include menu bar and child windows

### DIFF
--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -160,6 +160,10 @@ static bool init_screen_stream(struct screen_capture *sc)
 
                 [sc->stream_properties setWidth:(size_t) target_window.frame.size.width];
                 [sc->stream_properties setHeight:(size_t) target_window.frame.size.height];
+
+                if (@available(macOS 14.2, *)) {
+                    [sc->stream_properties setIncludeChildWindows:YES];
+                }
             }
         } break;
         case ScreenCaptureApplicationStream: {
@@ -176,6 +180,10 @@ static bool init_screen_stream(struct screen_capture *sc)
             content_filter = [[SCContentFilter alloc] initWithDisplay:target_display
                                                 includingApplications:target_application_array
                                                      exceptingWindows:empty_array];
+            if (@available(macOS 14.2, *)) {
+                content_filter.includeMenuBar = YES;
+            }
+
             [target_application_array release];
             [empty_array release];
 


### PR DESCRIPTION
### Description
Explicitly enable capture of the menu bar and child windows for application capture on macOS.

### Motivation and Context
macOS 14.2 changed internal defaults of SCK requiring the inclusion of the menu bar and child windows to be enabled explicitly.

This will have a slight negative impact on capture performance but is required to restore behaviour of prior macOS versions.

### How Has This Been Tested?
Tested on macOS 14.2.1.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
