### PR TITLE
libobs/graphics: Add support for param assign with type constructor

### DIFF
--- a/libobs/graphics/effect-parser.c
+++ b/libobs/graphics/effect-parser.c
@@ -1082,13 +1082,27 @@ static inline int ep_parse_param_assign_intfloat_array(struct effect_parser *ep,
 	}
 
 	/* -------------------------------------------- */
-
-	code = cf_next_token_should_be(&ep->cfp, "{", ";", NULL);
-	if (code != PARSE_SUCCESS)
-		return code;
+	if (!cf_next_token(&ep->cfp)) {
+		cf_adderror_unexpected_eof(&ep->cfp);
+		return PARSE_EOF;
+	}
+	char *end_char = NULL;
+	if (strref_cmp(&ep->cfp.cur_token->str, "{") == 0) {
+		end_char = "}";
+	} else if (strref_cmp(&ep->cfp.cur_token->str, param->type) == 0) {
+		end_char = ")";
+		code = cf_next_token_should_be(&ep->cfp, "(", ";", NULL);
+		if (code != PARSE_SUCCESS)
+			return code;
+	} else if (!cf_go_to_token(&ep->cfp, ";", NULL)) {
+		return PARSE_EOF;
+	} else {
+		cf_adderror_expecting(&ep->cfp, "{");
+		return PARSE_CONTINUE;
+	}
 
 	for (i = 0; i < intfloat_count; i++) {
-		char *next = ((i + 1) < intfloat_count) ? "," : "}";
+		char *next = ((i + 1) < intfloat_count) ? "," : end_char;
 
 		code = ep_parse_param_assign_intfloat(ep, param, is_float);
 		if (code != PARSE_SUCCESS)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add support for:
`uniform float4 test = float4(1,0,0,1);`
next to the existing:
`uniform float4 test = {1,0,0,1};`

### Motivation and Context
Support more shader stuff. This helps converting glsl shaders more easily.

### How Has This Been Tested?
On windows 11 by having a shader with the new param assignment

### Types of changes
- Tweak (non-breaking change to improve existing functionality) 
- 
### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
