### PR TITLE
rtmp-services: Add Hakuna Live RTMP service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 247,
+    "version": 248,
     "files": [
         {
             "name": "services.json",
-            "version": 247
+            "version": 248
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2799,6 +2799,29 @@
                 "max video bitrate": 12000,
                 "max audio bitrate": 320
             }
+        },
+        {
+            "name": "Hakuna Live - RTMP",
+            "servers": [
+                {
+                    "name": "Republic of Korea / Japan",
+                    "url": "rtmps://media-proxy.prod.an1.media.hpcnt.com/hakuna"
+                }
+            ],
+            "protocol": "RTMP",
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "bframes": 0
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Adding Hakuna Live's RTMP Ingest server address

### Motivation and Context
Hakuna Live is one of the global live streaming service platforms.
To make it easier for streamers to access Hakuna Live, add this address.

### How Has This Been Tested?
I followed [service submission guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines) and confirmed streaming's working.

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
