### PR TITLE
obs-ffmpeg: Add `disable_scenecut` option for NVENC

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -109,6 +109,7 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 	int gpu = (int)obs_data_get_int(settings, "gpu");
 	bool cbr_override = obs_data_get_bool(settings, "cbr");
 	int bf = (int)obs_data_get_int(settings, "bf");
+	bool disable_scenecut = obs_data_get_bool(settings, "disable_scenecut");
 
 	video_t *video = obs_encoder_video(enc->ffve.encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
@@ -169,6 +170,9 @@ static bool nvenc_update(struct nvenc_encoder *enc, obs_data_t *settings,
 
 	av_opt_set(enc->ffve.context->priv_data, "level", "auto", 0);
 	av_opt_set_int(enc->ffve.context->priv_data, "gpu", gpu, 0);
+
+	av_opt_set_int(enc->ffve.context->priv_data, "no-scenecut",
+		       disable_scenecut, 0);
 
 	// This is ugly but ffmpeg wipes priv_data on error and we need
 	// to know this to show a proper error message.

--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -456,6 +456,7 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings,
 	bool vbr = astrcmpi(rc, "VBR") == 0;
 	bool psycho_aq = !compatibility &&
 			 obs_data_get_bool(settings, "psycho_aq");
+	bool disable_scenecut = obs_data_get_bool(settings, "disable_scenecut");
 	NVENCSTATUS err;
 
 	video_t *video = obs_encoder_video(enc->encoder);
@@ -637,6 +638,8 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings,
 			lookahead = false;
 		}
 	}
+
+	enc->config.rcParams.disableIadapt = disable_scenecut;
 
 	/* psycho aq */
 	if (!compatibility) {


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is functionally the same as x264's `scenecut=0` option

### Motivation and Context
This allows for multiple NVENC encoders to stay GOP/keyframe aligned, which is interesting for applications using https://github.com/obsproject/obs-studio/pull/8093 targeting e.g. HLS or similar formats that require keyframes to be aligned

### How Has This Been Tested?
Tested via Twitch Enhanced Broadcasting

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
