### PR TITLE
obs-ffmpeg: Add native non-texture NVENC encoder

### DIFF
--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -197,6 +197,7 @@ build() {
         -DCEF_ROOT_DIR:PATH="${project_root}/.deps/cef_binary_${CEF_VERSION}_${target//-/_}"
         -DENABLE_AJA:BOOL=OFF
         -DENABLE_WEBRTC:BOOL=OFF
+        -DENABLE_NATIVE_NVENC:BOOL=OFF
       )
       if (( ! UBUNTU_2210_OR_LATER )) cmake_args+=(-DENABLE_NEW_MPEGTS_OUTPUT:BOOL=OFF)
 

--- a/cmake/Modules/FindFFnvcodec.cmake
+++ b/cmake/Modules/FindFFnvcodec.cmake
@@ -78,7 +78,7 @@ endif()
 find_package_handle_standard_args(
   FFnvcodec
   REQUIRED_VARS FFnvcodec_INCLUDE_DIR
-  VERSION_VAR FFnvcodec_VERSION REASON_FAILURE_MESSAGE "${FFnvcodec_ERROR_REASON}")
+  VERSION_VAR FFnvcodec_VERSION HANDLE_VERSION_RANGE REASON_FAILURE_MESSAGE "${FFnvcodec_ERROR_REASON}")
 mark_as_advanced(FFnvcodec_INCLUDE_DIR)
 unset(FFnvcodec_ERROR_REASON)
 

--- a/cmake/finders/FindFFnvcodec.cmake
+++ b/cmake/finders/FindFFnvcodec.cmake
@@ -78,7 +78,7 @@ endif()
 find_package_handle_standard_args(
   FFnvcodec
   REQUIRED_VARS FFnvcodec_INCLUDE_DIR
-  VERSION_VAR FFnvcodec_VERSION REASON_FAILURE_MESSAGE "${FFnvcodec_ERROR_REASON}")
+  VERSION_VAR FFnvcodec_VERSION HANDLE_VERSION_RANGE REASON_FAILURE_MESSAGE "${FFnvcodec_ERROR_REASON}")
 mark_as_advanced(FFnvcodec_INCLUDE_DIR)
 unset(FFnvcodec_ERROR_REASON)
 

--- a/plugins/obs-ffmpeg/cmake/dependencies.cmake
+++ b/plugins/obs-ffmpeg/cmake/dependencies.cmake
@@ -26,7 +26,7 @@ endif()
 
 if(OS_WINDOWS)
   find_package(AMF 1.4.29 REQUIRED)
-  find_package(FFnvcodec 12 REQUIRED)
+  find_package(FFnvcodec 12.0.0.0...<12.2.0.0 REQUIRED)
 
   add_library(obs-nvenc-version INTERFACE)
   add_library(OBS::obs-nvenc-version ALIAS obs-nvenc-version)

--- a/plugins/obs-ffmpeg/cmake/legacy.cmake
+++ b/plugins/obs-ffmpeg/cmake/legacy.cmake
@@ -2,6 +2,7 @@ project(obs-ffmpeg)
 
 option(ENABLE_FFMPEG_LOGGING "Enables obs-ffmpeg logging" OFF)
 option(ENABLE_NEW_MPEGTS_OUTPUT "Use native SRT/RIST mpegts output" ON)
