### PR TITLE
Don't invoke "remove_connection"

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -785,6 +785,7 @@ static inline bool obs_encoder_stop_internal(
 	if (last) {
 		remove_connection(encoder, true);
 		encoder->initialized = false;
+		encoder->is_full_stop = false;
 
 		if (encoder->destroy_on_stop) {
 			pthread_mutex_unlock(&encoder->init_mutex);
@@ -1248,10 +1249,20 @@ static inline void send_packet(struct obs_encoder *encoder,
 void full_stop(struct obs_encoder *encoder)
 {
 	if (encoder) {
+		if (encoder->is_full_stop) {
+			return;
+		}
+		encoder->is_full_stop = true;
+
 		pthread_mutex_lock(&encoder->outputs_mutex);
 		for (size_t i = 0; i < encoder->outputs.num; i++) {
 			struct obs_output *output = encoder->outputs.array[i];
-			obs_output_force_stop(output);
+
+			/* If checked "Enable Replay Buffer" from settings,
+			 * but not start it, don't invoke stop function */
+			if (obs_output_active(output)) {
+				obs_output_force_stop(output);
+			}
 
 			pthread_mutex_lock(&output->interleaved_mutex);
 			output->info.encoded_packet(output->context.data, NULL);
@@ -1259,12 +1270,17 @@ void full_stop(struct obs_encoder *encoder)
 		}
 		pthread_mutex_unlock(&encoder->outputs_mutex);
 
-		pthread_mutex_lock(&encoder->callbacks_mutex);
-		da_free(encoder->callbacks);
-		pthread_mutex_unlock(&encoder->callbacks_mutex);
-
-		remove_connection(encoder, false);
-		encoder->initialized = false;
+		/* Not need invoke "remove_connection",
+		 * it cause thread deadlock.
+		 *
+		 * call stack as:
+		 * gpu_encode_thread->send_off_encoder_packet
+		 * ->full_stop->remove_connection->stop_gpu_encode.
+		 * 
+		 * It will invoke "stop_gpu_encode" finally,
+		 * try stop itself in same thread, 100% deadlock,
+		 * Actually, encoder thread will invoke "remove_connection"
+		 * if last callback is removed. */
 	}
 }
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1300,6 +1300,8 @@ struct obs_encoder {
 
 	/* reconfigure encoder at next possible opportunity */
 	bool reconfigure_requested;
+
+	bool is_full_stop;
 };
 
 extern struct obs_encoder_info *find_encoder(const char *id);


### PR DESCRIPTION
### Description
if gpu encoder error happened, it will invoke "remove_connection",
call stack as below:
gpu_encode_thread->send_off_encoder_packet->full_stop->remove_connection->stop_gpu_encode,
It will invoke "stop_gpu_encode" finally, **try stop itself in same thread**, 100% deadlock,
Actually, encoder thread will invoke "remove_connection" if last callback is removed.

### Motivation and Context
Fixed issue #9946 

### How Has This Been Tested?
Add test code to simulate a encoder error
```
void send_off_encoder_packet(obs_encoder_t *encoder, bool success,
			     bool received, struct encoder_packet *pkt)
{
	if (!success) {
		blog(LOG_ERROR, "Error encoding with encoder '%s'",
		     encoder->context.name);
		full_stop(encoder);
		return;
	}
......
}
```
Change `if (!success)` to `if (true || !success)` to simulate a encoder error

### Types of changes
Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
