### PR TITLE
librtmp: Add missing extended timestamp in Type 3 chunks

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -4250,6 +4250,7 @@ RTMP_SendPacket(RTMP *r, RTMPPacket *packet, int queue)
         buffer += nChunkSize;
         hSize = 0;
 
+        // prepare to send off remaining data in Type 3 chunks
         if (nSize > 0)
         {
             header = buffer - 1;
@@ -4259,6 +4260,11 @@ RTMP_SendPacket(RTMP *r, RTMPPacket *packet, int queue)
                 header -= cSize;
                 hSize += cSize;
             }
+            if (t >= 0xffffff)
+            {
+                hSize += 4;
+                header -= 4;
+            }
             *header = (0xc0 | c);
             if (cSize)
             {
@@ -4267,6 +4273,8 @@ RTMP_SendPacket(RTMP *r, RTMPPacket *packet, int queue)
                 if (cSize == 2)
                     header[2] = tmp >> 8;
             }
+            if (t >= 0xffffff)
+                AMF_EncodeInt32(header+hSize-4, header+hSize, t);
         }
     }
     if (tbuf)


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
According to https://rtmp.veriskope.com/docs/spec/#5313-extended-timestamp extended timestamps need to be present in Type 3 chunks (`RTMP_PACKET_SIZE_MINIMUM`) if the previous chunk also included an extended timestamp

### Motivation and Context
Ran into this issue while playing around with sending large payloads in byte arrays (similar to Twitch VOD track) that exceeded the rtmp chunk size (thus librtmp split the payload over multiple packets, triggering this issue)

### How Has This Been Tested?
Add the following code to `rtmp-stream.c`:
```c
stream->start_dts_offset = get_ms_time(packet, packet->dts);
stream->start_dts_offset -= 0xffffff - 15000;
```
and send large INFO packets; the issue should be triggered within a few seconds

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
