### PR TITLE
libobs: Use 'important' usage key for macOS disk space calculations

### DIFF
--- a/libobs/util/platform-cocoa.m
+++ b/libobs/util/platform-cocoa.m
@@ -370,11 +370,11 @@ int64_t os_get_free_space(const char *path)
 
         NSDictionary *values = [fileURL resourceValuesForKeys:availableCapacityKeys error:nil];
 
-        NSNumber *availableOpportunisticSpace = values[NSURLVolumeAvailableCapacityForOpportunisticUsageKey];
+        NSNumber *availableImportantSpace = values[NSURLVolumeAvailableCapacityForImportantUsageKey];
         NSNumber *availableSpace = values[NSURLVolumeAvailableCapacityKey];
 
-        if (availableOpportunisticSpace.longValue > 0) {
-            return availableOpportunisticSpace.longValue;
+        if (availableImportantSpace.longValue > 0) {
+            return availableImportantSpace.longValue;
         } else {
             return availableSpace.longValue;
         }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->
A man, lost in a wood, stands at a crossroads. Hungry, tired, injured, and with 10 GB reported free according to Finder, he beseeches unto the void, "How is free disk space calculated on macOS?"

A voice emanates from the void. "Lo, `NSURLVolumeAvailableCapacityForOpportunisticUsageKey`".

A second calls forth. "Nay, `NSURLVolumeAvailableCapacityForImportantUsageKey`".

A third, more faintly. "`statvfs...`"

The voices begin to clamor together in discord. The answers become lost in a chorus of madness. They are drowned out. It is too late. You have perished. The disk... is already full.

## Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the free disk space calculation on macOS to use the value given to applications for "important usage", rather than "opportunistic usage." 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There is nothing in the way of hard documentation from Apple about what exactly a free disk space calculation for "opportunistic usage" includes versus "important usage." On my 1TB M1 Max machine with 32GB of RAM, these values can differ by 15 GB or more, despite there being only 5-6 GB of purgeable space according to Finder. As a user, I have found myself with 10 GB free according to Finder, but 0 GB free according to OBS, and unable to create recordings.

Without hard documentation, I cannot say why exactly this is, as most users seem to have more space afforded to them for "opportunistic usage." If there are others like me, however, I can foresee anger when they are met with the inability to record despite Finder telling them they have plenty of free disk space.

When I do consult the documentation for answers, I am met with this paragraph on the subject: 

<img width="822" alt="Screenshot 2024-02-05 at 7 29 00 PM" src="https://github.com/obsproject/obs-studio/assets/6864788/c1d4f9df-a50d-45f2-a0a9-86eac91c12af">

At the risk of undertaking hermeneutics, I would say that it seems like OBS's usage is much closer to constituting "important" than "opportunistic" under this definition. The user is doing more than wanting to play a video, they want to create one, whether as part of a production, or for personal endeavors; regardless, it's very much what they want to do. Hence, OBS should not stand in their way, and by using that query key we will think we are out of disk space when other, sillier applications can still write.

In testing, this seems to bring OBS much more in line with the value reported by Finder for free space, on my machine. This was the stated purpose of https://github.com/obsproject/obs-studio/pull/9881, and I think that whatever edge case my machine is was just not foreseen. Again, for most users, free space for opportunistic and important usage seem to be very close together, but for the edge cases, this seems to bring the space usage closer to the "commonly accepted value".

For volumes where this key reports 0 (exFAT, etc.), as would opportunistic, we still fall back to the basic `NSURLVolumeAvailableCapacityKey`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my machine. Before changes:
* Finder reports 82.57 GB free, 6.63 purgeable
* OBS reports 63.0 GB free

After changes:
* OBS reports 74.9 GB free.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
