### PR TITLE
obs-qsv11: Fix for QSV AV1 in multi-GPU system

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -79,30 +79,7 @@ void qsv_encoder_version(unsigned short *major, unsigned short *minor)
 
 qsv_t *qsv_encoder_open(qsv_param_t *pParams, enum qsv_codec codec)
 {
-	obs_video_info ovi;
-	obs_get_video_info(&ovi);
-	size_t adapter_idx = ovi.adapter;
-
-	// Select current adapter - will be iGPU if exists due to adapter reordering
-	if (codec == QSV_CODEC_AV1 && !adapters[adapter_idx].supports_av1) {
-		for (size_t i = 0; i < 4; i++) {
-			if (adapters[i].supports_av1) {
-				adapter_idx = i;
-				break;
-			}
-		}
-	} else if (!adapters[adapter_idx].is_intel) {
-		for (size_t i = 0; i < 4; i++) {
-			if (adapters[i].is_intel) {
-				adapter_idx = i;
-				break;
-			}
-		}
-	}
-
-	bool isDGPU = adapters[adapter_idx].is_dgpu;
-
-	QSV_Encoder_Internal *pEncoder = new QSV_Encoder_Internal(ver, isDGPU);
+	QSV_Encoder_Internal *pEncoder = new QSV_Encoder_Internal(ver);
 	mfxStatus sts = pEncoder->Open(pParams, codec);
 	if (sts != MFX_ERR_NONE) {
 
@@ -189,12 +166,6 @@ qsv_t *qsv_encoder_open(qsv_param_t *pParams, enum qsv_codec codec)
 	}
 
 	return (qsv_t *)pEncoder;
-}
-
-bool qsv_encoder_is_dgpu(qsv_t *pContext)
-{
-	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
-	return pEncoder->IsDGPU();
 }
 
 int qsv_encoder_headers(qsv_t *pContext, uint8_t **pSPS, uint8_t **pPPS,

--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -159,7 +159,6 @@ int qsv_param_default_preset(qsv_param_t *, const char *preset,
 int qsv_encoder_reconfig(qsv_t *, qsv_param_t *);
 void qsv_encoder_version(unsigned short *major, unsigned short *minor);
 qsv_t *qsv_encoder_open(qsv_param_t *, enum qsv_codec codec);
-bool qsv_encoder_is_dgpu(qsv_t *);
 void qsv_encoder_add_roi(qsv_t *, const struct obs_encoder_roi *roi);
 void qsv_encoder_clear_roi(qsv_t *pContext);
 int qsv_encoder_encode(qsv_t *, uint64_t, uint8_t *, uint8_t *, uint32_t,

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -71,7 +71,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 mfxHDL QSV_Encoder_Internal::g_DX_Handle = NULL;
 mfxU16 QSV_Encoder_Internal::g_numEncodersOpen = 0;
 
-QSV_Encoder_Internal::QSV_Encoder_Internal(mfxVersion &version, bool isDGPU)
+QSV_Encoder_Internal::QSV_Encoder_Internal(mfxVersion &version)
 	: m_pmfxSurfaces(NULL),
 	  m_pmfxENC(NULL),
 	  m_nSPSBufferSize(1024),
@@ -81,8 +81,8 @@ QSV_Encoder_Internal::QSV_Encoder_Internal(mfxVersion &version, bool isDGPU)
 	  m_nTaskIdx(0),
 	  m_nFirstSyncTask(0),
 	  m_outBitstream(),
-	  m_isDGPU(isDGPU),
-	  m_sessionData(NULL)
+	  m_sessionData(NULL),
+	  m_ver(version)
 {
 	mfxVariant tempImpl;
 	mfxStatus sts;

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class QSV_Encoder_Internal {
 public:
-	QSV_Encoder_Internal(mfxVersion &version, bool isDGPU);
+	QSV_Encoder_Internal(mfxVersion &version);
 	~QSV_Encoder_Internal();
 
 	mfxStatus Open(qsv_param_t *pParams, enum qsv_codec codec);
@@ -84,8 +84,6 @@ public:
 	void AddROI(mfxU32 left, mfxU32 top, mfxU32 right, mfxU32 bottom,
 		    mfxI16 delta);
 	void ClearROI();
-
-	bool IsDGPU() const { return m_isDGPU; }
 
 protected:
 	mfxStatus InitParams(qsv_param_t *pParams, enum qsv_codec codec);
@@ -135,7 +133,6 @@ private:
 	mfxBitstream m_outBitstream;
 	bool m_bUseD3D11;
 	bool m_bUseTexAlloc;
-	bool m_isDGPU;
 	static mfxU16 g_numEncodersOpen;
 	static mfxHDL
 		g_DX_Handle; // we only want one handle for all instances to use;

--- a/plugins/obs-qsv11/common_utils.cpp
+++ b/plugins/obs-qsv11/common_utils.cpp
@@ -6,6 +6,7 @@
 
 struct adapter_info adapters[MAX_ADAPTERS] = {0};
 size_t adapter_count = 0;
+size_t adapter_index = 0;
 
 void PrintErrString(int err, const char *filestr, int line)
 {

--- a/plugins/obs-qsv11/common_utils.h
+++ b/plugins/obs-qsv11/common_utils.h
@@ -23,6 +23,7 @@ struct adapter_info {
 #define MAX_ADAPTERS 10
 extern struct adapter_info adapters[MAX_ADAPTERS];
 extern size_t adapter_count;
+extern size_t adapter_index;
 
 void util_cpuid(int cpuinfo[4], int flags);
 void check_adapters(struct adapter_info *adapters, size_t *adapter_count);
@@ -162,7 +163,7 @@ int GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize);
 mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 		     mfxFrameAllocator *pmfxAllocator, mfxHDL *deviceHandle,
 		     bool bCreateSharedHandles, enum qsv_codec codec,
-		     void **data); //vpl change
+		     void **data);
 
 // Release global shared resources (device/display)
 void Release();

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -16,6 +16,7 @@
 
 #include <intrin.h>
 #include <inttypes.h>
+#include <obs-module.h>
 
 /* =======================================================
  * Windows implementation of OS-specific utility functions
@@ -28,6 +29,29 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 {
 	UNUSED_PARAMETER(codec);
 	UNUSED_PARAMETER(data);
+
+	obs_video_info ovi;
+	obs_get_video_info(&ovi);
+	mfxU32 adapter_idx = ovi.adapter;
+
+	// Select current adapter - will be iGPU if exists due to adapter reordering
+	if (codec == QSV_CODEC_AV1 && !adapters[adapter_idx].supports_av1) {
+		for (mfxU32 i = 0; i < 4; i++) {
+			if (adapters[i].supports_av1) {
+				adapter_idx = i;
+				break;
+			}
+		}
+	} else if (!adapters[adapter_idx].is_intel) {
+		for (mfxU32 i = 0; i < 4; i++) {
+			if (adapters[i].is_intel) {
+				adapter_idx = i;
+				break;
+			}
+		}
+	}
+
+	adapter_index = adapter_idx;
 
 	mfxStatus sts = MFX_ERR_NONE;
 	mfxVariant impl;
@@ -56,7 +80,7 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 			(const mfxU8 *)"mfxImplDescription.AccelerationMode",
 			impl);
 
-		sts = MFXCreateSession(loader, 0, pSession);
+		sts = MFXCreateSession(loader, adapter_idx, pSession);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 		// Create DirectX device context
@@ -109,7 +133,7 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 			(const mfxU8 *)"mfxImplDescription.AccelerationMode",
 			impl);
 
-		sts = MFXCreateSession(loader, 0, pSession);
+		sts = MFXCreateSession(loader, adapter_idx, pSession);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 	}
 	return sts;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -1093,7 +1093,7 @@ static inline void cap_resolution(struct obs_qsv *obsqsv,
 	uint32_t width = obs_encoder_get_width(obsqsv->encoder);
 	uint32_t height = obs_encoder_get_height(obsqsv->encoder);
 
-	if (qsv_encoder_is_dgpu(obsqsv->context))
+	if (adapters[adapter_index].is_dgpu == true)
 		qsv_platform = QSV_CPU_PLATFORM_UNKNOWN;
 
 	info->height = height;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixing a bug where OBS is selected to run on a GPU that does not support AV1 encoding, while there is an Intel dGPU in the same system. Instead of throwing an error, due to the other GPU being unable to encode AV1, the system will fall back to the dGPU that can run AV1 encoding.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixing this issue: https://github.com/obsproject/obs-studio/issues/9982 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on CLEVO laptop with Intel iGPU and dGPU while OBS is selected to run on the iGPU.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x ] My code is not on the master branch.
- [x ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
