### PR TITLE
mac-avcapture: Fix frame rate collection for camera device formats

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -197,6 +197,7 @@
         [self.deviceInput.device unlockForConfiguration];
         self.deviceInput = nil;
         self.isDeviceLocked = NO;
+        self.presetFormat = nil;
     }
 
     if (!device) {


### PR DESCRIPTION
### Description
Add additional frame rate ranges for otherwise identical device formats if colour primaries differ between the formats.

### Motivation and Context
Some devices will report different framerate ranges for formats that are identical apart from color primaries. Without taking these into account, only framerates for one color primary variant would be used to populate the framerate dropdown in the property view of the camera source.

Checking for a difference in color primaries when iterating over all available formats for a device thus requires checking for this variation and adding the additional frame rate range as well.

### How Has This Been Tested?
Tested on macOS 14.3.1 with a capture card device which reports different frame rate ranges depending on colour primaries (SMPTE_C vs EBU_3213).

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
