### PR TITLE
CI: Move Windows signing to reusable workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,8 +207,8 @@ jobs:
 
   sign-windows-build:
     name: Windows Signing ✍️
-    uses: ./.github/workflows/sign-windows.yaml
-    if: github.ref_type == 'tag'
+    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@7dcf55274568837c37ca2d869e37b83b9ff3e7cf
+    if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
     needs: build-project
     permissions:
       contents: 'read'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -205,94 +205,15 @@ jobs:
           pattern: macos-sparkle-update-*
           delete-merged: true
 
-  create-windows-update:
-    name: Create Windows Update 🥩
-    if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
-    runs-on: windows-2022
+  sign-windows-build:
+    name: Windows Signing ✍️
+    uses: ./.github/workflows/sign-windows.yaml
+    if: github.ref_type == 'tag'
     needs: build-project
     permissions:
       contents: 'read'
       id-token: 'write'
-    defaults:
-      run:
-        shell: pwsh
-    environment:
-      name: bouf
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          path: "repo"
-          fetch-depth: 0
-          ref: ${{ github.ref }}
-
-      - name: Set Up Environment 🔧
-        id: setup
-        env:
-          BOUF_ACTION_HASH: 'f9fdc601d0da8c3f18e0135d3f0ffbfba6544ff1742906ccfa9fdbe4bdea4bf9'
-        run: |
-          $channel = if ($env:GITHUB_REF_NAME -match "(beta|rc)") { "beta" } else { "stable" }
-          $shortHash = $env:GITHUB_SHA.Substring(0,9)
-          "channel=${channel}" >> $env:GITHUB_OUTPUT
-          "commitHash=${shortHash}" >> $env:GITHUB_OUTPUT
-          
-          # Ensure files in action haven't been modified
-          $folderHash = ''
-          $files = Get-ChildItem "${{ github.workspace }}\repo\.github\actions\bouf"
-          foreach ($file in $files) {
-            $folderHash += (Get-FileHash $file -Algorithm SHA256).Hash
-          }
-          # This is stupid but so is powershell
-          $stream = [IO.MemoryStream]::new([byte[]][char[]]$folderHash)
-          if ((Get-FileHash -InputStream $stream -Algorithm SHA256).Hash -ne "$env:BOUF_ACTION_HASH") {
-            throw "bouf action folder hash does not match."
-          }
-
-      - name: Download Artifact 📥
-        uses: actions/download-artifact@v4
-        with:
-          name: obs-studio-windows-x64-${{ steps.setup.outputs.commitHash }}
-          path: ${{ github.workspace }}/build
-
-      - name: Run bouf 🥩
-        uses: ./repo/.github/actions/bouf
-        with:
-          gcpWorkloadIdentityProvider: ${{ secrets.GCP_IDENTITY_POOL }}
-          gcpServiceAccountName: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
-          version: ${{ github.ref_name }}
-          channel: ${{ steps.setup.outputs.channel }}
-
-      - name: Upload Signed Build
-        uses: actions/upload-artifact@v4
-        with:
-          name: obs-studio-windows-x64-${{ github.ref_name }}-signed
-          compression-level: 6
-          path: ${{ github.workspace }}/output/install
-
-      - name: Upload PDBs
-        uses: actions/upload-artifact@v4
-        with:
-          name: obs-studio-windows-x64-${{ github.ref_name }}-pdbs
-          compression-level: 9
-          path: ${{ github.workspace }}/output/pdbs
-
-      - name: Upload Installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: obs-studio-windows-x64-${{ github.ref_name }}-installer
-          compression-level: 0
-          path: ${{ github.workspace }}/output/*.exe
-
-      - name: Upload Updater Files
-        uses: actions/upload-artifact@v4
-        with:
-          name: obs-studio-windows-x64-${{ github.ref_name }}-patches
-          compression-level: 0
-          path: |
-            ${{ github.workspace }}/output/updater
-            ${{ github.workspace }}/output/*.json
-            ${{ github.workspace }}/output/*.sig
-            ${{ github.workspace }}/output/*.txt
-            ${{ github.workspace }}/output/*.rst
+    secrets: inherit
 
   create-release:
     name: Create Release 🛫

--- a/.github/workflows/sign-windows.yaml
+++ b/.github/workflows/sign-windows.yaml
@@ -1,0 +1,85 @@
+name: Sign Windows Project
+on:
+  workflow_call:
+jobs:
+  create-windows-update:
+    name: Create Windows Update 🥩
+    runs-on: windows-2022
+    environment:
+      name: bouf
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Parse JWT
+        id: jwt
+        run: |
+          $token = ConvertTo-SecureString -String ${env:ACTIONS_ID_TOKEN_REQUEST_TOKEN} -AsPlainText
+          $jwt = Invoke-WebRequest -Uri "${env:ACTIONS_ID_TOKEN_REQUEST_URL}&audience=ignore" -Authentication Bearer -Token $token
+          $claim_b64 = (($jwt.Content | ConvertFrom-Json -AsHashtable).value -split '\.')[1]
+          $claim_b64 += '=' * (4 - $claim_b64.Length % 4)
+          $claim = [Text.Encoding]::Utf8.GetString([Convert]::FromBase64String($claim_b64)) | ConvertFrom-Json -AsHashtable
+          $sha = ${claim}.job_workflow_sha
+          Write-Output "Workflow SHA: ${sha}"
+          "workflow_sha=${sha}" >> $env:GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          path: "repo"
+          fetch-depth: 0
+          ref: ${{ steps.jwt.outputs.workflow_sha }}
+
+      - name: Set Up Environment 🔧
+        id: setup
+        run: |
+          $channel = if ($env:GITHUB_REF_NAME -match "(beta|rc)") { "beta" } else { "stable" }
+          $shortHash = $env:GITHUB_SHA.Substring(0,9)
+          "channel=${channel}" >> $env:GITHUB_OUTPUT
+          "commitHash=${shortHash}" >> $env:GITHUB_OUTPUT
+
+      - name: Download Artifact 📥
+        uses: actions/download-artifact@v4
+        with:
+          name: obs-studio-windows-x64-${{ steps.setup.outputs.commitHash }}
+          path: ${{ github.workspace }}/build
+
+      - name: Run bouf 🥩
+        uses: ./repo/.github/actions/bouf
+        with:
+          gcpWorkloadIdentityProvider: ${{ secrets.GCP_IDENTITY_POOL }}
+          gcpServiceAccountName: ${{ secrets.GCP_SERVICE_ACCOUNT_NAME }}
+          version: ${{ github.ref_name }}
+          channel: ${{ steps.setup.outputs.channel }}
+
+      - name: Upload Signed Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-studio-windows-x64-${{ github.ref_name }}-signed
+          compression-level: 6
+          path: ${{ github.workspace }}/output/install
+
+      - name: Upload PDBs
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-studio-windows-x64-${{ github.ref_name }}-pdbs
+          compression-level: 9
+          path: ${{ github.workspace }}/output/pdbs
+
+      - name: Upload Installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-studio-windows-x64-${{ github.ref_name }}-installer
+          compression-level: 0
+          path: ${{ github.workspace }}/output/*.exe
+
+      - name: Upload Updater Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-studio-windows-x64-${{ github.ref_name }}-patches
+          compression-level: 0
+          path: |
+            ${{ github.workspace }}/output/updater
+            ${{ github.workspace }}/output/*.json
+            ${{ github.workspace }}/output/*.sig
+            ${{ github.workspace }}/output/*.txt
+            ${{ github.workspace }}/output/*.rst


### PR DESCRIPTION
### Description

In order for the `job_workflow_sha` claim in the JWT to actually correspond to the workflow's last modification commit it has to be a reusable workflow. This is annoying, and somewhat silly given GitHub's documentation indicates otherwise, but what can you do...

Bonus points for there not being a way to get the ref of the currently executed reusable workflow, the only way I ([and others](https://github.com/actions/runner/issues/2417)) could find was to parse the JWT, which is "easy" here since this job uses it anyway.

Note: this PR needs to be merged via merge commit to avoid the hashes becoming invalid. Alternatively the second commit could be split into its own or directly pushed to master, but I'd like to not do that.

### Motivation and Context

Want to pin specific version of signing action/bouf configuration for Google Cloud Authentication.

### How Has This Been Tested?

Ran on my fork.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
