### PR TITLE
Use flathub-infra images & various other cleanups

### DIFF
--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -52,15 +52,9 @@ runs:
         done
 
         n_errors=$(echo $ret | jq '.errors | length')
-        for ((i = 0 ; i < $(echo $ret | jq '.errors | length') ; i++)); do
+        for ((i = 0 ; i < $n_errors ; i++)); do
           error=$(echo $ret | jq ".errors[$i]")
-
-          if [[ "${{ inputs.validateToPublish }}" == "false" && "${error//\"}" == "appstream-screenshots-not-mirrored" ]]; then
-            echo "::notice::$error found and ignored in the Flatpak ${{ inputs.artifact }}"
-            n_errors=$(($n_errors-1))
-          else
-            echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
-          fi
+          echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
         done
 
         [[ $n_errors == 0 ]] || exit 2

--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -7,10 +7,6 @@ inputs:
   path:
     description: Path to flatpak-builder manifest or Flatpak build directory
     required: true
-  validateToPublish:
-    description: If false, turns some errors to non-errors for non-publish workflow
-    required: false
-    default: true
   workingDirectory:
     description: Working directory to clone flatpak-builder-lint
     required: false

--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -33,23 +33,6 @@ runs:
             ;;
         esac
 
-    - uses: actions/checkout@v4
-      with:
-        repository: flathub/flatpak-builder-lint
-        ref: v2.0.13
-        path: flatpak-builder-lint
-        set-safe-directory: ${{ inputs.workingDirectory }}
-
-    - name: Install Dependencies 🛍️
-      shell: bash
-      working-directory: ${{ inputs.workingDirectory }}
-      run: |
-        : Install Dependencies 🛍️
-        echo ::group::Install Dependencies
-        dnf install -y -q poetry jq
-        poetry -q -C flatpak-builder-lint install
-        echo ::endgroup::
-
     - name: Run flatpak-builder-lint
       id: result
       shell: bash
@@ -57,7 +40,7 @@ runs:
       run: |
         : Run flatpak-builder-lint
         exit_code=0
-        ret=$(poetry -C flatpak-builder-lint run flatpak-builder-lint --exceptions ${{ inputs.artifact }} ${{ inputs.path }}) || exit_code=$?
+        ret=$(flatpak-builder-lint --exceptions ${{ inputs.artifact }} ${{ inputs.path }}) || exit_code=$?
         if [[ $exit_code != 0 && -z "$ret" ]]; then
           echo "::error::Error while running flatpak-builder-lint"
           exit 2

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -245,7 +245,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.5
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.5
       options: --privileged
     steps:
       - uses: actions/checkout@v4
@@ -264,8 +264,7 @@ jobs:
 
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-          echo '::group::Install GitHub CLI tool'
-          dnf install -y -q gh
+          echo '::group::Install actions/gh-actions-cache'
           gh extension install actions/gh-actions-cache
           echo '::endgroup::'
 

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -245,7 +245,7 @@ jobs:
       run:
         shell: bash
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.5
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.6
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -297,6 +297,7 @@ jobs:
           cache: ${{ fromJSON(steps.setup.outputs.cacheHit) || (github.event_name == 'push' && github.ref_name == 'master')}}
           restore-cache: ${{ fromJSON(steps.setup.outputs.cacheHit) }}
           cache-key: ${{ steps.setup.outputs.cacheKey }}
+          mirror-screenshots-url: https://dl.flathub.org/repo/screenshots
 
       - name: Validate build directory
         uses: ./.github/actions/flatpak-builder-lint

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -286,7 +286,6 @@ jobs:
         with:
           artifact: manifest
           path: build-aux/com.obsproject.Studio.json
-          validateToPublish: false
 
       - name: Build Flatpak Manifest 🧾
         uses: flatpak/flatpak-github-actions/flatpak-builder@0ab9dd6a6afa6fe7e292db0325171660bf5b6fdf
@@ -304,14 +303,12 @@ jobs:
         with:
           artifact: builddir
           path: flatpak_app
-          validateToPublish: false
 
       - name: Validate repository
         uses: ./.github/actions/flatpak-builder-lint
         with:
           artifact: repo
           path: repo
-          validateToPublish: false
 
   windows-build:
     name: Windows 🪟

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
       YOUTUBE_SECRET: ${{ secrets.YOUTUBE_SECRET }}
       YOUTUBE_SECRET_HASH: ${{ secrets.YOUTUBE_SECRET_HASH }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.5
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.6
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -126,11 +126,6 @@ jobs:
           test -f app-info/icons/flatpak/128x128/com.obsproject.Studio.png || { echo "Missing 128x128 icon in app-info!"; exit 1; }
           test -f app-info/xmls/com.obsproject.Studio.xml.gz || { echo "Missing com.obsproject.Studio.xml.gz in app-info!"; exit 1; }
 
-      - name: Commit Screenshots to OSTree Repository
-        run: |
-          : Commit Screenshots to OSTree Repository
-          ostree commit --repo=repo --canonical-permissions --branch=screenshots/x86_64 flatpak_app/screenshots
-
       - name: Validate build directory
         uses: ./.github/actions/flatpak-builder-lint
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,7 +59,7 @@ jobs:
       YOUTUBE_SECRET: ${{ secrets.YOUTUBE_SECRET }}
       YOUTUBE_SECRET_HASH: ${{ secrets.YOUTUBE_SECRET_HASH }}
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-6.5
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.5
       options: --privileged
     strategy:
       matrix:
@@ -81,7 +81,6 @@ jobs:
 
           git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-          dnf install -y -q gh
           gh extension install actions/gh-actions-cache
 
           cache_key='flatpak-builder-${{ hashFiles('build-aux/**/*.json') }}'


### PR DESCRIPTION
### Description

It's a ultimately a temporary workaround while the whole situation with libappstream, Flatpak, and flatpak-builder isn't figured out. But it does seem to work.

### Motivation and Context

The Flathub publishing workflow is broken due to an odd flatpak-builder / appstream impedance mismatch, and this works around that.

### How Has This Been Tested?

The publishing job goes beyond the build step: https://github.com/GeorgesStavracas/obs-studio/actions/runs/7888002165/job/21524497985 (CI fails because I don't have the OBS Studio publishing tokens in my repo, but that's not important)

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
