### PR TITLE
rtmp-services: Add Mavenx.gg

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 240,
+    "version": 241,
     "files": [
         {
             "name": "services.json",
-            "version": 240
+            "version": 241
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2633,6 +2633,23 @@
                 "max audio bitrate": 320,
                 "x264opts": "scenecut=0"
             }
+        },
+        {
+            "name": "MAVENX.GG",
+            "more_info_link": "https://mavenx.gg/about-us",
+            "servers": [
+                {
+                    "name": "MAVEN X Streaming",
+                    "url": "rtmp://rtmp.mavenx.tv/live"
+                }
+            ],
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000
+            }
         }
     ]
 }


### PR DESCRIPTION

### Description
I have added my streaming server in the file service.json and incremented the package.json
 No UI elements involved

### Motivation and Context
My change resolve nothing, it will just aa My streaming server to obs so people can stream using my server.
My modification fixes nothing.

### How Has This Been Tested?
This is testing at local OBS STUDIO


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->

New feature (Added my streaming server)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