+option(ENABLE_NATIVE_NVENC "Use native NVENC implementation" ON)
 
 find_package(
   FFmpeg REQUIRED
@@ -112,6 +113,13 @@ elseif(OS_POSIX AND NOT OS_MACOS)
   find_package(Libpci REQUIRED)
   target_sources(obs-ffmpeg PRIVATE obs-ffmpeg-vaapi.c vaapi-utils.c vaapi-utils.h)
   target_link_libraries(obs-ffmpeg PRIVATE Libva::va Libva::drm LIBPCI::LIBPCI)
+
+  if(ENABLE_NATIVE_NVENC)
+    find_package(FFnvcodec 12.0.0.0...<12.2.0.0 REQUIRED)
+    target_sources(obs-ffmpeg PRIVATE obs-nvenc.c obs-nvenc.h obs-nvenc-helpers.c obs-nvenc-ver.h)
+    target_link_libraries(obs-ffmpeg PRIVATE FFnvcodec::FFnvcodec)
+    target_compile_definitions(obs-ffmpeg PRIVATE NVCODEC_AVAILABLE)
+  endif()
 endif()
 
 setup_plugin_target(obs-ffmpeg)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -676,7 +676,7 @@ struct obs_encoder_info h264_nvenc_encoder_info = {
 	.get_extra_data = nvenc_extra_data,
 	.get_sei_data = nvenc_sei_data,
 	.get_video_info = nvenc_video_info,
-#ifdef _WIN32
+#if defined(_WIN32) || defined(NVCODEC_AVAILABLE)
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_INTERNAL,
 #else
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE,
@@ -698,7 +698,7 @@ struct obs_encoder_info hevc_nvenc_encoder_info = {
 	.get_extra_data = nvenc_extra_data,
 	.get_sei_data = nvenc_sei_data,
 	.get_video_info = nvenc_video_info,
-#ifdef _WIN32
+#if defined(_WIN32) || defined(NVCODEC_AVAILABLE)
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_INTERNAL,
 #else
 	.caps = OBS_ENCODER_CAP_DYN_BITRATE,

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -7,8 +7,12 @@
 #ifdef _WIN32
 #include <dxgi.h>
 #include <util/windows/win-version.h>
+#endif
 
+#if defined(_WIN32) || defined(NVCODEC_AVAILABLE)
 #include "obs-nvenc.h"
+
+#define OBS_NVENC_AVAILABLE
 #endif
 
 #if !defined(_WIN32) && !defined(__APPLE__)
@@ -236,7 +240,7 @@ static bool nvenc_device_available(void)
 }
 #endif
 
-#ifdef _WIN32
+#ifdef OBS_NVENC_AVAILABLE
 extern bool load_nvenc_lib(void);
 #endif
 
@@ -264,18 +268,9 @@ static bool nvenc_supported(bool *out_h264, bool *out_hevc, bool *out_av1)
 
 	bool success = h264 || hevc;
 	if (success) {
-#if defined(_WIN32)
+#ifdef OBS_NVENC_AVAILABLE
 		success = nvenc_device_available() && load_nvenc_lib();
 		av1 = success && (get_nvenc_ver() >= ((12 << 4) | 0));
-
-#elif defined(__linux__)
-		success = nvenc_device_available();
-		if (success) {
-			void *const lib = os_dlopen("libnvidia-encode.so.1");
-			success = lib != NULL;
-			if (success)
-				os_dlclose(lib);
-		}
 #else
 		void *const lib = os_dlopen("libnvidia-encode.so.1");
 		success = lib != NULL;
@@ -336,9 +331,12 @@ static bool hevc_vaapi_supported(void)
 #endif
 #endif
 
-#ifdef _WIN32
+#ifdef OBS_NVENC_AVAILABLE
 extern void obs_nvenc_load(bool h264, bool hevc, bool av1);
 extern void obs_nvenc_unload(void);
+#endif
+
+#ifdef _WIN32
 extern void amf_load(void);
 extern void amf_unload(void);
 #endif
@@ -381,7 +379,7 @@ bool obs_module_load(void)
 	if (nvenc_supported(&h264, &hevc, &av1)) {
 		blog(LOG_INFO, "NVENC supported");
 
-#ifdef _WIN32
+#ifdef OBS_NVENC_AVAILABLE
 		obs_nvenc_load(h264, hevc, av1);
 #endif
 		if (h264)
@@ -442,6 +440,8 @@ void obs_module_unload(void)
 
 #ifdef _WIN32
 	amf_unload();
+#endif
+#ifdef OBS_NVENC_AVAILABLE
 	obs_nvenc_unload();
 #endif
 }

--- a/plugins/obs-ffmpeg/obs-nvenc-helpers.c
+++ b/plugins/obs-ffmpeg/obs-nvenc-helpers.c
@@ -2,19 +2,26 @@
 #include <util/platform.h>
 #include <util/threading.h>
 #include <util/config-file.h>
-#include <util/windows/device-enum.h>
 #include <util/dstr.h>
 #include <util/pipe.h>
 
+#ifdef _WIN32
+#include <util/windows/device-enum.h>
+#endif
+
 static void *nvenc_lib = NULL;
+static void *cuda_lib = NULL;
 static pthread_mutex_t init_mutex = PTHREAD_MUTEX_INITIALIZER;
 NV_ENCODE_API_FUNCTION_LIST nv = {NV_ENCODE_API_FUNCTION_LIST_VER};
 NV_CREATE_INSTANCE_FUNC nv_create_instance = NULL;
+CudaFunctions *cu = NULL;
 
 #define error(format, ...) blog(LOG_ERROR, "[obs-nvenc] " format, ##__VA_ARGS__)
 
 bool nv_fail2(obs_encoder_t *encoder, void *session, const char *format, ...)
 {
+	UNUSED_PARAMETER(session);
+
 	struct dstr message = {0};
 	struct dstr error_message = {0};
 
@@ -98,15 +105,36 @@ bool nv_failed2(obs_encoder_t *encoder, void *session, NVENCSTATUS err,
 
 bool load_nvenc_lib(void)
 {
-	const char *const file = (sizeof(void *) == 8) ? "nvEncodeAPI64.dll"
-						       : "nvEncodeAPI.dll";
-	nvenc_lib = os_dlopen(file);
+#ifdef _WIN32
+	nvenc_lib = os_dlopen("nvEncodeAPI64.dll");
+#else
+	nvenc_lib = os_dlopen("libnvidia-encode.so.1");
+#endif
 	return nvenc_lib != NULL;
 }
 
 static void *load_nv_func(const char *func)
 {
 	void *func_ptr = os_dlsym(nvenc_lib, func);
+	if (!func_ptr) {
+		error("Could not load function: %s", func);
+	}
+	return func_ptr;
+}
+
+bool load_cuda_lib(void)
+{
+#ifdef _WIN32
+	cuda_lib = os_dlopen("nvcuda.dll");
+#else
+	cuda_lib = os_dlopen("libcuda.so.1");
+#endif
+	return cuda_lib != NULL;
+}
+
+static void *load_cuda_func(const char *func)
+{
+	void *func_ptr = os_dlsym(cuda_lib, func);
 	if (!func_ptr) {
 		error("Could not load function: %s", func);
 	}
@@ -227,6 +255,81 @@ static inline bool init_nvenc_internal(obs_encoder_t *encoder)
 	return true;
 }
 
+typedef struct cuda_function {
+	ptrdiff_t offset;
+	const char *name;
+} cuda_function;
+
+static const cuda_function cuda_functions[] = {
+	{offsetof(CudaFunctions, cuInit), "cuInit"},
+
+	{offsetof(CudaFunctions, cuDeviceGetCount), "cuDeviceGetCount"},
+	{offsetof(CudaFunctions, cuDeviceGet), "cuDeviceGet"},
+	{offsetof(CudaFunctions, cuDeviceGetAttribute), "cuDeviceGetAttribute"},
+
+	{offsetof(CudaFunctions, cuCtxCreate), "cuCtxCreate_v2"},
+	{offsetof(CudaFunctions, cuCtxDestroy), "cuCtxDestroy_v2"},
+	{offsetof(CudaFunctions, cuCtxPushCurrent), "cuCtxPushCurrent_v2"},
+	{offsetof(CudaFunctions, cuCtxPopCurrent), "cuCtxPopCurrent_v2"},
+
+	{offsetof(CudaFunctions, cuArray3DCreate), "cuArray3DCreate_v2"},
+	{offsetof(CudaFunctions, cuArrayDestroy), "cuArrayDestroy"},
+	{offsetof(CudaFunctions, cuMemcpy2D), "cuMemcpy2D_v2"},
+
+	{offsetof(CudaFunctions, cuGetErrorName), "cuGetErrorName"},
+	{offsetof(CudaFunctions, cuGetErrorString), "cuGetErrorString"},
+
+	{offsetof(CudaFunctions, cuMemHostRegister), "cuMemHostRegister_v2"},
+	{offsetof(CudaFunctions, cuMemHostUnregister), "cuMemHostUnregister"},
+};
+
+static const size_t num_cuda_funcs =
+	sizeof(cuda_functions) / sizeof(cuda_function);
+
+static bool init_cuda_internal(obs_encoder_t *encoder)
+{
+	static bool initialized = false;
+	static bool success = false;
+
+	if (initialized)
+		return success;
+	initialized = true;
+
+	if (!load_cuda_lib()) {
+		obs_encoder_set_last_error(encoder,
+					   "Loading CUDA library failed.");
+		return false;
+	}
+
+	cu = bzalloc(sizeof(CudaFunctions));
+
+	for (size_t idx = 0; idx < num_cuda_funcs; idx++) {
+		const cuda_function func = cuda_functions[idx];
+		void *fptr = load_cuda_func(func.name);
+
+		if (!fptr) {
+			error("Failed to find CUDA function: %s", func.name);
+			obs_encoder_set_last_error(
+				encoder, "Loading CUDA functions failed.");
+			return false;
+		}
+
+		*(uintptr_t *)((uintptr_t)cu + func.offset) = (uintptr_t)fptr;
+	}
+
+	success = true;
+	return true;
+}
+
+bool cuda_get_error_desc(CUresult res, const char **name, const char **desc)
+{
+	if (cu->cuGetErrorName(res, name) != CUDA_SUCCESS ||
+	    cu->cuGetErrorString(res, desc) != CUDA_SUCCESS)
+		return false;
+
+	return true;
+}
+
 bool init_nvenc(obs_encoder_t *encoder)
 {
 	bool success;
@@ -238,12 +341,32 @@ bool init_nvenc(obs_encoder_t *encoder)
 	return success;
 }
 
+bool init_cuda(obs_encoder_t *encoder)
+{
+	bool success;
+
+	pthread_mutex_lock(&init_mutex);
+	success = init_cuda_internal(encoder);
+	pthread_mutex_unlock(&init_mutex);
+
+	return success;
+}
+
+#ifdef _WIN32
 extern struct obs_encoder_info h264_nvenc_info;
 #ifdef ENABLE_HEVC
 extern struct obs_encoder_info hevc_nvenc_info;
 #endif
 extern struct obs_encoder_info av1_nvenc_info;
+#endif
 
+extern struct obs_encoder_info h264_nvenc_soft_info;
+#ifdef ENABLE_HEVC
+extern struct obs_encoder_info hevc_nvenc_soft_info;
+#endif
+extern struct obs_encoder_info av1_nvenc_soft_info;
+
+#ifdef _WIN32
 static bool enum_luids(void *param, uint32_t idx, uint64_t luid)
 {
 	struct dstr *cmd = param;
@@ -319,23 +442,42 @@ fail:
 
 	return av1_supported;
 }
+#else
+bool av1_supported()
+{
+	return get_nvenc_ver() >= ((12 << 4) | 0);
+}
+#endif
 
 void obs_nvenc_load(bool h264, bool hevc, bool av1)
 {
 	pthread_mutex_init(&init_mutex, NULL);
-	if (h264)
+	if (h264) {
+#ifdef _WIN32
 		obs_register_encoder(&h264_nvenc_info);
+#endif
+		obs_register_encoder(&h264_nvenc_soft_info);
+	}
 #ifdef ENABLE_HEVC
-	if (hevc)
+	if (hevc) {
+#ifdef _WIN32
 		obs_register_encoder(&hevc_nvenc_info);
 #endif
-	if (av1 && av1_supported())
+		obs_register_encoder(&hevc_nvenc_soft_info);
+	}
+#endif
+	if (av1 && av1_supported()) {
+#ifdef _WIN32
 		obs_register_encoder(&av1_nvenc_info);
-	else
+#endif
+		obs_register_encoder(&av1_nvenc_soft_info);
+	} else {
 		blog(LOG_WARNING, "[NVENC] AV1 is not supported");
+	}
 }
 
 void obs_nvenc_unload(void)
 {
+	bfree(cu);
 	pthread_mutex_destroy(&init_mutex);
 }

--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -1,27 +1,31 @@
 #include "obs-nvenc.h"
+
 #include <util/deque.h>
 #include <util/darray.h>
 #include <util/dstr.h>
 #include <obs-avc.h>
+#include <obs-hevc.h>
+
 #include <libavutil/rational.h>
+
+#ifdef _WIN32
 #define INITGUID
 #include <dxgi.h>
 #include <d3d11.h>
 #include <d3d11_1.h>
-#include <obs-hevc.h>
+#endif
 
 /* ========================================================================= */
 /* a hack of the ages: nvenc backward compatibility                          */
 
 #define CONFIGURED_NVENC_MAJOR 12
 #define CONFIGURED_NVENC_MINOR 1
-#define CONFIGURED_NVENC_VER \
-	(CONFIGURED_NVENC_MAJOR | (CONFIGURED_NVENC_MINOR << 24))
 
 /* we cannot guarantee structures haven't changed, so purposely break on
  * version change to force the programmer to update or remove backward
  * compatibility NVENC code. */
-#if CONFIGURED_NVENC_VER != NVENCAPI_VERSION
+#if CONFIGURED_NVENC_MAJOR != NVENCAPI_MAJOR_VERSION || \
+	CONFIGURED_NVENC_MINOR < NVENCAPI_MINOR_VERSION
 #error NVENC version changed, update or remove NVENC compatibility code
 #endif
 
@@ -54,14 +58,21 @@
 
 #define error_hr(msg) error("%s: %s: 0x%08lX", __FUNCTION__, msg, (uint32_t)hr);
 
+#ifndef _WIN32
+#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
 struct nv_bitstream;
 struct nv_texture;
 
+#ifdef _WIN32
 struct handle_tex {
 	uint32_t handle;
 	ID3D11Texture2D *tex;
 	IDXGIKeyedMutex *km;
 };
+#endif
 
 /* ------------------------------------------------------------------------- */
 /* Main Implementation Structure                                             */
@@ -95,7 +106,7 @@ struct nvenc_data {
 	NV_ENC_INITIALIZE_PARAMS params;
 	NV_ENC_CONFIG config;
 	int rc_lookahead;
-	int buf_count;
+	uint32_t buf_count;
 	int output_delay;
 	int buffers_queued;
 	size_t next_bitstream;
@@ -104,22 +115,28 @@ struct nvenc_data {
 	bool first_packet;
 	bool can_change_bitrate;
 	bool needs_compat_ver;
+	bool fallback;
 	int32_t bframes;
 
 	DARRAY(struct nv_bitstream) bitstreams;
-	DARRAY(struct nv_texture) textures;
-	DARRAY(struct handle_tex) input_textures;
+	DARRAY(struct nv_cuda_surface) surfaces;
+	NV_ENC_BUFFER_FORMAT surface_format;
 	struct deque dts_list;
 
 	DARRAY(uint8_t) packet_data;
 	int64_t packet_pts;
 	bool packet_keyframe;
 
+#ifdef _WIN32
+	DARRAY(struct nv_texture) textures;
+	DARRAY(struct handle_tex) input_textures;
 	ID3D11Device *device;
 	ID3D11DeviceContext *context;
+#endif
 
 	uint32_t cx;
 	uint32_t cy;
+	enum video_format in_format;
 
 	uint8_t *header;
 	size_t header_size;
@@ -130,6 +147,8 @@ struct nvenc_data {
 	int8_t *roi_map;
 	size_t roi_map_size;
 	uint32_t roi_increment;
+
+	CUcontext cu_ctx;
 };
 
 /* ------------------------------------------------------------------------- */
@@ -165,6 +184,7 @@ static void nv_bitstream_free(struct nvenc_data *enc, struct nv_bitstream *bs)
 /* ------------------------------------------------------------------------- */
 /* Texture Resource                                                          */
 
+#ifdef _WIN32
 struct nv_texture {
 	void *res;
 	ID3D11Texture2D *tex;
@@ -219,6 +239,7 @@ static bool nv_texture_init(struct nvenc_data *enc, struct nv_texture *nvtex)
 
 static void nv_texture_free(struct nvenc_data *enc, struct nv_texture *nvtex)
 {
+
 	if (nvtex->res) {
 		if (nvtex->mapped_res) {
 			nv.nvEncUnmapInputResource(enc->session,
@@ -226,6 +247,128 @@ static void nv_texture_free(struct nvenc_data *enc, struct nv_texture *nvtex)
 		}
 		nv.nvEncUnregisterResource(enc->session, nvtex->res);
 		nvtex->tex->lpVtbl->Release(nvtex->tex);
+	}
+}
+#endif
+
+/* ------------------------------------------------------------------------- */
+/* CUDA Stuff                                                                */
+
+/* CUDA error handling */
+
+static inline bool cuda_error_check(struct nvenc_data *enc, CUresult res,
+				    const char *func, const char *call)
+{
+	if (res == CUDA_SUCCESS)
+		return true;
+
+	const char *name, *desc;
+	if (cuda_get_error_desc(res, &name, &desc)) {
+		error("%s: CUDA call \"%s\" failed with %s (%d): %s", func,
+		      call, name, res, desc);
+	} else {
+		error("%s: CUDA call \"%s\" failed with %d", func, call, res);
+	}
+
+	return false;
+}
+
+#define CU_FAILED(call)                                        \
+	if (!cuda_error_check(enc, call, __FUNCTION__, #call)) \
+		return false;
+
+#define CU_CHECK(call)                                           \
+	if (!cuda_error_check(enc, call, __FUNCTION__, #call)) { \
+		success = false;                                 \
+		goto unmap;                                      \
+	}
+
+/* CUDA Surfaces */
+
+struct nv_cuda_surface {
+	CUarray tex;
+	NV_ENC_REGISTERED_PTR res;
+	NV_ENC_INPUT_PTR *mapped_res;
+};
+
+/* Missing from ffmpeg nvcodec headers, required for CUDA arrays to be usable in NVENC */
+static const int CUDA_ARRAY3D_SURFACE_LDST = 0x02;
+
+static bool nv_cuda_surface_init(struct nvenc_data *enc,
+				 struct nv_cuda_surface *nvsurf)
+{
+	const bool p010 = obs_p010_tex_active();
+	CUDA_ARRAY3D_DESCRIPTOR desc;
+	desc.Width = enc->cx;
+	desc.Height = enc->cy;
+	desc.Depth = 0;
+	desc.Flags = CUDA_ARRAY3D_SURFACE_LDST;
+	desc.NumChannels = 1;
+
+	if (!enc->fallback) {
+		desc.Format = p010 ? CU_AD_FORMAT_UNSIGNED_INT16
+				   : CU_AD_FORMAT_UNSIGNED_INT8;
+		desc.Height = enc->cy + enc->cy / 2;
+	} else {
+		switch (enc->surface_format) {
+		case NV_ENC_BUFFER_FORMAT_NV12:
+			desc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
+			// Additional half-height plane for UV data
+			desc.Height += enc->cy / 2;
+			break;
+		case NV_ENC_BUFFER_FORMAT_YUV420_10BIT:
+			desc.Format = CU_AD_FORMAT_UNSIGNED_INT16;
+			desc.Height += enc->cy / 2;
+			desc.NumChannels = 2; // number of bytes per element
+			break;
+		case NV_ENC_BUFFER_FORMAT_YUV444:
+			desc.Format = CU_AD_FORMAT_UNSIGNED_INT8;
+			desc.Height *= 3; // 3 full-size planes
+			break;
+		default:
+			error("Unknown input format: %d", enc->surface_format);
+			return false;
+		}
+	}
+
+	CU_FAILED(cu->cuArray3DCreate(&nvsurf->tex, &desc))
+
+	NV_ENC_REGISTER_RESOURCE res = {0};
+	res.version = enc->needs_compat_ver
+			      ? NV_ENC_REGISTER_RESOURCE_COMPAT_VER
+			      : NV_ENC_REGISTER_RESOURCE_VER;
+	res.resourceType = NV_ENC_INPUT_RESOURCE_TYPE_CUDAARRAY;
+	res.resourceToRegister = (void *)nvsurf->tex;
+	res.width = enc->cx;
+	res.height = enc->cy;
+	res.pitch = (uint32_t)(desc.Width * desc.NumChannels);
+	if (!enc->fallback) {
+		res.bufferFormat = p010 ? NV_ENC_BUFFER_FORMAT_YUV420_10BIT
+					: NV_ENC_BUFFER_FORMAT_NV12;
+	} else {
+		res.bufferFormat = enc->surface_format;
+	}
+
+	if (NV_FAILED(nv.nvEncRegisterResource(enc->session, &res))) {
+		return false;
+	}
+
+	nvsurf->res = res.registeredResource;
+	nvsurf->mapped_res = NULL;
+	return true;
+}
+
+static void nv_cuda_surface_free(struct nvenc_data *enc,
+				 struct nv_cuda_surface *nvsurf)
+{
+
+	if (nvsurf->res) {
+		if (nvsurf->mapped_res) {
+			nv.nvEncUnmapInputResource(enc->session,
+						   nvsurf->mapped_res);
+		}
+		nv.nvEncUnregisterResource(enc->session, nvsurf->res);
+		cu->cuArrayDestroy(nvsurf->tex);
 	}
 }
 
@@ -238,11 +381,23 @@ static const char *h264_nvenc_get_name(void *type_data)
 	return "NVIDIA NVENC H.264";
 }
 
+static const char *h264_nvenc_soft_get_name(void *type_data)
+{
+	UNUSED_PARAMETER(type_data);
+	return "NVIDIA NVENC H.264 (Fallback)";
+}
+
 #ifdef ENABLE_HEVC
 static const char *hevc_nvenc_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
 	return "NVIDIA NVENC HEVC";
+}
+
+static const char *hevc_nvenc_soft_get_name(void *type_data)
+{
+	UNUSED_PARAMETER(type_data);
+	return "NVIDIA NVENC HEVC (Fallback)";
 }
 #endif
 
@@ -250,6 +405,12 @@ static const char *av1_nvenc_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
 	return "NVIDIA NVENC AV1";
+}
+
+static const char *av1_nvenc_soft_get_name(void *type_data)
+{
+	UNUSED_PARAMETER(type_data);
+	return "NVIDIA NVENC AV1 (Fallback)";
 }
 
 static inline int nv_get_cap(struct nvenc_data *enc, NV_ENC_CAPS cap)
@@ -296,6 +457,7 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 	return true;
 }
 
+#ifdef _WIN32
 static HANDLE get_lib(struct nvenc_data *enc, const char *lib)
 {
 	HMODULE mod = GetModuleHandleA(lib);
@@ -361,15 +523,26 @@ static bool init_d3d11(struct nvenc_data *enc, obs_data_t *settings)
 	enc->context = context;
 	return true;
 }
+#endif
 
 static bool init_session(struct nvenc_data *enc)
 {
 	NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS params = {
 		NV_ENC_OPEN_ENCODE_SESSION_EX_PARAMS_VER};
-	params.device = enc->device;
-	params.deviceType = NV_ENC_DEVICE_TYPE_DIRECTX;
 	params.apiVersion = enc->needs_compat_ver ? NVENC_COMPAT_VER
 						  : NVENCAPI_VERSION;
+#ifdef _WIN32
+	if (enc->fallback) {
+		params.device = enc->cu_ctx;
+		params.deviceType = NV_ENC_DEVICE_TYPE_CUDA;
+	} else {
+		params.device = enc->device;
+		params.deviceType = NV_ENC_DEVICE_TYPE_DIRECTX;
+	}
+#else
+	params.device = enc->cu_ctx;
+	params.deviceType = NV_ENC_DEVICE_TYPE_CUDA;
+#endif
 
 	if (NV_FAILED(nv.nvEncOpenEncodeSessionEx(&params, &enc->session))) {
 		return false;
@@ -392,8 +565,9 @@ static void initialize_params(struct nvenc_data *enc, const GUID *nv_preset,
 	params->presetGUID = *nv_preset;
 	params->encodeWidth = width;
 	params->encodeHeight = height;
-	params->darWidth = enc->codec == CODEC_AV1 ? width : darWidth;
-	params->darHeight = enc->codec == CODEC_AV1 ? height : darHeight;
+	params->darWidth = enc->codec == CODEC_AV1 ? width : (uint32_t)darWidth;
+	params->darHeight = enc->codec == CODEC_AV1 ? height
+						    : (uint32_t)darHeight;
 	params->frameRateNum = fps_num;
 	params->frameRateDen = fps_den;
 	params->enableEncodeAsync = 0;
@@ -441,6 +615,12 @@ static inline NV_ENC_MULTI_PASS get_nv_multipass(const char *multipass)
 	} else {
 		return NV_ENC_MULTI_PASS_DISABLED;
 	}
+}
+
+static bool is_10_bit(const struct nvenc_data *enc)
+{
+	return enc->fallback ? enc->in_format == VIDEO_FORMAT_P010
+			     : obs_p010_tex_active();
 }
 
 static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings,
@@ -775,6 +955,8 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings,
 		vui_params->transferCharacteristics = 13;
 		vui_params->colourMatrix = 1;
 		break;
+	default:
+		break;
 	}
 
 	if (astrcmpi(rc, "lossless") == 0) {
@@ -788,7 +970,10 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings,
 	/* -------------------------- */
 	/* profile                    */
 
-	if (astrcmpi(profile, "main") == 0) {
+	if (enc->in_format == VIDEO_FORMAT_I444) {
+		config->profileGUID = NV_ENC_H264_PROFILE_HIGH_444_GUID;
+		h264_config->chromaFormatIDC = 3;
+	} else if (astrcmpi(profile, "main") == 0) {
 		config->profileGUID = NV_ENC_H264_PROFILE_MAIN_GUID;
 	} else if (astrcmpi(profile, "baseline") == 0) {
 		config->profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
@@ -881,7 +1066,7 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 		vui_params->chromaSampleLocationBot = 2;
 	}
 
-	hevc_config->pixelBitDepthMinus8 = obs_p010_tex_active() ? 2 : 0;
+	hevc_config->pixelBitDepthMinus8 = is_10_bit(enc) ? 2 : 0;
 
 	if (astrcmpi(rc, "cbr") == 0) {
 		hevc_config->outputBufferingPeriodSEI = 1;
@@ -892,9 +1077,12 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 	/* -------------------------- */
 	/* profile                    */
 
-	if (astrcmpi(profile, "main10") == 0) {
+	if (enc->in_format == VIDEO_FORMAT_I444) {
+		config->profileGUID = NV_ENC_HEVC_PROFILE_FREXT_GUID;
+		hevc_config->chromaFormatIDC = 3;
+	} else if (astrcmpi(profile, "main10") == 0) {
 		config->profileGUID = NV_ENC_HEVC_PROFILE_MAIN10_GUID;
-	} else if (obs_p010_tex_active()) {
+	} else if (is_10_bit(enc)) {
 		blog(LOG_WARNING, "[obs-nvenc] Forcing main10 for P010");
 		config->profileGUID = NV_ENC_HEVC_PROFILE_MAIN10_GUID;
 	} else {
@@ -982,7 +1170,7 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 
 	av1_config->level = NV_ENC_LEVEL_AV1_AUTOSELECT;
 	av1_config->chromaFormatIDC = 1;
-	av1_config->pixelBitDepthMinus8 = obs_p010_tex_active() ? 2 : 0;
+	av1_config->pixelBitDepthMinus8 = is_10_bit(enc) ? 2 : 0;
 	av1_config->inputPixelBitDepthMinus8 = av1_config->pixelBitDepthMinus8;
 	av1_config->numFwdRefs = 1;
 	av1_config->numBwdRefs = 1;
@@ -998,7 +1186,7 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 static bool init_bitstreams(struct nvenc_data *enc)
 {
 	da_reserve(enc->bitstreams, enc->buf_count);
-	for (int i = 0; i < enc->buf_count; i++) {
+	for (uint32_t i = 0; i < enc->buf_count; i++) {
 		struct nv_bitstream bitstream;
 		if (!nv_bitstream_init(enc, &bitstream)) {
 			return false;
@@ -1010,10 +1198,11 @@ static bool init_bitstreams(struct nvenc_data *enc)
 	return true;
 }
 
+#ifdef _WIN32
 static bool init_textures(struct nvenc_data *enc)
 {
 	da_reserve(enc->textures, enc->buf_count);
-	for (int i = 0; i < enc->buf_count; i++) {
+	for (uint32_t i = 0; i < enc->buf_count; i++) {
 		struct nv_texture texture;
 		if (!nv_texture_init(enc, &texture)) {
 			return false;
@@ -1023,6 +1212,71 @@ static bool init_textures(struct nvenc_data *enc)
 	}
 
 	return true;
+}
+#endif
+
+static bool init_cuda_surfaces(struct nvenc_data *enc)
+{
+	switch (enc->in_format) {
+	case VIDEO_FORMAT_P010:
+		enc->surface_format = NV_ENC_BUFFER_FORMAT_YUV420_10BIT;
+		break;
+	case VIDEO_FORMAT_I444:
+		enc->surface_format = NV_ENC_BUFFER_FORMAT_YUV444;
+		break;
+	default:
+		enc->surface_format = NV_ENC_BUFFER_FORMAT_NV12;
+	}
+
+	da_reserve(enc->surfaces, enc->buf_count);
+
+	CU_FAILED(cu->cuCtxPushCurrent(enc->cu_ctx))
+	for (uint32_t i = 0; i < enc->buf_count; i++) {
+		struct nv_cuda_surface buf;
+		if (!nv_cuda_surface_init(enc, &buf)) {
+			return false;
+		}
+
+		da_push_back(enc->surfaces, &buf);
+	}
+	CU_FAILED(cu->cuCtxPopCurrent(NULL))
+
+	return true;
+}
+
+static bool init_cuda_ctx(struct nvenc_data *enc, obs_data_t *settings)
+{
+	int count;
+	CUdevice device;
+	const int gpu = (int)obs_data_get_int(settings, "gpu");
+
+	CU_FAILED(cu->cuInit(0))
+	CU_FAILED(cu->cuDeviceGetCount(&count))
+	if (!count) {
+		NV_FAIL("No CUDA devices found");
+		return false;
+	}
+	CU_FAILED(cu->cuDeviceGet(&device, gpu))
+	CU_FAILED(cu->cuCtxCreate(&enc->cu_ctx, 0, device))
+	CU_FAILED(cu->cuCtxPopCurrent(NULL))
+
+	return true;
+}
+
+static enum video_format get_preferred_format(enum video_format format)
+{
+	switch (format) {
+	case VIDEO_FORMAT_I010:
+	case VIDEO_FORMAT_P010:
+		return VIDEO_FORMAT_P010;
+	case VIDEO_FORMAT_RGBA:
+	case VIDEO_FORMAT_BGRA:
+	case VIDEO_FORMAT_BGRX:
+	case VIDEO_FORMAT_I444:
+		return VIDEO_FORMAT_I444;
+	default:
+		return VIDEO_FORMAT_NV12;
+	}
 }
 
 static void nvenc_destroy(void *data);
@@ -1045,18 +1299,23 @@ static bool init_specific_encoder(struct nvenc_data *enc, obs_data_t *settings,
 static bool init_encoder(struct nvenc_data *enc, enum codec_type codec,
 			 obs_data_t *settings, obs_encoder_t *encoder)
 {
+	UNUSED_PARAMETER(codec);
+	UNUSED_PARAMETER(encoder);
+
 	int bf = (int)obs_data_get_int(settings, "bf");
 	const bool support_10bit =
 		nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_10BIT_ENCODE);
 	const int bf_max = nv_get_cap(enc, NV_ENC_CAPS_NUM_MAX_BFRAMES);
 
-	if (obs_p010_tex_active() && !support_10bit) {
+	video_t *video = obs_encoder_video(enc->encoder);
+	const struct video_output_info *voi = video_output_get_info(video);
+	enc->in_format = get_preferred_format(voi->format);
+
+	if (is_10_bit(enc) && !support_10bit) {
 		NV_FAIL(obs_module_text("NVENC.10bitUnsupported"));
 		return false;
 	}
 
-	video_t *video = obs_encoder_video(enc->encoder);
-	const struct video_output_info *voi = video_output_get_info(video);
 	switch (voi->format) {
 	case VIDEO_FORMAT_I010:
 	case VIDEO_FORMAT_P010:
@@ -1067,6 +1326,8 @@ static bool init_encoder(struct nvenc_data *enc, enum codec_type codec,
 		case VIDEO_CS_2100_HLG:
 			NV_FAIL(obs_module_text("NVENC.8bitUnsupportedHdr"));
 			return false;
+		default:
+			break;
 		}
 	}
 
@@ -1098,12 +1359,13 @@ static bool init_encoder(struct nvenc_data *enc, enum codec_type codec,
 }
 
 static void *nvenc_create_internal(enum codec_type codec, obs_data_t *settings,
-				   obs_encoder_t *encoder)
+				   obs_encoder_t *encoder, bool texture)
 {
 	struct nvenc_data *enc = bzalloc(sizeof(*enc));
 	enc->encoder = encoder;
 	enc->codec = codec;
 	enc->first_packet = true;
+	enc->fallback = !texture;
 
 	NV_ENCODE_API_FUNCTION_LIST init = {NV_ENCODE_API_FUNCTION_LIST_VER};
 
@@ -1122,10 +1384,26 @@ static void *nvenc_create_internal(enum codec_type codec, obs_data_t *settings,
 	if (!init_nvenc(encoder)) {
 		goto fail;
 	}
+	if (
+#ifdef _WIN32
+		!texture &&
+#endif
+		!init_cuda(encoder)) {
+		goto fail;
+	}
 	if (NV_FAILED(nv_create_instance(&init))) {
 		goto fail;
 	}
-	if (!init_d3d11(enc, settings)) {
+#ifdef _WIN32
+	if (texture && !init_d3d11(enc, settings)) {
+		goto fail;
+	}
+#endif
+	if (
+#ifdef _WIN32
+		!texture &&
+#endif
+		!init_cuda_ctx(enc, settings)) {
 		goto fail;
 	}
 	if (get_nvenc_ver() == COMPATIBILITY_VERSION) {
@@ -1140,13 +1418,23 @@ static void *nvenc_create_internal(enum codec_type codec, obs_data_t *settings,
 	if (!init_bitstreams(enc)) {
 		goto fail;
 	}
-	if (!init_textures(enc)) {
+#ifdef _WIN32
+	if (texture && !init_textures(enc)) {
 		goto fail;
 	}
-
-#ifdef ENABLE_HEVC
-	enc->codec = codec;
 #endif
+	if (
+#ifdef _WIN32
+		!texture &&
+#endif
+		!init_cuda_surfaces(enc)) {
+		goto fail;
+	}
+	enc->codec = codec;
+
+	if (enc->cu_ctx)
+		cu->cuCtxPopCurrent(NULL);
+
 	return enc;
 
 fail:
@@ -1155,51 +1443,59 @@ fail:
 }
 
 static void *nvenc_create_base(enum codec_type codec, obs_data_t *settings,
-			       obs_encoder_t *encoder)
+			       obs_encoder_t *encoder, bool texture)
 {
 	/* this encoder requires shared textures, this cannot be used on a
 	 * gpu other than the one OBS is currently running on. */
 	const int gpu = (int)obs_data_get_int(settings, "gpu");
-	if (gpu != 0) {
+	if (gpu != 0 && texture) {
 		blog(LOG_INFO,
-		     "[obs-nvenc] different GPU selected by user, falling back to ffmpeg");
+		     "[obs-nvenc] different GPU selected by user, falling back "
+		     "to non-texture encoder");
 		goto reroute;
 	}
 
 	if (obs_encoder_scaling_enabled(encoder)) {
-		if (!obs_encoder_gpu_scaling_enabled(encoder)) {
+		if (!obs_encoder_gpu_scaling_enabled(encoder) && texture) {
 			blog(LOG_INFO,
-			     "[obs-nvenc] CPU scaling enabled, falling back to ffmpeg");
+			     "[obs-nvenc] CPU scaling enabled, falling back to"
+			     " non-texture encoder");
 			goto reroute;
 		}
 		blog(LOG_INFO, "[obs-nvenc] GPU scaling enabled");
 	}
 
-	if (!obs_p010_tex_active() && !obs_nv12_tex_active()) {
+	if (texture && !obs_p010_tex_active() && !obs_nv12_tex_active()) {
 		blog(LOG_INFO,
-		     "[obs-nvenc] nv12/p010 not active, falling back to ffmpeg");
+		     "[obs-nvenc] nv12/p010 not active, falling back to "
+		     "non-texture encoder");
 		goto reroute;
 	}
 
 	struct nvenc_data *enc =
-		nvenc_create_internal(codec, settings, encoder);
+		nvenc_create_internal(codec, settings, encoder, texture);
 
 	if (enc) {
 		return enc;
 	}
 
 reroute:
+	if (!texture) {
+		blog(LOG_ERROR,
+		     "Already in fallback encoder, can't fall back further!");
+		return NULL;
+	}
+
 	switch (codec) {
 	case CODEC_H264:
-		return obs_encoder_create_rerouted(encoder, "ffmpeg_nvenc");
+		return obs_encoder_create_rerouted(encoder,
+						   "obs_nvenc_h264_cuda");
 	case CODEC_HEVC:
 		return obs_encoder_create_rerouted(encoder,
-						   "ffmpeg_hevc_nvenc");
+						   "obs_nvenc_hevc_cuda");
 	case CODEC_AV1:
-		obs_encoder_set_last_error(
-			encoder,
-			obs_module_text("NVENC.NoAV1FallbackPossible"));
-		break;
+		return obs_encoder_create_rerouted(encoder,
+						   "obs_nvenc_av1_cuda");
 	}
 
 	return NULL;
@@ -1207,19 +1503,38 @@ reroute:
 
 static void *h264_nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)
 {
-	return nvenc_create_base(CODEC_H264, settings, encoder);
+	return nvenc_create_base(CODEC_H264, settings, encoder, true);
 }
 
 #ifdef ENABLE_HEVC
 static void *hevc_nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)
 {
-	return nvenc_create_base(CODEC_HEVC, settings, encoder);
+	return nvenc_create_base(CODEC_HEVC, settings, encoder, true);
 }
 #endif
 
 static void *av1_nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)
 {
-	return nvenc_create_base(CODEC_AV1, settings, encoder);
+	return nvenc_create_base(CODEC_AV1, settings, encoder, true);
+}
+
+static void *h264_nvenc_soft_create(obs_data_t *settings,
+				    obs_encoder_t *encoder)
+{
+	return nvenc_create_base(CODEC_H264, settings, encoder, false);
+}
+
+#ifdef ENABLE_HEVC
+static void *hevc_nvenc_soft_create(obs_data_t *settings,
+				    obs_encoder_t *encoder)
+{
+	return nvenc_create_base(CODEC_HEVC, settings, encoder, false);
+}
+#endif
+
+static void *av1_nvenc_soft_create(obs_data_t *settings, obs_encoder_t *encoder)
+{
+	return nvenc_create_base(CODEC_AV1, settings, encoder, false);
 }
 
 static bool get_encoded_packet(struct nvenc_data *enc, bool finalize);
@@ -1227,6 +1542,9 @@ static bool get_encoded_packet(struct nvenc_data *enc, bool finalize);
 static void nvenc_destroy(void *data)
 {
 	struct nvenc_data *enc = data;
+
+	if (enc->cu_ctx)
+		cu->cuCtxPushCurrent(enc->cu_ctx);
 
 	if (enc->encode_started) {
 		uint32_t struct_ver = enc->needs_compat_ver
@@ -1237,8 +1555,13 @@ static void nvenc_destroy(void *data)
 		nv.nvEncEncodePicture(enc->session, &params);
 		get_encoded_packet(enc, true);
 	}
+#ifdef _WIN32
 	for (size_t i = 0; i < enc->textures.num; i++) {
 		nv_texture_free(enc, &enc->textures.array[i]);
+	}
+#endif
+	for (size_t i = 0; i < enc->surfaces.num; i++) {
+		nv_cuda_surface_free(enc, &enc->surfaces.array[i]);
 	}
 	for (size_t i = 0; i < enc->bitstreams.num; i++) {
 		nv_bitstream_free(enc, &enc->bitstreams.array[i]);
@@ -1246,6 +1569,7 @@ static void nvenc_destroy(void *data)
 	if (enc->session) {
 		nv.nvEncDestroyEncoder(enc->session);
 	}
+#ifdef _WIN32
 	for (size_t i = 0; i < enc->input_textures.num; i++) {
 		ID3D11Texture2D *tex = enc->input_textures.array[i].tex;
 		IDXGIKeyedMutex *km = enc->input_textures.array[i].km;
@@ -1258,18 +1582,27 @@ static void nvenc_destroy(void *data)
 	if (enc->device) {
 		enc->device->lpVtbl->Release(enc->device);
 	}
+#endif
+	if (enc->cu_ctx) {
+		cu->cuCtxPopCurrent(NULL);
+		cu->cuCtxDestroy(enc->cu_ctx);
+	}
 
 	bfree(enc->header);
 	bfree(enc->sei);
 	deque_free(&enc->dts_list);
-	da_free(enc->textures);
+	da_free(enc->surfaces);
 	da_free(enc->bitstreams);
+#ifdef _WIN32
+	da_free(enc->textures);
 	da_free(enc->input_textures);
+#endif
 	da_free(enc->packet_data);
 	bfree(enc->roi_map);
 	bfree(enc);
 }
 
+#ifdef _WIN32
 static ID3D11Texture2D *get_tex_from_handle(struct nvenc_data *enc,
 					    uint32_t handle,
 					    IDXGIKeyedMutex **km_out)
@@ -1313,6 +1646,7 @@ static ID3D11Texture2D *get_tex_from_handle(struct nvenc_data *enc,
 	da_push_back(enc->input_textures, &new_ht);
 	return input_tex;
 }
+#endif
 
 static bool get_encoded_packet(struct nvenc_data *enc, bool finalize)
 {
@@ -1330,7 +1664,14 @@ static bool get_encoded_packet(struct nvenc_data *enc, bool finalize)
 	for (size_t i = 0; i < count; i++) {
 		size_t cur_bs_idx = enc->cur_bitstream;
 		struct nv_bitstream *bs = &enc->bitstreams.array[cur_bs_idx];
-		struct nv_texture *nvtex = &enc->textures.array[cur_bs_idx];
+#ifdef _WIN32
+		struct nv_texture *nvtex =
+			enc->fallback ? NULL : &enc->textures.array[cur_bs_idx];
+		struct nv_cuda_surface *surf =
+			enc->fallback ? &enc->surfaces.array[cur_bs_idx] : NULL;
+#else
+		struct nv_cuda_surface *surf = &enc->surfaces.array[cur_bs_idx];
+#endif
 
 		/* ---------------- */
 
@@ -1373,8 +1714,8 @@ static bool get_encoded_packet(struct nvenc_data *enc, bool finalize)
 		}
 
 		/* ---------------- */
-
-		if (nvtex->mapped_res) {
+#ifdef _WIN32
+		if (nvtex && nvtex->mapped_res) {
 			NVENCSTATUS err;
 			err = nv.nvEncUnmapInputResource(s, nvtex->mapped_res);
 			if (nv_failed(enc->encoder, err, __FUNCTION__,
@@ -1382,6 +1723,18 @@ static bool get_encoded_packet(struct nvenc_data *enc, bool finalize)
 				return false;
 			}
 			nvtex->mapped_res = NULL;
+		}
+#endif
+		/* ---------------- */
+
+		if (surf && surf->mapped_res) {
+			NVENCSTATUS err;
+			err = nv.nvEncUnmapInputResource(s, surf->mapped_res);
+			if (nv_failed(enc->encoder, err, __FUNCTION__,
+				      "unmap")) {
+				return false;
+			}
+			surf->mapped_res = NULL;
 		}
 
 		/* ---------------- */
@@ -1443,7 +1796,7 @@ static void add_roi(struct nvenc_data *enc, NV_ENC_PIC_PARAMS *params)
 		return;
 	}
 
-	uint32_t mb_size;
+	uint32_t mb_size = 0;
 	switch (enc->codec) {
 	case CODEC_H264:
 		/* H.264 is always 16x16 */
@@ -1485,83 +1838,35 @@ static void add_roi(struct nvenc_data *enc, NV_ENC_PIC_PARAMS *params)
 	params->qpDeltaMapSize = (uint32_t)map_size;
 }
 
-static bool nvenc_encode_tex(void *data, uint32_t handle, int64_t pts,
-			     uint64_t lock_key, uint64_t *next_key,
-			     struct encoder_packet *packet,
-			     bool *received_packet)
+static bool nvenc_encode_shared(struct nvenc_data *enc, struct nv_bitstream *bs,
+				void *pic, int64_t pts,
+				struct encoder_packet *packet,
+				bool *received_packet)
 {
-	struct nvenc_data *enc = data;
-	ID3D11Device *device = enc->device;
-	ID3D11DeviceContext *context = enc->context;
-	ID3D11Texture2D *input_tex;
-	ID3D11Texture2D *output_tex;
-	IDXGIKeyedMutex *km;
-	struct nv_texture *nvtex;
-	struct nv_bitstream *bs;
-	NVENCSTATUS err;
-
-	if (handle == GS_INVALID_HANDLE) {
-		error("Encode failed: bad texture handle");
-		*next_key = lock_key;
-		return false;
-	}
-
-	bs = &enc->bitstreams.array[enc->next_bitstream];
-	nvtex = &enc->textures.array[enc->next_bitstream];
-
-	input_tex = get_tex_from_handle(enc, handle, &km);
-	output_tex = nvtex->tex;
-
-	if (!input_tex) {
-		*next_key = lock_key;
-		return false;
-	}
-
-	deque_push_back(&enc->dts_list, &pts, sizeof(pts));
-
-	/* ------------------------------------ */
-	/* copy to output tex                   */
-
-	km->lpVtbl->AcquireSync(km, lock_key, INFINITE);
-
-	context->lpVtbl->CopyResource(context, (ID3D11Resource *)output_tex,
-				      (ID3D11Resource *)input_tex);
-
-	km->lpVtbl->ReleaseSync(km, *next_key);
-
-	/* ------------------------------------ */
-	/* map output tex so nvenc can use it   */
-
-	NV_ENC_MAP_INPUT_RESOURCE map = {NV_ENC_MAP_INPUT_RESOURCE_VER};
-	map.registeredResource = nvtex->res;
-	if (NV_FAILED(nv.nvEncMapInputResource(enc->session, &map))) {
-		return false;
-	}
-
-	nvtex->mapped_res = map.mappedResource;
-
-	/* ------------------------------------ */
-	/* do actual encode call                */
-
 	NV_ENC_PIC_PARAMS params = {0};
 	params.version = enc->needs_compat_ver ? NV_ENC_PIC_PARAMS_COMPAT_VER
 					       : NV_ENC_PIC_PARAMS_VER;
 	params.pictureStruct = NV_ENC_PIC_STRUCT_FRAME;
-	params.inputBuffer = nvtex->mapped_res;
-	params.bufferFmt = obs_p010_tex_active()
-				   ? NV_ENC_BUFFER_FORMAT_YUV420_10BIT
-				   : NV_ENC_BUFFER_FORMAT_NV12;
+	params.inputBuffer = pic;
 	params.inputTimeStamp = (uint64_t)pts;
 	params.inputWidth = enc->cx;
 	params.inputHeight = enc->cy;
 	params.inputPitch = enc->cx;
 	params.outputBitstream = bs->ptr;
 
+	if (enc->fallback) {
+		params.bufferFmt = enc->surface_format;
+	} else {
+		params.bufferFmt = obs_p010_tex_active()
+					   ? NV_ENC_BUFFER_FORMAT_YUV420_10BIT
+					   : NV_ENC_BUFFER_FORMAT_NV12;
+	}
+
 	/* Add ROI map if enabled */
 	if (obs_encoder_has_roi(enc->encoder))
 		add_roi(enc, &params);
 
-	err = nv.nvEncEncodePicture(enc->session, &params);
+	NVENCSTATUS err = nv.nvEncEncodePicture(enc->session, &params);
 	if (err != NV_ENC_SUCCESS && err != NV_ENC_ERR_NEED_MORE_INPUT) {
 		nv_failed(enc->encoder, err, __FUNCTION__,
 			  "nvEncEncodePicture");
@@ -1606,6 +1911,201 @@ static bool nvenc_encode_tex(void *data, uint32_t handle, int64_t pts,
 	return true;
 }
 
+#ifdef _WIN32
+static bool nvenc_encode_tex(void *data, uint32_t handle, int64_t pts,
+			     uint64_t lock_key, uint64_t *next_key,
+			     struct encoder_packet *packet,
+			     bool *received_packet)
+{
+	struct nvenc_data *enc = data;
+	ID3D11DeviceContext *context = enc->context;
+	ID3D11Texture2D *input_tex;
+	ID3D11Texture2D *output_tex;
+	IDXGIKeyedMutex *km;
+	struct nv_texture *nvtex;
+	struct nv_bitstream *bs;
+
+	if (handle == GS_INVALID_HANDLE) {
+		error("Encode failed: bad texture handle");
+		*next_key = lock_key;
+		return false;
+	}
+
+	bs = &enc->bitstreams.array[enc->next_bitstream];
+	nvtex = &enc->textures.array[enc->next_bitstream];
+
+	input_tex = get_tex_from_handle(enc, handle, &km);
+	output_tex = nvtex->tex;
+
+	if (!input_tex) {
+		*next_key = lock_key;
+		return false;
+	}
+
+	deque_push_back(&enc->dts_list, &pts, sizeof(pts));
+
+	/* ------------------------------------ */
+	/* copy to output tex                   */
+
+	km->lpVtbl->AcquireSync(km, lock_key, INFINITE);
+
+	context->lpVtbl->CopyResource(context, (ID3D11Resource *)output_tex,
+				      (ID3D11Resource *)input_tex);
+
+	km->lpVtbl->ReleaseSync(km, *next_key);
+
+	/* ------------------------------------ */
+	/* map output tex so nvenc can use it   */
+
+	NV_ENC_MAP_INPUT_RESOURCE map = {NV_ENC_MAP_INPUT_RESOURCE_VER};
+	map.registeredResource = nvtex->res;
+	if (NV_FAILED(nv.nvEncMapInputResource(enc->session, &map))) {
+		return false;
+	}
+
+	nvtex->mapped_res = map.mappedResource;
+
+	/* ------------------------------------ */
+	/* do actual encode call                */
+
+	return nvenc_encode_shared(enc, bs, nvtex->mapped_res, pts, packet,
+				   received_packet);
+}
+#endif
+
+static inline bool nvenc_copy_frame(struct nvenc_data *enc,
+				    struct encoder_frame *frame,
+				    struct nv_cuda_surface *surf)
+{
+	bool success = true;
+	size_t height = enc->cy;
+	size_t width = enc->cx;
+	CUDA_MEMCPY2D m = {0};
+
+	m.srcMemoryType = CU_MEMORYTYPE_HOST;
+	m.dstMemoryType = CU_MEMORYTYPE_ARRAY;
+	m.dstArray = surf->tex;
+	m.WidthInBytes = width;
+	m.Height = height;
+
+	CU_FAILED(cu->cuCtxPushCurrent(enc->cu_ctx))
+
+	if (enc->surface_format == NV_ENC_BUFFER_FORMAT_NV12) {
+		/* Page-locks the host memory so that it can be DMAd directly
+		 * rather than CUDA doing an internal copy to page-locked
+		 * memory before actually DMA-ing to the GPU. */
+		CU_CHECK(cu->cuMemHostRegister(frame->data[0],
+					       frame->linesize[0] * height, 0))
+		CU_CHECK(cu->cuMemHostRegister(
+			frame->data[1], frame->linesize[1] * height / 2, 0))
+
+		m.srcPitch = frame->linesize[0];
+		m.srcHost = frame->data[0];
+		CU_FAILED(cu->cuMemcpy2D(&m))
+
+		m.srcPitch = frame->linesize[1];
+		m.srcHost = frame->data[1];
+		m.dstY += height;
+		m.Height /= 2;
+		CU_FAILED(cu->cuMemcpy2D(&m))
+	} else if (enc->surface_format == NV_ENC_BUFFER_FORMAT_YUV420_10BIT) {
+		CU_CHECK(cu->cuMemHostRegister(frame->data[0],
+					       frame->linesize[0] * height, 0))
+		CU_CHECK(cu->cuMemHostRegister(
+			frame->data[1], frame->linesize[1] * height / 2, 0))
+
+		// P010 lines are double the size (16 bit per pixel)
+		m.WidthInBytes *= 2;
+
+		m.srcPitch = frame->linesize[0];
+		m.srcHost = frame->data[0];
+		CU_FAILED(cu->cuMemcpy2D(&m))
+
+		m.srcPitch = frame->linesize[1];
+		m.srcHost = frame->data[1];
+		m.dstY += height;
+		m.Height /= 2;
+		CU_FAILED(cu->cuMemcpy2D(&m))
+	} else { // I444
+		CU_CHECK(cu->cuMemHostRegister(frame->data[0],
+					       frame->linesize[0] * height, 0))
+		CU_CHECK(cu->cuMemHostRegister(frame->data[1],
+					       frame->linesize[1] * height, 0))
+		CU_CHECK(cu->cuMemHostRegister(frame->data[2],
+					       frame->linesize[2] * height, 0))
+
+		m.srcPitch = frame->linesize[0];
+		m.srcHost = frame->data[0];
+		CU_FAILED(cu->cuMemcpy2D(&m))
+
+		m.srcPitch = frame->linesize[1];
+		m.srcHost = frame->data[1];
+		m.dstY += height;
+		CU_FAILED(cu->cuMemcpy2D(&m))
+
+		m.srcPitch = frame->linesize[2];
+		m.srcHost = frame->data[2];
+		m.dstY += height;
+		CU_FAILED(cu->cuMemcpy2D(&m))
+	}
+
+unmap:
+	if (frame->data[0])
+		cu->cuMemHostUnregister(frame->data[0]);
+	if (frame->data[1])
+		cu->cuMemHostUnregister(frame->data[1]);
+	if (frame->data[2])
+		cu->cuMemHostUnregister(frame->data[2]);
+
+	CU_FAILED(cu->cuCtxPopCurrent(NULL))
+
+	return success;
+}
+
+static bool nvenc_encode_soft(void *data, struct encoder_frame *frame,
+			      struct encoder_packet *packet,
+			      bool *received_packet)
+{
+	struct nvenc_data *enc = data;
+	struct nv_cuda_surface *surf;
+	struct nv_bitstream *bs;
+
+	bs = &enc->bitstreams.array[enc->next_bitstream];
+	surf = &enc->surfaces.array[enc->next_bitstream];
+
+	deque_push_back(&enc->dts_list, &frame->pts, sizeof(frame->pts));
+
+	/* ------------------------------------ */
+	/* copy to CUDA surface                 */
+
+	if (!nvenc_copy_frame(enc, frame, surf))
+		return false;
+
+	/* ------------------------------------ */
+	/* map output tex so nvenc can use it   */
+
+	NV_ENC_MAP_INPUT_RESOURCE map = {NV_ENC_MAP_INPUT_RESOURCE_VER};
+	map.registeredResource = surf->res;
+	map.mappedBufferFmt = enc->surface_format;
+
+	if (NV_FAILED(nv.nvEncMapInputResource(enc->session, &map)))
+		return false;
+
+	surf->mapped_res = map.mappedResource;
+
+	/* ------------------------------------ */
+	/* do actual encode call                */
+
+	return nvenc_encode_shared(enc, bs, surf->mapped_res, frame->pts,
+				   packet, received_packet);
+}
+
+static void nvenc_soft_video_info(void *data, struct video_scale_info *info)
+{
+	struct nvenc_data *enc = data;
+	info->format = enc->in_format;
+}
+
 extern void h264_nvenc_defaults(obs_data_t *settings);
 extern obs_properties_t *h264_nvenc_properties(void *unused);
 #ifdef ENABLE_HEVC
@@ -1641,6 +2141,7 @@ static bool nvenc_sei_data(void *data, uint8_t **sei, size_t *size)
 	return true;
 }
 
+#ifdef _WIN32
 struct obs_encoder_info h264_nvenc_info = {
 	.id = "jim_nvenc",
 	.codec = "h264",
@@ -1691,4 +2192,75 @@ struct obs_encoder_info av1_nvenc_info = {
 	.get_defaults = av1_nvenc_defaults,
 	.get_properties = av1_nvenc_properties,
 	.get_extra_data = nvenc_extra_data,
+};
+#endif
+
+struct obs_encoder_info h264_nvenc_soft_info = {
+	.id = "obs_nvenc_h264_cuda",
+	.codec = "h264",
+	.type = OBS_ENCODER_VIDEO,
+#ifdef _WIN32
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI |
+		OBS_ENCODER_CAP_INTERNAL,
+	.get_name = h264_nvenc_soft_get_name,
+#else
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI,
+	.get_name = h264_nvenc_get_name,
+#endif
+	.create = h264_nvenc_soft_create,
+	.destroy = nvenc_destroy,
+	.update = nvenc_update,
+	.encode = nvenc_encode_soft,
+	.get_defaults = h264_nvenc_defaults,
+	.get_properties = h264_nvenc_properties,
+	.get_extra_data = nvenc_extra_data,
+	.get_sei_data = nvenc_sei_data,
+	.get_video_info = nvenc_soft_video_info,
+};
+
+#ifdef ENABLE_HEVC
+struct obs_encoder_info hevc_nvenc_soft_info = {
+	.id = "obs_nvenc_hevc_cuda",
+	.codec = "hevc",
+	.type = OBS_ENCODER_VIDEO,
+#ifdef _WIN32
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI |
+		OBS_ENCODER_CAP_INTERNAL,
+	.get_name = hevc_nvenc_soft_get_name,
+#else
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI,
+	.get_name = hevc_nvenc_get_name,
+#endif
+	.create = hevc_nvenc_soft_create,
+	.destroy = nvenc_destroy,
+	.update = nvenc_update,
+	.encode = nvenc_encode_soft,
+	.get_defaults = hevc_nvenc_defaults,
+	.get_properties = hevc_nvenc_properties,
+	.get_extra_data = nvenc_extra_data,
+	.get_sei_data = nvenc_sei_data,
+	.get_video_info = nvenc_soft_video_info,
+};
+#endif
+
+struct obs_encoder_info av1_nvenc_soft_info = {
+	.id = "obs_nvenc_av1_cuda",
+	.codec = "av1",
+	.type = OBS_ENCODER_VIDEO,
+#ifdef _WIN32
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI |
+		OBS_ENCODER_CAP_INTERNAL,
+	.get_name = av1_nvenc_soft_get_name,
+#else
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI,
+	.get_name = av1_nvenc_get_name,
+#endif
+	.create = av1_nvenc_soft_create,
+	.destroy = nvenc_destroy,
+	.update = nvenc_update,
+	.encode = nvenc_encode_soft,
+	.get_defaults = av1_nvenc_defaults,
+	.get_properties = av1_nvenc_properties,
+	.get_extra_data = nvenc_extra_data,
+	.get_video_info = nvenc_soft_video_info,
 };

--- a/plugins/obs-ffmpeg/obs-nvenc.h
+++ b/plugins/obs-ffmpeg/obs-nvenc.h
@@ -1,11 +1,43 @@
 #pragma once
 
+#ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#endif
 
 #include <obs-module.h>
 #include <ffnvcodec/nvEncodeAPI.h>
+#include <ffnvcodec/dynlink_cuda.h>
+
 #include "obs-nvenc-ver.h"
+
+/* Missing from FFmpeg headers */
+typedef CUresult CUDAAPI tcuMemHostRegister(void *p, size_t bytesize,
+					    unsigned int Flags);
+typedef CUresult CUDAAPI tcuMemHostUnregister(void *p);
+
+typedef struct CudaFunctions {
+	tcuInit *cuInit;
+
+	tcuDeviceGetCount *cuDeviceGetCount;
+	tcuDeviceGet *cuDeviceGet;
+	tcuDeviceGetAttribute *cuDeviceGetAttribute;
+
+	tcuCtxCreate_v2 *cuCtxCreate;
+	tcuCtxDestroy_v2 *cuCtxDestroy;
+	tcuCtxPushCurrent_v2 *cuCtxPushCurrent;
+	tcuCtxPopCurrent_v2 *cuCtxPopCurrent;
+
+	tcuArray3DCreate *cuArray3DCreate;
+	tcuArrayDestroy *cuArrayDestroy;
+	tcuMemcpy2D_v2 *cuMemcpy2D;
+
+	tcuGetErrorName *cuGetErrorName;
+	tcuGetErrorString *cuGetErrorString;
+
+	tcuMemHostRegister *cuMemHostRegister;
+	tcuMemHostUnregister *cuMemHostUnregister;
+} CudaFunctions;
 
 typedef NVENCSTATUS(NVENCAPI *NV_CREATE_INSTANCE_FUNC)(
 	NV_ENCODE_API_FUNCTION_LIST *);
@@ -13,8 +45,11 @@ typedef NVENCSTATUS(NVENCAPI *NV_CREATE_INSTANCE_FUNC)(
 extern const char *nv_error_name(NVENCSTATUS err);
 extern NV_ENCODE_API_FUNCTION_LIST nv;
 extern NV_CREATE_INSTANCE_FUNC nv_create_instance;
+extern CudaFunctions *cu;
 extern uint32_t get_nvenc_ver(void);
 extern bool init_nvenc(obs_encoder_t *encoder);
+extern bool init_cuda(obs_encoder_t *encoder);
+bool cuda_get_error_desc(CUresult res, const char **name, const char **desc);
 bool nv_fail2(obs_encoder_t *encoder, void *session, const char *format, ...);
 bool nv_failed2(obs_encoder_t *encoder, void *session, NVENCSTATUS err,
 		const char *func, const char *call);


### PR DESCRIPTION
### Description

Replaces the FFmpeg fallback in the "new" NVENC encoder with a native non-texture encoder.

Also adds support for the non-texture encoder on Linux.

Superseedes/Closes #8794 

### Motivation and Context

The FFmpeg fallback sucks I hate it.

### How Has This Been Tested?

Tested H.264 encoder on my 4090 with the latest driver on Windows and Linux. 

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
