### PR TITLE
UI: Fill audio meter background each update (#9842)

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1417,6 +1417,10 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 
 	QPainter painter(this);
 
+	// Paint window background color (as widget is opaque)
+	QColor background = palette().color(QPalette::ColorRole::Window);
+	painter.fillRect(event->region().boundingRect(), background);
+
 	if (vertical)
 		height -= METER_PADDING * 2;
 
@@ -1425,11 +1429,6 @@ void VolumeMeter::paintEvent(QPaintEvent *event)
 	if (event->region().boundingRect() != getBarRect()) {
 		if (needLayoutChange())
 			doLayout();
-
-		// Paint window background color (as widget is opaque)
-		QColor background =
-			palette().color(QPalette::ColorRole::Window);
-		painter.fillRect(widgetRect, background);
 
 		if (vertical) {
 			paintVTicks(painter,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Since the audio mixer widget is marked as being opaque it is necessary to draw all of it's pixels in the drawing region. Pixels not being drawn will leave transparent pixels (on Wayland at least) causing undesired effects.

Previously, the background was not filled when only the meters were repainted. Since the meters don't paint the complete region (spacing, padding etc.) some pixels in the region ended up not being painted.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Addressing https://github.com/obsproject/obs-studio/issues/9824

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Locally run on GNOME/Wayland which was affected by the bug. After applied fix, the audio mixer looks correctly.

Hopefully this does not regress other platforms..

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
