### PR TITLE
Rework command line argument stuff

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -118,6 +118,7 @@ target_sources(
           util/file-serializer.h
           util/lexer.c
           util/lexer.h
+          util/pipe.c
           util/pipe.h
           util/platform.c
           util/platform.h

--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -198,6 +198,7 @@ target_sources(
           util/profiler.c
           util/profiler.h
           util/profiler.hpp
+          util/pipe.c
           util/pipe.h
           util/serializer.h
           util/sse-intrin.h

--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -31,14 +31,14 @@ struct os_process_pipe {
 	FILE *err_file;
 };
 
-os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
-					  const char *type)
+os_process_pipe_t *os_process_pipe_create_internal(const char *bin, char **argv,
+						   const char *type)
 {
 	struct os_process_pipe process_pipe = {0};
 	struct os_process_pipe *out;
 	posix_spawn_file_actions_t file_actions;
 
-	if (!cmd_line || !type) {
+	if (!bin || !argv || !type) {
 		return NULL;
 	}
 
@@ -94,9 +94,8 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 					 STDERR_FILENO);
 
 	int pid;
-	char *argv[4] = {"sh", "-c", (char *)cmd_line, NULL};
-
-	int ret = posix_spawn(&pid, "/bin/sh", &file_actions, NULL, argv, NULL);
+	int ret = posix_spawn(&pid, bin, &file_actions, NULL,
+			      (char *const *)argv, NULL);
 
 	posix_spawn_file_actions_destroy(&file_actions);
 
@@ -125,6 +124,23 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 	out = bmalloc(sizeof(os_process_pipe_t));
 	*out = process_pipe;
 	return out;
+}
+
+os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
+					  const char *type)
+{
+	if (!cmd_line)
+		return NULL;
+
+	char *argv[3] = {"-c", (char *)cmd_line, NULL};
+	return os_process_pipe_create_internal("/bin/sh", argv, type);
+}
+
+os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+					   const char *type)
+{
+	char **argv = os_process_args_get_argv(args);
+	return os_process_pipe_create_internal(argv[0], argv, type);
 }
 
 int os_process_pipe_destroy(os_process_pipe_t *pp)

--- a/libobs/util/pipe-windows.c
+++ b/libobs/util/pipe-windows.c
@@ -19,6 +19,7 @@
 
 #include "platform.h"
 #include "bmem.h"
+#include "dstr.h"
 #include "pipe.h"
 
 struct os_process_pipe {
@@ -143,6 +144,69 @@ error:
 	CloseHandle(output);
 	CloseHandle(input);
 	return NULL;
+}
+
+static inline void add_backslashes(struct dstr *str, size_t count)
+{
+	while (count--)
+		dstr_cat_ch(str, '\\');
+}
+
+os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+					   const char *type)
+{
+	struct dstr cmd_line = {0};
+
+	/* Convert list to command line as Windows does not have any API that
+	 * allows us to just pass argc/argv. */
+	char **argv = os_process_args_get_argv(args);
+
+	/* Based on Python subprocess module implementation. */
+	while (*argv) {
+		size_t bs_count = 0;
+		const char *arg = *argv;
+		bool needs_quotes = strlen(arg) == 0 ||
+				    strstr(arg, " ") != NULL ||
+				    strstr(arg, "\t") != NULL;
+
+		if (cmd_line.len)
+			dstr_cat_ch(&cmd_line, ' ');
+		if (needs_quotes)
+			dstr_cat_ch(&cmd_line, '"');
+
+		while (*arg) {
+			if (*arg == '\\') {
+				bs_count++;
+			} else if (*arg == '"') {
+				add_backslashes(&cmd_line, bs_count * 2);
+				dstr_cat(&cmd_line, "\\\"");
+				bs_count = 0;
+			} else {
+				if (bs_count) {
+					add_backslashes(&cmd_line, bs_count);
+					bs_count = 0;
+				}
+				dstr_cat_ch(&cmd_line, *arg);
+			}
+
+			arg++;
+		}
+
+		if (bs_count)
+			add_backslashes(&cmd_line, bs_count);
+
+		if (needs_quotes) {
+			add_backslashes(&cmd_line, bs_count);
+			dstr_cat_ch(&cmd_line, '"');
+		}
+
+		argv++;
+	}
+
+	os_process_pipe_t *ret = os_process_pipe_create(cmd_line.array, type);
+
+	dstr_free(&cmd_line);
+	return ret;
 }
 
 int os_process_pipe_destroy(os_process_pipe_t *pp)

