### PR TITLE
deps/media-playback: Detect and handle video res changes when using hardware decoding

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -337,6 +337,17 @@ static int decode_packet(struct mp_decode *d, int *got_frame)
 			return ret;
 		}
 
+		/* does not check for color format or other parameter changes which would require frame buffer realloc */
+		if (d->sw_frame->data[0] &&
+		    (d->sw_frame->width != d->hw_frame->width ||
+		     d->sw_frame->height != d->hw_frame->height)) {
+			blog(LOG_DEBUG,
+			     "MP: hardware frame size changed from %dx%d to %dx%d. reallocating frame",
+			     d->sw_frame->width, d->sw_frame->height,
+			     d->hw_frame->width, d->hw_frame->height);
+			av_frame_unref(d->sw_frame);
+		}
+
 		int err = av_hwframe_transfer_data(d->sw_frame, d->hw_frame, 0);
 		if (err) {
 			ret = 0;


### PR DESCRIPTION
### Description
When playing back videos with the media source and using hardware decoding, we do not properly handle video resolution changes. If the resolution grows, a compositing-like effect happens where video data is written to only a portion of the space. If the resolution shrinks, it writes out of memory bounds and undefined behavior occurs.

This happens because we rely on `av_hwframe_transfer_data()` to initialize the `d->sw_frame` buffer and width/height parameters, however that function only does the initialization if the destination buffer is unallocated, it does not check for *differences*. As such, this adds logic to detect resolution changes and free the current sw_frame buffer in order to trigger allocation of the correct buffer size.

This is somewhat related to #5010, but fixes this lack of handling in another part of the code.

### Motivation and Context
Users often times have no idea that their media files even contain a resolution change. In other cases (mainly livestream playback), resolution changes may be intentional. Either way, we crashes are bad, and basically every other piece of media player software out there handles this correctly.

### How Has This Been Tested?
Ubuntu 22.04: Played a Twitch clip .mp4 which contains an f with transition to their disconnection protection slate (720p->1080p). No crashes observed with fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
