### PR TITLE
mac-capture: Fix crash in device reconnect handler

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -811,11 +811,6 @@ static void coreaudio_uninit(struct coreaudio_data *ca)
 		bfree(ca->channel_names);
 		ca->channel_names = NULL;
 	}
-
-	if (ca->channel_map) {
-		bfree(ca->channel_map);
-		ca->channel_map = NULL;
-	}
 }
 
 /* ------------------------------------------------------------------------- */
@@ -854,6 +849,12 @@ static void coreaudio_destroy(void *data)
 		coreaudio_shutdown(ca);
 
 		os_event_destroy(ca->exit_event);
+
+		if (ca->channel_map) {
+			bfree(ca->channel_map);
+			ca->channel_map = NULL;
+		}
+
 		bfree(ca->device_name);
 		bfree(ca->device_uid);
 		bfree(ca);


### PR DESCRIPTION
### Description
Splits the memory cleanup for channel maps and channel names in macOS audio capture source.

### Motivation and Context
The uninit function prematurely released the memory allocated for the channel map setting, which exists in the scope of source life cycle (compared to channel names which are valid during the life cycle of a configured device).

Splitting up the clean-up for both (memory for channel names is released when the device is uninitialised, memory for channel map setting is released when the source is removed) ensures that the memory is released but pointers don't become unexpectedly invalid.

### How Has This Been Tested?
Tested on macOS 14.3.1, disconnecting and reconnecting a device with active channel map setting, then checking for leaked memory on shutdown.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