--- a/libobs/util/pipe.c
+++ b/libobs/util/pipe.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2023 Dennis Sädtler <dennis@obsproject.com>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "pipe.h"
+#include "darray.h"
+#include "dstr.h"
+
+struct os_process_args {
+	DARRAY(char *) arguments;
+};
+
+struct os_process_args *os_process_args_create(const char *executable)
+{
+	struct os_process_args *args = bzalloc(sizeof(struct os_process_args));
+	char *str = bstrdup(executable);
+	da_push_back(args->arguments, &str);
+	/* Last item in argv must be NULL. */
+	char *terminator = NULL;
+	da_push_back(args->arguments, &terminator);
+	return args;
+}
+
+void os_process_args_add_arg(struct os_process_args *args, const char *arg)
+{
+	char *str = bstrdup(arg);
+	/* Insert before NULL list terminator. */
+	da_insert(args->arguments, args->arguments.num - 1, &str);
+}
+
+void os_process_args_add_argf(struct os_process_args *args, const char *format,
+			      ...)
+{
+	va_list va_args;
+	struct dstr tmp = {0};
+
+	va_start(va_args, format);
+	dstr_vprintf(&tmp, format, va_args);
+	da_insert(args->arguments, args->arguments.num - 1, &tmp.array);
+	va_end(va_args);
+}
+
+size_t os_process_args_get_argc(struct os_process_args *args)
+{
+	/* Do not count terminating NULL. */
+	return args->arguments.num - 1;
+}
+
+char **os_process_args_get_argv(const struct os_process_args *args)
+{
+	return args->arguments.array;
+}
+
+void os_process_args_destroy(struct os_process_args *args)
+{
+	if (!args)
+		return;
+
+	for (size_t idx = 0; idx < args->arguments.num; idx++)
+		bfree(args->arguments.array[idx]);
+
+	da_free(args->arguments);
+	bfree(args);
+}

--- a/libobs/util/pipe.h
+++ b/libobs/util/pipe.h
@@ -25,6 +25,9 @@ extern "C" {
 struct os_process_pipe;
 typedef struct os_process_pipe os_process_pipe_t;
 
+struct os_process_args;
+typedef struct os_process_args os_process_args_t;
+
 EXPORT os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 						 const char *type);
 EXPORT int os_process_pipe_destroy(os_process_pipe_t *pp);
@@ -35,6 +38,18 @@ EXPORT size_t os_process_pipe_read_err(os_process_pipe_t *pp, uint8_t *data,
 				       size_t len);
 EXPORT size_t os_process_pipe_write(os_process_pipe_t *pp, const uint8_t *data,
 				    size_t len);
+
+EXPORT struct os_process_args *os_process_args_create(const char *executable);
+EXPORT void os_process_args_add_arg(struct os_process_args *args,
+				    const char *arg);
+#ifndef _MSC_VER
+__attribute__((__format__(__printf__, 2, 3)))
+#endif
+EXPORT void
+os_process_args_add_argf(struct os_process_args *args, const char *format, ...);
+EXPORT char **os_process_args_get_argv(const struct os_process_args *args);
+EXPORT size_t os_process_args_get_argc(struct os_process_args *args);
+EXPORT void os_process_args_destroy(struct os_process_args *args);
 
 #ifdef __cplusplus
 }

--- a/libobs/util/pipe.h
+++ b/libobs/util/pipe.h
@@ -30,6 +30,8 @@ typedef struct os_process_args os_process_args_t;
 
 EXPORT os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 						 const char *type);
