### PR TITLE
UI: Fix RTMP check in Advanced output

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2273,8 +2273,8 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 	obs_service_t *service_obj = main->GetService();
 	const char *protocol = obs_service_get_protocol(service_obj);
 	if (protocol) {
-		if (strncmp(protocol, RTMP_PROTOCOL, strlen(RTMP_PROTOCOL)) ==
-		    0)
+		if (astrcmpi_n(protocol, RTMP_PROTOCOL,
+			       strlen(RTMP_PROTOCOL)) == 0)
 			is_rtmp = true;
 	}
 


### PR DESCRIPTION
### Description
RTMP protocol was not being recognized due to a string sensitive comparison; this changes to a case insensitive comparison to fix the issue. Fixes a bug found in beta channel.

### Motivation and Context
Fix a bug.
The bad detection of protocol was preventing Twitch VOD track from being enabled. 

### How Has This Been Tested?
Untested but the fix is obvious.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
