### PR TITLE
CI: Limit format checks to changed files only

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -60,6 +60,6 @@ runs:
           print ::endgroup::
 
           print ::group::Run clang-format-16
-          ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check
+          ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.c|*.h|*.cpp|*.hpp|*.m|*.mm)}
           print ::endgroup::
         }

--- a/.github/actions/run-cmake-format/action.yaml
+++ b/.github/actions/run-cmake-format/action.yaml
@@ -59,6 +59,6 @@ runs:
           print ::endgroup::
 
           print ::group::Run cmake-format
-          ./build-aux/run-cmake-format --fail-${{ inputs.failCondition }} --check
+          ./build-aux/run-cmake-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.cmake|*CMakeLists.txt)}
           print ::endgroup::
         }

--- a/.github/actions/run-swift-format/action.yaml
+++ b/.github/actions/run-swift-format/action.yaml
@@ -59,6 +59,6 @@ runs:
           print ::endgroup::
 
           print ::group::Run swift-format
-          ./build-aux/run-swift-format --fail-${{ inputs.failCondition }} --check
+          ./build-aux/run-swift-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.swift)}
           print ::endgroup::
         }


### PR DESCRIPTION
### Description
Changes CI formatting actions (and associated formatting script) to accept a list of files.

### Motivation and Context
Before the CI checks for source code and CMake files would always check the entire source code even if just a single files has been changed.

With this update, the formatting script is enhanced to accept a list of files (which is generated as a condition to run the script in the first place) which ensures that a PR will only fail validation over files it changed itself.

### How Has This Been Tested?
Tested the script locally with no list of files provided and different number of specified file paths.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
