### PR TITLE
libobs: Add filter for save file path property

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -173,8 +173,8 @@ Property Object Functions
 
    Adds a 'path' property.  Can be a directory or a file.
 
-   If target is a file path, the filters should be this format, separated by
-   double semicolons, and extensions separated by space::
+   If target is a file path or file save, the filters should be this format,
+   separated by double semicolons, and extensions separated by space::
 
      "Example types 1 and 2 (*.ex1 *.ex2);;Example type 3 (*.ex3)"
 
@@ -187,9 +187,10 @@ Property Object Functions
                            - **OBS_PATH_DIRECTORY** - Directory
 
    :param    filter:       If type is a file path, then describes the file filter
-                           that the user can browse.  Items are separated via
-                           double semicolons.  If multiple file types in a
-                           filter, separate with space.
+                           that the user can browse. If type is a save path,
+                           then describes the file types the file can be
+                           saved as. Items are separated via double semicolons.
+                           If multiple file types in a filter, separate with space.
    :param    default_path: The default path to start in, or *NULL*
    :return:                The property
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -616,7 +616,7 @@ obs_property_t *obs_properties_add_path(obs_properties_t *props,
 	data->type = type;
 	data->default_path = bstrdup(default_path);
 
-	if (data->type == OBS_PATH_FILE)
+	if (data->type == OBS_PATH_FILE || data->type == OBS_PATH_FILE_SAVE)
 		data->filter = bstrdup(filter);
 
 	return p;


### PR DESCRIPTION
### Description
File path properties allow for filters to be set that limit the file types shown in the file select dialog.  QT allows the same filters to be used in a File Save dialog, to limit the file types/extensions a user can save a file as.  This PR uses the provided `filter` value in the `obs_properties_add_path` to limit the save-as file types/extensions in the file save dialog.  This can be seen in the sample dialog below, where the save as type of Preset (*.snoise) is populated in the dropdown.  This has the added benefit of automatically adding the file extension provided to the saved file.  Currently for `OBS_PATH_FILE_SAVE` dialogs, the filters are silently ignored.
![image](https://github.com/obsproject/obs-studio/assets/72580859/bbd29cbf-5680-466c-b018-d7a194c5705f)

### Motivation and Context
This feature is useful for plugin authors, as it will allow limiting the file types and extensions for any file saved through the save dialog box.

### How Has This Been Tested?
This has been tested on Windows 11 with the latest HEAD of obs studio for a save file dialog being developed in an upcoming plugin I am working on.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
