### PR TITLE
UI: Update exportOptions template for macOS release code signing

### DIFF
--- a/UI/cmake/macos/exportOptions-extension.plist.in
+++ b/UI/cmake/macos/exportOptions-extension.plist.in
@@ -10,6 +10,10 @@
 		<string>${OBS_PROVISIONING_PROFILE}</string>
 	</dict>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Developer ID Application</string>
+	<key>teamID</key>
+	<string>${OBS_CODESIGN_TEAM}</string>
 </dict>
 </plist>

--- a/UI/cmake/macos/exportOptions.plist.in
+++ b/UI/cmake/macos/exportOptions.plist.in
@@ -5,6 +5,10 @@
 	<key>method</key>
 	<string>developer-id</string>
 	<key>signingStyle</key>
-	<string>automatic</string>
+	<string>manual</string>
+	<key>signingCertificate</key>
+	<string>Developer ID Application</string>
+	<key>teamID</key>
+	<string>${OBS_CODESIGN_TEAM}</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Description
Attempts to fix code signing with a provisioning profile on GitHub Actions CI runs.


### Motivation and Context
Automatic signing does not seem to work with Xcode 15 anymore, instead manual signing needs to be used for manually provided provisioning profiles.

### How Has This Been Tested?
Using `xcodebuild -export` with the updated exportOptions file successfully exported the application with Xcode 15.1 locally.

Conclusive test requires a tagged push after this has been merged.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
