### PR TITLE
obs-ffmpeg: Only use NVENC compatibility hack if necessary

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -238,7 +238,6 @@ static bool nvenc_device_available(void)
 
 #ifdef _WIN32
 extern bool load_nvenc_lib(void);
-extern uint32_t get_nvenc_ver();
 #endif
 
 /* please remove this annoying garbage and the associated garbage in

--- a/plugins/obs-ffmpeg/obs-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/obs-nvenc-helpers.c
@@ -115,10 +115,14 @@ static void *load_nv_func(const char *func)
 
 typedef NVENCSTATUS(NVENCAPI *NV_MAX_VER_FUNC)(uint32_t *);
 
-uint32_t get_nvenc_ver()
+uint32_t get_nvenc_ver(void)
 {
 	static NV_MAX_VER_FUNC nv_max_ver = NULL;
 	static bool failed = false;
+	static uint32_t ver = 0;
+
+	if (!failed && ver)
+		return ver;
 
 	if (!nv_max_ver) {
 		if (failed)
@@ -132,7 +136,6 @@ uint32_t get_nvenc_ver()
 		}
 	}
 
-	uint32_t ver = 0;
 	if (nv_max_ver(&ver) != NV_ENC_SUCCESS) {
 		return 0;
 	}

--- a/plugins/obs-ffmpeg/obs-nvenc.h
+++ b/plugins/obs-ffmpeg/obs-nvenc.h
@@ -13,6 +13,7 @@ typedef NVENCSTATUS(NVENCAPI *NV_CREATE_INSTANCE_FUNC)(
 extern const char *nv_error_name(NVENCSTATUS err);
 extern NV_ENCODE_API_FUNCTION_LIST nv;
 extern NV_CREATE_INSTANCE_FUNC nv_create_instance;
+extern uint32_t get_nvenc_ver(void);
 extern bool init_nvenc(obs_encoder_t *encoder);
 bool nv_fail2(obs_encoder_t *encoder, void *session, const char *format, ...);
 bool nv_failed2(obs_encoder_t *encoder, void *session, NVENCSTATUS err,


### PR DESCRIPTION
### Description

Changes fallback to use NVENC version reported by driver to determine which version should be used, rather than always using the old version for non-AV1 codecs.

### Motivation and Context

- We might want to actually use a newer SDK features at some point (e.g. explicit split encoding in 12.1)
- The ROI feature #10039 breaks when using the compat version, this should fix that by not using it when unnecessary

### How Has This Been Tested?

NVENC still works on my 4090.

This has *not* been tested on a system that requires the compatibility workaround as my current GPU is not supported by driver versions that old (pre-Oct 2022), but I don't see why it would break.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
