### PR TITLE
UI: Cancel session end request on commitDataRequest() signal

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1428,6 +1428,9 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 	snInt = new QSocketNotifier(sigintFd[1], QSocketNotifier::Read, this);
 	connect(snInt, &QSocketNotifier::activated, this,
 		&OBSApp::ProcessSigInt);
+#else
+	connect(qApp, &QGuiApplication::commitDataRequest, this,
+		&OBSApp::commitData);
 #endif
 
 	sleepInhibitor = os_inhibit_sleep_create("OBS Video/audio");
@@ -3269,6 +3272,16 @@ void OBSApp::ProcessSigInt(void)
 		main->close();
 #endif
 }
+
+#ifdef _WIN32
+void OBSApp::commitData(QSessionManager &manager)
+{
+	if (auto main = App()->GetMainWindow()) {
+		QMetaObject::invokeMethod(main, "close", Qt::QueuedConnection);
+		manager.cancel();
+	}
+}
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -22,6 +22,8 @@
 #include <QPointer>
 #ifndef _WIN32
 #include <QSocketNotifier>
+#else
+#include <QSessionManager>
 #endif
 #include <obs.hpp>
 #include <util/lexer.h>
@@ -132,6 +134,9 @@ private:
 #ifndef _WIN32
 	static int sigintFd[2];
 	QSocketNotifier *snInt = nullptr;
+#else
+private slots:
+	void commitData(QSessionManager &manager);
 #endif
 
 public:


### PR DESCRIPTION
### Description

This effectively returns `FALSE` for `WM_QUERYENDSESSION` which will throw up the "This app is blocking shutdown" message until the OBS process exits. This allows any shutdown cleanup to run without windows killing the process.

### Motivation and Context

More all-encompassing alternative to #9927

Fixes #9877 until we have a better idea for a long-term solution.

This is a port of #9928. While a more comprehensive solution would probably have us implement Qt's aboutToQuit signal, doing so would likely require a large refactor of our shutdown process. @PatTheMav and I have concluded that such a refactor is unlikely to materialize any time soon, and the alternative without this patch is a bad experience for users.

### How Has This Been Tested?

Tested in a VM and in 30.0.1 and 30.0.2.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
