### PR TITLE
libobs: Fix audio doubling with multiple main view mixes

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -564,7 +564,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in,
 						    audio);
 			push_audio_tree(NULL, source, audio);
 
-			if (view == &obs->data.main_view)
+			if (obs->video.mixes.array[j] == obs->video.main_mix)
 				da_push_back(audio->root_nodes, &source);
 		}
 		pthread_mutex_unlock(&view->channels_mutex);


### PR DESCRIPTION
### Description

Fixes audio issue reported in https://github.com/obsproject/obs-studio/pull/10091#issuecomment-1905992836 by only adding the root source for the main mix rather than every mix that uses the main view.

### Motivation and Context

Since scaled mixes also use the main view their root audio nodes would be added multiple times, leading to constructive interference and an increase in volume.

### How Has This Been Tested?

Used media source with ffmpeg sine wave generator, then used `volumedetect` filter in FFmpeg to check recording volume.

No scaling (master):
```
[Parsed_volumedetect_0 @ 0000015d3afe2ac0] mean_volume: -21.1 dB
[Parsed_volumedetect_0 @ 0000015d3afe2ac0] max_volume: -17.4 dB
```
GPU scaling (master):
```
[Parsed_volumedetect_0 @ 0000024149d94180] mean_volume: -15.1 dB
[Parsed_volumedetect_0 @ 0000024149d94180] max_volume: -12.0 dB
```
GPU scaling (this PR):
```
[Parsed_volumedetect_0 @ 00000155d0f82a40] mean_volume: -21.1 dB
[Parsed_volumedetect_0 @ 00000155d0f82a40] max_volume: -17.4 dB
```

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
