### PR TITLE
libobs: Fix GPU scaling using the main mix

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -276,7 +276,7 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 		struct obs_core_video_mix *current = obs->video.mixes.array[i];
 		const struct video_output_info *voi =
 			video_output_get_info(current->video);
-		if (current->view != &obs->data.main_view)
+		if (current->view != current_mix->view)
 			continue;
 
 		if (voi->width != encoder->scaled_width ||


### PR DESCRIPTION
### Description
Fix GPU scaling using the main mix
Was missed in #9937

### Motivation and Context
Want to have the correct view for the scaled video

### How Has This Been Tested?
On windows 64 by trying to gpu scale an encoder to same as main.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
