### PR TITLE
cmake: Update build requirements to Xcode 15.1 and macOS 14.2 SDK

### DIFF
--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -23,8 +23,8 @@ endif()
 set_property(CACHE CMAKE_OSX_ARCHITECTURES PROPERTY STRINGS arm64 x86_64)
 
 # Ensure recent enough Xcode and platform SDK
-set(_obs_macos_minimum_sdk 13.1) # Keep in sync with Xcode
-set(_obs_macos_minimum_xcode 14.2) # Keep in sync with SDK
+set(_obs_macos_minimum_sdk 14.2) # Keep in sync with Xcode
+set(_obs_macos_minimum_xcode 15.1) # Keep in sync with SDK
 message(DEBUG "macOS SDK Path: ${CMAKE_OSX_SYSROOT}")
 string(REGEX MATCH ".+/MacOSX.platform/Developer/SDKs/MacOSX([0-9]+\\.[0-9])+\\.sdk$" _ ${CMAKE_OSX_SYSROOT})
 set(_obs_macos_current_sdk ${CMAKE_MATCH_1})


### PR DESCRIPTION
### Description
Increases build system requirements for macOS builds to Xcode 15.1 and associated macOS 14.2 platform SDK.

### Motivation and Context
Allows the project to use recent fixes and changes to macOS frameworks and also allows restoration of functionality available in older macOS versions that changed in 14.2 and beyond.

Ensures that https://github.com/obsproject/obs-studio/pull/10065 will not break on local builds.

### How Has This Been Tested?
Tested with macOS 14.2.1 and Xcode 15.1 on CI as well as locally.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
