### PR TITLE
CI: Update third-party GitHub Actions

### DIFF
--- a/.github/actions/qt-xml-validator/action.yaml
+++ b/.github/actions/qt-xml-validator/action.yaml
@@ -33,7 +33,7 @@ runs:
         echo ::endgroup::
 
     - name: Register Annotations 📝
-      uses: korelstar/xmllint-problem-matcher@22352420d1d3e8f18d311d76284c4f5f71982222
+      uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0
 
     - name: Validate XML 💯
       shell: bash

--- a/.github/actions/services-validator/action.yaml
+++ b/.github/actions/services-validator/action.yaml
@@ -110,7 +110,7 @@ runs:
         path: ${{ inputs.workingDirectory }}/other/*
 
     - name: Create pull request 🔧
-      uses: peter-evans/create-pull-request@ad43dccb4d726ca8514126628bec209b8354b6dd
+      uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50
       if: fromJSON(inputs.createPullRequest) && fromJSON(inputs.runServiceChecks) && fromJSON(steps.services-check.outputs.make_pr)
       with:
         author: 'Service Checker <commits@obsproject.com>'

--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -197,7 +197,7 @@ runs:
         popd
 
     - name: Set Up steamcmd 🚂
-      uses: CyberAndrii/setup-steamcmd@b786e0da44db3d817e66fa3910a9560cb28c9323
+      uses: CyberAndrii/setup-steamcmd@29e114af032a947f5ed57832409070d6e4cbfce3
 
     - name: Generate Steam auth code 🔐
       id: steam-totp

--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -201,7 +201,7 @@ runs:
 
     - name: Generate Steam auth code 🔐
       id: steam-totp
-      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      uses: CyberAndrii/steam-totp@45775c32193801a84d19d94076d72a2ece010948
       if: ${{ ! fromJSON(inputs.preview) }}
       with:
         shared_secret: ${{ inputs.steamSecret }}
@@ -248,7 +248,7 @@ runs:
 
     - name: Generate Steam auth code 🔐
       id: steam-totp-playtest
-      uses: CyberAndrii/steam-totp@c7f636bc64e77f1b901e0420b7890813141508ee
+      uses: CyberAndrii/steam-totp@45775c32193801a84d19d94076d72a2ece010948
       if: ${{ ! fromJSON(inputs.preview) && fromJSON(steps.asset-info.outputs.is_prerelease) }}
       with:
         shared_secret: ${{ inputs.steamSecret }}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
CI: Update third-party GitHub Actions

This PR updates four third-party actions. These updates should be low-impact. The update with the biggest diff is peter-evans/create-pull-request, though the bulk of the changes are in docs, tests, and generated files. If we don't want to review this diff now, I can pull that update out and we can put it in a different PR later.

----

CI: Update korelstar/xmllint-problem-matcher GitHub Action

We're currently using korelstar/xmllint-problem-matcher v1.1.0 which is based on the deprecated node16. This was fixed in v1.2.0, so let's update to that version's commit.

https://github.com/korelstar/xmllint-problem-matcher/compare/22352420d1d3e8f18d311d76284c4f5f71982222..1bd292d642ddf3d369d02aaa8b262834d61198c0

----

CI: Update CyberAndrii/setup-steamcmd GitHub Action

We're currently using CyberAndrii/setup-steamcmd b786e0da44 which is based on the deprecated node16. This was fixed in 29e114af03, so let's update to that commit.

https://github.com/CyberAndrii/setup-steamcmd/compare/b786e0da44db3d817e66fa3910a9560cb28c9323..29e114af032a947f5ed57832409070d6e4cbfce3

----

CI: Update CyberAndrii/steam-totp GitHub Action

We're currently using CyberAndrii/steam-totp c7f636bc64 which is based on the deprecated node16. This was fixed in 45775c3219, so let's update to that commit.

https://github.com/CyberAndrii/steam-totp/compare/c7f636bc64e77f1b901e0420b7890813141508ee..45775c32193801a84d19d94076d72a2ece010948

----

CI: Update peter-evans/create-pull-request GitHub Action

We're currently using peter-evans/create-pull-request v4.1.4 which is based on the deprecated node16. This was fixed in v6.0.0, so let's update to that commit.

https://github.com/peter-evans/create-pull-request/compare/ad43dccb4d726ca8514126628bec209b8354b6dd..b1ddad2c994a25fbc81a28b3ec0e368bb2021c50

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Reduce CI warnings. Prevent eventual CI errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
