### PR TITLE
win-dshow: Add generated Windows resource file to virtualcam sources

### DIFF
--- a/plugins/win-dshow/virtualcam-module/CMakeLists.txt
+++ b/plugins/win-dshow/virtualcam-module/CMakeLists.txt
@@ -60,7 +60,13 @@ if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
   target_sources(
     _virtualcam
     INTERFACE # cmake-format: sortable
-              placeholder.cpp sleepto.c sleepto.h virtualcam-filter.cpp virtualcam-filter.hpp virtualcam-module.cpp)
+              ${CMAKE_CURRENT_BINARY_DIR}/virtualcam-module.rc
+              placeholder.cpp
+              sleepto.c
+              sleepto.h
+              virtualcam-filter.cpp
+              virtualcam-filter.hpp
+              virtualcam-module.cpp)
   target_include_directories(_virtualcam INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
   target_compile_definitions(_virtualcam INTERFACE VIRTUALCAM_AVAILABLE)
   set_property(TARGET _virtualcam PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")


### PR DESCRIPTION
### Description
Add the generated Windows resource file to the shared interface sources of the 64-bit and 32-bit virtual camera sources.

### Motivation and Context
Ensures that the generated virtual camera DLLs contain correct metadata information.

### How Has This Been Tested?
Tested on Windows 11, checked the properties of the generated DLL files.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
