### PR TITLE
libobs: Add memory leak trace

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -3315,8 +3315,6 @@ int main(int argc, char *argv[])
 
 	base_get_log_handler(&def_log_handler, nullptr);
 
-	obs_set_cmdline_args(argc, argv);
-
 	for (int i = 1; i < argc; i++) {
 		if (arg_is(argv[i], "--multi", "-m")) {
 			multi = true;
@@ -3390,6 +3388,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--steam", nullptr)) {
 			steam = true;
 
+		} else if (arg_is(argv[i], "--bmem-trace", nullptr)) {
+			bmem_trace_enable();
+
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::string help =
 				"--help, -h: Get list of available commands.\n\n"
@@ -3411,6 +3412,7 @@ int main(int argc, char *argv[])
 				"--only-bundled-plugins: Only load included (first-party) plugins\n"
 				"--disable-shutdown-check: Disable unclean shutdown detection.\n"
 				"--verbose: Make log more verbose.\n"
+				"--bmem-trace: Keep stack traces of memory to log leaks on shutdown.\n"
 				"--always-on-top: Start in 'always on top' mode.\n\n"
 				"--unfiltered_log: Make log unfiltered.\n\n"
 				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n"
@@ -3431,6 +3433,8 @@ int main(int argc, char *argv[])
 			exit(0);
 		}
 	}
