### PR TITLE
UI: Use signal vectors for transform & source tree

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -182,17 +182,7 @@ void SourceTreeItem::paintEvent(QPaintEvent *event)
 
 void SourceTreeItem::DisconnectSignals()
 {
-	sceneRemoveSignal.Disconnect();
-	itemRemoveSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	visibleSignal.Disconnect();
-	lockedSignal.Disconnect();
-	renameSignal.Disconnect();
-	removeSignal.Disconnect();
-
-	if (obs_sceneitem_is_group(sceneitem))
-		groupReorderSignal.Disconnect();
+	sigs.clear();
 }
 
 void SourceTreeItem::Clear()
@@ -279,19 +269,18 @@ void SourceTreeItem::ReconnectSignals()
 	obs_source_t *sceneSource = obs_scene_get_source(scene);
 	signal_handler_t *signal = obs_source_get_signal_handler(sceneSource);
 
-	sceneRemoveSignal.Connect(signal, "remove", removeItem, this);
-	itemRemoveSignal.Connect(signal, "item_remove", removeItem, this);
-	visibleSignal.Connect(signal, "item_visible", itemVisible, this);
-	lockedSignal.Connect(signal, "item_locked", itemLocked, this);
-	selectSignal.Connect(signal, "item_select", itemSelect, this);
-	deselectSignal.Connect(signal, "item_deselect", itemDeselect, this);
+	sigs.emplace_back(signal, "remove", removeItem, this);
+	sigs.emplace_back(signal, "item_remove", removeItem, this);
+	sigs.emplace_back(signal, "item_visible", itemVisible, this);
+	sigs.emplace_back(signal, "item_locked", itemLocked, this);
+	sigs.emplace_back(signal, "item_select", itemSelect, this);
+	sigs.emplace_back(signal, "item_deselect", itemDeselect, this);
 
 	if (obs_sceneitem_is_group(sceneitem)) {
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 		signal = obs_source_get_signal_handler(source);
 
-		groupReorderSignal.Connect(signal, "reorder", reorderGroup,
-					   this);
+		sigs.emplace_back(signal, "reorder", reorderGroup, this);
 	}
 
 	/* --------------------------------------------------------- */
@@ -315,8 +304,8 @@ void SourceTreeItem::ReconnectSignals()
 
 	obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 	signal = obs_source_get_signal_handler(source);
-	renameSignal.Connect(signal, "rename", renamed, this);
-	removeSignal.Connect(signal, "remove", removeSource, this);
+	sigs.emplace_back(signal, "rename", renamed, this);
+	sigs.emplace_back(signal, "remove", removeSource, this);
 }
 
 void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -65,15 +65,7 @@ private:
 
 	SourceTree *tree;
 	OBSSceneItem sceneitem;
-	OBSSignal sceneRemoveSignal;
-	OBSSignal itemRemoveSignal;
-	OBSSignal groupReorderSignal;
-	OBSSignal selectSignal;
-	OBSSignal deselectSignal;
-	OBSSignal visibleSignal;
-	OBSSignal lockedSignal;
-	OBSSignal renameSignal;
-	OBSSignal removeSignal;
+	std::vector<OBSSignal> sigs;
 
 	virtual void paintEvent(QPaintEvent *event) override;
 

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -123,27 +123,23 @@ OBSBasicTransform::~OBSBasicTransform()
 
 void OBSBasicTransform::SetScene(OBSScene scene)
 {
-	transformSignal.Disconnect();
-	selectSignal.Disconnect();
-	deselectSignal.Disconnect();
-	removeSignal.Disconnect();
-	lockSignal.Disconnect();
+	sigs.clear();
 
 	if (scene) {
 		OBSSource source = obs_scene_get_source(scene);
 		signal_handler_t *signal =
 			obs_source_get_signal_handler(source);
 
-		transformSignal.Connect(signal, "item_transform",
-					OBSSceneItemTransform, this);
-		removeSignal.Connect(signal, "item_remove", OBSSceneItemRemoved,
-				     this);
-		selectSignal.Connect(signal, "item_select", OBSSceneItemSelect,
-				     this);
-		deselectSignal.Connect(signal, "item_deselect",
-				       OBSSceneItemDeselect, this);
-		lockSignal.Connect(signal, "item_locked", OBSSceneItemLocked,
-				   this);
+		sigs.emplace_back(signal, "item_transform",
+				  OBSSceneItemTransform, this);
+		sigs.emplace_back(signal, "item_remove", OBSSceneItemRemoved,
+				  this);
+		sigs.emplace_back(signal, "item_select", OBSSceneItemSelect,
+				  this);
+		sigs.emplace_back(signal, "item_deselect", OBSSceneItemDeselect,
+				  this);
+		sigs.emplace_back(signal, "item_locked", OBSSceneItemLocked,
+				  this);
 	}
 }
 

--- a/UI/window-basic-transform.hpp
+++ b/UI/window-basic-transform.hpp
@@ -17,11 +17,7 @@ private:
 	OBSBasic *main;
 	OBSSceneItem item;
 	OBSSignal channelChangedSignal;
-	OBSSignal transformSignal;
-	OBSSignal removeSignal;
-	OBSSignal selectSignal;
-	OBSSignal deselectSignal;
-	OBSSignal lockSignal;
+	std::vector<OBSSignal> sigs;
 
 	std::string undo_data;
 


### PR DESCRIPTION
### Description
Cleans up signal code

### Motivation and Context
Less code

### How Has This Been Tested?
Used source tree and transform dialog

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
