### PR TITLE
obs-ffmpeg: Fix issue with B-frames introducing motion blur

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1294,8 +1294,16 @@ static bool amf_avc_init(void *data, obs_data_t *settings)
 	int64_t bf = obs_data_get_int(settings, "bf");
 
 	if (enc->bframes_supported) {
-		set_avc_property(enc, MAX_CONSECUTIVE_BPICTURES, 3);
+		set_avc_property(enc, MAX_CONSECUTIVE_BPICTURES, bf);
 		set_avc_property(enc, B_PIC_PATTERN, bf);
+
+		/* AdaptiveMiniGOP is suggested for some types of content such
+		 * as those with high motion. This only takes effect if
+		 * Pre-Analysis is enabled.
+		 */
+		if (bf > 0) {
+			set_avc_property(enc, ADAPTIVE_MINIGOP, true);
+		}
 
 	} else if (bf != 0) {
 		warn("B-Frames set to %lld but b-frames are not "

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1066,6 +1066,7 @@ static void amf_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, "rate_control", "CBR");
 	obs_data_set_default_string(settings, "preset", "quality");
 	obs_data_set_default_string(settings, "profile", "high");
+	obs_data_set_default_int(settings, "bf", 3);
 }
 
 static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If a user sets both `AdaptiveMiniGOP=true` and `EnablePreAnalysis=true` in the AMF/FFmpeg options field, AMF will adaptively insert B-pictures, and no longer uses the fixed B pattern. Since `MAX_CONSECUTIVE_BPICTURES` is hard-coded to 3, the max B-frame UI setting is not respected. Furthermore, for a fixed B-frames pattern, it is expected that increasing B-frames can cause a quality drop for certain content such as with high motion. AdaptiveMiniGOP is recommended when using B-frames to improve the quality in such cases. AdaptiveMiniGOP is dependent on PreAnalysis which means that trying to enable it without having PreAnalysis turned ON will have no negative effect (AdaptiveMiniGOP won't be enabled).

Additionally, if a UI element for enabling PreAnalysis such as a checkbox is added, it can be used to check if both B-frames > 0 and PreAnalysis is ON before trying to enable AdaptiveMiniGOP.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This PR addresses [GPUOpen/AMF Issue \#433](https://github.com/GPUOpen-LibrariesAndSDKs/AMF/issues/433) regarding quality in OBS recording.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 10 with an AMD Radeon RX 7900 XTX as well as a second machine where output bitstreams were inspected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
