### PR TITLE
libobs-opengl: Specify display attributes

### DIFF
--- a/libobs-opengl/gl-wayland-egl.c
+++ b/libobs-opengl/gl-wayland-egl.c
@@ -190,7 +190,9 @@ static struct gl_platform *gl_wayland_egl_platform_create(gs_device_t *device,
 
 	device->plat = plat;
 
-	plat->display = eglGetDisplay(plat->wl_display);
+	const EGLAttrib plat_attribs[] = {EGL_NONE};
+	plat->display = eglGetPlatformDisplay(EGL_PLATFORM_WAYLAND_EXT,
+					      plat->wl_display, plat_attribs);
 	if (plat->display == EGL_NO_DISPLAY) {
 		blog(LOG_ERROR, "eglGetDisplay failed");
 		goto fail_display_init;

--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -155,8 +155,9 @@ static EGLDisplay get_egl_display(struct gl_platform *plat)
 							  : NULL);
 
 	if (eglGetPlatformDisplayEXT) {
+		const EGLint plat_attribs[] = {EGL_NONE};
 		edisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_X11_EXT,
-						    display, NULL);
+						    display, plat_attribs);
 		if (EGL_NO_DISPLAY == edisplay)
 			blog(LOG_ERROR, "Failed to get EGL/X11 display");
 	}


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This is functionally a no-op, but works around a driver bug that prevents use of eglQueryDisplayAttribEXT. This makes us more likely to not trigger the driver bug and that gs_enum_adapters works correctly.

This is just a fixup for the earlier `gs_enum_adapters` functionality.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Drivers will return illegal values which make us think we are running on software renderers after Qt loads. This should avoid the Qt issue at least until drivers get fixed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Setup the safety mode popup to get qt to render before obs' graphics backend is loaded. Observe device enumeration returns invalid values before the fix and correct display devices after the fix.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
