### PR TITLE
rtmp-services: Add Livito.TV

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 241,
+    "version": 242,
     "files": [
         {
             "name": "services.json",
-            "version": 241
+            "version": 242
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2610,6 +2610,24 @@
             }
         },
         {
+            "name": "Livito | لیویتو",
+            "common": false,
+            "more_info_link": "https://livito.tv/help",
+            "stream_key_link": "https://livito.tv/panel/stream#StreamUrlAndKey",
+            "servers": [
+                {
+                    "name": "Auto",
+                    "url": "rtmp://rtmp.livito.tv/livestream"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
+        },
+        {
             "name": "PandaTV | 팬더티비",
             "common": false,
             "servers": [


### PR DESCRIPTION
### Description
Adding Livito.TV to OBS-Studio's Ingest List.


### Motivation and Context
This pull request adds the website of [Livito.TV](https://livito.tv) , which is the one of biggest streaming platform in Iran with more than 3 years of availability and a user base of over 20,000 users, to OBS-Studio's ingest list. By adding this website to the ingest list, OBS-Studio users will be able to easily and conveniently use Livito.tv as a source for their live streams and content.

### How Has This Been Tested?
- Copy JSON files to %APPDATA%\obs-studio\plugin_config\rtmp-services: Manually copied the JSON files to the appropriate location where OBS-Studio reads ingest settings.
- JSON validation: Ensured that the JSON files are well-formed and adhered to the required format for OBS-Studio's ingest list.
- Checked settings: Verified that Livito.TV appears in the updated ingest list within OBS-Studio's settings.
- Connection testing: Attempted to connect to the servers provided by Livito.TV to ensure successful streaming functionality.
- According to [Service Submission Guidelines](https://github.com/obsproject/obs-studio/wiki/Service-Submission-Guidelines)

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.