### PR TITLE
Get the device pixel ratio from the correct device

### DIFF
--- a/plugins/obs-vst/win/EditorWidget-win.cpp
+++ b/plugins/obs-vst/win/EditorWidget-win.cpp
@@ -35,8 +35,8 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 	LONG_PTR wndPtr = (LONG_PTR)effect;
 	SetWindowLongPtr(windowHandle, -21 /*GWLP_USERDATA*/, wndPtr);
 
-	QWidget *widget = QWidget::createWindowContainer(
-		QWindow::fromWinId((WId)windowHandle), nullptr);
+	QWindow *window = QWindow::fromWinId((WId)windowHandle);
+	QWidget *widget = QWidget::createWindowContainer(window, nullptr);
 	widget->move(0, 0);
 	QGridLayout *layout = new QGridLayout();
 	layout->setContentsMargins(0, 0, 0, 0);
@@ -52,7 +52,7 @@ void EditorWidget::buildEffectContainer(AEffect *effect)
 		// on Windows, the size reported by 'effect' is larger than
 		// its actuall size by a factor of the monitor's ui scale,
 		// so the window size should be divided by the factor
-		qreal scale_factor = devicePixelRatioF();
+		qreal scale_factor = window->devicePixelRatio();
 		int width = vstRect->right - vstRect->left;
 		int height = vstRect->bottom - vstRect->top;
 		width = static_cast<int>(width / scale_factor);
@@ -81,7 +81,8 @@ void EditorWidget::handleResizeRequest(int, int)
 		// on Windows, the size reported by 'effect' is larger than
 		// its actuall size by a factor of the monitor's ui scale,
 		// so the window size should be divided by the factor
-		qreal scale_factor = devicePixelRatioF();
+		QWindow *window = QWindow::fromWinId((WId)windowHandle);
+		qreal scale_factor = window->devicePixelRatio();
 		int width = rec->right - rec->left;
 		int height = rec->bottom - rec->top;
 		width = static_cast<int>(width / scale_factor);


### PR DESCRIPTION
Fixes small mistake in 542cb876dce6077bb24fa5ee0439e7d21ac53f59

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Should fix a small mistake in 542cb876dce6077bb24fa5ee0439e7d21ac53f59 by taking the scaling factor (dpi) from the display the widget is on, instead of the main display

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The old commit took the scale factor with devicePixelRatioF, but that seems to be the scale factor of the main monitor.
Which is not necessarily the same as the scale factor the VST plugin (widget) is on.

And this indeed causes a problem in the following situation
- I'm running OBS on my second monitor on 100%
- My main monitor is running on 125%
- I open the plugin window, which reports a size of 1000x500 (and creates a child window of that size)
- OBS gives me a host window on my second (100%) monitor

Expected behaviour:
- The host window is 1000x500 as it is on a 100% monitor

Observed behaviour:
- The host window is scaled down to 800x400 (divided by 1.25)

Here is an image of the consequences (note the cut-off contents on the right and bottom sides):
![image](https://github.com/obsproject/obs-studio/assets/10848631/a9497ec2-e165-475f-aa93-47960a8ed650)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
I'm calling a function on a specific window.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
This is my first ever pull request, no idea what to do or how to do these things. I just wanted to fix a bug.