### PR TITLE
UI: Fix context bar not updating on delete

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -839,6 +839,8 @@ void SourceTreeModel::Remove(obs_sceneitem_t *item)
 
 	if (is_group)
 		UpdateGroupState(true);
+
+	OBSBasic::Get()->UpdateContextBarDeferred();
 }
 
 OBSSceneItem SourceTreeModel::Get(int idx)


### PR DESCRIPTION
### Description
This fixes a bug where the source context bar wouldn't update when a scene item is deleted.

### Motivation and Context
Fixes bug

### How Has This Been Tested?
Deleted a source and made sure the context bar was updated

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
