### PR TITLE
mac-avcapture: Add color format selection for capture card source

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -448,8 +448,11 @@
             return NO;
         }
     } else {
+        int inputFormat;
         CMFormatDescriptionRef formatDescription = self.deviceInput.device.activeFormat.formatDescription;
-        inputFourCC = CMFormatDescriptionGetMediaSubType(formatDescription);
+        inputFormat = (int) obs_data_get_int(self.captureInfo->settings, "input_format");
+        inputFourCC = [OBSAVCapture fourCharCodeFromFormat:inputFormat withRange:VIDEO_RANGE_DEFAULT];
+
         colorSpace = [OBSAVCapture colorspaceFromDescription:formatDescription];
         videoRange = ([OBSAVCapture isFullRangeFormat:inputFourCC]) ? VIDEO_RANGE_FULL : VIDEO_RANGE_PARTIAL;
     }

--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -117,7 +117,7 @@ static obs_properties_t *av_capture_properties(void *capture_info_aliased)
         configure_property(frame_rates, isFastPath, isFastPath, NULL, NULL);
         configure_property(color_space, !isFastPath, !isFastPath, NULL, NULL);
         configure_property(video_range, !isFastPath, !isFastPath, NULL, NULL);
-        configure_property(input_format, !isFastPath, !isFastPath, NULL, NULL);
+        configure_property(input_format, true, true, NULL, NULL);
     }
 
     return properties;


### PR DESCRIPTION
### Description
Adds colour format selection to Capture Card source to unbreak situations where specific resolutions do not support the same colour format as the device format the source was created with.

### Motivation and Context
Some devices do not support all color formats at all resolutions, but the capture card source automatically uses an available color format and compares it against the available format for a specific resolution.

Without being able to change this format, some resolutions do not work as CMIO will not be able to find a compatible format. Thus the color format needs to be manually selected for capture card sources as well.

### How Has This Been Tested?
Tested on macOS 14.3.1 with Elgato HD 60x which supports NV12 and YUY2 up to 1080p but only supports NV12 for 2560x1440 and 3840x2160.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
