### PR TITLE
win-capture: Fix leak in wasapi reroute proc call

### DIFF
--- a/plugins/win-capture/audio-helpers.c
+++ b/plugins/win-capture/audio-helpers.c
@@ -22,10 +22,10 @@ static inline void reroute_wasapi_source(obs_source_t *wasapi,
 					 obs_source_t *target)
 {
 	proc_handler_t *ph = obs_source_get_proc_handler(wasapi);
-	calldata_t *cd = calldata_create();
-	calldata_set_ptr(cd, "target", target);
-	proc_handler_call(ph, "reroute_audio", cd);
-	calldata_free(cd);
+	calldata_t cd = {0};
+	calldata_set_ptr(&cd, "target", target);
+	proc_handler_call(ph, "reroute_audio", &cd);
+	calldata_free(&cd);
 }
 
 void setup_audio_source(obs_source_t *parent, obs_source_t **child,


### PR DESCRIPTION
### Description

Fixes a memory leak.

### Motivation and Context

Leaks bad.

### How Has This Been Tested?

Ran.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
