### PR TITLE
Add SPA_VIDEO_FORMAT_{ABGR,xBGR} to PipeWire formats

### DIFF
--- a/libobs-opengl/gl-subsystem.h
+++ b/libobs-opengl/gl-subsystem.h
@@ -45,6 +45,10 @@ static inline GLenum convert_gs_format(enum gs_color_format format)
 		return GL_BGRA;
 	case GS_BGRA:
 		return GL_BGRA;
+	case GS_XRGB:
+		return GL_RGBA;
+	case GS_ARGB:
+		return GL_RGBA;
 	case GS_R10G10B10A2:
 		return GL_RGBA;
 	case GS_RGBA16:
@@ -99,6 +103,10 @@ static inline GLenum convert_gs_internal_format(enum gs_color_format format)
 		return GL_SRGB8;
 	case GS_BGRA:
 		return GL_SRGB8_ALPHA8;
+	case GS_XRGB:
+		return GL_SRGB8;
+	case GS_ARGB:
+		return GL_SRGB8_ALPHA8;
 	case GS_R10G10B10A2:
 		return GL_RGB10_A2;
 	case GS_RGBA16:
@@ -152,6 +160,10 @@ static inline GLenum get_gl_format_type(enum gs_color_format format)
 	case GS_BGRX:
 		return GL_UNSIGNED_BYTE;
 	case GS_BGRA:
+		return GL_UNSIGNED_BYTE;
+	case GS_XRGB:
+		return GL_UNSIGNED_BYTE;
+	case GS_ARGB:
 		return GL_UNSIGNED_BYTE;
 	case GS_R10G10B10A2:
 		return GL_UNSIGNED_INT_2_10_10_10_REV;

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -60,6 +60,8 @@ enum gs_color_format {
 	GS_RGBA,
 	GS_BGRX,
 	GS_BGRA,
+	GS_XRGB,
+	GS_ARGB,
 	GS_R10G10B10A2,
 	GS_RGBA16,
 	GS_R16,
@@ -1018,6 +1020,8 @@ static inline uint32_t gs_get_format_bpp(enum gs_color_format format)
 	case GS_RGBA:
 	case GS_BGRX:
 	case GS_BGRA:
+	case GS_XRGB:
+	case GS_ARGB:
 	case GS_R10G10B10A2:
 	case GS_RG16F:
 	case GS_R32F:

--- a/plugins/linux-pipewire/formats.c
+++ b/plugins/linux-pipewire/formats.c
@@ -44,6 +44,15 @@ static const struct obs_pw_video_format supported_formats[] = {
 		"ABGR8888",
 	},
 	{
+		SPA_VIDEO_FORMAT_ABGR,
+		DRM_FORMAT_RGBA8888,
+		GS_ARGB,
+		VIDEO_FORMAT_NONE,
+		false,
+		4,
+		"RGBA8888",
+	},
+	{
 		SPA_VIDEO_FORMAT_BGRx,
 		DRM_FORMAT_XRGB8888,
 		GS_BGRX,
@@ -60,6 +69,15 @@ static const struct obs_pw_video_format supported_formats[] = {
 		true,
 		4,
 		"XBGR8888",
+	},
+	{
+		SPA_VIDEO_FORMAT_xBGR,
+		DRM_FORMAT_RGBX8888,
+		GS_XRGB,
+		VIDEO_FORMAT_NONE,
+		false,
+		4,
+		"RGBX8888",
 	},
 	{
 		SPA_VIDEO_FORMAT_YUY2,

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -280,6 +280,7 @@ static const uint32_t supported_formats_async[] = {
 static const uint32_t supported_formats_sync[] = {
 	SPA_VIDEO_FORMAT_BGRA,       SPA_VIDEO_FORMAT_RGBA,
 	SPA_VIDEO_FORMAT_BGRx,       SPA_VIDEO_FORMAT_RGBx,
+	SPA_VIDEO_FORMAT_ABGR,       SPA_VIDEO_FORMAT_xBGR,
 #if PW_CHECK_VERSION(0, 3, 41)
 	SPA_VIDEO_FORMAT_ABGR_210LE, SPA_VIDEO_FORMAT_xBGR_210LE,
 #endif


### PR DESCRIPTION
### Description
This change fixes screen and window capture with PipeWire for me  
(KDE Plasma Wayland 6.0, NVIDIA driver 545.29.06, PipeWire 1.0.1).

Without these formats, format negotiation fails, and no image is captured.

### Motivation and Context
This lets me use OBS Studio for screen recordings in a KDE Plasma Wayland session (in addition to Spectacle).

### How Has This Been Tested?
Tested in a portable build of OBS Studio in the Plasma 6 RC1 session.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
