### PR TITLE
win-dshow: Fix YUY2 line size error

### DIFF
--- a/plugins/win-dshow/tiny-nv12-scale.c
+++ b/plugins/win-dshow/tiny-nv12-scale.c
@@ -159,7 +159,7 @@ static void nv12_convert_to_yuy2(nv12_scale_t *s, uint8_t *dst_start,
 				 const uint8_t *src_start)
 {
 	const int size = s->src_cx * s->src_cy;
-	const int size_dst_line = s->src_cx * 4;
+	const int size_dst_line = s->src_cx * 2;
 
 	register const uint8_t *src_y = src_start;
 	register const uint8_t *src_uv = src_y + size;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
NV12 to YUY2 scale will cause obs-virtualcam-module64.dll crash with error YUY2 line size

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
obs-virtualcam-module64.dll will cause my app crash because of this logic error

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
it's tested in my PC
OBS Video Color format select NV12 && Capture App Select YUY2
![image](https://github.com/obsproject/obs-studio/assets/82763161/a29e95ae-d79e-43a4-9b27-e356e685181f)
![image](https://github.com/obsproject/obs-studio/assets/82763161/60020a65-71bd-40a5-b959-88de3a4de390)


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
