### PR TITLE
CI: Fix Steam workflow getting confused by PDBs

### DIFF
--- a/.github/actions/steam-upload/action.yaml
+++ b/.github/actions/steam-upload/action.yaml
@@ -168,7 +168,7 @@ runs:
 
         print '::group::Prepare Windows x64 assets'
         mkdir -p steam-windows && pushd steam-windows
-        unzip ${root_dir}/(#i)obs-studio-*.zip
+        unzip ${root_dir}/(#i)obs-studio-(^*-pdbs).zip
         rm ${root_dir}/(#i)obs-studio-*.zip
 
         cp -r ${root_dir}/build-aux/steam/scripts_windows scripts


### PR DESCRIPTION
### Description

Fix Steam workflow failing because PDBs are now part of releases.

### Motivation and Context

Do not want CI runs to fail anymore :(

### How Has This Been Tested?

Tested on my fork.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
