### PR TITLE
aja: Add v210 pixel format support to capture plugin

### DIFF
--- a/plugins/aja/aja-common.cpp
+++ b/plugins/aja/aja-common.cpp
@@ -201,12 +201,11 @@ void populate_video_format_list(NTV2DeviceID deviceID, obs_property_t *list,
 	}
 }
 
-void populate_pixel_format_list(NTV2DeviceID deviceID, obs_property_t *list)
+void populate_pixel_format_list(NTV2DeviceID deviceID,
+				const std::vector<NTV2PixelFormat> &fmts,
+				obs_property_t *list)
 {
-	const NTV2PixelFormat supported_pix_fmts[] = {kDefaultAJAPixelFormat,
-						      NTV2_FBF_24BIT_BGR};
-
-	for (auto &&pf : supported_pix_fmts) {
+	for (auto &&pf : fmts) {
 		if (NTV2DeviceCanDoFrameBufferFormat(deviceID, pf)) {
 			obs_property_list_add_int(
 				list,
@@ -300,6 +299,8 @@ video_format AJAPixelFormatToOBSVideoFormat(NTV2PixelFormat pf)
 		obs_video_format = VIDEO_FORMAT_BGRA;
 		break;
 	case NTV2_FBF_10BIT_YCBCR:
+		obs_video_format = VIDEO_FORMAT_V210;
+		break;
 	case NTV2_FBF_10BIT_RGB:
 	case NTV2_FBF_8BIT_YCBCR_YUY2:
 	case NTV2_FBF_10BIT_DPX:

--- a/plugins/aja/aja-common.hpp
+++ b/plugins/aja/aja-common.hpp
@@ -44,6 +44,7 @@ populate_video_format_list(NTV2DeviceID deviceID, obs_property_t *list,
 			   NTV2VideoFormat genlockFormat = NTV2_FORMAT_UNKNOWN,
 			   bool want4KHFR = false, bool matchFPS = false);
 extern void populate_pixel_format_list(NTV2DeviceID deviceID,
+				       const std::vector<NTV2PixelFormat> &fmts,
 				       obs_property_t *list);
 extern void populate_sdi_transport_list(obs_property_t *list,
 					NTV2DeviceID deviceID,

--- a/plugins/aja/aja-output.cpp
+++ b/plugins/aja/aja-output.cpp
@@ -936,7 +936,9 @@ bool aja_output_device_changed(void *data, obs_properties_t *props,
 				   false, MATCH_OBS_FRAMERATE);
 
 	obs_property_list_clear(pix_fmt_list);
-	populate_pixel_format_list(deviceID, pix_fmt_list);
+	populate_pixel_format_list(deviceID,
+				   {kDefaultAJAPixelFormat, NTV2_FBF_24BIT_BGR},
+				   pix_fmt_list);
 
 	IOSelection io_select = static_cast<IOSelection>(
 		obs_data_get_int(settings, kUIPropOutput.id));

--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -614,7 +614,10 @@ bool AJASource::ReadWireFormats(NTV2DeviceID device_id, IOSelection io_select,
 		if (vpids.size() > 0) {
 			auto vpid = *vpids.begin();
 			if (vpid.Sampling() == VPIDSampling_YUV_422) {
-				pf = NTV2_FBF_8BIT_YCBCR;
+				if (vpid.BitDepth() == VPIDBitDepth_8)
+					pf = NTV2_FBF_8BIT_YCBCR;
+				else if (vpid.BitDepth() == VPIDBitDepth_10)
+					pf = NTV2_FBF_10BIT_YCBCR;
 				blog(LOG_INFO,
 				     "AJASource::ReadWireFormats - Detected pixel format %s",
 				     NTV2FrameBufferFormatToString(pf, true)
@@ -745,7 +748,10 @@ bool aja_source_device_changed(void *data, obs_properties_t *props,
 	obs_property_list_clear(pix_fmt_list);
 	obs_property_list_add_int(pix_fmt_list, obs_module_text("Auto"),
 				  kAutoDetect);
-	populate_pixel_format_list(deviceID, pix_fmt_list);
+	populate_pixel_format_list(deviceID,
+				   {kDefaultAJAPixelFormat,
+				    NTV2_FBF_10BIT_YCBCR, NTV2_FBF_24BIT_BGR},
+				   pix_fmt_list);
 
 	IOSelection io_select = static_cast<IOSelection>(
 		obs_data_get_int(settings, kUIPropInput.id));

--- a/plugins/aja/aja-vpid-data.cpp
+++ b/plugins/aja/aja-vpid-data.cpp
@@ -6,7 +6,9 @@ VPIDData::VPIDData()
 	  mStandardA{VPIDStandard_Unknown},
 	  mStandardB{VPIDStandard_Unknown},
 	  mSamplingA{VPIDSampling_XYZ_444},
-	  mSamplingB{VPIDSampling_XYZ_444}
+	  mSamplingB{VPIDSampling_XYZ_444},
+	  mBitDepthA{VPIDBitDepth_8},
+	  mBitDepthB{VPIDBitDepth_8}
 {
 }
 
@@ -16,7 +18,9 @@ VPIDData::VPIDData(ULWord vpidA, ULWord vpidB)
 	  mStandardA{VPIDStandard_Unknown},
 	  mStandardB{VPIDStandard_Unknown},
 	  mSamplingA{VPIDSampling_XYZ_444},
-	  mSamplingB{VPIDSampling_XYZ_444}
+	  mSamplingB{VPIDSampling_XYZ_444},
+	  mBitDepthA{VPIDBitDepth_8},
+	  mBitDepthB{VPIDBitDepth_8}
 {
 	Parse();
 }
@@ -27,7 +31,9 @@ VPIDData::VPIDData(const VPIDData &other)
 	  mStandardA{VPIDStandard_Unknown},
 	  mStandardB{VPIDStandard_Unknown},
 	  mSamplingA{VPIDSampling_XYZ_444},
-	  mSamplingB{VPIDSampling_XYZ_444}
+	  mSamplingB{VPIDSampling_XYZ_444},
+	  mBitDepthA{VPIDBitDepth_8},
+	  mBitDepthB{VPIDBitDepth_8}
 {
 	Parse();
 }
@@ -37,7 +43,9 @@ VPIDData::VPIDData(VPIDData &&other)
 	  mStandardA{VPIDStandard_Unknown},
 	  mStandardB{VPIDStandard_Unknown},
 	  mSamplingA{VPIDSampling_XYZ_444},
-	  mSamplingB{VPIDSampling_XYZ_444}
+	  mSamplingB{VPIDSampling_XYZ_444},
+	  mBitDepthA{VPIDBitDepth_8},
+	  mBitDepthB{VPIDBitDepth_8}
 {
 	Parse();
 }
@@ -46,6 +54,12 @@ VPIDData &VPIDData::operator=(const VPIDData &other)
 {
 	mVpidA = other.mVpidA;
 	mVpidB = other.mVpidB;
+	mStandardA = other.mStandardA;
+	mStandardB = other.mStandardB;
+	mSamplingA = other.mSamplingA;
+	mSamplingB = other.mSamplingB;
+	mBitDepthA = other.mBitDepthA;
+	mBitDepthB = other.mBitDepthB;
 	return *this;
 }
 
@@ -53,6 +67,12 @@ VPIDData &VPIDData::operator=(VPIDData &&other)
 {
 	mVpidA = other.mVpidA;
 	mVpidB = other.mVpidB;
+	mStandardA = other.mStandardA;
+	mStandardB = other.mStandardB;
+	mSamplingA = other.mSamplingA;
+	mSamplingB = other.mSamplingB;
+	mBitDepthA = other.mBitDepthA;
+	mBitDepthB = other.mBitDepthB;
 	return *this;
 }
 
@@ -82,11 +102,13 @@ void VPIDData::Parse()
 	parserA.SetVPID(mVpidA);
 	mStandardA = parserA.GetStandard();
 	mSamplingA = parserA.GetSampling();
+	mBitDepthA = parserA.GetBitDepth();
 
 	CNTV2VPID parserB;
 	parserB.SetVPID(mVpidB);
 	mStandardB = parserB.GetStandard();
 	mSamplingB = parserB.GetSampling();
+	mBitDepthB = parserB.GetBitDepth();
 }
 
 bool VPIDData::IsRGB() const
@@ -110,4 +132,9 @@ VPIDStandard VPIDData::Standard() const
 VPIDSampling VPIDData::Sampling() const
 {
 	return mSamplingA;
+}
+
+VPIDBitDepth VPIDData::BitDepth() const
+{
+	return mBitDepthA;
 }

--- a/plugins/aja/aja-vpid-data.hpp
+++ b/plugins/aja/aja-vpid-data.hpp
@@ -30,6 +30,7 @@ public:
 
 	VPIDStandard Standard() const;
 	VPIDSampling Sampling() const;
+	VPIDBitDepth BitDepth() const;
 
 private:
 	ULWord mVpidA;
@@ -38,6 +39,8 @@ private:
 	VPIDSampling mSamplingA;
 	VPIDStandard mStandardB;
 	VPIDSampling mSamplingB;
+	VPIDBitDepth mBitDepthA;
+	VPIDBitDepth mBitDepthB;
 };
 
 using VPIDDataList = std::vector<VPIDData>;


### PR DESCRIPTION
Allow selecting v210 pixel format in the AJA capture plugin.

Enable auto-detection of SDI v210 pixel format when capturing from an AJA SDI device.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change adds the v210 format to the list of usable pixel formats in the AJA capture plugin. It also enables the auto-detection of the v210 format from the SDI signal. If the AJA device is configured for v210 format the appropriate OBS video format will be used in the format conversion pipeline (`VIDEO_FORMAT_V210`).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The recent addition of the v210 pixel format conversion shaders to OBS now allows the AJA capture plugin to enable v210 as an available pixel format.

NOTE: The v210 format is not yet available for use in the AJA Output plugin as the OBS FFMPEG format conversion pipeline does not support it. I tried forcing 10-bit YCbCr it in the OBS FFMPEG pipeline but the video looked bad. The swscale library appears not to support v210 yet: https://trac.ffmpeg.org/ticket/4661

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested by capturing a v210 pixel format signal from other AJA devices (Ki Pro Ultra 12G and Kona 5) and verifying that it looked correct in OBS. Verified that the correct pixel format conversion shader path was being taken in the OBS video capture pipeline.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
