### PR TITLE
UI: Move warnings to bottom of settings window

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -3908,6 +3908,24 @@
                       </widget>
                      </widget>
                     </item>
+                    <item>
+                     <widget class="QFrame" name="advOutRecInfo">
+                      <layout class="QVBoxLayout" name="advOutRecInfoLayout">
+                       <property name="leftMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="topMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="rightMargin">
+                        <number>0</number>
+                       </property>
+                       <property name="bottomMargin">
+                        <number>0</number>
+                       </property>
+                      </layout>
+                     </widget>
+                    </item>
                    </layout>
                   </widget>
                   <widget class="QWidget" name="advOutputAudioTracksTab">

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5202,10 +5202,7 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 			errorMsg.isEmpty() ? "warningLabel" : "errorLabel");
 		advOutRecWarning->setWordWrap(true);
 
-		QFormLayout *formLayout = reinterpret_cast<QFormLayout *>(
-			ui->advOutRecTopContainer->layout());
-
-		formLayout->addRow(nullptr, advOutRecWarning);
+		ui->advOutRecInfoLayout->addWidget(advOutRecWarning);
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Add a new QVBoxLayout to OBSBasicSettings.ui to show the warnings in the output advanced recording settings.


**Old layout for warnings in advanced recording settings:**
![AdvancedOldSettings](https://github.com/obsproject/obs-studio/assets/119502068/f1278012-0f27-4748-8239-adc56d23a4a3)


**New layout for warnings in advanced recording settings:**
![AdvancedNewSettings](https://github.com/obsproject/obs-studio/assets/119502068/7eeca6bd-7b91-43d8-99da-4d2b752b644c)

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This PR fixes isssue #9276
It also improves the UI so the warnings shown in the advanced Output Recording Settings are consistent with the ones shown in the simple Output tab.


**Simple Output settings (old and new):**
![SimpleOutputSettings](https://github.com/obsproject/obs-studio/assets/119502068/b24cc38a-4a0a-4d2c-9b29-d0b5645b4051)

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

Tests are conducted by manually entering MPEG-4 (.mp4) in the recording format and resizing the settings window.

**Environment:**

- windows 11 Version 10.0.22631 Build 22631

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes

<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
