### PR TITLE
libobs: Prevent encoder reconfiguration after initialization

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -859,6 +859,13 @@ void obs_encoder_set_scaled_size(obs_encoder_t *encoder, uint32_t width,
 		     obs_encoder_get_name(encoder));
 		return;
 	}
+	if (encoder->initialized) {
+		blog(LOG_WARNING,
+		     "encoder '%s': Cannot set the scaled resolution "
+		     "after the encoder has been initialized",
+		     obs_encoder_get_name(encoder));
+		return;
+	}
 
 	const struct video_output_info *voi;
 	voi = video_output_get_info(encoder->media);
@@ -895,6 +902,13 @@ void obs_encoder_set_gpu_scale_type(obs_encoder_t *encoder,
 		     obs_encoder_get_name(encoder));
 		return;
 	}
+	if (encoder->initialized) {
+		blog(LOG_WARNING,
+		     "encoder '%s': Cannot enable GPU scaling "
+		     "after the encoder has been initialized",
+		     obs_encoder_get_name(encoder));
+		return;
+	}
 
 	encoder->gpu_scale_type = gpu_scale_type;
 }
@@ -917,6 +931,14 @@ bool obs_encoder_set_frame_rate_divisor(obs_encoder_t *encoder,
 		blog(LOG_WARNING,
 		     "encoder '%s': Cannot set frame rate divisor "
 		     "while the encoder is active",
+		     obs_encoder_get_name(encoder));
+		return false;
+	}
+
+	if (encoder->initialized) {
+		blog(LOG_WARNING,
+		     "encoder '%s': Cannot set frame rate divisor "
+		     "after the encoder has been initialized",
 		     obs_encoder_get_name(encoder));
 		return false;
 	}
@@ -1087,6 +1109,13 @@ void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 		blog(LOG_WARNING,
 		     "encoder '%s': Cannot apply a new video_t "
 		     "object while the encoder is active",
+		     obs_encoder_get_name(encoder));
+		return;
+	}
+	if (encoder->initialized) {
+		blog(LOG_WARNING,
+		     "encoder '%s': Cannot apply a new video_t object "
+		     "after the encoder has been initialized",
 		     obs_encoder_get_name(encoder));
 		return;
 	}


### PR DESCRIPTION
### Description

Prevents an encoder relying on GPU scaling from being assignment a video output that has different dimensions.

### Motivation and Context

Users reported issues about invalid output when using automatically started video recording.

The underlying issue is a race condition in the UI, but this seems like a good thing to do anyways and will prevent this issue from happening until we can fix the UI.

Race condition:
- `OBSBasic::StartStreaming()`
    + Calls `AdvancedOutput::SetupStreaming()`
        * Calls `AdvancedOutput::SetupOutputs()`
            - Assigns `obs_get_video()` to streaming/recording encoders
    + Calls `AdvancedOutput::StartStreaming()` which starts streaming output
        - The GPU scaled output is set up here during encoder init
    + Calls `OBSBasic::StartRecording()`
        * Calls `AdvancedOutput::StartRecording()`
            - Checks `Active()`, which at this point is still `false` despite the streaming output starting up and encoders being initialised
            - Calls `AdvancedOutput::SetupOutputs()` *again* which resets the scaled encoder to the unscaled output mix
                + At this point the scaled mix is leaked, as it will not be free'd until shutdown
- Outputs start and `Active()` becomes `true`
- Scaled encoder receives unscaled textures, things go wrong.

### How Has This Been Tested?

Tested with config provided by @Lordmau5 for reproduction.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
