### PR TITLE
UI: Use signal vector for status bar

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -507,11 +507,11 @@ void OBSBasicStatusBar::StreamStarted(obs_output_t *output)
 {
 	streamOutput = output;
 
-	signal_handler_connect(obs_output_get_signal_handler(streamOutput),
-			       "reconnect", OBSOutputReconnect, this);
-	signal_handler_connect(obs_output_get_signal_handler(streamOutput),
-			       "reconnect_success", OBSOutputReconnectSuccess,
-			       this);
+	streamSigs.emplace_back(obs_output_get_signal_handler(streamOutput),
+				"reconnect", OBSOutputReconnect, this);
+	streamSigs.emplace_back(obs_output_get_signal_handler(streamOutput),
+				"reconnect_success", OBSOutputReconnectSuccess,
+				this);
 
 	retries = 0;
 	lastBytesSent = 0;
@@ -522,12 +522,7 @@ void OBSBasicStatusBar::StreamStarted(obs_output_t *output)
 void OBSBasicStatusBar::StreamStopped()
 {
 	if (streamOutput) {
-		signal_handler_disconnect(
-			obs_output_get_signal_handler(streamOutput),
-			"reconnect", OBSOutputReconnect, this);
-		signal_handler_disconnect(
-			obs_output_get_signal_handler(streamOutput),
-			"reconnect_success", OBSOutputReconnectSuccess, this);
+		streamSigs.clear();
 
 		ReconnectClear();
 		streamOutput = nullptr;

--- a/UI/window-basic-status-bar.hpp
+++ b/UI/window-basic-status-bar.hpp
@@ -28,6 +28,7 @@ private:
 	StatusBarWidget *statusWidget = nullptr;
 
 	obs_output_t *streamOutput = nullptr;
+	std::vector<OBSSignal> streamSigs;
 	obs_output_t *recordOutput = nullptr;
 	bool active = false;
 	bool overloadedNotify = true;


### PR DESCRIPTION
### Description
The stream output signals are now put inside of a vector.

### Motivation and Context
Less code

### How Has This Been Tested?
Disconnected and reconnected stream

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