+EXPORT os_process_pipe_t *os_process_pipe_create2(const os_process_args_t *args,
+						  const char *type);
 EXPORT int os_process_pipe_destroy(os_process_pipe_t *pp);
 
 EXPORT size_t os_process_pipe_read(os_process_pipe_t *pp, uint8_t *data,

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -134,7 +134,8 @@ bool active(struct ffmpeg_muxer *stream)
 }
 
 static void add_video_encoder_params(struct ffmpeg_muxer *stream,
-				     struct dstr *cmd, obs_encoder_t *vencoder)
+				     os_process_args_t *args,
+				     obs_encoder_t *vencoder)
 {
 	obs_data_t *settings = obs_encoder_get_settings(vencoder);
 	int bitrate = (int)obs_data_get_int(settings, "bitrate");
@@ -185,41 +186,48 @@ static void add_video_encoder_params(struct ffmpeg_muxer *stream,
 	const enum AVColorRange range = (info->range == VIDEO_RANGE_FULL)
 						? AVCOL_RANGE_JPEG
 						: AVCOL_RANGE_MPEG;
+	const enum AVChromaLocation chroma_location = determine_chroma_location(
+		obs_to_ffmpeg_video_format(info->format), spc);
 
 	const int max_luminance =
 		(trc == AVCOL_TRC_SMPTE2084)
 			? (int)obs_get_video_hdr_nominal_peak_level()
 			: ((trc == AVCOL_TRC_ARIB_STD_B67) ? 1000 : 0);
 
-	dstr_catf(cmd, "%s %d %d %d %d %d %d %d %d %d %d %d %d ",
-		  obs_encoder_get_codec(vencoder), bitrate,
-		  obs_output_get_width(stream->output),
-		  obs_output_get_height(stream->output), (int)pri, (int)trc,
-		  (int)spc, (int)range,
-		  (int)determine_chroma_location(
-			  obs_to_ffmpeg_video_format(info->format), spc),
-		  max_luminance, (int)info->fps_num, (int)info->fps_den,
-		  (int)codec_tag);
+	os_process_args_add_arg(args, obs_encoder_get_codec(vencoder));
+	os_process_args_add_argf(args, "%d", bitrate);
+	os_process_args_add_argf(args, "%d",
+				 obs_output_get_width(stream->output));
+	os_process_args_add_argf(args, "%d",
+				 obs_output_get_height(stream->output));
+	os_process_args_add_argf(args, "%d", (int)pri);
+	os_process_args_add_argf(args, "%d", (int)trc);
+	os_process_args_add_argf(args, "%d", (int)spc);
+	os_process_args_add_argf(args, "%d", (int)range);
+	os_process_args_add_argf(args, "%d", (int)chroma_location);
+	os_process_args_add_argf(args, "%d", max_luminance);
+	os_process_args_add_argf(args, "%d", (int)info->fps_num);
+	os_process_args_add_argf(args, "%d", (int)info->fps_den);
+	os_process_args_add_argf(args, "%d", codec_tag);
 }
 
-static void add_audio_encoder_params(struct dstr *cmd, obs_encoder_t *aencoder)
+static void add_audio_encoder_params(os_process_args_t *args,
+				     obs_encoder_t *aencoder)
 {
 	obs_data_t *settings = obs_encoder_get_settings(aencoder);
 	int bitrate = (int)obs_data_get_int(settings, "bitrate");
 	audio_t *audio = obs_get_audio();
-	struct dstr name = {0};
 
 	obs_data_release(settings);
 
-	dstr_copy(&name, obs_encoder_get_name(aencoder));
-	dstr_replace(&name, "\"", "\"\"");
-
-	dstr_catf(cmd, "\"%s\" %d %d %d %d ", name.array, bitrate,
-		  (int)obs_encoder_get_sample_rate(aencoder),
-		  (int)obs_encoder_get_frame_size(aencoder),
-		  (int)audio_output_get_channels(audio));
-
-	dstr_free(&name);
+	os_process_args_add_arg(args, obs_encoder_get_name(aencoder));
+	os_process_args_add_argf(args, "%d", bitrate);
+	os_process_args_add_argf(args, "%d",
+				 (int)obs_encoder_get_sample_rate(aencoder));
+	os_process_args_add_argf(args, "%d",
+				 (int)obs_encoder_get_frame_size(aencoder));
+	os_process_args_add_argf(args, "%d",
+				 (int)audio_output_get_channels(audio));
 }
 
 static void log_muxer_params(struct ffmpeg_muxer *stream, const char *settings)
@@ -250,15 +258,15 @@ static void log_muxer_params(struct ffmpeg_muxer *stream, const char *settings)
 	av_dict_free(&dict);
 }
 
