### PR TITLE
docs: Add deque to the table of content and fix ROI underline

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -267,7 +267,7 @@ Raw Frame Data Structure (encoder_frame)
 
 
 Encoder Region of Interest Structure (obs_encoder_roi)
------------------------------------------
+------------------------------------------------------
 
 .. struct:: obs_encoder_roi
 
@@ -277,7 +277,7 @@ Encoder Region of Interest Structure (obs_encoder_roi)
             uint32_t bottom
             uint32_t left
             uint32_t right
-   
+
    The rectangle edges of the region are specified as number of pixels from the input video's top and left edges (i.e. row/column 0).
 
 .. member:: float priority
@@ -562,7 +562,7 @@ General Encoder Functions
 .. function:: void obs_encoder_enum_roi(obs_encoder_t *encoder, void (*enum_proc)(void *, struct obs_encoder_roi *), void *param)
 
     Enumerate currently configured ROIs by invoking callback for each entry, in reverse order of addition (i.e. most recent to oldest).
-    
+
     **Note:** If the encoder has scaling enabled the struct passed to the callback will be scaled accordingly.
 
 ---------------------
@@ -570,7 +570,7 @@ General Encoder Functions
 .. function:: uint32_t obs_encoder_get_roi_increment(const obs_encoder_t *encoder)
 
    Encoders shall refresh their ROI configuration if the increment value changes.
-    
+
    :return: Increment/revision of ROI list
 
 ---------------------

--- a/docs/sphinx/reference-libobs-util-circlebuf.rst
+++ b/docs/sphinx/reference-libobs-util-circlebuf.rst
@@ -4,7 +4,8 @@ Circular Buffers
 A circular buffer that will automatically increase in size as necessary
 as data is pushed to the front or back.
 
-.. deprecated:: 3X.0
+.. deprecated:: 30.1
+   Replaced by :doc:`reference-libobs-util-deque`
 
 .. code:: cpp
 

--- a/docs/sphinx/reference-libobs-util.rst
+++ b/docs/sphinx/reference-libobs-util.rst
@@ -9,6 +9,7 @@ Platform/Utility API Reference (libobs/util)
    reference-libobs-util-circlebuf
    reference-libobs-util-config-file
    reference-libobs-util-darray
+   reference-libobs-util-deque
    reference-libobs-util-dstr
    reference-libobs-util-platform
    reference-libobs-util-profiler


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes warnings that sphinx reported that comes from "recent" changes:
- Add deque to libobs/util table of content
- Fix title underline of obs_encoder_roi

Also fix a deprecation note for circlebuf that was set to a placeholder version (`3X.0`).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix docs warnings right after I found them.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

`make html` and Sphinx didn't complain of the issues fixed by the changes and deque is shown in the libobs/util TOC.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
