### PR TITLE
win-capture: Disable audio source when game capture unhooks

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -380,6 +380,10 @@ static void stop_capture(struct game_capture *gc)
 		calldata_set_ptr(&data, "source", gc->source);
 		signal_handler_signal(sh, "unhooked", &data);
 		calldata_free(&data);
+
+		// Also update audio source to stop capturing
+		if (gc->audio_source)
+			reconfigure_audio_source(gc->audio_source, NULL);
 	}
 
 	gc->copy_texture = NULL;


### PR DESCRIPTION
### Description

If game capture gets unhooked, set audio source window to `NULL` to avoid it still capturing stuff.

### Motivation and Context

Fixes issue reported in 30.1 beta.

### How Has This Been Tested?

Untested.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
