### PR TITLE
UI: Fix unused-variable

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7576,16 +7576,16 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 
 	const obs_encoder_t *videoEncoder =
 		obs_output_get_video_encoder(outputHandler->fileOutput);
-	const obs_encoder_t *audioEncoder =
-		obs_output_get_audio_encoder(outputHandler->fileOutput, 0);
 	const char *vCodecName = obs_encoder_get_codec(videoEncoder);
-	const char *aCodecName = obs_encoder_get_codec(audioEncoder);
 	const char *format = config_get_string(
 		config, isSimpleMode ? "SimpleOutput" : "AdvOut", "RecFormat2");
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 5, 100)
+	const obs_encoder_t *audioEncoder =
+		obs_output_get_audio_encoder(outputHandler->fileOutput, 0);
+	const char *aCodecName = obs_encoder_get_codec(audioEncoder);
 	bool audio_is_pcm = strncmp(aCodecName, "pcm", 3) == 0;
 
-#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(60, 5, 100)
 	/* FFmpeg <= 6.0 cannot remux AV1+PCM into any supported format. */
 	if (audio_is_pcm && strcmp(vCodecName, "av1") == 0)
 		return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Some variables were not guarded for being unused when built with FFmpeg 6.1

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix building UI with #9787

```
[build] …/obs-studio/UI/window-basic-main.cpp: In member function ‘void OBSBasic::AutoRemux(QString, bool)’:
[build] …/obs-studio/UI/window-basic-main.cpp:7586:14: error: unused variable ‘audio_is_pcm’ [-Werror=unused-variable]
[build]  7586 |         bool audio_is_pcm = strncmp(aCodecName, "pcm", 3) == 0;
[build]       |              ^~~~~~~~~~~~
```

```
[build] …/obs-studio/UI/window-basic-main.cpp: In member function ‘void OBSBasic::AutoRemux(QString, bool)’:
[build] …/obs-studio/UI/window-basic-main.cpp:7582:21: error: unused variable ‘aCodecName’ [-Werror=unused-variable]
[build]  7582 |         const char *aCodecName = obs_encoder_get_codec(audioEncoder);
[build]       |                     ^~~~~~~~~~
```

```
build] …/obs-studio/UI/window-basic-main.cpp: In member function ‘void OBSBasic::AutoRemux(QString, bool)’:
[build] …/obs-studio/UI/window-basic-main.cpp:7579:30: error: unused variable ‘audioEncoder’ [-Werror=unused-variable]
[build]  7579 |         const obs_encoder_t *audioEncoder =
[build]       |                              ^~~~~~~~~~~~
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Build #9787 locally with FFmpeg 6.1

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
