### PR TITLE
UI: Don't reserve signal vector size

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1856,7 +1856,6 @@ void OBSBasic::InitOBSCallbacks()
 {
 	ProfileScope("OBSBasic::InitOBSCallbacks");
 
-	signalHandlers.reserve(signalHandlers.size() + 7);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_create",
 				    OBSBasic::SourceCreated, this);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_remove",

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2710,8 +2710,6 @@ void OBSBasicSettings::LoadAudioSources()
 		HookWidget(pttCB, CHECK_CHANGED, AUDIO_CHANGED);
 		HookWidget(pttSB, SCROLL_CHANGED, AUDIO_CHANGED);
 
-		audioSourceSignals.reserve(audioSourceSignals.size() + 4);
-
 		auto handler = obs_source_get_signal_handler(source);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_mute_changed",


### PR DESCRIPTION
### Description
In no other place in the program do we reserve the vector size when using them for signals. This creates an extra step
if signals are added or removed.

### Motivation and Context
One less extra step to worry about

### How Has This Been Tested?
Ran OBS and everything still worked

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
