### PR TITLE
UI: Move projector rename signal

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3344,11 +3344,6 @@ void OBSBasic::RenameSources(OBSSource source, QString newName,
 			volumes[i]->SetName(newName);
 	}
 
-	for (size_t i = 0; i < projectors.size(); i++) {
-		if (projectors[i]->GetSource() == source)
-			projectors[i]->RenameProjector(prevName, newName);
-	}
-
 	if (vcamConfig.type == VCamOutputType::SourceOutput &&
 	    prevName == QString::fromStdString(vcamConfig.source))
 		vcamConfig.source = newName.toStdString();

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -21,8 +21,10 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 {
 	OBSSource source = GetSource();
 	if (source) {
-		destroyedSignal.Connect(obs_source_get_signal_handler(source),
-					"destroy", OBSSourceDestroyed, this);
+		sigs.emplace_back(obs_source_get_signal_handler(source),
+				  "rename", OBSSourceRenamed, this);
+		sigs.emplace_back(obs_source_get_signal_handler(source),
+				  "destroy", OBSSourceDestroyed, this);
 	}
 
 	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
@@ -106,6 +108,8 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 
 OBSProjector::~OBSProjector()
 {
+	sigs.clear();
+
 	bool isMultiview = type == ProjectorType::Multiview;
 	obs_display_remove_draw_callback(
 		GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender,
@@ -213,6 +217,17 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 		obs_render_main_texture();
 
 	endRegion();
+}
+
+void OBSProjector::OBSSourceRenamed(void *data, calldata_t *params)
+{
+	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
+	QString oldName = calldata_string(params, "prev_name");
+	QString newName = calldata_string(params, "new_name");
+
+	QMetaObject::invokeMethod(window, "RenameProjector",
+				  Q_ARG(QString, oldName),
+				  Q_ARG(QString, newName));
 }
 
 void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)

--- a/UI/window-projector.hpp
+++ b/UI/window-projector.hpp
@@ -19,10 +19,11 @@ class OBSProjector : public OBSQTDisplay {
 
 private:
 	OBSWeakSourceAutoRelease weakSource;
-	OBSSignal destroyedSignal;
+	std::vector<OBSSignal> sigs;
 
 	static void OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy);
 	static void OBSRender(void *data, uint32_t cx, uint32_t cy);
+	static void OBSSourceRenamed(void *data, calldata_t *params);
 	static void OBSSourceDestroyed(void *data, calldata_t *params);
 
 	void mousePressEvent(QMouseEvent *event) override;
@@ -53,6 +54,7 @@ private slots:
 	void OpenWindowedProjector();
 	void AlwaysOnTopToggled(bool alwaysOnTop);
 	void ScreenRemoved(QScreen *screen_);
+	void RenameProjector(QString oldName, QString newName);
 
 public:
 	OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
@@ -63,7 +65,6 @@ public:
 	ProjectorType GetProjectorType();
 	int GetMonitor();
 	static void UpdateMultiviewProjectors();
-	void RenameProjector(QString oldName, QString newName);
 	void SetHideCursor();
 
 	bool IsAlwaysOnTop() const;


### PR DESCRIPTION
### Description
This moves the renaming of projectors from OBSBasic to OBSProjector.

### Motivation and Context
Makes projector code more self contained

### How Has This Been Tested?
Renamed sources

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
