### PR TITLE
obs-ffmpeg: Fix incorrect CMake list syntax

### DIFF
--- a/plugins/obs-ffmpeg/cmake/dependencies.cmake
+++ b/plugins/obs-ffmpeg/cmake/dependencies.cmake
@@ -54,7 +54,7 @@ if(ENABLE_NEW_MPEGTS_OUTPUT)
   endforeach()
 
   if(_error_messages)
-    list(JOIN "\n" _error_string _error_string)
+    list(JOIN _error_messages "\n" _error_string)
     message(
       FATAL_ERROR
         "${_error_string}\n Disable this error by setting ENABLE_NEW_MPEGTS_OUTPUT to OFF or providing the build system with required SRT and Rist libraries."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix incorrect CMake `list` invocation. The current syntax had arguments in the incorrect order and also incorrectly used `_error_string` twice. Fix the syntax to join the `_error_messages` strings into `_error_string` so that the error messages are correctly displayed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want CMake errors to be clear when they occur.

https://cmake.org/cmake/help/v3.27/command/list.html#join
> `list(JOIN <list> <glue> <output variable>)`
>
> New in version 3.12.
> 
> Returns a string joining all list's elements using the glue string. To join multiple strings, which are not part of a list, use [`string(JOIN)`](https://cmake.org/cmake/help/v3.27/command/string.html#join).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally against a copy of deps where librist could not be found to ensure the error message appeared.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
