### PR TITLE
obs-filters: Do not load NVVFX on OpenGL

### DIFF
--- a/plugins/obs-filters/obs-filters.c
+++ b/plugins/obs-filters/obs-filters.c
@@ -84,7 +84,10 @@ bool obs_module_load(void)
 	obs_register_source(&luma_key_filter);
 	obs_register_source(&luma_key_filter_v2);
 #ifdef LIBNVVFX_ENABLED
-	if (load_nvvfx())
+	obs_enter_graphics();
+	const bool direct3d = gs_get_device_type() == GS_DEVICE_DIRECT3D_11;
+	obs_leave_graphics();
+	if (direct3d && load_nvvfx())
 		obs_register_source(&nvidia_greenscreen_filter_info);
 #endif
 	return true;


### PR DESCRIPTION
### Description
Do not load nvvfx when started with opengl

### Motivation and Context
I want to be able to test opengl on windows without crashes as nvidia greenscreen filter uses `NvCVImage_InitFromD3D11Texture`

### How Has This Been Tested?
On windows 11 by starting with directx and with opengl

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
