### PR TITLE
cmake: Update MbedTLS finder to support MSVC Debug configuration

### DIFF
--- a/cmake/finders/FindMbedTLS.cmake
+++ b/cmake/finders/FindMbedTLS.cmake
@@ -194,6 +194,7 @@ if(MbedTLS_FOUND)
         MbedTLS::MbedTLS
         PROPERTIES INTERFACE_COMPILE_OPTIONS "${PC_MbedTLS_CFLAGS_OTHER}"
                    INTERFACE_INCLUDE_DIRECTORIES "${MbedTLS_INCLUDE_DIR}"
+                   INTERFACE_LINK_OPTIONS "$<$<AND:$<PLATFORM_ID:Windows>,$<CONFIG:DEBUG>>:/NODEFAULTLIB:MSVCRT>"
                    VERSION ${MbedTLS_VERSION})
     endif()
   endforeach()


### PR DESCRIPTION
### Description
Remove `DEFAULTLIB` directive of MbedTLS for Debug builds on Windows.

### Motivation and Context
Natively compiled MbedTLS for Windows will use the non-debug platform library, which will lead to a linker error when building OBS in debug configuration with MSVC.

Neutralizing the linker directive for Debug builds on Windows unbreaks the build configuration without the need to ship separate debug variants of MbedTLS.

### How Has This Been Tested?
Tested on Windows 11 with natively compiled MbedTLS static libraries.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
