### PR TITLE
UI: Reserve size of congestion vector

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -42,6 +42,8 @@ OBSBasicStatusBar::OBSBasicStatusBar(QWidget *parent)
 	  streamingActivePixmap(QIcon(":/res/images/streaming-active.svg")
 					.pixmap(QSize(16, 16)))
 {
+	congestionArray.reserve(congestionUpdateSeconds);
+
 	statusWidget = new StatusBarWidget(this);
 	statusWidget->ui->delayInfo->setText("");
 	statusWidget->ui->droppedFrames->setText(


### PR DESCRIPTION
### Description
This reserves the size of the congestion vector in the status bar, so it isn't resized every second.

### Motivation and Context
Performance improvement, nothing noticeable but an improvement nonetheless

### How Has This Been Tested?
Testing by streaming and checking if the congestion indicator still worked as expected

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
