### PR TITLE
libobs: Add `obs_encoder_parent_video()` method

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -526,10 +526,14 @@ General Encoder Functions
 ---------------------
 
 .. function:: video_t *obs_encoder_video(const obs_encoder_t *encoder)
+              video_t *obs_encoder_parent_video(const obs_encoder_t *encoder)
               audio_t *obs_encoder_audio(const obs_encoder_t *encoder)
 
    :return: The video/audio handler associated with this encoder, or
-            *NULL* if none or not a matching encoder type
+            *NULL* if none or not a matching encoder type.
+            *parent_video* returns the "original" video handler
+            associated with this encoder, regardless of whether an FPS
+            divisor is set.
 
 ---------------------
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1166,6 +1166,21 @@ video_t *obs_encoder_video(const obs_encoder_t *encoder)
 	return encoder->fps_override ? encoder->fps_override : encoder->media;
 }
 
+video_t *obs_encoder_parent_video(const obs_encoder_t *encoder)
+{
+	if (!obs_encoder_valid(encoder, "obs_encoder_parent_video"))
+		return NULL;
+	if (encoder->info.type != OBS_ENCODER_VIDEO) {
+		blog(LOG_WARNING,
+		     "obs_encoder_parent_video: "
+		     "encoder '%s' is not a video encoder",
+		     obs_encoder_get_name(encoder));
+		return NULL;
+	}
+
+	return encoder->media;
+}
+
 audio_t *obs_encoder_audio(const obs_encoder_t *encoder)
 {
 	if (!obs_encoder_valid(encoder, "obs_encoder_audio"))

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2554,6 +2554,13 @@ EXPORT void obs_encoder_set_audio(obs_encoder_t *encoder, audio_t *audio);
 EXPORT video_t *obs_encoder_video(const obs_encoder_t *encoder);
 
 /**
+ * Returns the parent video output context used with this encoder, or NULL if not
+ * a video context. Used when an FPS divisor is set, where the original video
+ * context would not otherwise be gettable.
+ */
+EXPORT video_t *obs_encoder_parent_video(const obs_encoder_t *encoder);
+
+/**
  * Returns the audio output context used with this encoder, or NULL if not
  * a audio context
  */


### PR DESCRIPTION
### Description
Allows parent (original) video object of an encoder with an FPS divisor to be fetched.

### Motivation and Context
When implementing a non-shared-texture encoder, I needed to be able to determine the original video_t object to use as a reference for a cross-encoder frame caching system. Since FPS division creates a new video_t object, multiple encoders cannot be associated with each other if one of them has a divisor set, as the video_t object will be different.

### How Has This Been Tested?
Ubuntu 22.04, runs

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
