### PR TITLE
cmake: Provide a clear error on version check fail

### DIFF
--- a/cmake/Modules/VersionConfig.cmake
+++ b/cmake/Modules/VersionConfig.cmake
@@ -17,9 +17,14 @@ if(NOT DEFINED OBS_VERSION_OVERRIDE)
     execute_process(
       COMMAND git describe --always --tags --dirty=-modified
       OUTPUT_VARIABLE _OBS_VERSION
+      ERROR_VARIABLE _GIT_DESCRIBE_ERR
       WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
       RESULT_VARIABLE _OBS_VERSION_RESULT
       OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(_GIT_DESCRIBE_ERR)
+      message(FATAL_ERROR "Could not fetch OBS version tag from git.\n" ${_GIT_DESCRIBE_ERR})
+    endif()
 
     if(_OBS_VERSION_RESULT EQUAL 0)
       if(${_OBS_VERSION} MATCHES "rc[0-9]+$")

--- a/cmake/common/versionconfig.cmake
+++ b/cmake/common/versionconfig.cmake
@@ -10,9 +10,14 @@ if(NOT DEFINED OBS_VERSION_OVERRIDE AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git
   execute_process(
     COMMAND git describe --always --tags --dirty=-modified
     OUTPUT_VARIABLE _obs_version
+    ERROR_VARIABLE _git_describe_err
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     RESULT_VARIABLE _obs_version_result
     OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+  if(_git_describe_err)
+    message(FATAL_ERROR "Could not fetch OBS version tag from git.\n" ${_git_describe_err})
+  endif()
 
   if(_obs_version_result EQUAL 0)
     string(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1;\\2;\\3" _obs_version_canonical ${_obs_version})


### PR DESCRIPTION
### Description
when git describe fails to get a git tag for the OBS Version, a non-fatal message is printed, and the generator is left to continue, usually ending up with a more cryptic error message down the line, such as in #7705.

Instead, dump the git output together with a short description of what actually happened, and exit fatally so the problematic line of code is clear. An added advantage is that the git output is printed in red instead of (say) white on colour-enabled terminals.

### Motivation and Context
Gives developers a more clear error for debugging issues like #7705.

### How Has This Been Tested?
Tested with CMake 3.25 on Debian 12.

Examples:

#### Before:
```
$ cmake -S . -B YOUR_BUILD_DIRECTORY -G Ninja  -DCEF_ROOT_DIR="../obs-deps/cef_binary_5060_linux_x86_64"       -DENABLE_PIPEWIRE=OFF        -DENABLE_AJA=0         -DENABLE_WEBRTC=1        -DQT_VERSION=6                                               
-- OBS:  Application Version:  - Build Number: 16                                                                                                                                                                                                                                         
CMake Warning at CMakeLists.txt:46 (project):                                                                                                                                                                                                                                             
  VERSION keyword not followed by a value or was followed by a value that                                                                                                                                                                                                                 
  expanded to nothing.                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libOpenGL.so                                                                                                                                                                                                                                   
-- Found FFmpeg: /usr/lib/x86_64-linux-gnu/libavcodec.so (found version "#define LIBAVCODEC_VERSION_MINOR  37;#define LIBAVCODEC_VERSION_MICRO 100.37.100") found components: avcodec avdevice avutil avformat                                                                            
-- OBS:  ENABLED    obslua                                                                                                                                                                                                                                                                
-- OBS:  obs-scripting -> Luajit found.                                                                                                                                                                                                                                                   
-- OBS:  ENABLED    obspython                                                                                                                                                                                                                                                             
-- OBS:  obs-scripting -> Python 3.11.2 found.
-- XCB[XCB]: Found component XCB                                      
-- Found XCB: /usr/lib/x86_64-linux-gnu/libxcb.so  found components: XCB 
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libOpenGL.so  found components: EGL 
-- Found Wayland: /usr/lib/x86_64-linux-gnu/libwayland-client.so;/usr/lib/x86_64-linux-gnu/libwayland-server.so;/usr/lib/x86_64-linux-gnu/libwayland-egl.so;/usr/lib/x86_64-linux-gnu/libwayland-cursor.so   
-- Found FFmpeg: /usr/lib/x86_64-linux-gnu/libavformat.so (found version "#define LIBAVFORMAT_VERSION_MINOR  27;#define LIBAVFORMAT_VERSION_MICRO 100.27.100") found components: avformat avutil swscale swresample avcodec 
-- OBS:  -> PulseAudio found - audio monitoring enabled
-- Found Wayland: /usr/lib/x86_64-linux-gnu/libwayland-client.so;/usr/lib/x86_64-linux-gnu/libwayland-server.so;/usr/lib/x86_64-linux-gnu/libwayland-egl.so;/usr/lib/x86_64-linux-gnu/libwayland-cursor.so  found components: Client 
CMake Error at /usr/share/cmake-3.25/Modules/WriteBasicConfigVersionFile.cmake:43 (message):
  No VERSION specified for WRITE_BASIC_CONFIG_VERSION_FILE()
Call Stack (most recent call first):
  /usr/share/cmake-3.25/Modules/CMakePackageConfigHelpers.cmake:237 (write_basic_config_version_file)
  cmake/Modules/ObsHelpers.cmake:269 (write_basic_package_version_file)
  cmake/Modules/ObsHelpers_Linux.cmake:13 (_export_target)
  libobs/cmake/legacy.cmake:502 (export_target)
  cmake/Modules/ObsHelpers.cmake:473 (include)
  libobs/CMakeLists.txt:3 (legacy_check)


-- Configuring incomplete, errors occurred!
See also "/src/obs-studio/YOUR_BUILD_DIRECTORY/CMakeFiles/CMakeOutput.log".
```

#### After:
```
$ cmake -S . -B YOUR_BUILD_DIRECTORY -G Ninja  -DCEF_ROOT_DIR="../obs-deps/cef_binary_5060_linux_x86_64"       -DENABLE_PIPEWIRE=OFF        -DENABLE_AJA=0         -DENABLE_WEBRTC=1        -DQT_VERSION=6 
CMake Error at cmake/Modules/VersionConfig.cmake:26 (message):
  Could not fetch OBS version tag from git.

  fatal: detected dubious ownership in repository at '/src/obs-studio'

  To add an exception for this directory, call:

  

        git config --global --add safe.directory /src/obs-studio

Call Stack (most recent call first):
  CMakeLists.txt:38 (include)


-- Configuring incomplete, errors occurred!
See also "/src/obs-studio/YOUR_BUILD_DIRECTORY/CMakeFiles/CMakeOutput.log".
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
