### PR TITLE
UI: Add --no-studio-mode command line option

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -98,6 +98,7 @@ static bool unfiltered_log = false;
 bool opt_start_streaming = false;
 bool opt_start_recording = false;
 bool opt_studio_mode = false;
+bool opt_no_studio_mode = false;
 bool opt_start_replaybuffer = false;
 bool opt_start_virtualcam = false;
 bool opt_minimize_tray = false;
@@ -3390,6 +3391,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--studio-mode", nullptr)) {
 			opt_studio_mode = true;
 
+		} else if (arg_is(argv[i], "--no-studio-mode", nullptr)) {
+			opt_no_studio_mode = true;
+
 		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
 			opt_allow_opengl = true;
 
@@ -3415,6 +3419,7 @@ int main(int argc, char *argv[])
 				"--profile <string>: Use specific profile.\n"
 				"--scene <string>: Start with specific scene.\n\n"
 				"--studio-mode: Enable studio mode.\n"
+				"--no-studio-mode: Disable studio mode.\n"
 				"--minimize-to-tray: Minimize to system tray.\n"
 #if ALLOW_PORTABLE_MODE
 				"--portable, -p: Use portable mode.\n"
@@ -3443,6 +3448,12 @@ int main(int argc, char *argv[])
 				  << App()->GetVersionString(false) << "\n";
 			exit(0);
 		}
+	}
+
+	if (opt_studio_mode && opt_no_studio_mode) {
+		std::cout
+			<< "Can't use \"--studio-mode\" and \"--no-studio-mode\" together.\n";
+		exit(1);
 	}
 
 #if ALLOW_PORTABLE_MODE

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -284,6 +284,7 @@ extern bool opt_start_replaybuffer;
 extern bool opt_start_virtualcam;
 extern bool opt_minimize_tray;
 extern bool opt_studio_mode;
+extern bool opt_no_studio_mode;
 extern bool opt_allow_opengl;
 extern bool opt_always_on_top;
 extern std::string opt_starting_scene;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2094,13 +2094,16 @@ void OBSBasic::OBSInit()
 	editPropertiesMode = config_get_bool(
 		App()->GlobalConfig(), "BasicWindow", "EditPropertiesMode");
 
-	if (!opt_studio_mode) {
+	if (!opt_studio_mode && !opt_no_studio_mode) {
 		SetPreviewProgramMode(config_get_bool(App()->GlobalConfig(),
 						      "BasicWindow",
 						      "PreviewProgramMode"));
-	} else {
+	} else if (opt_studio_mode) {
 		SetPreviewProgramMode(true);
 		opt_studio_mode = false;
+	} else {
+		SetPreviewProgramMode(false);
+		opt_no_studio_mode = false;
 	}
 
 #define SET_VISIBILITY(name, control)                                         \


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds `--no-studio-mode` as a new command line option.
Starting OBS with this option will run OBS with the studio mode disabled.

Logically, the `--no-studio-mode` conflicts with the `--studio-mode` option, so if both options are used, the program prints an error that says '_Can't use "--studio-mode" and "--no-studio-mode" together._' and exists with code 1.

If OBS is run without specifying `--studio-mode` and `--no-studio-mode`, the studio mode state will assume its most recent state (if it was disabled it will still be disables and vice versa).

The help message was also updated to show this new option.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was creating different profiles and scene collections to keep my OBS setup organized.
To simplify my use of OBS, I decided to create multiple .desktop entries to launch OBS with different profiles and scenes.
I wanted some .desktop entries to launch OBS with studio mode enabled and some others with studio mode disabled. This is when I noticed I couldn't tell OBS to disable studio mode using a command line option.
I tried searching online but I couldn't find anything, so I decided to add this feature myself.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Tested on an Arch Linux machine, kernel version 6.7.1 .
- Compiled with `-DENABLE_BROWSER=OFF -DCMAKE_BUILD_TYPE=Debug -DENABLE_WEBRTC=OFF -DLINUX_PORTABLE=ON -DCMAKE_INSTALL_PREFIX="${HOME}/obs-studio-portable"`.
(These flags were used to facilitate the compiling process since I didn't have all the things needed to compile OBS with the defaults. I don't have any reason to believe this may not work with a _normal copy_ of OBS.)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
