### PR TITLE
UI: Allow ignoring crash reports

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2676,7 +2676,7 @@ static void main_crash_handler(const char *format, va_list args,
 		string(message_buffer.get(), message_buffer.get() + size);
 
 	int ret = MessageBoxA(NULL, finalMessage.c_str(), "OBS has crashed!",
-			      MB_YESNO | MB_ICONERROR | MB_TASKMODAL);
+			      MB_YESNOCANCEL | MB_ICONERROR | MB_TASKMODAL);
 
 	if (ret == IDYES) {
 		size_t len = strlen(text);
@@ -2690,8 +2690,11 @@ static void main_crash_handler(const char *format, va_list args,
 		SetClipboardData(CF_TEXT, mem);
 		CloseClipboard();
 	}
+	
+	if (ret == IDYES || ret == IDNO) {
+		exit(-1);
+	}
 
-	exit(-1);
 }
 
 static void load_debug_privilege(void)


### PR DESCRIPTION
### Description
Changes the Crash MessageBox to add a Cancel button, so users can opt to copy and quit the crash log, or cancel it.

### Motivation and Context
This helps in cases where an error has occurred, but isn't significant enough to need to be reported or reproduced.
Here is just one example by a streamer ignoring it by not choosing yes / no: https://youtube.com/watch?v=RMiOtRFwbAg
With this change, they could just ignore it, and close the popup and keep the stream running, just like nothing has gone wrong.

### How Has This Been Tested?
This change has not been tested, but it is clear it should work and not affect any other areas of the code.
All that has changed is which type of model buttons to use is, and moving the ``exit(-1)`` into an if statement.
Clicking YES or NO will quit the application as normal, and clicking cancel does the same as no, without running ``exit(-1)``.

### Types of changes
Tweak: UI

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

### Quick Note
I assume my Pull Request may be closed due to not testing it or pushing it onto the right branch, I really don't know where to start, but at least I provided code that (at least to my extent) will work. i couldn't see what branch to use, but the master branch is being committed to already so I hoped this wouldn't be too much of an issue, even if this is pull request is taken as an issue with a code suggestion instead of a pull request by itself.
