### PR TITLE
UI: Use normal source width for screenshots

### DIFF
--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -68,8 +68,8 @@ void ScreenshotObj::Screenshot()
 	OBSSource source = OBSGetStrongRef(weakSource);
 
 	if (source) {
-		cx = obs_source_get_base_width(source);
-		cy = obs_source_get_base_height(source);
+		cx = obs_source_get_width(source);
+		cy = obs_source_get_height(source);
 	} else {
 		obs_video_info ovi;
 		obs_get_video_info(&ovi);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes an issue where filters that resize a source, like "Crop/Pad" or "Scaling/Aspect Ratio", change the texture but the new source size gets ignored, effectively either cropping the screenshot or giving it black borders.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #9956

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.2
Took a screenshot of a source that had a Crop/Pad filter applied and confirmed that the black border has gone away.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
