### PR TITLE
UI: Volume signal cleanup

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -5,6 +5,7 @@
 #include "mute-checkbox.hpp"
 #include "slider-ignorewheel.hpp"
 #include "slider-absoluteset-style.hpp"
+#include "source-label.hpp"
 #include <QFontDatabase>
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -219,16 +220,6 @@ void VolControl::updateText()
 	slider->setAccessibleName(accText);
 }
 
-QString VolControl::GetName() const
-{
-	return nameLabel->text();
-}
-
-void VolControl::SetName(const QString &newName)
-{
-	nameLabel->setText(newName);
-}
-
 void VolControl::EmitConfigClicked()
 {
 	emit ConfigClicked();
@@ -253,7 +244,7 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	  vertical(vertical),
 	  contextMenu(nullptr)
 {
-	nameLabel = new QLabel();
+	nameLabel = new OBSSourceLabel(source);
 	volLabel = new QLabel();
 	mute = new MuteCheckBox();
 

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -379,14 +379,13 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	obs_fader_add_callback(obs_fader, OBSVolumeChanged, this);
 	obs_volmeter_add_callback(obs_volmeter, OBSVolumeLevel, this);
 
-	signal_handler_connect(obs_source_get_signal_handler(source), "mute",
-			       OBSVolumeMuted, this);
-	signal_handler_connect(obs_source_get_signal_handler(source),
-			       "audio_mixers", OBSMixersOrMonitoringChanged,
-			       this);
-	signal_handler_connect(obs_source_get_signal_handler(source),
-			       "audio_monitoring", OBSMixersOrMonitoringChanged,
-			       this);
+	sigs.emplace_back(obs_source_get_signal_handler(source), "mute",
+			  OBSVolumeMuted, this);
+	sigs.emplace_back(obs_source_get_signal_handler(source), "audio_mixers",
+			  OBSMixersOrMonitoringChanged, this);
+	sigs.emplace_back(obs_source_get_signal_handler(source),
+			  "audio_monitoring", OBSMixersOrMonitoringChanged,
+			  this);
 
 	QWidget::connect(slider, &VolumeSlider::valueChanged, this,
 			 &VolControl::SliderChanged);
@@ -422,14 +421,7 @@ VolControl::~VolControl()
 	obs_fader_remove_callback(obs_fader, OBSVolumeChanged, this);
 	obs_volmeter_remove_callback(obs_volmeter, OBSVolumeLevel, this);
 
-	signal_handler_disconnect(obs_source_get_signal_handler(source), "mute",
-				  OBSVolumeMuted, this);
-	signal_handler_disconnect(obs_source_get_signal_handler(source),
-				  "audio_mixers", OBSMixersOrMonitoringChanged,
-				  this);
-	signal_handler_disconnect(obs_source_get_signal_handler(source),
-				  "audio_monitoring",
-				  OBSMixersOrMonitoringChanged, this);
+	sigs.clear();
 
 	if (contextMenu)
 		contextMenu->close();

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -272,6 +272,7 @@ protected:
 class QLabel;
 class QSlider;
 class MuteCheckBox;
+class OBSSourceLabel;
 
 class VolControl : public QWidget {
 	Q_OBJECT
@@ -279,7 +280,7 @@ class VolControl : public QWidget {
 private:
 	OBSSource source;
 	std::vector<OBSSignal> sigs;
-	QLabel *nameLabel;
+	OBSSourceLabel *nameLabel;
 	QLabel *volLabel;
 	VolumeMeter *volMeter;
 	QSlider *slider;
@@ -320,9 +321,6 @@ public:
 	~VolControl();
 
 	inline obs_source_t *GetSource() const { return source; }
-
-	QString GetName() const;
-	void SetName(const QString &newName);
 
 	void SetMeterDecayRate(qreal q);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);

--- a/UI/volume-control.hpp
+++ b/UI/volume-control.hpp
@@ -278,6 +278,7 @@ class VolControl : public QWidget {
 
 private:
 	OBSSource source;
+	std::vector<OBSSignal> sigs;
 	QLabel *nameLabel;
 	QLabel *volLabel;
 	VolumeMeter *volMeter;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3339,11 +3339,6 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 {
 	RenameListValues(ui->scenes, newName, prevName);
 
-	for (size_t i = 0; i < volumes.size(); i++) {
-		if (volumes[i]->GetName().compare(prevName) == 0)
-			volumes[i]->SetName(newName);
-	}
-
 	if (vcamConfig.type == VCamOutputType::SourceOutput &&
 	    prevName == QString::fromStdString(vcamConfig.source))
 		vcamConfig.source = newName.toStdString();


### PR DESCRIPTION
### Description
Commit 1 - Use vector for volume signals
Commit 2 - Use OBSSourceLabel for volume controls

### Motivation and Context
Cleaner code

### How Has This Been Tested?
Used volume controls and renamed sources

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
