### PR TITLE
UI: Implement GPU scaling options

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1037,6 +1037,7 @@ Basic.Settings.Output.NoSpaceFileName="Generate File Name without Space"
 
 # basic mode 'output' settings - advanced section
 Basic.Settings.Output.Adv.Rescale="Rescale Output"
+Basic.Settings.Output.Adv.Rescale.Disabled="Disabled"
 Basic.Settings.Output.Adv.AudioTrack="Audio Track"
 Basic.Settings.Output.Adv.Streaming="Streaming"
 Basic.Settings.Output.Adv.Streaming.Settings="Streaming Settings"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -2590,7 +2590,7 @@
                             <widget class="QComboBox" name="advOutEncoder"/>
                            </item>
                            <item row="4" column="0">
-                            <widget class="QCheckBox" name="advOutUseRescale">
+                            <widget class="QLabel" name="advOutUseRescale">
                              <property name="sizePolicy">
                               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
                                <horstretch>0</horstretch>
@@ -2606,14 +2606,21 @@
                             </widget>
                            </item>
                            <item row="4" column="1">
-                            <widget class="QComboBox" name="advOutRescale">
-                             <property name="enabled">
-                              <bool>false</bool>
-                             </property>
-                             <property name="editable">
-                              <bool>true</bool>
-                             </property>
-                            </widget>
+                            <layout class="QHBoxLayout" name="horizontalLayout_10">
+                             <item>
+                              <widget class="QComboBox" name="advOutRescaleFilter" />
+                             </item>
+                             <item>
+                              <widget class="QComboBox" name="advOutRescale">
+                               <property name="enabled">
+                                <bool>false</bool>
+                               </property>
+                               <property name="editable">
+                                <bool>true</bool>
+                               </property>
+                              </widget>
+                             </item>
+                            </layout>
                            </item>
                           </layout>
                          </widget>
@@ -3200,7 +3207,7 @@
                                 </widget>
                                </item>
                                <item row="6" column="0">
-                                <widget class="QCheckBox" name="advOutRecUseRescale">
+                                <widget class="QLabel" name="advOutRecUseRescale">
                                  <property name="sizePolicy">
                                   <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                                    <horstretch>0</horstretch>
@@ -3230,6 +3237,9 @@
                                   <property name="bottomMargin">
                                    <number>0</number>
                                   </property>
+                                  <item>
+                                   <widget class="QComboBox" name="advOutRecRescaleFilter" />
+                                  </item>
                                   <item>
                                    <widget class="QComboBox" name="advOutRecRescale">
                                     <property name="enabled">
@@ -7937,7 +7947,7 @@
   <tabstop>advOutMultiTrack5</tabstop>
   <tabstop>advOutMultiTrack6</tabstop>
   <tabstop>advOutEncoder</tabstop>
-  <tabstop>advOutUseRescale</tabstop>
+  <tabstop>advOutRescaleFilter</tabstop>
   <tabstop>advOutRescale</tabstop>
   <tabstop>advOutRecType</tabstop>
   <tabstop>advOutRecPath</tabstop>
@@ -7951,7 +7961,7 @@
   <tabstop>advOutRecTrack5</tabstop>
   <tabstop>advOutRecTrack6</tabstop>
   <tabstop>advOutRecEncoder</tabstop>
-  <tabstop>advOutRecUseRescale</tabstop>
+  <tabstop>advOutRecRescaleFilter</tabstop>
   <tabstop>advOutRecRescale</tabstop>
   <tabstop>advOutMuxCustom</tabstop>
   <tabstop>advOutSplitFile</tabstop>
@@ -8371,22 +8381,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>advOutUseRescale</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>advOutRescale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>269</x>
-     <y>192</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>656</x>
-     <y>192</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>advOutRecType</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>stackedWidget</receiver>
@@ -8399,22 +8393,6 @@
     <hint type="destinationlabel">
      <x>560</x>
      <y>391</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>advOutRecUseRescale</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>advOutRecRescale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>289</x>
