### PR TITLE
Adjust AV1 tiles at 4K+ (v2)

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -938,6 +938,14 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 	if (config->rcParams.rateControlMode == NV_ENC_PARAMS_RC_CBR)
 		av1_config->enableBitstreamPadding = 1;
 
+#define PIXELCOUNT_4K (3840 * 2160)
+
+	/* If size is 4K+, set tiles to 2 uniform columns. */
+	if ((voi->width * voi->height) >= PIXELCOUNT_4K) {
+		av1_config->enableCustomTileConfig = 0;
+		av1_config->numTileColumns = 2;
+	}
+
 	switch (voi->colorspace) {
 	case VIDEO_CS_601:
 		av1_config->colorPrimaries = 6;

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -331,6 +331,17 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams,
 		}
 	}
 
+	constexpr uint32_t pixelcount_4k = 3840 * 2160;
+	/* If size is 4K+, set tile columns per frame to 2. */
+	if (codec == QSV_CODEC_AV1 &&
+	    (pParams->nWidth * pParams->nHeight) >= pixelcount_4k) {
+		memset(&m_ExtAv1TileParam, 0, sizeof(m_ExtAv1TileParam));
+		m_ExtAv1TileParam.Header.BufferId = MFX_EXTBUFF_AV1_TILE_PARAM;
+		m_ExtAv1TileParam.Header.BufferSz = sizeof(m_ExtAv1TileParam);
+		m_ExtAv1TileParam.NumTileColumns = 2;
+		extendedBuffers.push_back((mfxExtBuffer *)&m_ExtAv1TileParam);
+	}
+
 #if defined(_WIN32)
 	// TODO: Ask about this one on VAAPI too.
 	memset(&m_ExtVideoSignalInfo, 0, sizeof(m_ExtVideoSignalInfo));

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -123,6 +123,7 @@ private:
 	mfxExtCodingOption2 m_co2;
 	mfxExtCodingOption m_co;
 	mfxExtHEVCParam m_ExtHEVCParam{};
+	mfxExtAV1TileParam m_ExtAv1TileParam{};
 	mfxExtVideoSignalInfo m_ExtVideoSignalInfo{};
 	mfxExtChromaLocInfo m_ExtChromaLocInfo{};
 	mfxExtMasteringDisplayColourVolume m_ExtMasteringDisplayColourVolume{};


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use 2 tiles in NVENC AV1 for 4K+. When resolution is 4K or higher, use 2 uniform tile columns for NVENC AV1.

Use 2 tiles in QSV AV1 for 4K+. When resolution is 4K or higher, use 2 tile columns for QSV AV1.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Single-tile 4K videos are more difficult to decode. Using 1x2 or 2x1 tiles for 4K should make decoding easier.

This is an updated version of #8788. Defines and constexpr variables have been trimmed down. NVENC is now set to 1x2 (1 row, 2 columns) instead of 2x2.

See also [YouTube's tiling recommendations](https://support.google.com/youtube/answer/2853702):
>Minimum of 2 tile columns for AV1-encoded streams at resolutions of 3840x2160 and above

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Previously tested in the original PR, but could use retesting given the adjustments. I did test the QSV change and verified with ffprobe that the resulting file was 1x2 tiles (1 row, 2 columns). More testing would be welcomed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
