### PR TITLE
image-source: Fix crash when randomize with 0 files

### DIFF
--- a/plugins/image-source/obs-slideshow-mk2.c
+++ b/plugins/image-source/obs-slideshow-mk2.c
@@ -377,7 +377,12 @@ static struct source_data get_new_source(struct slideshow *ss,
 static void restart_slides(struct slideshow *ss)
 {
 	struct slideshow_data *ssd = &ss->data;
-	size_t start_idx = ssd->randomize ? (size_t)rand() % ssd->files.num : 0;
+	size_t start_idx = 0;
+
+	if (ssd->randomize && ssd->files.num > 0) {
+		start_idx = (size_t)rand() % ssd->files.num;
+	}
+
 	struct active_slides new_slides = {0};
 
 	if (ssd->files.num) {


### PR DESCRIPTION
### Description
Check if the number of files is zero before trying to randomize.

### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/10188

### How Has This Been Tested?
Windows only.

Build, add fresh image slideshow source (no files), click randomize. Does not crash.
Try to add a folder with 2000 files, let it run thru a couple of images.
Remove folder (back to 0 files), randomize still enabled, checking breakpoints for sane output.
Re-add folder with 2000 files.
Random function still works (the selection seems random'y).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
