### PR TITLE
UI: Change default format for release builds to fMP4/fMOV

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1462,9 +1462,8 @@ static const double scaled_vals[] = {1.0,         1.25, (1.0 / 0.75), 1.5,
 				     2.5,         2.75, 3.0,          0.0};
 
 extern void CheckExistingCookieId();
-#if OBS_RELEASE_CANDIDATE == 0 && OBS_BETA == 0
-#define DEFAULT_CONTAINER "mkv"
-#elif defined(__APPLE__)
+
+#ifdef __APPLE__
 #define DEFAULT_CONTAINER "fragmented_mov"
 #else
 #define DEFAULT_CONTAINER "fragmented_mp4"


### PR DESCRIPTION
### Description

Sets default output format to fragmented MP4 on Linux/Windows and fragmented MOV on macOS (for ProRes support).

### Motivation and Context

Originally, this change was limited to pre-release builds to gather feedback (#8516), since no complaints have really shown up since last year it's probably time to make it the default in release builds to finalise the implementation of https://github.com/obsproject/rfcs/pull/51.

### How Has This Been Tested?

N/A

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
