### PR TITLE
libobs: Pass parent pointer into signal_item_remove

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -128,7 +128,8 @@ static const struct {
 	/* clang-format on */
 };
 
-static inline void signal_item_remove(struct obs_scene_item *item)
+static inline void signal_item_remove(struct obs_scene *parent,
+				      struct obs_scene_item *item)
 {
 	struct calldata params;
 	uint8_t stack[128];
@@ -136,7 +137,7 @@ static inline void signal_item_remove(struct obs_scene_item *item)
 	calldata_init_fixed(&params, stack, sizeof(stack));
 	calldata_set_ptr(&params, "item", item);
 
-	signal_parent(item->parent, "item_remove", &params);
+	signal_parent(parent, "item_remove", &params);
 }
 
 static const char *scene_getname(void *unused)
@@ -2325,12 +2326,13 @@ void obs_sceneitem_release(obs_sceneitem_t *item)
 
 static void obs_sceneitem_remove_internal(obs_sceneitem_t *item)
 {
+	obs_scene_t *parent = item->parent;
 	item->removed = true;
 
 	set_visibility(item, false);
 
 	detach_sceneitem(item);
-	signal_item_remove(item);
+	signal_item_remove(parent, item);
 
 	obs_sceneitem_set_transition(item, true, NULL);
 	obs_sceneitem_set_transition(item, false, NULL);
@@ -3522,7 +3524,7 @@ void obs_sceneitem_group_ungroup(obs_sceneitem_t *item)
 	obs_sceneitem_t *first;
 	obs_sceneitem_t *last;
 
-	signal_item_remove(item);
+	signal_item_remove(scene, item);
 
 	full_lock(scene);
 


### PR DESCRIPTION
### Description

With https://github.com/obsproject/obs-studio/commit/aaf8d8b38fba518d6dbeef92fbf75b0738843d10 changing the order `item->parent` would be NULL thus resulting in a crash.

### Motivation and Context

Fix my dumb mistake from apparently not testing this (properly).

### How Has This Been Tested?

OBS runs and doesn't crash :)

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
