### PR TITLE
obs-webrtc: Implement whip-common obs_service_info and Add hakuna service whip

### DIFF
--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -253,7 +253,8 @@ private:
 	/* stream */
 	void InitStreamPage();
 	inline bool IsCustomService() const;
-	inline bool IsWHIP() const;
+	inline bool IsWHIPCustom() const;
+	inline bool IsWHIPCommon() const;
 	void LoadServices(bool showAll);
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();

--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -15,8 +15,17 @@ add_library(obs-webrtc MODULE)
 add_library(OBS::webrtc ALIAS obs-webrtc)
 
 target_sources(
-  obs-webrtc PRIVATE # cmake-format: sortable
-                     obs-webrtc.cpp whip-output.cpp whip-output.h whip-custom.cpp whip-custom.h whip-common.cpp whip-common.h whip-utils.h common.h)
+  obs-webrtc
+  PRIVATE # cmake-format: sortable
+          common.h
+          obs-webrtc.cpp
+          whip-common.cpp
+          whip-common.h
+          whip-custom.cpp
+          whip-custom.h
+          whip-output.cpp
+          whip-output.h
+          whip-utils.h)
 
 target_link_libraries(obs-webrtc PRIVATE OBS::libobs LibDataChannel::LibDataChannel CURL::libcurl)
 

--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(OBS::webrtc ALIAS obs-webrtc)
 
 target_sources(
   obs-webrtc PRIVATE # cmake-format: sortable
-                     obs-webrtc.cpp whip-output.cpp whip-output.h whip-service.cpp whip-service.h whip-utils.h)
+                     obs-webrtc.cpp whip-output.cpp whip-output.h whip-custom.cpp whip-custom.h whip-common.cpp whip-common.h whip-utils.h common.h)
 
 target_link_libraries(obs-webrtc PRIVATE OBS::libobs LibDataChannel::LibDataChannel CURL::libcurl)
 

--- a/plugins/obs-webrtc/common.h
+++ b/plugins/obs-webrtc/common.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define MAX_CODECS 3
+
+static const char *audio_codecs[MAX_CODECS] = {"opus"};
+static const char *video_codecs[MAX_CODECS] = {"h264"};

--- a/plugins/obs-webrtc/obs-webrtc.cpp
+++ b/plugins/obs-webrtc/obs-webrtc.cpp
@@ -1,7 +1,8 @@
 #include <obs-module.h>
 
 #include "whip-output.h"
-#include "whip-service.h"
+#include "whip-common.h"
+#include "whip-custom.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("obs-webrtc", "en-US")
@@ -13,7 +14,8 @@ MODULE_EXPORT const char *obs_module_description(void)
 bool obs_module_load()
 {
 	register_whip_output();
-	register_whip_service();
+	register_whip_common();
+	register_whip_custom();
 
 	return true;
 }

