### PR TITLE
obs-webrtc: Add additional error messaging for WHIP output

### DIFF
--- a/plugins/obs-webrtc/data/locale/en-US.ini
+++ b/plugins/obs-webrtc/data/locale/en-US.ini
@@ -1,3 +1,6 @@
 Output.Name="WHIP Output"
 Service.Name="WHIP Service"
 Service.BearerToken="Bearer Token"
+
+Error.InvalidSDP="WHIP server responded with invalid SDP: %1"
+Error.NoRemoteDescription="Failed to set remote description: %1"

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -407,12 +407,24 @@ bool WHIPOutput::Connect()
 		do_log(LOG_ERROR, "WHIP server responded with invalid SDP: %s",
 		       err.what());
 		cleanup();
+		struct dstr error_message;
+		dstr_init_copy(&error_message,
+			       obs_module_text("Error.InvalidSDP"));
+		dstr_replace(&error_message, "%1", err.what());
+		obs_output_set_last_error(output, error_message.array);
+		dstr_free(&error_message);
 		obs_output_signal_stop(output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
 	} catch (const std::exception &err) {
 		do_log(LOG_ERROR, "Failed to set remote description: %s",
 		       err.what());
 		cleanup();
+		struct dstr error_message;
+		dstr_init_copy(&error_message,
+			       obs_module_text("Error.NoRemoteDescription"));
+		dstr_replace(&error_message, "%1", err.what());
+		obs_output_set_last_error(output, error_message.array);
+		dstr_free(&error_message);
 		obs_output_signal_stop(output, OBS_OUTPUT_CONNECT_FAILED);
 		return false;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adding to the previous commit, let's also use obs_output_set_last_error to provide localized error messages to the user if we run into these failure cases.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Suggested by @notr1ch .

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested the build locally on Windows 11. Have not tested the actual error conditions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
