### PR TITLE
libobs: Fix free disk space calculation on macOS

### DIFF
--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -363,23 +363,19 @@ int64_t os_get_free_space(const char *path)
     if (path) {
         NSURL *fileURL = [NSURL fileURLWithPath:@(path)];
 
-        NSDictionary *values = [fileURL resourceValuesForKeys:@[NSURLVolumeIsLocalKey] error:nil];
+        NSArray *availableCapacityKeys = @[
+            NSURLVolumeAvailableCapacityKey, NSURLVolumeAvailableCapacityForImportantUsageKey,
+            NSURLVolumeAvailableCapacityForOpportunisticUsageKey
+        ];
 
-        BOOL isLocalVolume = [values[NSURLVolumeIsLocalKey] boolValue];
+        NSDictionary *values = [fileURL resourceValuesForKeys:availableCapacityKeys error:nil];
 
-        NSURLResourceKey volumeKey;
+        NSNumber *availableOpportunisticSpace = values[NSURLVolumeAvailableCapacityForOpportunisticUsageKey];
+        NSNumber *availableSpace = values[NSURLVolumeAvailableCapacityKey];
 
-        if (isLocalVolume) {
-            volumeKey = NSURLVolumeAvailableCapacityForOpportunisticUsageKey;
+        if (availableOpportunisticSpace.longValue > 0) {
+            return availableOpportunisticSpace.longValue;
         } else {
-            volumeKey = NSURLVolumeAvailableCapacityKey;
-        }
-
-        values = [fileURL resourceValuesForKeys:@[volumeKey] error:nil];
-
-        NSNumber *availableSpace = values[volumeKey];
-
-        if (availableSpace) {
             return availableSpace.longValue;
         }
     }


### PR DESCRIPTION
### Description
New space availability keys seem to have very specific file system requirements not documented anywhere. Using the opportunistic free space key opportunistically (and falling back on the legacy value otherwise) should always yield a "good-enough" free disk space value.

### Motivation and Context
Fixes inability to record videos to ExFAT and FAT32 volumes on macOS.

### How Has This Been Tested?
Tested on macOS 14.3 with APFS, HFS+, ExFAT, FAT32, and mounted network volumes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
