### PR TITLE
UI: Fix paused text stacking

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -550,9 +550,13 @@ void OBSBasicStatusBar::RecordingStopped()
 
 void OBSBasicStatusBar::RecordingPaused()
 {
-	QString text = statusWidget->ui->recordTime->text() +
-		       QStringLiteral(" (PAUSED)");
-	statusWidget->ui->recordTime->setText(text);
+	if (!statusWidget->ui->recordTime->text().contains(
+		    QStringLiteral(" (PAUSED)"))) {
+		QString text = statusWidget->ui->recordTime->text() +
+			       QStringLiteral(" (PAUSED)");
+
+		statusWidget->ui->recordTime->setText(text);
+	}
 
 	if (recordOutput) {
 		statusWidget->ui->recordIcon->setPixmap(recordingPausePixmap);


### PR DESCRIPTION
### Description
Whenever the pause button was clicked rapidly the " (PAUSED)" string next to the recording timestamp was repeated.
As shown is this screenshot:
![image](https://github.com/obsproject/obs-studio/assets/7949410/075b21d9-f58c-4068-ac53-167f708e4c3c)
I simply added a condition to prevent changing the text if the " (PAUSED)" string is already appended to the timestamp
![image](https://github.com/obsproject/obs-studio/assets/7949410/229efb73-6f5a-49a0-ad27-1f63809c1ef8)

### Motivation and Context
Just a simple UI contribution to fix issue #10218 

### How Has This Been Tested?
Tested on windows 10.
OBS version 30.0.2.
Simply clicked rapidly the pause button to attest that the string didn't appended more than once.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
