### PR TITLE
obs-webrtc: Avoid crashing on invalid answer

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -401,7 +401,21 @@ bool WHIPOutput::Connect()
 	response.erase(0, response.find("v=0"));
 
 	rtc::Description answer(response, "answer");
-	peer_connection->setRemoteDescription(answer);
+	try {
+		peer_connection->setRemoteDescription(answer);
+	} catch (const std::invalid_argument &err) {
+		do_log(LOG_ERROR, "WHIP server responded with invalid SDP: %s",
+		       err.what());
+		cleanup();
+		obs_output_signal_stop(output, OBS_OUTPUT_CONNECT_FAILED);
+		return false;
+	} catch (const std::exception &err) {
+		do_log(LOG_ERROR, "Failed to set remote description: %s",
+		       err.what());
+		cleanup();
+		obs_output_signal_stop(output, OBS_OUTPUT_CONNECT_FAILED);
+		return false;
+	}
 	cleanup();
 	return true;
 }


### PR DESCRIPTION
### Description
PeerConnection::setRemoteDescription validates the input SDP, throwing an exception whenever it is invalid.

Currently, instead of handling the exception, we just crash.

Instead, add an exception handler which logs a short description of the issue as well as the error message from the exception.

### Motivation and Context
I develop an open-source WebRTC app, and one of the most confusing parts during development was when OBS would crash when my (not production-ready) server would give an invalid SDP answer. Fix that in this PR.

### How Has This Been Tested?
Simply respond with any invalid SDP on the WHIP endpoint - e.g. the string "hello".

#### Before:
```
info: ---------------------------------                                                                                                                                                                                                                
info: [FFmpeg libopus encoder: 'simple_opus'] bitrate: 160, channels: 2, channel_layout: stereo                                                                                                                                                        
                                                                                                                                                                                                                                                       
info: [obs-webrtc] [whip_output: 'simple_stream'] PeerConnection state is now: Connecting                                                                                                                                                              
terminate called after throwing an instance of 'std::invalid_argument'                                                                                                                                                                                 
  what():  Remote description has no ICE user fragment                                                                                                                                                                                                 
Aborted (core dumped)                                                                                                    
```

#### After:
```
info: ---------------------------------                                                                                                                                                                                                                
info: [FFmpeg libopus encoder: 'simple_opus'] bitrate: 160, channels: 2, channel_layout: stereo                                                                                                                                                        
                                                                                                                                                                                                                                                       
info: [obs-webrtc] [whip_output: 'simple_stream'] PeerConnection state is now: Connecting                                                                                                                                                              
error: [obs-webrtc] [whip_output: 'simple_stream'] WHIP server responded with invalid SDP: Remote description has no ICE user fragment                                                                                                                 
info: [obs-webrtc] [whip_output: 'simple_stream'] PeerConnection state is now: Closed                                                                                                                                                                  
info: ==== Streaming Stop ================================================                                                                                                                                                                             
```

No crash, instead the standard UI popup appears:
![Screenshot from 2024-02-28 21-45-08](https://github.com/obsproject/obs-studio/assets/31630318/5610da45-eaaa-4ce5-850a-9c203576bf1d)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
