### PR TITLE
CI: Switch to macOS 14 runners and Xcode 15.2

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -59,7 +59,7 @@ jobs:
 
   macos-build:
     name: macOS 🍏
-    runs-on: macos-13
+    runs-on: macos-14
     needs: check-event
     strategy:
       fail-fast: false
@@ -80,12 +80,8 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 15.1 and AppleScript'
-          sudo xcode-select --switch /Applications/Xcode_15.1.app/Contents/Developer
-          sudo sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db \
-            "INSERT OR REPLACE INTO access VALUES('kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552);"
-          sudo sqlite3 /Library/Application\ Support/com.apple.TCC/TCC.db \
-            "INSERT OR REPLACE INTO access VALUES('kTCCServiceAppleEvents','/usr/local/opt/runner/provisioner/provisioner',1,2,3,1,NULL,NULL,0,'com.apple.finder',X'fade0c000000002c00000001000000060000000200000010636f6d2e6170706c652e66696e64657200000003',NULL,1592919552);"
+          print '::group::Enable Xcode 15.2'
+          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -15,7 +15,7 @@ jobs:
           failCondition: error
 
   swift-format:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -34,7 +34,7 @@ jobs:
   services-validation:
     name: Validate Services 🕵️
     if: github.repository_owner == 'obsproject' && inputs.job == 'services'
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       checks: write
       contents: write
@@ -68,7 +68,7 @@ jobs:
   steam-upload:
     name: Upload Steam Builds 🚂
     if: github.repository_owner == 'obsproject' && inputs.job == 'steam'
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/steam-upload

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -166,7 +166,7 @@ jobs:
     name: Upload Steam Builds 🚂
     needs: check-tag
     if: github.repository_owner == 'obsproject' && fromJSON(needs.check-tag.outputs.validTag)
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/steam-upload

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -139,7 +139,7 @@ jobs:
   create-appcast:
     name: Create Sparkle Appcast 🎙️
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
-    runs-on: macos-13
+    runs-on: macos-14
     needs: build-project
     strategy:
       fail-fast: false
@@ -234,7 +234,7 @@ jobs:
           $shortHash = $env:GITHUB_SHA.Substring(0,9)
           "channel=${channel}" >> $env:GITHUB_OUTPUT
           "commitHash=${shortHash}" >> $env:GITHUB_OUTPUT
-          
+
           # Ensure files in action haven't been modified
           $folderHash = ''
           $files = Get-ChildItem "${{ github.workspace }}\repo\.github\actions\bouf"

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
   services-availability:
     name: Check Service Availability 🛜
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-13
+    runs-on: macos-14
     permissions:
       checks: write
       contents: write
@@ -133,7 +133,7 @@ jobs:
     name: Upload Steam Builds 🚂
     needs: [build-project]
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-13
+    runs-on: macos-14
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The macOS 14 runners are M1-based and more performant than the macOS 13 runners. They also seems less prone to random failure.

Since the access table has changed between macOS 13 and 14, try removing the hack to enable AppleScript. Also update to Xcode 15.2.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

The difference is staggering. You can find example runs with and without caching on my fork:
https://github.com/RytoEX/obs-studio/actions/runs/7749758334

Here are some average build and package times (based on averages across 6-10 runs of each scenario):

| Runner   | Cached | Build Time | Package Time |
| -------- | ------ | ---------- | ------------ |
| macos-13 | YES    | 7m20s      | 8m18s        |
| macos-13 | NO     | 9m43s      | 7m05s        |
| macos-14 | YES    | 4m16s      | 48s          |
| macos-14 | NO     | 4m38s      | 50s          |

Of course, I don't have signing/notarization set up on my fork, so the real packaging time may be higher than this, but I haven't yet seen the disk image creation fail or repeat.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my fork's CI.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
