### PR TITLE
Enable exporting CMake interface target

### DIFF
--- a/cmake/Modules/ObsHelpers.cmake
+++ b/cmake/Modules/ObsHelpers.cmake
@@ -251,10 +251,13 @@ function(export_target target)
       COMPONENT obs_libraries
       ${_EXCLUDE})
 
-  include(GenerateExportHeader)
-  generate_export_header(${target} EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${target}_EXPORT.h)
+  get_target_property(target_type ${target} TYPE)
+  if(NOT target_type STREQUAL INTERFACE_LIBRARY)
+    include(GenerateExportHeader)
+    generate_export_header(${target} EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/${target}_EXPORT.h)
 
-  target_sources(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${target}_EXPORT.h)
+    target_sources(${target} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/${target}_EXPORT.h)
+  endif()
 
   set(TARGETS_EXPORT_NAME "${target}Targets")
   include(CMakePackageConfigHelpers)

--- a/cmake/Modules/ObsHelpers_Windows.cmake
+++ b/cmake/Modules/ObsHelpers_Windows.cmake
@@ -234,7 +234,8 @@ function(export_target target)
       COMPONENT obs_libraries
       EXCLUDE_FROM_ALL)
 
-  if(MSVC)
+  get_target_property(target_type ${target} TYPE)
+  if(MSVC AND NOT target_type STREQUAL INTERFACE_LIBRARY)
     install(
       FILES $<TARGET_PDB_FILE:${target}>
       CONFIGURATIONS "RelWithDebInfo" "Debug"

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -274,12 +274,15 @@ function(target_export target)
   set(exclude_variant EXCLUDE_FROM_ALL)
   _target_export(${target})
 
-  install(
-    FILES "$<TARGET_PDB_FILE:${target}>"
-    CONFIGURATIONS RelWithDebInfo Debug Release
-    DESTINATION "${OBS_EXECUTABLE_DESTINATION}"
-    COMPONENT Development
-    OPTIONAL)
+  get_target_property(target_type ${target} TYPE)
+  if(NOT target_type STREQUAL INTERFACE_LIBRARY)
+    install(
+      FILES "$<TARGET_PDB_FILE:${target}>"
+      CONFIGURATIONS RelWithDebInfo Debug Release
+      DESTINATION "${OBS_EXECUTABLE_DESTINATION}"
+      COMPONENT Development
+      OPTIONAL)
+  endif()
 endfunction()
 
 # Helper function to add resources into bundle


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Required by:
- https://github.com/obsproject/obs-browser/pull/431
- https://github.com/obsproject/obs-websocket/pull/1196

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Needed to enable installing obs-websocket-api  and obs-browser-api headers
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Build on Linux (still uses legacy path) with obs-browser-api PR and check if the header is installed, which is the case.

Ci for Windows and macOS, headers install needs to be checked locally
- Tested on Windows,  `--component Development` adds the header

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
