### PR TITLE
libobs: Log Mac model identifier

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -72,13 +72,13 @@ static void log_processor_name(void)
     if (ret != 0)
         return;
 
-    name = malloc(size);
+    name = bmalloc(size);
 
     ret = sysctlbyname("machdep.cpu.brand_string", name, &size, NULL, 0);
     if (ret == 0)
         blog(LOG_INFO, "CPU Name: %s", name);
 
-    free(name);
+    bfree(name);
 }
 
 static void log_processor_speed(void)

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -93,6 +93,25 @@ static void log_processor_speed(void)
         blog(LOG_INFO, "CPU Speed: %lldMHz", freq / 1000000);
 }
 
+static void log_model_name(void)
+{
+    char *name = NULL;
+    size_t size;
+    int ret;
+
+    ret = sysctlbyname("hw.model", NULL, &size, NULL, 0);
+    if (ret != 0)
+        return;
+
+    name = bmalloc(size);
+
+    ret = sysctlbyname("hw.model", name, &size, NULL, 0);
+    if (ret == 0)
+        blog(LOG_INFO, "Model Identifier: %s", name);
+
+    bfree(name);
+}
+
 static void log_processor_cores(void)
 {
     blog(LOG_INFO, "Physical Cores: %d, Logical Cores: %d", os_get_physical_cores(), os_get_logical_cores());
@@ -139,6 +158,7 @@ void log_system_info(void)
     log_processor_speed();
     log_processor_cores();
     log_available_memory();
+    log_model_name();
     log_os();
     log_emulation_status();
     log_kernel_version();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds hardware model identifier strings (e.g. `MacBookPro18,2` to logs on macOS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Providing support or debugging issues with OBS on Mac frequently involves querying the user about their hardware beyond just the CPU or GPU. This is because the same chip in a Mac can have different capabilities inside a different chassis, and the user may need different advice accordingly. An M1 chip inside a 13" MacBook Pro has a very different thermal envelope than inside a MacBook Air, for example.

There currently isn't any way to see a user's exact model of machine from logs for Apple Silicon machines. For Intel machines, determining a user's model year currently involves looking up either their CPU or GPU model and seeing which Macs used it, which is a relatively complex series of steps to figure out what should be fairly simple. 

With this change, the model identifier is now listed conveniently in logs to streamline debugging.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my Apple Silicon machine. The function added is basically a carbon copy of other string-finding functions in `obs-cocoa.m`, just with a different sysctl call, so the surface area for issues is very small.

### Other

I aimed to log a more human-readable string (e.g. `iMac (Late 2017)`), but this [seems to require a non-trivial amount of effort](https://apple.stackexchange.com/questions/98080/can-a-macs-model-year-be-determined-with-a-terminal-command). 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
