### PR TITLE
UI: Fix Remux window only being usable once

### DIFF
--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -585,13 +585,11 @@ void RemuxQueueModel::endProcessing()
 	}
 
 	// Signal that the insertion point exists again.
-
+	isProcessing = false;
 	if (!autoRemux) {
 		beginInsertRows(QModelIndex(), queue.length(), queue.length());
 		endInsertRows();
 	}
-
-	isProcessing = false;
 
 	emit dataChanged(index(0, RemuxEntryColumn::State),
 			 index(queue.length(), RemuxEntryColumn::State));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The beginInsertRows/endInsertRows calls seem to signal that the rowCount has changed, and that views should adjust accordingly. The isProcessing boolean changes the returned value of RemuxQueueModel::rowCount, which seems to cause the empty row in the table model to disappear permanently. I still don't know why it used to work this way and no longer does.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #9878

I haven't done any Qt bisects yet between 6.5.2 and 6.5.3 to figure out exactly what commit changed this behavior, but these are my current guesses:
* https://github.com/qt/qtbase/commit/25f92391a48b6acb41e44eab7bdcd0086f46d427
* https://github.com/qt/qtbase/commit/703b48a7c01223e9163ded1fddc9940bdc5028a6

I still don't know if this change is correct, and would appreciate reviews.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
