### PR TITLE
UI: Fix a bug with Output Settings not updating & Toggle audio multi-tracks correctly

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -180,6 +180,28 @@ void OBSBasicSettings::LoadStream1Settings()
 				  Qt::QueuedConnection);
 }
 
+#define SRT_PROTOCOL "srt"
+#define RIST_PROTOCOL "rist"
+
+bool OBSBasicSettings::AllowsMultiTrack(const char *protocol)
+{
+	return astrcmpi_n(protocol, SRT_PROTOCOL, strlen(SRT_PROTOCOL)) == 0 ||
+	       astrcmpi_n(protocol, RIST_PROTOCOL, strlen(RIST_PROTOCOL)) == 0;
+}
+
+void OBSBasicSettings::SwapMultiTrack(const char *protocol)
+{
+	if (protocol) {
+		if (AllowsMultiTrack(protocol)) {
+			ui->advStreamTrackWidget->setCurrentWidget(
+				ui->streamMultiTracks);
+		} else {
+			ui->advStreamTrackWidget->setCurrentWidget(
+				ui->streamSingleTracks);
+		}
+	}
+}
+
 void OBSBasicSettings::SaveStream1Settings()
 {
 	bool customServer = IsCustomService();
@@ -264,6 +286,7 @@ void OBSBasicSettings::SaveStream1Settings()
 	}
 
 	SaveCheckBox(ui->ignoreRecommended, "Stream1", "IgnoreRecommended");
+	SwapMultiTrack(QT_TO_UTF8(protocol));
 }
 
 void OBSBasicSettings::UpdateMoreInfoLink()
@@ -509,6 +532,13 @@ void OBSBasicSettings::on_service_currentIndexChanged(int idx)
 		if (idx == 0)
 			lastCustomServer = ui->customServer->text();
 	}
+
+	if (!IsCustomService()) {
+		ui->advStreamTrackWidget->setCurrentWidget(
+			ui->streamSingleTracks);
+	} else {
+		SwapMultiTrack(QT_TO_UTF8(protocol));
+	}
 }
 
 void OBSBasicSettings::on_customServer_textChanged(const QString &)
@@ -520,6 +550,8 @@ void OBSBasicSettings::on_customServer_textChanged(const QString &)
 
 	if (ServiceSupportsCodecCheck())
 		lastCustomServer = ui->customServer->text();
+
+	SwapMultiTrack(QT_TO_UTF8(protocol));
 }
 
 void OBSBasicSettings::ServiceChanged(bool resetFields)

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -255,7 +255,6 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	main->SetService(newService);
 	main->SaveService();
-	LoadOutputSettings();
 	main->auth = auth;
 	if (!!main->auth) {
 		main->auth->LoadUI();

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2057,16 +2057,6 @@ static inline QString makeFormatToolTip()
 	return html;
 }
 
-#define RTMP_PROTOCOL "rtmp"
-#define SRT_PROTOCOL "srt"
-#define RIST_PROTOCOL "rist"
-
-inline bool allowsMultiTrack(const char *protocol)
-{
-	return astrcmpi_n(protocol, SRT_PROTOCOL, strlen(SRT_PROTOCOL)) == 0 ||
-	       astrcmpi_n(protocol, RIST_PROTOCOL, strlen(RIST_PROTOCOL)) == 0;
-}
-
 void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 {
 	const char *rescaleRes =
@@ -2118,21 +2108,10 @@ void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 	ui->advOutMultiTrack5->setChecked(audioMixes & (1 << 4));
 	ui->advOutMultiTrack6->setChecked(audioMixes & (1 << 5));
 
-	bool is_multitrack_output = false;
 	obs_service_t *service_obj = main->GetService();
 	const char *protocol = nullptr;
 	protocol = obs_service_get_protocol(service_obj);
-	if (protocol) {
-		is_multitrack_output = allowsMultiTrack(protocol);
-	}
-
-	if (is_multitrack_output) {
-		ui->advStreamTrackWidget->setCurrentWidget(
-			ui->streamMultiTracks);
-	} else {
-		ui->advStreamTrackWidget->setCurrentWidget(
-			ui->streamSingleTracks);
-	}
+	SwapMultiTrack(protocol);
 }
 
 OBSPropertiesView *

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -383,6 +383,9 @@ private:
 	bool ServiceAndACodecCompatible();
 	bool ServiceSupportsCodecCheck();
 
+	inline bool AllowsMultiTrack(const char *protocol);
+	void SwapMultiTrack(const char *protocol);
+
 private slots:
 	void on_theme_activated(int idx);
 


### PR DESCRIPTION
### Description
This does two things:
1. This removes the LoadOutputSettings() called in SaveStream1Settings. It caused a bug when trying to save Output settings when both Stream and Output settings have been changed but the changes have not been applied by hitting the 'Apply' button in Settings.
Credits: Rodney made the correct guess for the faulty line.
2. This fixes the display of audio multi-tracks which must alternate between radio buttons (single track protocols) to checkboxes
(mpegts). The LoadOutputSettings call was used to do that update but it was too broad. Instead we use (a) the signal when a service is changed to switch back from mpegts multi-track to single track; (b) the signal when a URL is input in the Server text field of Custom service; (c) when Stream settings are saved.


### Motivation and Context
Fixes a bug found in 30.1 beta.
The function was introduced by me in https://github.com/obsproject/obs-studio/pull/9028 .
It was used to toggle the display of audio multi-tracks checkboxes instead of radio buttons.

The repro steps in beta are as follows:
- change the stream service but don't hit apply,
- change the output settings from Simple to Advanced or the converse,
- hit Apply
- the output Settings are reverted.

The reason why this occurs is because when one hits apply, the stream settings are saved before the output settings.
But since they load the output settings, the changes for the outputs are reverted.

But we still want to display correctly audio multi track buttons (either radio or checkboxes). This is the goal of the second commit.

### How Has This Been Tested?
The bug is fixed.
SRT multi-track audio still works (tested from obs to wowza).
Multi-track buttons alternate correctly between radio or checkboxes as a function of the Service or as a function of the protocol when Custom service is picked.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
