### PR TITLE
CI: Fix scheduled language file check running on same commit hash

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -116,6 +116,7 @@ jobs:
           fi
 
       - name: Check for Changed Files ✅
+        if: fromJSON(steps.nightly-checks.outputs.passed)
         uses: ./.github/actions/check-changes
         id: checks
         with:


### PR DESCRIPTION
### Description
Fix warnings in scheduled nightly workflow runs when master branch has not been updated between runs.

### Motivation and Context
When a prior scheduled nightly run is detected with the identical commit hash, then the entire language file check should be skipped.

This adds the missing condition to skip the check for changed files removing the unnecessary warning contained in the workflow results.

### How Has This Been Tested?
Needs to be checked on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
