### PR TITLE
UI: Fix closing OBS with floating docks

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1042,6 +1042,7 @@ public:
 	void SetDisplayAffinity(QWindow *window);
 
 	QColor GetSelectionColor() const;
+	inline bool Closing() { return closing; }
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-dock.cpp
+++ b/UI/window-dock.cpp
@@ -1,5 +1,6 @@
 #include "window-dock.hpp"
 #include "obs-app.hpp"
+#include "window-basic-main.hpp"
 
 #include <QMessageBox>
 #include <QCheckBox>
@@ -27,7 +28,7 @@ void OBSDock::closeEvent(QCloseEvent *event)
 
 	bool warned = config_get_bool(App()->GlobalConfig(), "General",
 				      "WarnedAboutClosingDocks");
-	if (!warned) {
+	if (!OBSBasic::Get()->Closing() && !warned) {
 		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection,
 					  Q_ARG(VoidFunc, msgBox));
 	}


### PR DESCRIPTION
### Description
When OBS is closed and there is a floating dock, a Windows system sound is emitted. This fixes that by not executing the close dock dialog when OBS is closing.

### Motivation and Context
Fixes bug

### How Has This Been Tested?
Made sure the dock closing dialog is never triggered when OBS is closed

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
