### PR TITLE
UI: Use OBSSourceLabel for item widget labels

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -3,6 +3,7 @@
 #include "source-tree.hpp"
 #include "qt-wrappers.hpp"
 #include "platform.hpp"
+#include "source-label.hpp"
 
 #include <obs-frontend-api.h>
 #include <obs.h>
@@ -96,7 +97,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	lock->setAccessibleDescription(
 		QTStr("Basic.Main.Sources.LockDescription").arg(name));
 
-	label = new QLabel(QT_UTF8(name));
+	label = new OBSSourceLabel(source);
 	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 	label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 	label->setAttribute(Qt::WA_TranslucentBackground);
@@ -288,15 +289,6 @@ void SourceTreeItem::ReconnectSignals()
 
 	/* --------------------------------------------------------- */
 
-	auto renamed = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ =
-			reinterpret_cast<SourceTreeItem *>(data);
-		const char *name = calldata_string(cd, "new_name");
-
-		QMetaObject::invokeMethod(this_, "Renamed",
-					  Q_ARG(QString, QT_UTF8(name)));
-	};
-
 	auto removeSource = [](void *data, calldata_t *) {
 		SourceTreeItem *this_ =
 			reinterpret_cast<SourceTreeItem *>(data);
@@ -307,7 +299,6 @@ void SourceTreeItem::ReconnectSignals()
 
 	obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 	signal = obs_source_get_signal_handler(source);
-	sigs.emplace_back(signal, "rename", renamed, this);
 	sigs.emplace_back(signal, "remove", removeSource, this);
 }
 
@@ -470,7 +461,6 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 				redo, uuid, uuid);
 
 	obs_source_set_name(source, newName.c_str());
-	label->setText(QT_UTF8(newName.c_str()));
 }
 
 bool SourceTreeItem::eventFilter(QObject *object, QEvent *event)
@@ -507,11 +497,6 @@ void SourceTreeItem::LockedChanged(bool locked)
 {
 	lock->setChecked(locked);
 	OBSBasic::Get()->UpdateEditMenu();
-}
-
-void SourceTreeItem::Renamed(const QString &name)
-{
-	label->setText(name);
 }
 
 void SourceTreeItem::Update(bool force)

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -13,6 +13,7 @@
 #include <obs-frontend-api.h>
 
 class QLabel;
+class OBSSourceLabel;
 class QCheckBox;
 class QLineEdit;
 class SourceTree;
@@ -57,7 +58,7 @@ private:
 	QCheckBox *vis = nullptr;
 	QCheckBox *lock = nullptr;
 	QHBoxLayout *boxLayout = nullptr;
-	QLabel *label = nullptr;
+	OBSSourceLabel *label = nullptr;
 
 	QLineEdit *editor = nullptr;
 
@@ -79,7 +80,6 @@ private slots:
 
 	void VisibilityChanged(bool visible);
 	void LockedChanged(bool locked);
-	void Renamed(const QString &name);
 
 	void ExpandClicked(bool checked);
 

--- a/UI/visibility-item-widget.cpp
+++ b/UI/visibility-item-widget.cpp
@@ -1,6 +1,7 @@
 #include "visibility-item-widget.hpp"
 #include "qt-wrappers.hpp"
 #include "obs-app.hpp"
+#include "source-label.hpp"
 #include <QListWidget>
 #include <QLineEdit>
 #include <QHBoxLayout>
@@ -12,11 +13,8 @@
 VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 	: source(source_),
 	  enabledSignal(obs_source_get_signal_handler(source), "enable",
-			OBSSourceEnabled, this),
-	  renamedSignal(obs_source_get_signal_handler(source), "rename",
-			OBSSourceRenamed, this)
+			OBSSourceEnabled, this)
 {
-	const char *name = obs_source_get_name(source);
 	bool enabled = obs_source_enabled(source);
 
 	vis = new QCheckBox();
@@ -24,7 +22,7 @@ VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 	vis->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 	vis->setChecked(enabled);
 
-	label = new QLabel(QT_UTF8(name));
+	label = new OBSSourceLabel(source);
 	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
 	QHBoxLayout *itemLayout = new QHBoxLayout();
@@ -50,26 +48,10 @@ void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)
 				  Q_ARG(bool, enabled));
 }
 
-void VisibilityItemWidget::OBSSourceRenamed(void *param, calldata_t *data)
-{
-	VisibilityItemWidget *window =
-		reinterpret_cast<VisibilityItemWidget *>(param);
-	const char *name = calldata_string(data, "new_name");
-
-	QMetaObject::invokeMethod(window, "SourceRenamed",
-				  Q_ARG(QString, QT_UTF8(name)));
-}
-
 void VisibilityItemWidget::SourceEnabled(bool enabled)
 {
 	if (vis->isChecked() != enabled)
 		vis->setChecked(enabled);
-}
-
-void VisibilityItemWidget::SourceRenamed(QString name)
-{
-	if (label && name != label->text())
-		label->setText(name);
 }
 
 void VisibilityItemWidget::SetColor(const QColor &color, bool active_,

--- a/UI/visibility-item-widget.hpp
+++ b/UI/visibility-item-widget.hpp
@@ -9,28 +9,25 @@ class QLineEdit;
 class QListWidget;
 class QListWidgetItem;
 class QCheckBox;
+class OBSSourceLabel;
 
 class VisibilityItemWidget : public QWidget {
 	Q_OBJECT
 
 private:
 	OBSSource source;
-	QLabel *label = nullptr;
+	OBSSourceLabel *label = nullptr;
 	QCheckBox *vis = nullptr;
-	QString oldName;
 
 	OBSSignal enabledSignal;
-	OBSSignal renamedSignal;
 
 	bool active = false;
 	bool selected = false;
 
 	static void OBSSourceEnabled(void *param, calldata_t *data);
-	static void OBSSourceRenamed(void *param, calldata_t *data);
 
 private slots:
 	void SourceEnabled(bool enabled);
-	void SourceRenamed(QString name);
 
 public:
 	VisibilityItemWidget(obs_source_t *source);


### PR DESCRIPTION
### Description
This changes the labels for the source tree/visibility item widgets to use OBSSourceLabel, as it handles the renaming of sources.

### Motivation and Context
Less code

### How Has This Been Tested?
Renamed sources in the filters dialog and the source tree

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
