### PR TITLE
obs-ffmpeg: Fix wrong framerate in VUI header

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1506,14 +1506,13 @@ static void amf_avc_create_internal(amf_base *enc, obs_data_t *settings)
 			 enc->amf_characteristic);
 	set_avc_property(enc, OUTPUT_COLOR_PRIMARIES, enc->amf_primaries);
 	set_avc_property(enc, FULL_RANGE_COLOR, enc->full_range);
+	set_avc_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	amf_avc_init(enc, settings);
 
 	res = enc->amf_encoder->Init(enc->amf_format, enc->cx, enc->cy);
 	if (res != AMF_OK)
 		throw amf_error("AMFComponent::Init failed", res);
-
-	set_avc_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	res = enc->amf_encoder->GetProperty(AMF_VIDEO_ENCODER_EXTRADATA, &p);
 	if (res == AMF_OK && p.type == AMF_VARIANT_INTERFACE)
@@ -1853,6 +1852,7 @@ static void amf_hevc_create_internal(amf_base *enc, obs_data_t *settings)
 			  enc->amf_characteristic);
 	set_hevc_property(enc, OUTPUT_COLOR_PRIMARIES, enc->amf_primaries);
 	set_hevc_property(enc, NOMINAL_RANGE, enc->full_range);
+	set_hevc_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	if (is_hdr) {
 		const int hdr_nominal_peak_level =
@@ -1884,8 +1884,6 @@ static void amf_hevc_create_internal(amf_base *enc, obs_data_t *settings)
 	res = enc->amf_encoder->Init(enc->amf_format, enc->cx, enc->cy);
 	if (res != AMF_OK)
 		throw amf_error("AMFComponent::Init failed", res);
-
-	set_hevc_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	res = enc->amf_encoder->GetProperty(AMF_VIDEO_ENCODER_HEVC_EXTRADATA,
 					    &p);
@@ -2197,14 +2195,13 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 	set_av1_property(enc, OUTPUT_TRANSFER_CHARACTERISTIC,
 			 enc->amf_characteristic);
 	set_av1_property(enc, OUTPUT_COLOR_PRIMARIES, enc->amf_primaries);
+	set_av1_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	amf_av1_init(enc, settings);
 
 	res = enc->amf_encoder->Init(enc->amf_format, enc->cx, enc->cy);
 	if (res != AMF_OK)
 		throw amf_error("AMFComponent::Init failed", res);
-
-	set_av1_property(enc, FRAMERATE, enc->amf_frame_rate);
 
 	AMFVariant p;
 	res = enc->amf_encoder->GetProperty(AMF_VIDEO_ENCODER_AV1_EXTRA_DATA,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This PR changes frame rate setting for AMF encoders.
Frame rate should be defined before AMF encoder initialization, because this information is used for setting vui_time_scale in SPS (Sequence Parameter Set) inside HEVC encoder. If frame rate isn't defined before encoder initialization, then AMF encoder writes default frame rate into VUI (30 fps).

### Motivation and Context

Some applications like DaVinchi Resolve use information about frame rate from SPS.
AMF encoder writes frame rate into SPS during initialization (Init() function), so if frame rate wasn't defined before initialization,
then AMF wrote default frame rate (30fps) into vui_time_scale inside SPS.
As a result, Davinchi Resolve runs video in 2x speed if we have 60 FPS video.
This issue appeared after AMD driver update  to 23.11.1, because it contains a fix for missing information in VUI:
Here is a related issue: https://github.com/obsproject/obs-studio/issues/9195 
Before that fix AMF encoder didn't write VUI information and major applications take information from the stream, 
but since the SPS was fixed, some applications started to use VUI information from header.
Please pay in attention that issue appeared in HEVC video only, but I fixed for all AMF encoders to prevent possible regressions in future.

Here is a public discussions of this issue:  
https://www.reddit.com/r/davinciresolve/comments/17tmd88/recent_issue_videos_imported_to_davinci_play_at/
https://www.reddit.com/r/davinciresolve/comments/12n9oc9/issue_resolve_downsampeling_a_60fps_source_file/  
https://www.reddit.com/r/davinciresolve/comments/17uknqg/comment/k959wh6/?context=3

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested  it on AMD GPU with RDNA (RX5000 and later) architecture with latest  23.11.1, Windows 10.
OBS-studio built from latest master. 
I recorded mkv video with 60 FPS by using OBS with AMF HEVC encoder and analyze output video with VTC lab media analyzer: https://media-analyzer.pro/app
In "HEVC Sequence Parameter Set (SPS)" section vui_time_scale  should be set to 60 (0x3C).
In addition, you might import the video into DaVinchi Resolve 18.6.4 and check that playback works correctly. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