+
+	obs_set_cmdline_args(argc, argv);
 
 #if ALLOW_PORTABLE_MODE
 	if (!portable_mode) {
@@ -3478,6 +3482,10 @@ int main(int argc, char *argv[])
 
 	delete_safe_mode_sentinel();
 	blog(LOG_INFO, "Number of memory leaks: %ld", bnum_allocs());
+
+	if (bmem_trace_is_enabled())
+		bmem_trace_dump(LOG_ERROR);
+
 	base_set_log_handler(nullptr, nullptr);
 
 	if (restart || restart_safe) {

--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -21,6 +21,13 @@
 #include "platform.h"
 #include "threading.h"
 
+#ifdef _WIN32
+#include <Windows.h>
+#include <dbghelp.h>
+#else
+#include <execinfo.h>
+#endif
+
 /*
  * NOTE: totally jacked the mem alignment trick from ffmpeg, credit to them:
  *   http://www.ffmpeg.org/
@@ -44,53 +51,309 @@
 #define ALIGNMENT_HACK 1
 #endif
 
+#define BMEM_TRACE_DEPTH 9
+
+struct bmem_trace {
+	struct bmem_trace *next;
+	struct bmem_trace **prev_next;
+	void *buffer[BMEM_TRACE_DEPTH];
+	int nptrs;
+	size_t size;
+};
+
+#define BMEM_TRACE_SIZE_BYTE \
+	((sizeof(struct bmem_trace) + ALIGNMENT - 1) / ALIGNMENT * ALIGNMENT)
+#define BMEM_OVERRUN_TEST_BYTE ALIGNMENT
+
+// TODO: Currently using constant value. Use `calc_crc32` to check contents of `struct bmem_trace`.
+#define BMEM_OVERRUN_TEST_CODE 0xB3
+
+static struct bmem_trace *trace_first = NULL;
+static pthread_mutex_t bmem_trace_mutex = PTHREAD_MUTEX_INITIALIZER;
+static bool bmem_trace_enabled = false;
+
+void bmem_trace_enable()
+{
+	if (bnum_allocs() || trace_first) {
+		blog(LOG_ERROR,
+		     "bmem_trace_enable: tried to enable bmem_trace with existing allocations");
+		return;
+	}
+	bmem_trace_enabled = true;
+}
+
+bool bmem_trace_is_enabled()
+{
+	return bmem_trace_enabled;
+}
+
+static void bmem_trace_dump_once(int log_level, struct bmem_trace *bt);
+
+#ifdef _WIN32
+
+static inline int backtrace(void **buffer, int size)
+{
+	return (int)CaptureStackBackTrace(1, size, buffer, NULL);
+}
+
+typedef BOOL(WINAPI *SYMINITIALIZE)(HANDLE process, PCTSTR user_search_path,
+				    BOOL invade_process);
+typedef BOOL(WINAPI *SYMFROMADDR)(HANDLE process, DWORD64 address,
+				  PDWORD64 displacement, PSYMBOL_INFOW symbol);
+
+typedef BOOL(WINAPI *SYMREFRESHMODULELIST)(HANDLE process);
+
+extern bool sym_initialize_called;
+
+char **backtrace_symbols(const void **stack, int size)
+{
+	int frame;
+	DWORD64 displacement = 0;
+	char buf[sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR)];
+	SYMBOL_INFOW *pSymbol = (SYMBOL_INFOW *)buf;
+	pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+	pSymbol->MaxNameLen = MAX_SYM_NAME;
+	IMAGEHLP_LINE64 line = {0};
+	line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+	HANDLE process = GetCurrentProcess();
+
+	HMODULE dbghelp = LoadLibraryW(L"DbgHelp");
+	if (!dbghelp)
+		return NULL;
+
+	SYMINITIALIZE sym_initialize =
+		(SYMINITIALIZE)GetProcAddress(dbghelp, "SymInitialize");
+	SYMREFRESHMODULELIST sym_refresh_module_list =
+		(SYMREFRESHMODULELIST)GetProcAddress(dbghelp,
+						     "SymRefreshModuleList");
+	SYMFROMADDR sym_from_addr =
+		(SYMFROMADDR)GetProcAddress(dbghelp, "SymFromAddrW");
+
+	if (!sym_initialize_called)
+		sym_initialize(process, NULL, TRUE);
+	else
+		sym_refresh_module_list(process);
+
+	char *buffer = malloc(sizeof(char *) * size +
+			      MAX_SYM_NAME * sizeof(TCHAR) * size);
+	if (!buffer)
+		return NULL;
+
+	for (frame = 0; frame < size; frame++) {
+		char *pos = buffer + sizeof(char *) * size +
+			    MAX_SYM_NAME * sizeof(TCHAR) * frame;
+		pos[0] = 0;
+		((char **)buffer)[frame] = pos;
+		DWORD64 address = (DWORD64)(stack[frame]);
+		if (!address)
+			continue;
+
+		//get symbol name for address
+		if (!sym_from_addr(process, address, (PDWORD64)&displacement,
+				   pSymbol))
+			continue;
+
+		os_wcs_to_utf8(pSymbol->Name, pSymbol->NameLen, pos,
+			       MAX_SYM_NAME * sizeof(TCHAR));
+	}
+	return (char **)buffer;
+}
+#endif
+
+static inline void register_trace(void *ptr, size_t size)
+{
+	struct bmem_trace *bt = ptr;
+	void *buffer[BMEM_TRACE_DEPTH + 2];
+	int nptrs = backtrace(buffer, BMEM_TRACE_DEPTH + 2);
+	if (nptrs > 2) {
+		bt->nptrs = nptrs - 2;
+		memcpy(bt->buffer, buffer + 2, (nptrs - 2) * sizeof(void *));
+	} else {
+		bt->nptrs = 0;
+	}
+	bt->size = size;
+
+	pthread_mutex_lock(&bmem_trace_mutex);
+	bt->prev_next = &trace_first;
+	bt->next = trace_first;
+	trace_first = bt;
+	if (bt->next)
+		bt->next->prev_next = &bt->next;
+	pthread_mutex_unlock(&bmem_trace_mutex);
+}
+
+static void unregister_trace(void *ptr)
+{
+	struct bmem_trace *bt = ptr;
+	pthread_mutex_lock(&bmem_trace_mutex);
+	if (*bt->prev_next != bt) {
+		blog(LOG_ERROR,
+		     "unregister_trace corrupted *prev_next=%p expected %p prev_next: %p next: %p",
+		     *bt->prev_next, bt, bt->prev_next, bt->next);
+		bmem_trace_dump_once(LOG_ERROR, bt);
+		if (bt->next)
+			bmem_trace_dump_once(LOG_ERROR, bt->next);
+		pthread_mutex_unlock(&bmem_trace_mutex);
+		return;
+	}
+	*bt->prev_next = bt->next;
+	if (bt->next)
+		bt->next->prev_next = bt->prev_next;
+	bt->prev_next = NULL;
+	bt->next = NULL;
+	pthread_mutex_unlock(&bmem_trace_mutex);
+}
+
+static void reregister_trace(void *ptr, size_t size)
+{
+	struct bmem_trace *bt = ptr;
+	bt->size = size;
+	if (bt->next)
+		bt->next->prev_next = &bt->next;
+	*bt->prev_next = bt;
+}
+
+static void bmem_trace_dump_once(int log_level, struct bmem_trace *bt)
+{
+	int nptrs = bt->nptrs;
+	if (nptrs <= 0 || nptrs > BMEM_TRACE_DEPTH) {
+		blog(LOG_ERROR, "backtrace buffer broken %p nptrs=%d", bt,
+		     bt->nptrs);
+		return;
+	}
+	char **strings = backtrace_symbols(bt->buffer, nptrs);
+	if (!strings) {
+		blog(LOG_ERROR, "backtrace_symbols for memory returns NULL");
+	} else {
+		for (int i = 0; i < nptrs; i++) {
+			blog(log_level, "memory leak trace[%d]: %s", i,
+			     strings[i]);
+		}
+		free(strings);
+	}
+}
+
+static void bmem_overrun_test_set(uint8_t *ptr)
+{
+	for (uint8_t i = 0; i < BMEM_OVERRUN_TEST_BYTE; i++)
+		ptr[i] = BMEM_OVERRUN_TEST_CODE + i;
+}
+
+static void bmem_overrun_test_check(uint8_t *ptr)
+{
+	bool pass = true;
+	for (size_t i = 0; i < BMEM_OVERRUN_TEST_BYTE; i++)
+		pass &= ptr[i] == BMEM_OVERRUN_TEST_CODE + i;
+	if (!pass) {
+		blog(LOG_ERROR, "bmem_overrun_test_check: failed at %p", ptr);
+	}
+}
+
+void bmem_trace_dump(int log_level)
+{
+	if (!bmem_trace_enabled) {
+		blog(LOG_ERROR, "bmem_trace_dump: bmem_trace not enabled");
+		return;
+	}
+
+	pthread_mutex_lock(&bmem_trace_mutex);
+	int n = 0;
+	for (struct bmem_trace *bt = trace_first; bt; bt = bt->next) {
+		blog(log_level, "memory leak[%d] %p", n, bt);
+		bmem_trace_dump_once(log_level, bt);
+		n++;
+	}
+	pthread_mutex_unlock(&bmem_trace_mutex);
+}
+
 static void *a_malloc(size_t size)
 {
+	size_t mem_size = size;
+
+	if (bmem_trace_enabled)
+		mem_size += BMEM_TRACE_SIZE_BYTE + BMEM_OVERRUN_TEST_BYTE;
+
 #ifdef ALIGNED_MALLOC
-	return _aligned_malloc(size, ALIGNMENT);
+	void *ptr = _aligned_malloc(mem_size, ALIGNMENT);
 #elif ALIGNMENT_HACK
 	void *ptr = NULL;
 	long diff;
 
-	ptr = malloc(size + ALIGNMENT);
+	ptr = malloc(mem_size + ALIGNMENT);
 	if (ptr) {
 		diff = ((~(long)ptr) & (ALIGNMENT - 1)) + 1;
 		ptr = (char *)ptr + diff;
 		((char *)ptr)[-1] = (char)diff;
 	}
+#else
+	void *ptr = malloc(mem_size);
+#endif
+
+	if (bmem_trace_enabled && ptr) {
+		register_trace(ptr, size);
+		ptr = (uint8_t *)ptr + BMEM_TRACE_SIZE_BYTE;
+		bmem_overrun_test_set((uint8_t *)ptr + size);
+	}
 
 	return ptr;
-#else
-	return malloc(size);
-#endif
 }
 
 static void *a_realloc(void *ptr, size_t size)
 {
-#ifdef ALIGNED_MALLOC
-	return _aligned_realloc(ptr, size, ALIGNMENT);
-#elif ALIGNMENT_HACK
-	long diff;
-
 	if (!ptr)
 		return a_malloc(size);
-	diff = ((char *)ptr)[-1];
-	ptr = realloc((char *)ptr - diff, size + diff);
+
+	size_t mem_size = size;
+
+	if (bmem_trace_enabled) {
+		struct bmem_trace *trace =
+			(struct bmem_trace *)((uint8_t *)ptr -
+					      BMEM_TRACE_SIZE_BYTE);
+		bmem_overrun_test_check((uint8_t *)ptr + trace->size);
+		ptr = (uint8_t *)ptr - BMEM_TRACE_SIZE_BYTE;
+		mem_size += BMEM_TRACE_SIZE_BYTE + BMEM_OVERRUN_TEST_BYTE;
+		pthread_mutex_lock(&bmem_trace_mutex);
+	}
+
+#ifdef ALIGNED_MALLOC
+	ptr = _aligned_realloc(ptr, mem_size, ALIGNMENT);
+#elif ALIGNMENT_HACK
+	long diff = ((unsigned char *)ptr)[-1];
+	ptr = realloc((char *)ptr - diff, mem_size + diff);
 	if (ptr)
 		ptr = (char *)ptr + diff;
-	return ptr;
 #else
-	return realloc(ptr, size);
+	ptr = realloc(ptr, mem_size);
 #endif
+	if (bmem_trace_enabled && ptr) {
+		reregister_trace(ptr, size);
+		pthread_mutex_unlock(&bmem_trace_mutex);
+		ptr = (uint8_t *)ptr + BMEM_TRACE_SIZE_BYTE;
+		bmem_overrun_test_set((uint8_t *)ptr + size);
+	} else if (bmem_trace_enabled) {
+		pthread_mutex_unlock(&bmem_trace_mutex);
+	}
+	return ptr;
 }
 
 static void a_free(void *ptr)
 {
+	if (!ptr)
+		return;
+
+	if (bmem_trace_enabled) {
+		struct bmem_trace *trace =
+			(struct bmem_trace *)((uint8_t *)ptr -
+					      BMEM_TRACE_SIZE_BYTE);
+		bmem_overrun_test_check((uint8_t *)ptr + trace->size);
+		ptr = (uint8_t *)ptr - BMEM_TRACE_SIZE_BYTE;
+		unregister_trace((uint8_t *)ptr);
+	}
+
 #ifdef ALIGNED_MALLOC
 	_aligned_free(ptr);
 #elif ALIGNMENT_HACK
-	if (ptr)
-		free((char *)ptr - ((char *)ptr)[-1]);
+	free((char *)ptr - ((char *)ptr)[-1]);
 #else
 	free(ptr);
 #endif

--- a/libobs/util/bmem.h
+++ b/libobs/util/bmem.h
@@ -43,6 +43,10 @@ EXPORT long bnum_allocs(void);
 
 EXPORT void *bmemdup(const void *ptr, size_t size);
 
+EXPORT void bmem_trace_enable();
+EXPORT bool bmem_trace_is_enabled();
+EXPORT void bmem_trace_dump(int log_level);
+
 static inline void *bzalloc(size_t size)
 {
 	void *mem = bmalloc(size);


### PR DESCRIPTION
### Description
Add command-line `--bmem-trace` to enable keeping stacktraces for each `bmalloc` which includes `bzalloc`
On shutdown the stack traces are printed in the OBS log file like this:
> Number of memory leaks: 1
> memory leak[0] 00000263DF6C2C80
> memory leak trace[0]: bmalloc
> memory leak trace[1]: bzalloc
> memory leak trace[2]: obs_context_init_control
> memory leak trace[3]: obs_source_init
> memory leak trace[4]: obs_source_create_internal
> memory leak trace[5]: obs_source_create_private
> memory leak trace[6]: CanvasDock::CanvasDock
> memory leak trace[7]: obs_module_post_load
> memory leak trace[8]: obs_post_load_modules

It also does a simple memory overrun test for each allocation.
It can only be enabled when there are no allocations, that is why `obs_set_cmdline_args` moved down.

Based on https://github.com/norihiro/obs-studio/tree/bmem-trace-memory-leak by @norihiro 

### Motivation and Context
Want an easy way to find the cause of memory leaks that users have that can not be easily replicated.

### How Has This Been Tested?
On windows 64 bit

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.