--- a/plugins/obs-webrtc/whip-common.cpp
+++ b/plugins/obs-webrtc/whip-common.cpp
@@ -1,0 +1,104 @@
+#include "whip-common.h"
+
+WHIPCommon::WHIPCommon(obs_data_t *settings, obs_service_t *)
+	: server(),
+	  bearer_token()
+{
+	Update(settings);
+}
+
+void WHIPCommon::Update(obs_data_t *settings)
+{
+	server = obs_data_get_string(settings, "server");
+	bearer_token = obs_data_get_string(settings, "bearer_token");
+}
+
+obs_properties_t *WHIPCommon::Properties()
+{
+	obs_properties_t *ppts = obs_properties_create();
+
+	obs_properties_add_text(ppts, "server", "URL", OBS_TEXT_DEFAULT);
+	obs_properties_add_text(ppts, "bearer_token",
+				obs_module_text("Service.BearerToken"),
+				OBS_TEXT_PASSWORD);
+
+	return ppts;
+}
+
+void WHIPCommon::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
+{
+	// For now, ensure maximum compatibility with webrtc peers
+	if (video_settings) {
+		obs_data_set_int(video_settings, "bf", 0);
+		obs_data_set_bool(video_settings, "repeat_headers", true);
+	}
+}
+
+const char *WHIPCommon::GetConnectInfo(enum obs_service_connect_info type)
+{
+	switch (type) {
+	case OBS_SERVICE_CONNECT_INFO_SERVER_URL:
+		return server.c_str();
+	case OBS_SERVICE_CONNECT_INFO_BEARER_TOKEN:
+		return bearer_token.c_str();
+	default:
+		return nullptr;
+	}
+}
+
+bool WHIPCommon::CanTryToConnect()
+{
+	return !server.empty();
+}
+
+void register_whip_common()
+{
+	struct obs_service_info info = {};
+
+	info.id = "whip_common";
+	info.get_name = [](void *) -> const char * {
+		return obs_module_text("Service.Name");
+	};
+	info.create = [](obs_data_t *settings,
+			 obs_service_t *service) -> void * {
+		return new WHIPCommon(settings, service);
+	};
+	info.destroy = [](void *priv_data) {
+		delete static_cast<WHIPCommon *>(priv_data);
+	};
+	info.update = [](void *priv_data, obs_data_t *settings) {
+		static_cast<WHIPCommon *>(priv_data)->Update(settings);
+	};
+	info.get_properties = [](void *) -> obs_properties_t * {
+		return WHIPCommon::Properties();
+	};
+	info.get_protocol = [](void *) -> const char * {
+		return "WHIP";
+	};
+	info.get_url = [](void *priv_data) -> const char * {
+		return static_cast<WHIPCommon *>(priv_data)->server.c_str();
+	};
+	info.get_output_type = [](void *) -> const char * {
+		return "whip_output";
+	};
+	info.apply_encoder_settings = [](void *, obs_data_t *video_settings,
+					 obs_data_t *audio_settings) {
+		WHIPCommon::ApplyEncoderSettings(video_settings,
+						 audio_settings);
+	};
+	info.get_supported_video_codecs = [](void *) -> const char ** {
+		return video_codecs;
+	};
+	info.get_supported_audio_codecs = [](void *) -> const char ** {
+		return audio_codecs;
+	};
+	info.can_try_to_connect = [](void *priv_data) -> bool {
+		return static_cast<WHIPCommon *>(priv_data)->CanTryToConnect();
+	};
+	info.get_connect_info = [](void *priv_data,
+				   uint32_t type) -> const char * {
+		return static_cast<WHIPCommon *>(priv_data)->GetConnectInfo(
+			(enum obs_service_connect_info)type);
+	};
+	obs_register_service(&info);
+}

--- a/plugins/obs-webrtc/whip-common.h
+++ b/plugins/obs-webrtc/whip-common.h
@@ -1,14 +1,13 @@
 #pragma once
 #include <obs-module.h>
 #include <string>
+#include "common.h"
 
