### PR TITLE
UI: Remove unused 'no scene' code

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -712,10 +712,6 @@ Basic.TransformWindow.BoundsType.Stretch="Stretch to bounds"
 Basic.TransformWindow.Title="Edit Transform for '%1'"
 Basic.TransformWindow.NoSelectedSource="No source selected"
 
-# no scene warning
-Basic.Main.AddSourceHelp.Title="Cannot Add Source"
-Basic.Main.AddSourceHelp.Text="You need to have at least 1 scene to add a source."
-
 # basic mode main window
 Basic.Main.Scenes="Scenes"
 Basic.Main.Sources="Sources"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -6244,14 +6244,6 @@ QMenu *OBSBasic::CreateAddSourcePopupMenu()
 
 void OBSBasic::AddSourcePopupMenu(const QPoint &pos)
 {
-	if (!GetCurrentScene()) {
-		// Tell the user he needs a scene first (help beginners).
-		OBSMessageBox::information(
-			this, QTStr("Basic.Main.AddSourceHelp.Title"),
-			QTStr("Basic.Main.AddSourceHelp.Text"));
-		return;
-	}
-
 	QScopedPointer<QMenu> popup(CreateAddSourcePopupMenu());
 	if (popup)
 		popup->exec(pos);


### PR DESCRIPTION
### Description
Since we require there to be always at least one scene, this 'no scene' code is never used.

### Motivation and Context
Remove unneeded code

### How Has This Been Tested?
Compiled OBS

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
