### PR TITLE
UI: Switch to bigger units for high bitrate/large recordings

### DIFF
--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -546,10 +546,20 @@ void OBSBasicStats::OutputLabels::Update(obs_output_t *output, bool rec)
 	setThemeID(status, themeID);
 
 	long double num = (long double)totalBytes / (1024.0l * 1024.0l);
+	const char *unit = "MiB";
+	if (num > 1024) {
+		num /= 1024;
+		unit = "GiB";
+	}
+	megabytesSent->setText(QString("%1 %2").arg(num, 0, 'f', 1).arg(unit));
 
-	megabytesSent->setText(
-		QString("%1 MB").arg(QString::number(num, 'f', 1)));
-	bitrate->setText(QString("%1 kb/s").arg(QString::number(kbps, 'f', 0)));
+	num = kbps;
+	unit = "kb/s";
+	if (num >= 10'000) {
+		num /= 1000;
+		unit = "Mb/s";
+	}
+	bitrate->setText(QString("%1 %2").arg(num, 0, 'f', 0).arg(unit));
 
 	if (!rec) {
 		int total = output ? obs_output_get_total_frames(output) : 0;


### PR DESCRIPTION
### Description

Switch output bitrate and file size in stats dock to larger units when appropiate.

| Before | After |
| - | - |
| ![before](https://github.com/obsproject/obs-studio/assets/3123295/e0784166-f54a-4aff-b510-a37ef20321a1) | ![after](https://github.com/obsproject/obs-studio/assets/3123295/7b6e0cb7-d9b7-49af-8096-a3b4cb0a870f)  |

### Motivation and Context

Suggested by a couple people and seems to make sense.

### How Has This Been Tested?

See screenshots above.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
