### PR TITLE
CI: Do not install python on macOS

### DIFF
--- a/.github/actions/services-validator/action.yaml
+++ b/.github/actions/services-validator/action.yaml
@@ -51,8 +51,8 @@ runs:
         if [[ "${RUNNER_OS}" == Linux ]]; then
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+          brew install --overwrite --quiet python3
         fi
-        brew install --overwrite --quiet python@3.11
         python3 -m pip install jsonschema json_source_map requests aiohttp
         echo ::endgroup::
 


### PR DESCRIPTION
### Description

macOS and the GitHub runners have python3 preinstalled. We only needed to specify a version because aiohttp wasn't compatible with 3.12, but that's no longer the case.

### Motivation and Context

Fixes job.

### How Has This Been Tested?

Ran on fork.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
