### PR TITLE
CI: Fix broken pip install to use ephemeral virtual environment

### DIFF
--- a/.github/actions/compatibility-validator/action.yaml
+++ b/.github/actions/compatibility-validator/action.yaml
@@ -31,6 +31,10 @@ runs:
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
         fi
         brew install --quiet python3
+
+        python3 -m venv .venv
+
+        source .venv/bin/activate
         python3 -m pip install jsonschema json_source_map
         echo ::endgroup::
 
@@ -43,6 +47,7 @@ runs:
         shopt -s extglob
 
         echo ::group::Schema Validation
+        source .venv/bin/activate
         python3 -u \
           .github/scripts/utils.py/check-jsonschema.py \
           --loglevel INFO \

--- a/.github/actions/services-validator/action.yaml
+++ b/.github/actions/services-validator/action.yaml
@@ -53,6 +53,10 @@ runs:
           echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
           brew install --overwrite --quiet python3
         fi
+
+        python3 -m venv .venv
+
+        source .venv/bin/activate
         python3 -m pip install jsonschema json_source_map requests aiohttp
         echo ::endgroup::
 
@@ -66,6 +70,8 @@ runs:
         shopt -s extglob
 
         echo ::group::Run Validation
+
+        source .venv/bin/activate
         python3 -u \
           .github/scripts/utils.py/check-jsonschema.py \
           plugins/rtmp-services/data/@(services|package).json \
@@ -101,6 +107,8 @@ runs:
         API_SERVERS: ${{ inputs.checkApiServers }}
       run: |
         : Check for defunct services 📉
+
+        source .venv/bin/activate
         python3 -u .github/scripts/utils.py/check-services.py
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Description
Change validator actions to use a virtual environment to install PIP modules required for validator scripts.

### Motivation and Context
Python 3.11 and later support a system-wide configuration setting that marks the system packages as "externally managed" (e.g. to force using apt packages instead of pip packages).

This breaks installation of the modules necessary to run the validators, so use a virtual environment instead.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
