### PR TITLE
deps/obs-scripting: Fix lua tick crash

### DIFF
--- a/deps/obs-scripting/obs-scripting-lua.c
+++ b/deps/obs-scripting/obs-scripting-lua.c
@@ -154,22 +154,6 @@ static bool load_lua_script(struct obs_lua_script *data)
 		}
 	}
 
-	lua_getglobal(script, "script_tick");
-	if (lua_isfunction(script, -1)) {
-		pthread_mutex_lock(&tick_mutex);
-
-		struct obs_lua_script *next = first_tick_script;
-		data->next_tick = next;
-		data->p_prev_next_tick = &first_tick_script;
-		if (next)
-			next->p_prev_next_tick = &data->next_tick;
-		first_tick_script = data;
-
-		data->tick = luaL_ref(script, LUA_REGISTRYINDEX);
-
-		pthread_mutex_unlock(&tick_mutex);
-	}
-
 	lua_getglobal(script, "script_properties");
 	if (lua_isfunction(script, -1))
 		data->get_properties = luaL_ref(script, LUA_REGISTRYINDEX);
@@ -224,6 +208,23 @@ static bool load_lua_script(struct obs_lua_script *data)
 	}
 
 	data->script = script;
+
+	lua_getglobal(script, "script_tick");
+	if (lua_isfunction(script, -1)) {
+		pthread_mutex_lock(&tick_mutex);
+
+		struct obs_lua_script *next = first_tick_script;
+		data->next_tick = next;
+		data->p_prev_next_tick = &first_tick_script;
+		if (next)
+			next->p_prev_next_tick = &data->next_tick;
+		first_tick_script = data;
+
+		data->tick = luaL_ref(script, LUA_REGISTRYINDEX);
+
+		pthread_mutex_unlock(&tick_mutex);
+	}
+
 	success = true;
 
 fail:


### PR DESCRIPTION
### Description
Fix race condition where `script_tick` is called before `script` is set on the `struct obs_lua_script`

### Motivation and Context
I don't like a crash in the lua scripts when switching scene collections

### How Has This Been Tested?
On windows 11, by testing if scripts still load correctly

### Types of changes

- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