-#define MAX_CODECS 3
-
-struct WHIPService {
+struct WHIPCommon {
 	std::string server;
 	std::string bearer_token;
 
-	WHIPService(obs_data_t *settings, obs_service_t *service);
+	WHIPCommon(obs_data_t *settings, obs_service_t *service);
 
 	void Update(obs_data_t *settings);
 	static obs_properties_t *Properties();
@@ -18,4 +17,4 @@ struct WHIPService {
 	const char *GetConnectInfo(enum obs_service_connect_info type);
 };
 
-void register_whip_service();
+void register_whip_common();

--- a/plugins/obs-webrtc/whip-custom.cpp
+++ b/plugins/obs-webrtc/whip-custom.cpp
@@ -1,22 +1,19 @@
-#include "whip-service.h"
+#include "whip-custom.h"
 
-const char *audio_codecs[MAX_CODECS] = {"opus"};
-const char *video_codecs[MAX_CODECS] = {"h264"};
-
-WHIPService::WHIPService(obs_data_t *settings, obs_service_t *)
+WHIPCustom::WHIPCustom(obs_data_t *settings, obs_service_t *)
 	: server(),
 	  bearer_token()
 {
 	Update(settings);
 }
 
-void WHIPService::Update(obs_data_t *settings)
+void WHIPCustom::Update(obs_data_t *settings)
 {
 	server = obs_data_get_string(settings, "server");
 	bearer_token = obs_data_get_string(settings, "bearer_token");
 }
 
-obs_properties_t *WHIPService::Properties()
+obs_properties_t *WHIPCustom::Properties()
 {
 	obs_properties_t *ppts = obs_properties_create();
 
@@ -28,7 +25,7 @@ obs_properties_t *WHIPService::Properties()
 	return ppts;
 }
 
-void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
+void WHIPCustom::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 {
 	// For now, ensure maximum compatibility with webrtc peers
 	if (video_settings) {
@@ -37,7 +34,7 @@ void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 	}
 }
 
-const char *WHIPService::GetConnectInfo(enum obs_service_connect_info type)
+const char *WHIPCustom::GetConnectInfo(enum obs_service_connect_info type)
 {
 	switch (type) {
 	case OBS_SERVICE_CONNECT_INFO_SERVER_URL:
@@ -49,12 +46,12 @@ const char *WHIPService::GetConnectInfo(enum obs_service_connect_info type)
 	}
 }
 
-bool WHIPService::CanTryToConnect()
+bool WHIPCustom::CanTryToConnect()
 {
 	return !server.empty();
 }
 
-void register_whip_service()
+void register_whip_custom()
 {
 	struct obs_service_info info = {};
 
@@ -64,30 +61,30 @@ void register_whip_service()
 	};
 	info.create = [](obs_data_t *settings,
 			 obs_service_t *service) -> void * {
-		return new WHIPService(settings, service);
+		return new WHIPCustom(settings, service);
 	};
 	info.destroy = [](void *priv_data) {
-		delete static_cast<WHIPService *>(priv_data);
+		delete static_cast<WHIPCustom *>(priv_data);
 	};
 	info.update = [](void *priv_data, obs_data_t *settings) {
-		static_cast<WHIPService *>(priv_data)->Update(settings);
+		static_cast<WHIPCustom *>(priv_data)->Update(settings);
 	};
 	info.get_properties = [](void *) -> obs_properties_t * {
-		return WHIPService::Properties();
+		return WHIPCustom::Properties();
 	};
 	info.get_protocol = [](void *) -> const char * {
 		return "WHIP";
 	};
 	info.get_url = [](void *priv_data) -> const char * {
-		return static_cast<WHIPService *>(priv_data)->server.c_str();
+		return static_cast<WHIPCustom *>(priv_data)->server.c_str();
 	};
 	info.get_output_type = [](void *) -> const char * {
 		return "whip_output";
 	};
 	info.apply_encoder_settings = [](void *, obs_data_t *video_settings,
 					 obs_data_t *audio_settings) {
-		WHIPService::ApplyEncoderSettings(video_settings,
-						  audio_settings);
+		WHIPCustom::ApplyEncoderSettings(video_settings,
+						 audio_settings);
 	};
 	info.get_supported_video_codecs = [](void *) -> const char ** {
 		return video_codecs;
@@ -96,11 +93,11 @@ void register_whip_service()
 		return audio_codecs;
 	};
 	info.can_try_to_connect = [](void *priv_data) -> bool {
-		return static_cast<WHIPService *>(priv_data)->CanTryToConnect();
+		return static_cast<WHIPCustom *>(priv_data)->CanTryToConnect();
 	};
 	info.get_connect_info = [](void *priv_data,
 				   uint32_t type) -> const char * {
-		return static_cast<WHIPService *>(priv_data)->GetConnectInfo(
+		return static_cast<WHIPCustom *>(priv_data)->GetConnectInfo(
 			(enum obs_service_connect_info)type);
 	};
 	obs_register_service(&info);

--- a/plugins/obs-webrtc/whip-custom.h
+++ b/plugins/obs-webrtc/whip-custom.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <obs-module.h>
+#include <string>
+#include "common.h"
+
+struct WHIPCustom {
+	std::string server;
+	std::string bearer_token;
+
+	WHIPCustom(obs_data_t *settings, obs_service_t *service);
+
+	void Update(obs_data_t *settings);
+	static obs_properties_t *Properties();
+	static void ApplyEncoderSettings(obs_data_t *video_settings,
+					 obs_data_t *audio_settings);
+	bool CanTryToConnect();
+	const char *GetConnectInfo(enum obs_service_connect_info type);
+};
+
+void register_whip_custom();

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2633,6 +2633,28 @@
                 "max audio bitrate": 320,
                 "x264opts": "scenecut=0"
             }
+        },
+        {
+            "name": "Hakuna Live - WHIP",
+            "protocol": "WHIP",
+            "servers": [
+                {
+                    "name": "Republic of Korea",
+                    "url": "https://media-server-broker-b2c.prod.an2.media.hpcnt.com/whip"
+                },
+                {
+                    "name": "Japan",
+                    "url": "https://media-server-broker-b2c.prod.an1.media.hpcnt.com/whip"
+                },
+                {
+                    "name": "India, SEA, Thailand, Vietnam, Taiwan",
+                    "url": "https://media-server-broker-b2c.prod.as1.media.hpcnt.com/whip"
+                },
+                {
+                    "name": "Mideast, Turkey, Europe",
+                    "url": "https://media-server-broker-b2c.prod.ec1.media.hpcnt.com/whip"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added whip-common as a obs_service_info so that any contributor can add WHIP address in services.json.
As hyperconnect, the developer of hakuna live, officially supports media ingestion via WHIP, I have included a list of hakuna live's WHIP servers in the service.json.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
To use WHIP to ingest, We only choose "WHIP" service like custom service for RTMP.
Adding whip-common service makes you can define WHIP service into services.json. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
After adding whip-common, I modified services.json then tried to stream to hakuna live WHIP server.
I checked sevice.json which is for server configuration save file is successfully created and I confirmed WHIP service is selected when I re-open obs studio correctly.

### Types of changes
Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
