### PR TITLE
libobs: Fix texture encoder duping frames when queue full

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -256,6 +256,7 @@ struct obs_tex_frame {
 	uint64_t lock_key;
 	int count;
 	bool released;
+	bool skip;
 };
 
 struct obs_task_info {

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -137,6 +137,18 @@ static void *gpu_encode_thread(void *data)
 			if (skip)
 				continue;
 
+			if (tf.skip) {
+				/* Skip frame but increment PTS to maintain
+				 * sync if encoder already started. */
+				if (encoder->start_ts) {
+					encoder->cur_pts +=
+						encoder->timebase_num *
+						encoder->frame_rate_divisor;
+				}
+
+				continue;
+			}
+
 			if (!encoder->start_ts)
 				encoder->start_ts = timestamp;
 
@@ -182,9 +194,13 @@ static void *gpu_encode_thread(void *data)
 
 		if (--tf.count) {
 			tf.timestamp += interval;
-			deque_push_front(&video->gpu_encoder_queue, &tf,
-					 sizeof(tf));
-
+			deque_push_back(&video->gpu_encoder_queue, &tf,
+					sizeof(tf));
+			if (tf.skip) {
+				video_output_inc_texture_skipped_frames(
+					video->video);
+			}
+		} else if (tf.skip) {
 			video_output_inc_texture_skipped_frames(video->video);
 		} else {
 			deque_push_back(&video->gpu_encoder_avail_queue, &tf,
@@ -243,7 +259,8 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 
 		struct obs_tex_frame frame = {.tex = tex,
 					      .tex_uv = tex_uv,
-					      .handle = handle};
+					      .handle = handle,
+					      .skip = false};
 
 		deque_push_back(&video->gpu_encoder_avail_queue, &frame,
 				sizeof(frame));


### PR DESCRIPTION
### Description

Fixes an oversight with `queue_frame()` where the first frame in the queue would be duplicated if there are no available free queue slots, thus keeping the encoder busy with duplicate frames rather than allowing it to work through the existing queue.

By changing the condition to only duplicate frames if there are free slots *and* the current frames needs duplication this snowballing issue no longer occurs.

Additionally, to avoid calling `circlebuf_pop_front()` on an empty buffer frames are now skipped if no items are available in the queue.

### Motivation and Context

Want to be able to push GPU encoders to the limit without it falling apart when tabbing in and out of a game.

### How Has This Been Tested?

Twitch "enhanced broadcasting" dev build with 4 NVENC encoders running slow presets/tunes.

Note that this issue is rather hard to reproduce with a single encode session, in my case I noticed it with 4 running: 1440p120 AV1 (p7), 1080p60 AV1 (p7), 720p60 HEVC (p5), and 480p30 H.264 (p3).

However, I have been able to trigger it with a single encoder in some cases, it just required tabbing in and out of a GPU intensive game running in exclusive fullscreen.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
