### PR TITLE
obs-ffmpeg: Add procedure to save a shorter replay

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -347,6 +347,17 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		QMetaObject::invokeMethod(main, "ReplayBufferSave");
 	}
 
+	void obs_frontend_replay_buffer_save_duration(long long usec) override
+	{
+		proc_handler_t *ph = obs_output_get_proc_handler(
+			main->outputHandler->replayBuffer);
+		uint8_t stack[128];
+		calldata cd;
+		calldata_init_fixed(&cd, stack, sizeof(stack));
+		calldata_set_int(&cd, "usec", usec);
+		proc_handler_call(ph, "save_duration", &cd);
+	}
+
 	void obs_frontend_replay_buffer_stop(void) override
 	{
 		QMetaObject::invokeMethod(main, "StopReplayBuffer");

--- a/UI/frontend-plugins/frontend-tools/data/scripts/clip.lua
+++ b/UI/frontend-plugins/frontend-tools/data/scripts/clip.lua
@@ -1,0 +1,60 @@
+obs         = obslua
+hotkey_id   = obs.OBS_INVALID_HOTKEY_ID
+duration    = 30
+
+function save_clip(pressed)
+  if not pressed then
+    return
+  end
+
+  local replay_buffer = obs.obs_frontend_get_replay_buffer_output()
+  if replay_buffer == nil then
+    return
+  end
+
+  local cd = obs.calldata_create()
+  local ph = obs.obs_output_get_proc_handler(replay_buffer)
+  obs.calldata_set_int(cd, "usec", duration * 1000 * 1000)
+  obs.proc_handler_call(ph, "save_duration", cd)
+
+  obs.calldata_destroy(cd)
+  obs.obs_output_release(replay_buffer)
+end
+
+-- A function named script_update will be called when settings are changed
+function script_update(settings)
+  duration = obs.obs_data_get_int(settings, "Clip.Duration")
+end
+
+-- A function named script_description returns the description shown to
+-- the user
+function script_description()
+	return "When the \"Save Clip\" hotkey is triggered, save a clip of the configured duration from the replay buffer"
+end
+
+-- A function named script_properties defines the properties that the user
+-- can change for the entire script module itself
+function script_properties()
+	local props = obs.obs_properties_create()
+  obs.obs_properties_add_int(props, "Clip.Duration", "Clip Duration in seconds", 5, 3600, 1);
+	return props
+end
+
+-- A function named script_load will be called on startup
+function script_load(settings)
+	hotkey_id = obs.obs_hotkey_register_frontend("Clip.Save", "Save Clip", save_clip)
+	local hotkey_save_array = obs.obs_data_get_array(settings, "Clip.Save")
+	obs.obs_hotkey_load(hotkey_id, hotkey_save_array)
+	obs.obs_data_array_release(hotkey_save_array)
+end
+
+-- A function named script_save will be called when the script is saved
+--
+-- NOTE: This function is usually used for saving extra data (such as in this
+-- case, a hotkey's save data).  Settings set via the properties are saved
+-- automatically.
+function script_save(settings)
+	local hotkey_save_array = obs.obs_hotkey_save(hotkey_id)
+	obs.obs_data_set_array(settings, "Clip.Save", hotkey_save_array)
+	obs.obs_data_array_release(hotkey_save_array)
+end

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -297,6 +297,12 @@ void obs_frontend_replay_buffer_save(void)
 		c->obs_frontend_replay_buffer_save();
 }
 
+void obs_frontend_replay_buffer_save_duration(long long usec)
+{
+	if (callbacks_valid())
+		c->obs_frontend_replay_buffer_save_duration(usec);
+}
+
 void obs_frontend_replay_buffer_stop(void)
 {
 	if (callbacks_valid())

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -193,6 +193,7 @@ EXPORT bool obs_frontend_recording_split_file(void);
 
 EXPORT void obs_frontend_replay_buffer_start(void);
 EXPORT void obs_frontend_replay_buffer_save(void);
+EXPORT void obs_frontend_replay_buffer_save_duration(long long usec);
 EXPORT void obs_frontend_replay_buffer_stop(void);
 EXPORT bool obs_frontend_replay_buffer_active(void);
 

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -56,6 +56,8 @@ struct obs_frontend_callbacks {
 
 	virtual void obs_frontend_replay_buffer_start(void) = 0;
 	virtual void obs_frontend_replay_buffer_save(void) = 0;
+	virtual void
+	obs_frontend_replay_buffer_save_duration(long long usec) = 0;
 	virtual void obs_frontend_replay_buffer_stop(void) = 0;
 	virtual bool obs_frontend_replay_buffer_active(void) = 0;
 

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -665,6 +665,13 @@ Functions
 
 ---------------------------------------
 
+.. function:: void obs_frontend_replay_buffer_save_duration(int usec)
+
+   Save a shorter subset of the replay buffer if it is active. 
+   :param usec: Maximum duration to save in microseconds (saved buffer will usually be a bit shorter)
+
+----------------------------------------
+
 .. function:: bool obs_frontend_replay_buffer_active(void)
 
    :return: *true* if replay buffer active, *false* otherwise

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.h
@@ -33,6 +33,7 @@ struct ffmpeg_muxer {
 
 	/* replay buffer */
 	int64_t save_ts;
+	int64_t save_time;
 	int keyframes;
 	obs_hotkey_id hotkey;
 	volatile bool muxing;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This adds a 'save_duration' procedure to the replay buffer output that allows one to save a shorter part of the replay buffer.

### Motivation and Context
There are a few requests out there to have 'multiple replay buffers' which usually means being able to have multiple hotkeys to save replays of different lengths. This was also my use case, I sometimes want to register the last 15 minutes of gameplay, but a lot more often I just want 30 seconds or so. See also this [ideas link](https://ideas.obsproject.com/posts/263/multiple-replay-buffer-hotkeys-with-different-time-length)

The current way to have this are a bit janky at best, you either have to go for a somewhat out of date fork (https://github.com/TheDark/obs-studio), or use scripts that process the replay file after the fact.

This isn't a full implementation of multiple replay buffer lengths, but it makes it a lot easier for an external script to do it and do it consistently.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I mostly tested this manually by saving shorter replays manually with a small lua script that just binds a hotkey to save the last 30 seconds. I also tried saving normal replays to confirm there was no effect on the base feature. I'm on a laptop with Windows 11 23H2 (OS Build 22631.3155) and a 3070, which is used for the encoding.
I only touched the code for saving the replay buffer and creating the replay buffer output, so those should be the only parts of the code subject to potential issues.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
