### PR TITLE
win-capture: Add line break for capture audio tooltip

### DIFF
--- a/plugins/win-capture/data/locale/en-US.ini
+++ b/plugins/win-capture/data/locale/en-US.ini
@@ -40,7 +40,7 @@ GameCapture.Rgb10a2Space.Srgb="sRGB"
 GameCapture.Rgb10a2Space.2100PQ="Rec. 2100 (PQ)"
 Mode="Mode"
 CaptureAudio="Capture Audio (BETA)"
-CaptureAudio.TT="When enabled, creates an \"Application Audio Capture\" source that automatically updates to the currently captured window/application. Note that if Desktop Audio is configured, this could result in doubled audio."
+CaptureAudio.TT="When enabled, creates an \"Application Audio Capture\" source that automatically updates to the currently captured window/application.\nNote that if Desktop Audio is configured, this could result in doubled audio."
 AudioSuffix="Audio"
 
 # Generic compatibility messages


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Capture Audio (BETA) tooltip are long.
Add line break makes the tooltip easier to read.

If this is incorrect, we would appreciate it if you could correct it.

Before
![Before Capture Audio](https://github.com/obsproject/obs-studio/assets/24505855/2d7071b3-c010-48ac-b47b-a19b73fd43e2)

After
![After Capture Audio](https://github.com/obsproject/obs-studio/assets/24505855/4c3a8216-8157-4515-9fcd-bb76150b2c1e)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
See the #beta-testing channel on Discord.
https://discord.com/channels/348973006581923840/1203061968366206996/1203103512674705501

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I opened the translation file and changed the strings to confirm.
Use Windows 11 22H3 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
