### PR TITLE
frontend-tools: Fix output timer stopping recording on unpause

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -218,7 +218,7 @@ void OutputTimer::UnpauseRecordingTimer()
 	if (!ui->pauseRecordTimer->isChecked())
 		return;
 
-	if (!recordingTimer->isActive())
+	if (recordingTimeLeft > 0 && !recordingTimer->isActive())
 		recordingTimer->start(recordingTimeLeft);
 }
 

--- a/UI/frontend-plugins/frontend-tools/output-timer.hpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.hpp
@@ -40,5 +40,5 @@ private:
 	QTimer *streamingTimerDisplay;
 	QTimer *recordingTimerDisplay;
 
-	int recordingTimeLeft;
+	int recordingTimeLeft = -1;
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If the "Pause timer when recording is paused" option in the Output Timer settings was enabled, even if an Output Timer was not being used, a recording may stop when attempting to unpause it. This was due to the check in the UnpauseRecordingTimer function being too loose and only checking for if the recording timer was not active. Let's initialize the recordingTimeLeft variable to -1 and check that it's greater than 0 before attempting to restart a recording timer.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix a bug that appeared at least as early as OBS Studio 30.1.0-beta1. Do not want recordings stopping unexpectedly or prematurely.

When uninitialized, recordingTimeLeft could be something like -842150451. A negative value passed to QTimer's `start` function results in this:
```
13:12:39.929: QObject::startTimer: Timers cannot have negative intervals
13:12:39.929: recordingTimeLeft: -842150451
```

This negative interval warning happened at least as early as October 17, 2023 according to old notes of mine.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
