### PR TITLE
rtmp-services: Add Streamway to ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 244,
+    "version": 245,
     "files": [
         {
             "name": "services.json",
-            "version": 244
+            "version": 245
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2677,6 +2677,29 @@
                 "profile": "high",
                 "bframes": 0
             }
+        },
+        {
+            "name": "Streamway",
+            "common": false,
+            "more_info_link": "https://support.streamway.in/how-to-connect-obs-studio-to-streamway/",
+            "stream_key_link": "https://app.streamway.in/broadcasts",
+            "servers": [
+                {
+                    "name": "Primary",
+                    "url": "rtmp://injest.streamway.in/LiveApp"
+                },
+                {
+                    "name": "Backup",
+                    "url": "rtmps://bkp.streamway.in:443/live"
+                }
+            ],
+            "protocol": "RTMP",
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Adding Streamway to OBS-Studio's Ingest List

### Motivation and Context
Streamway (https://streamway.in) is a re-streaming and CDN provider, that allows users to livestream on multiple social media platforms like YouTube, Facebook, LinkedIn, Twitch, Twitter and many more at same time, so broadcasters can get more views and maximise their autocancel.  Streamway also acts as a live CDN to allow Broadcasters to publish livestream directly on their custom Mobile app or websites. Streamway is wildly used in India with more than 3 years of availability.

By adding this website to the ingest list, OBS-Studio users will be able to easily and conveniently use Streamway as a source for their live streams and content.

### How Has This Been Tested?
- [x] JSON validation: Ensured that the JSON files are well-formed and adhered to the required format for OBS-Studio's ingest list.
- [x] Copy JSON files to %APPDATA%\obs-studio\plugin_config\rtmp-services: Manually copied the JSON files to the appropriate location where OBS-Studio reads ingest settings.
- [x] Checked settings: Verified that "Streamway" appears in the updated ingest list within OBS-Studio's settings.
- [x] Connection testing: Attempted to connect to the servers provided by "Streamway" to ensure successful streaming functionality.
- [x] According to [Service Submission Guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines)

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