-static void add_stream_key(struct dstr *cmd, struct ffmpeg_muxer *stream)
+static void add_stream_key(os_process_args_t *args, struct ffmpeg_muxer *stream)
 {
-	dstr_catf(cmd, "\"%s\" ",
-		  dstr_is_empty(&stream->stream_key)
-			  ? ""
-			  : stream->stream_key.array);
+	os_process_args_add_arg(args, dstr_is_empty(&stream->stream_key)
+					      ? ""
+					      : stream->stream_key.array);
 }
 
-static void add_muxer_params(struct dstr *cmd, struct ffmpeg_muxer *stream)
+static void add_muxer_params(os_process_args_t *args,
+			     struct ffmpeg_muxer *stream)
 {
 	struct dstr mux = {0};
 
@@ -272,16 +280,13 @@ static void add_muxer_params(struct dstr *cmd, struct ffmpeg_muxer *stream)
 	}
 
 	log_muxer_params(stream, mux.array);
-
-	dstr_replace(&mux, "\"", "\\\"");
-
-	dstr_catf(cmd, "\"%s\" ", mux.array ? mux.array : "");
+	os_process_args_add_arg(args, mux.array ? mux.array : "");
 
 	dstr_free(&mux);
 }
 
-static void build_command_line(struct ffmpeg_muxer *stream, struct dstr *cmd,
-			       const char *path)
+static void build_command_line(struct ffmpeg_muxer *stream,
+			       os_process_args_t **args, const char *path)
 {
 	obs_encoder_t *vencoder = obs_output_get_video_encoder(stream->output);
 	obs_encoder_t *aencoders[MAX_AUDIO_MIXES];
@@ -297,39 +302,36 @@ static void build_command_line(struct ffmpeg_muxer *stream, struct dstr *cmd,
 		num_tracks++;
 	}
 
-	dstr_init_move_array(cmd, os_get_executable_path_ptr(FFMPEG_MUX));
-	dstr_insert_ch(cmd, 0, '\"');
-	dstr_cat(cmd, "\" \"");
+	char *exe = os_get_executable_path_ptr(FFMPEG_MUX);
+	*args = os_process_args_create(exe);
+	bfree(exe);
 
-	dstr_copy(&stream->path, path);
-	dstr_replace(&stream->path, "\"", "\"\"");
-	dstr_cat_dstr(cmd, &stream->path);
-
-	dstr_catf(cmd, "\" %d %d ", vencoder ? 1 : 0, num_tracks);
+	os_process_args_add_arg(*args, path);
+	os_process_args_add_argf(*args, "%d", vencoder ? 1 : 0);
+	os_process_args_add_argf(*args, "%d", num_tracks);
 
 	if (vencoder)
-		add_video_encoder_params(stream, cmd, vencoder);
+		add_video_encoder_params(stream, *args, vencoder);
 
 	if (num_tracks) {
-		const char *codec = obs_encoder_get_codec(aencoders[0]);
-		dstr_cat(cmd, codec);
-		dstr_cat(cmd, " ");
+		os_process_args_add_arg(*args,
+					obs_encoder_get_codec(aencoders[0]));
 
 		for (int i = 0; i < num_tracks; i++) {
-			add_audio_encoder_params(cmd, aencoders[i]);
+			add_audio_encoder_params(*args, aencoders[i]);
 		}
 	}
 
-	add_stream_key(cmd, stream);
-	add_muxer_params(cmd, stream);
+	add_stream_key(*args, stream);
+	add_muxer_params(*args, stream);
 }
 
 void start_pipe(struct ffmpeg_muxer *stream, const char *path)
 {
-	struct dstr cmd;
-	build_command_line(stream, &cmd, path);
-	stream->pipe = os_process_pipe_create(cmd.array, "w");
-	dstr_free(&cmd);
+	os_process_args_t *args = NULL;
+	build_command_line(stream, &args, path);
+	stream->pipe = os_process_pipe_create2(args, "w");
+	os_process_args_destroy(args);
 }
 
 static void set_file_not_readable_error(struct ffmpeg_muxer *stream,


### PR DESCRIPTION
### Description

- Adds new `os_process_args_t` and associated API to construct command line arguments
- Adds `os_process_pipe_create2()` to take advantage of new API
- Migrates `obs-ffmpeg-mux` to the new API

### Motivation and Context

Want a saner API than passing stuff to `/bin/sh` and dying inside while concatenating strings.

### How Has This Been Tested?

Recorded with output that requires ffmpeg muxer.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