-     <y>317</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>662</x>
-     <y>317</y>
     </hint>
    </hints>
   </connection>

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1810,9 +1810,10 @@ inline bool AdvancedOutput::allowsMultiTrack()
 
 inline void AdvancedOutput::SetupStreaming()
 {
-	bool rescale = config_get_bool(main->Config(), "AdvOut", "Rescale");
 	const char *rescaleRes =
 		config_get_string(main->Config(), "AdvOut", "RescaleRes");
+	int rescaleFilter =
+		config_get_int(main->Config(), "AdvOut", "RescaleFilter");
 	int multiTrackAudioMixes = config_get_int(main->Config(), "AdvOut",
 						  "StreamMultiTrackAudioMixes");
 	unsigned int cx = 0;
@@ -1820,7 +1821,7 @@ inline void AdvancedOutput::SetupStreaming()
 	int idx = 0;
 	bool is_multitrack_output = allowsMultiTrack();
 
-	if (rescale && rescaleRes && *rescaleRes) {
+	if (rescaleFilter != OBS_SCALE_DISABLE && rescaleRes && *rescaleRes) {
 		if (sscanf(rescaleRes, "%ux%u", &cx, &cy) != 2) {
 			cx = 0;
 			cy = 0;
@@ -1840,6 +1841,8 @@ inline void AdvancedOutput::SetupStreaming()
 	}
 
 	obs_encoder_set_scaled_size(videoStreaming, cx, cy);
+	obs_encoder_set_gpu_scale_type(videoStreaming,
+				       (obs_scale_type)rescaleFilter);
 
 	const char *id = obs_service_get_id(main->GetService());
 	if (strcmp(id, "rtmp_custom") == 0) {
@@ -1856,9 +1859,10 @@ inline void AdvancedOutput::SetupRecording()
 		config_get_string(main->Config(), "AdvOut", "RecFilePath");
 	const char *mux =
 		config_get_string(main->Config(), "AdvOut", "RecMuxerCustom");
-	bool rescale = config_get_bool(main->Config(), "AdvOut", "RecRescale");
 	const char *rescaleRes =
 		config_get_string(main->Config(), "AdvOut", "RecRescaleRes");
+	int rescaleFilter =
+		config_get_int(main->Config(), "AdvOut", "RecRescaleFilter");
 	int tracks;
 
 	const char *recFormat =
@@ -1890,7 +1894,8 @@ inline void AdvancedOutput::SetupRecording()
 			obs_output_set_video_encoder(replayBuffer,
 						     videoStreaming);
 	} else {
-		if (rescale && rescaleRes && *rescaleRes) {
+		if (rescaleFilter != OBS_SCALE_DISABLE && rescaleRes &&
+		    *rescaleRes) {
 			if (sscanf(rescaleRes, "%ux%u", &cx, &cy) != 2) {
 				cx = 0;
 				cy = 0;
@@ -1898,6 +1903,8 @@ inline void AdvancedOutput::SetupRecording()
 		}
 
 		obs_encoder_set_scaled_size(videoRecording, cx, cy);
+		obs_encoder_set_gpu_scale_type(videoRecording,
+					       (obs_scale_type)rescaleFilter);
 		obs_output_set_video_encoder(fileOutput, videoRecording);
 		if (replayBuffer)
 			obs_output_set_video_encoder(replayBuffer,

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1596,6 +1596,21 @@ bool OBSBasic::InitBasicConfigDefaults()
 	MigrateFormat("SimpleOutput");
 
 	/* ----------------------------------------------------- */
+	/* Migrate output scale setting to GPU scaling options.  */
+
+	if (config_get_bool(basicConfig, "AdvOut", "Rescale") &&
+	    !config_has_user_value(basicConfig, "AdvOut", "RescaleFilter")) {
+		config_set_int(basicConfig, "AdvOut", "RescaleFilter",
+			       OBS_SCALE_BILINEAR);
+	}
+
+	if (config_get_bool(basicConfig, "AdvOut", "RecRescale") &&
+	    !config_has_user_value(basicConfig, "AdvOut", "RecRescaleFilter")) {
+		config_set_int(basicConfig, "AdvOut", "RecRescaleFilter",
+			       OBS_SCALE_BILINEAR);
+	}
+
+	/* ----------------------------------------------------- */
 
 	if (changed)
 		config_save_safe(basicConfig, "tmp", nullptr);


### PR DESCRIPTION
### Description

Adds a combobox to set GPU scaling filter to the advanced output UI:

![2024-01-21_00-49-43_iWu4oS](https://github.com/obsproject/obs-studio/assets/3123295/532bca1d-d4b3-4560-89c2-29fe9e5ac4d6)

### Motivation and Context

- Allows people to use texture encoders such as NVENC while using rescaling
- Higher qualty scaling

### How Has This Been Tested?

NVENC and x264.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
