### PR TITLE
mac-virtualcam: Compare camera UUIDs using CFUUID

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -377,8 +377,10 @@ static bool virtualcam_output_start(void *data)
         CMIOObjectGetPropertyData(kCMIOObjectSystemObject, &address, 0, NULL, size, &used, device_data);
 
         vcam->deviceID = 0;
-        NSString *OBSVirtualCamUUID = [[NSBundle bundleWithIdentifier:@"com.obsproject.mac-virtualcam"]
+        NSString *OBSVirtualCamUUIDString = [[NSBundle bundleWithIdentifier:@"com.obsproject.mac-virtualcam"]
             objectForInfoDictionaryKey:@"OBSCameraDeviceUUID"];
+        CFUUIDRef OBSVirtualCamUUID =
+            CFUUIDCreateFromString(kCFAllocatorDefault, (CFStringRef) OBSVirtualCamUUIDString);
 
         size_t num_elements = size / sizeof(CMIOObjectID);
         for (size_t i = 0; i < num_elements; i++) {
@@ -390,15 +392,19 @@ static bool virtualcam_output_start(void *data)
             CMIOObjectGetPropertyDataSize(cmioDevice, &address, 0, NULL, &device_name_size);
             CFStringRef uid;
             CMIOObjectGetPropertyData(cmioDevice, &address, 0, NULL, device_name_size, &used, &uid);
-            const char *uid_string = CFStringGetCStringPtr(uid, kCFStringEncodingUTF8);
-            if (uid_string && strcmp(uid_string, OBSVirtualCamUUID.UTF8String) == 0) {
+            CFUUIDRef deviceUUID = CFUUIDCreateFromString(kCFAllocatorDefault, uid);
+
+            if (CFEqual(OBSVirtualCamUUID, deviceUUID)) {
                 vcam->deviceID = cmioDevice;
                 CFRelease(uid);
+                CFRelease(deviceUUID);
                 break;
             } else {
                 CFRelease(uid);
+                CFRelease(deviceUUID);
             }
         }
+        CFRelease(OBSVirtualCamUUID);
 
         if (!vcam->deviceID) {
             obs_output_set_last_error(vcam->output, obs_module_text("Error.SystemExtension.CameraUnavailable"));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Resolves a small issue related to custom OBS virtual camera builds.

When starting virtual camera output on macOS, a UUID string comparison is used to locate the CMIO extension associated with OBS. This UUID string, as stored in the app bundle, can be either lowercase or uppercase depending on the parameters originally provided to CMake. The variant returned from CMIO internals is always uppercase. ~~Since OBS is using a string comparison to compare the UUIDs, this PR changes the comparison to be case insensitive.~~ This PR changes the comparison to use `CFUUID`s created from the strings and `CFEqual` to check equality, rendering any questions of case sensitivity moot.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When debugging the Mac virtual camera with a separate code signing identity from OBS, it is necessary to generate new UUIDs for the virtual camera to successfully differentiate the custom virtual camera from the official OBS virtual camera. People building OBS in this fashion who are not familiar with this intricacy might define generate a lowercase UUID string and be confused when OBS cannot find its own virtual camera extension.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my machine to verify the virtual camera output can still be started.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
