### PR TITLE
UI: Fix `Start Virtual Camera` Text Cut Off in Corresponding Button

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1938,6 +1938,8 @@ void OBSBasic::AddVCamButton()
 			    QStringLiteral("configIconSmall"),
 			    &OBSBasic::VCamConfigButtonClicked);
 	vcamButton->insert(2);
+	vcamButton->first()->setSizePolicy(QSizePolicy::Minimum,
+					   QSizePolicy::Minimum);
 }
 
 void OBSBasic::ResetOutputs()


### PR DESCRIPTION
> [!TIP]
> This summary has been updated to match the most recent code change

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Change size policy of "Start Virtual Camera" button to ensure the minimum width of "Controls" panel is greater than or equal to the minimum width of "Start Virtual Camera" button plus the gear (settings) icon. Text cutoff is thus eliminated.

Old minimum width of "Controls" panel:
<img width="166" alt="ui before fix, text gets truncated" src="https://github.com/obsproject/obs-studio/assets/114868133/4810f478-4c6b-4954-9a2c-5a8eaa708faa">

New minimum width of "Controls" panel:
<img width="215" alt="Screenshot 2024-03-03 at 5 45 24 PM" src="https://github.com/obsproject/obs-studio/assets/114868133/3caab48f-439a-49c5-bf59-ef31b331d46d">

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This PR fixes #10210.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tests are conducted by manually resizing "Controls" panel.
Solution works for both LTR and RTL languages.

Environment:  
- macOS Ventura 13.6.4 (22G513)
  Arch: x86_64
- Xcode 15.2
  Build version 15C500b

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!-- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
