### PR TITLE
libobs: Add YUVA pixel format

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -778,6 +778,7 @@ Functions used by outputs
            VIDEO_FORMAT_YVYU,
            VIDEO_FORMAT_YUY2, /* YUYV */
            VIDEO_FORMAT_UYVY,
+	       VIDEO_FORMAT_UYVA, /* two-plane, packed luma/chroma like UYVY and then alpha plane */
 
            /* packed uncompressed formats */
            VIDEO_FORMAT_RGBA,

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1547,6 +1547,7 @@ Functions used by sources
            VIDEO_FORMAT_YVYU,
            VIDEO_FORMAT_YUY2, /* YUYV */
            VIDEO_FORMAT_UYVY,
+	       VIDEO_FORMAT_UYVA, /* two-plane, packed luma/chroma like UYVY and then alpha plane */
 
            /* packed uncompressed formats */
            VIDEO_FORMAT_RGBA,

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -579,6 +579,19 @@ float3 PSUYVY_Reverse(FragTexTex frag_in) : TARGET
 	return rgb;
 }
 
+float4 PSUYVA_Reverse(VertTexTexPos frag_in) : TARGET
+{
+	float2 y01 = image.Load(int3(frag_in.uvuv.xy, 0)).yw;
+	float2 cbcr = image.Sample(def_sampler, frag_in.uvuv.zw, 0.0).zx;
+	float leftover = frac(frag_in.uvuv.x);
+	float y = (leftover < 0.5) ? y01.x : y01.y;
+	float alpha_x = (leftover < 0.5) ? frag_in.uvuv.x * 2 : frag_in.uvuv.x * 2 + 1;
+	float alpha = image1.Load(int3(alpha_x, frag_in.uvuv.y, 0)).x;
+	float3 yuv = float3(y, cbcr);
+	float3 rgb = YUV_to_RGB(yuv);
+	return float4(rgb, alpha);
+}
+
 float3 PSYUY2_Reverse(FragTexTex frag_in) : TARGET
 {
 	float2 y01 = image.Load(int3(frag_in.uvuv.xy, 0)).zx;
@@ -1432,6 +1445,15 @@ technique UYVY_Reverse
 	{
 		vertex_shader = VSPacked422Left_Reverse(id);
 		pixel_shader  = PSUYVY_Reverse(frag_in);
+	}
+}
+
+technique UYVA_Reverse
+{
+	pass
+	{
+		vertex_shader = VSPacked422Left_Reverse(id);
+		pixel_shader  = PSUYVA_Reverse(frag_in);
 	}
 }
 

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -18,7 +18,8 @@
 #include "video-frame.h"
 
 #define HALF(size) ((size + 1) / 2)
-#define ALIGN(size, alignment) *size = (*size + alignment - 1) & (~(alignment - 1));
+#define ALIGN(size, alignment) \
+	*size = (*size + alignment - 1) & (~(alignment - 1));
 
 static inline void align_size(size_t *size, size_t alignment)
 {
@@ -31,163 +32,171 @@ static inline void align_uint32(uint32_t *size, size_t alignment)
 }
 
 /* assumes already-zeroed array */
-void video_frame_get_linesizes(uint32_t linesize[MAX_AV_PLANES], enum video_format format, uint32_t width)
+void video_frame_get_linesizes(uint32_t linesize[MAX_AV_PLANES],
+			       enum video_format format, uint32_t width)
 {
 	switch (format) {
-		default:
-		case VIDEO_FORMAT_NONE:
-			break;
-		case VIDEO_FORMAT_BGR3: /* one plane: triple width */
-			linesize[0] = width * 3;
-			break;
-		case VIDEO_FORMAT_RGBA: /* one plane: quadruple width */
-		case VIDEO_FORMAT_BGRA:
-		case VIDEO_FORMAT_BGRX:
-		case VIDEO_FORMAT_AYUV:
-		case VIDEO_FORMAT_R10L:
-			linesize[0] = width * 4;
-			break;
-		case VIDEO_FORMAT_P416: /* two planes: double width, quadruple width */
-			linesize[0] = width * 2;
-			linesize[1] = width * 4;
-			break;
-		case VIDEO_FORMAT_I420: /* three planes: full width, half width, half width */
-		case VIDEO_FORMAT_I422:
-			linesize[0] = width;
-			linesize[1] = HALF(width);
-			linesize[2] = HALF(width);
-			break;
-		case VIDEO_FORMAT_I210: /* three planes: double width, full width, full width */
-		case VIDEO_FORMAT_I010:
-			linesize[0] = width * 2;
-			linesize[1] = width;
-			linesize[2] = width;
-			break;
-		case VIDEO_FORMAT_I40A: /* four planes: full width, half width, half width, full width */
-		case VIDEO_FORMAT_I42A:
-			linesize[0] = width;
-			linesize[1] = HALF(width);
-			linesize[2] = HALF(width);
-			linesize[3] = width;
-			break;
+	default:
+	case VIDEO_FORMAT_NONE:
+		break;
+	case VIDEO_FORMAT_BGR3: /* one plane: triple width */
+		linesize[0] = width * 3;
+		break;
+	case VIDEO_FORMAT_RGBA: /* one plane: quadruple width */
+	case VIDEO_FORMAT_BGRA:
+	case VIDEO_FORMAT_BGRX:
+	case VIDEO_FORMAT_AYUV:
+	case VIDEO_FORMAT_R10L:
+		linesize[0] = width * 4;
+		break;
+	case VIDEO_FORMAT_P416: /* two planes: double width, quadruple width */
+		linesize[0] = width * 2;
+		linesize[1] = width * 4;
+		break;
+	case VIDEO_FORMAT_I420: /* three planes: full width, half width, half width */
+	case VIDEO_FORMAT_I422:
+		linesize[0] = width;
+		linesize[1] = HALF(width);
+		linesize[2] = HALF(width);
+		break;
+	case VIDEO_FORMAT_I210: /* three planes: double width, full width, full width */
+	case VIDEO_FORMAT_I010:
+		linesize[0] = width * 2;
+		linesize[1] = width;
+		linesize[2] = width;
+		break;
+	case VIDEO_FORMAT_I40A: /* four planes: full width, half width, half width, full width */
+	case VIDEO_FORMAT_I42A:
+		linesize[0] = width;
+		linesize[1] = HALF(width);
+		linesize[2] = HALF(width);
+		linesize[3] = width;
+		break;
 
-		case VIDEO_FORMAT_YVYU: /* one plane: double width */
-		case VIDEO_FORMAT_YUY2:
-		case VIDEO_FORMAT_UYVY:
-			linesize[0] = width * 2;
-			break;
-		case VIDEO_FORMAT_P010: /* two planes: all double width */
-		case VIDEO_FORMAT_P216:
-			linesize[0] = width * 2;
-			linesize[1] = width * 2;
-			break;
-		case VIDEO_FORMAT_I412: /* three planes: all double width */
-			linesize[0] = width * 2;
-			linesize[1] = width * 2;
-			linesize[2] = width * 2;
-			break;
-		case VIDEO_FORMAT_YA2L: /* four planes: all double width */
-			linesize[0] = width * 2;
-			linesize[1] = width * 2;
-			linesize[2] = width * 2;
-			linesize[3] = width * 2;
-			break;
+	case VIDEO_FORMAT_YVYU: /* one plane: double width */
+	case VIDEO_FORMAT_YUY2:
+	case VIDEO_FORMAT_UYVY:
+		linesize[0] = width * 2;
+		break;
+	case VIDEO_FORMAT_UYVA: /* two planes: one double width, one single width */
+		linesize[0] = width * 2;
+		linesize[1] = width;
+		break;
+	case VIDEO_FORMAT_P010: /* two planes: all double width */
+	case VIDEO_FORMAT_P216:
+		linesize[0] = width * 2;
+		linesize[1] = width * 2;
+		break;
+	case VIDEO_FORMAT_I412: /* three planes: all double width */
+		linesize[0] = width * 2;
+		linesize[1] = width * 2;
+		linesize[2] = width * 2;
+		break;
+	case VIDEO_FORMAT_YA2L: /* four planes: all double width */
+		linesize[0] = width * 2;
+		linesize[1] = width * 2;
+		linesize[2] = width * 2;
+		linesize[3] = width * 2;
+		break;
 
-		case VIDEO_FORMAT_Y800: /* one plane: full width */
-			linesize[0] = width;
-			break;
-		case VIDEO_FORMAT_NV12: /* two planes: all full width */
-			linesize[0] = width;
-			linesize[1] = width;
-			break;
-		case VIDEO_FORMAT_I444: /* three planes: all full width */
-			linesize[0] = width;
-			linesize[1] = width;
-			linesize[2] = width;
-			break;
-		case VIDEO_FORMAT_YUVA: /* four planes: all full width */
-			linesize[0] = width;
-			linesize[1] = width;
-			linesize[2] = width;
-			linesize[3] = width;
-			break;
+	case VIDEO_FORMAT_Y800: /* one plane: full width */
+		linesize[0] = width;
+		break;
+	case VIDEO_FORMAT_NV12: /* two planes: all full width */
+		linesize[0] = width;
+		linesize[1] = width;
+		break;
+	case VIDEO_FORMAT_I444: /* three planes: all full width */
+		linesize[0] = width;
+		linesize[1] = width;
+		linesize[2] = width;
+		break;
+	case VIDEO_FORMAT_YUVA: /* four planes: all full width */
+		linesize[0] = width;
+		linesize[1] = width;
+		linesize[2] = width;
+		linesize[3] = width;
+		break;
 
-		case VIDEO_FORMAT_V210: { /* one plane: bruh (Little Endian Compressed) */
-			align_uint32(&width, 48);
-			linesize[0] = ((width + 5) / 6) * 16;
-			break;
-		}
+	case VIDEO_FORMAT_V210: { /* one plane: bruh (Little Endian Compressed) */
+		align_uint32(&width, 48);
+		linesize[0] = ((width + 5) / 6) * 16;
+		break;
+	}
 	}
 }
 
-void video_frame_get_plane_heights(uint32_t heights[MAX_AV_PLANES], enum video_format format, uint32_t height)
+void video_frame_get_plane_heights(uint32_t heights[MAX_AV_PLANES],
+				   enum video_format format, uint32_t height)
 {
 	switch (format) {
-		default:
-		case VIDEO_FORMAT_NONE:
-			return;
+	default:
+	case VIDEO_FORMAT_NONE:
+		return;
 
-		case VIDEO_FORMAT_I420: /* three planes: full height, half height, half height */
-		case VIDEO_FORMAT_I010:
-			heights[0] = height;
-			heights[1] = height / 2;
-			heights[2] = height / 2;
-			break;
+	case VIDEO_FORMAT_I420: /* three planes: full height, half height, half height */
+	case VIDEO_FORMAT_I010:
+		heights[0] = height;
+		heights[1] = height / 2;
+		heights[2] = height / 2;
+		break;
 
-		case VIDEO_FORMAT_NV12: /* two planes: full height, half height */
-		case VIDEO_FORMAT_P010:
-			heights[0] = height;
-			heights[1] = height / 2;
-			break;
+	case VIDEO_FORMAT_NV12: /* two planes: full height, half height */
+	case VIDEO_FORMAT_P010:
+		heights[0] = height;
+		heights[1] = height / 2;
+		break;
 
-		case VIDEO_FORMAT_Y800: /* one plane: full height */
-		case VIDEO_FORMAT_YVYU:
-		case VIDEO_FORMAT_YUY2:
-		case VIDEO_FORMAT_UYVY:
-		case VIDEO_FORMAT_RGBA:
-		case VIDEO_FORMAT_BGRA:
-		case VIDEO_FORMAT_BGRX:
-		case VIDEO_FORMAT_BGR3:
-		case VIDEO_FORMAT_AYUV:
-		case VIDEO_FORMAT_V210:
-		case VIDEO_FORMAT_R10L:
-			heights[0] = height;
-			break;
+	case VIDEO_FORMAT_Y800: /* one plane: full height */
+	case VIDEO_FORMAT_YVYU:
+	case VIDEO_FORMAT_YUY2:
+	case VIDEO_FORMAT_UYVY:
+	case VIDEO_FORMAT_RGBA:
+	case VIDEO_FORMAT_BGRA:
+	case VIDEO_FORMAT_BGRX:
+	case VIDEO_FORMAT_BGR3:
+	case VIDEO_FORMAT_AYUV:
+	case VIDEO_FORMAT_V210:
+	case VIDEO_FORMAT_R10L:
+		heights[0] = height;
+		break;
 
-		case VIDEO_FORMAT_I444: /* three planes: all full height */
-		case VIDEO_FORMAT_I422:
-		case VIDEO_FORMAT_I210:
-		case VIDEO_FORMAT_I412:
-			heights[0] = height;
-			heights[1] = height;
-			heights[2] = height;
-			break;
+	case VIDEO_FORMAT_I444: /* three planes: all full height */
+	case VIDEO_FORMAT_I422:
+	case VIDEO_FORMAT_I210:
+	case VIDEO_FORMAT_I412:
+		heights[0] = height;
+		heights[1] = height;
+		heights[2] = height;
+		break;
 
-		case VIDEO_FORMAT_I40A: /* four planes: full height, half height, half height, full height */
-			heights[0] = height;
-			heights[1] = height / 2;
-			heights[2] = height / 2;
-			heights[0] = height;
-			break;
+	case VIDEO_FORMAT_I40A: /* four planes: full height, half height, half height, full height */
+		heights[0] = height;
+		heights[1] = height / 2;
+		heights[2] = height / 2;
+		heights[0] = height;
+		break;
 
-		case VIDEO_FORMAT_I42A: /* four planes: all full height */
-		case VIDEO_FORMAT_YUVA:
-		case VIDEO_FORMAT_YA2L:
-			heights[0] = height;
-			heights[1] = height;
-			heights[2] = height;
-			heights[3] = height;
-			break;
+	case VIDEO_FORMAT_I42A: /* four planes: all full height */
+	case VIDEO_FORMAT_YUVA:
+	case VIDEO_FORMAT_YA2L:
+		heights[0] = height;
+		heights[1] = height;
+		heights[2] = height;
+		heights[3] = height;
+		break;
 
-		case VIDEO_FORMAT_P216: /* two planes: all full height */
-		case VIDEO_FORMAT_P416:
-			heights[0] = height;
-			heights[1] = height;
-			break;
+	case VIDEO_FORMAT_P216: /* two planes: all full height */
+	case VIDEO_FORMAT_P416:
+	case VIDEO_FORMAT_UYVA:
+		heights[0] = height;
+		heights[1] = height;
+		break;
 	}
 }
 
-void video_frame_init(struct video_frame *frame, enum video_format format, uint32_t width, uint32_t height)
+void video_frame_init(struct video_frame *frame, enum video_format format,
+		      uint32_t width, uint32_t height)
 {
 	size_t size = 0;
 	uint32_t linesizes[MAX_AV_PLANES];
@@ -229,9 +238,8 @@ void video_frame_init(struct video_frame *frame, enum video_format format, uint3
 			continue;
 		frame->data[i] = frame->data[0] + offsets[i - 1];
 		frame->linesize[i] = linesizes[i];
+		assert(((uintptr_t)frame->data[i] % alignment) == 0);
 	}
-
-	assert(((uintptr_t)frame->data[i] % alignment) == 0);
 }
 
 void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
@@ -249,15 +257,20 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 		if (!heights[i])
 			continue;
 		if (src->linesize[i] == dst->linesize[i]) {
-			memcpy(dst->data[i], src->data[i], src->linesize[i] * heights[i]);
+			memcpy(dst->data[i], src->data[i],
+			       src->linesize[i] * heights[i]);
 		} else { /* linesizes which do not match must be copied line-by-line */
 			size_t src_linesize = src->linesize[i];
 			size_t dst_linesize = dst->linesize[i];
 			/* determine how much we can write (frames with different line sizes require more )*/
-			size_t linesize = src_linesize < dst_linesize ? src_linesize : dst_linesize;
+			size_t linesize = src_linesize < dst_linesize
+						  ? src_linesize
+						  : dst_linesize;
 			for (uint32_t i = 0; i < heights[i]; i++) {
-				uint8_t *src_pos = src->data[i] + (src_linesize * i);
-				uint8_t *dst_pos = dst->data[i] + (dst_linesize * i);
+				uint8_t *src_pos =
+					src->data[i] + (src_linesize * i);
+				uint8_t *dst_pos =
+					dst->data[i] + (dst_linesize * i);
 				memcpy(dst_pos, src_pos, linesize);
 			}
 		}

--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -14,404 +14,252 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
-
+#include <assert.h>
 #include "video-frame.h"
 
-#define ALIGN_SIZE(size, align) size = (((size) + (align - 1)) & (~(align - 1)))
+#define HALF(size) ((size + 1) / 2)
+#define ALIGN(size, alignment) *size = (*size + alignment - 1) & (~(alignment - 1));
 
-/* messy code alarm */
-void video_frame_init(struct video_frame *frame, enum video_format format,
-		      uint32_t width, uint32_t height)
+static inline void align_size(size_t *size, size_t alignment)
 {
-	size_t size;
-	size_t offsets[MAX_AV_PLANES];
+	ALIGN(size, alignment);
+}
+
+static inline void align_uint32(uint32_t *size, size_t alignment)
+{
+	ALIGN(size, alignment);
+}
+
+/* assumes already-zeroed array */
+void video_frame_get_linesizes(uint32_t linesize[MAX_AV_PLANES], enum video_format format, uint32_t width)
+{
+	switch (format) {
+		default:
+		case VIDEO_FORMAT_NONE:
+			break;
+		case VIDEO_FORMAT_BGR3: /* one plane: triple width */
+			linesize[0] = width * 3;
+			break;
+		case VIDEO_FORMAT_RGBA: /* one plane: quadruple width */
+		case VIDEO_FORMAT_BGRA:
+		case VIDEO_FORMAT_BGRX:
+		case VIDEO_FORMAT_AYUV:
+		case VIDEO_FORMAT_R10L:
+			linesize[0] = width * 4;
+			break;
+		case VIDEO_FORMAT_P416: /* two planes: double width, quadruple width */
+			linesize[0] = width * 2;
+			linesize[1] = width * 4;
+			break;
+		case VIDEO_FORMAT_I420: /* three planes: full width, half width, half width */
+		case VIDEO_FORMAT_I422:
+			linesize[0] = width;
+			linesize[1] = HALF(width);
+			linesize[2] = HALF(width);
+			break;
+		case VIDEO_FORMAT_I210: /* three planes: double width, full width, full width */
+		case VIDEO_FORMAT_I010:
+			linesize[0] = width * 2;
+			linesize[1] = width;
+			linesize[2] = width;
+			break;
+		case VIDEO_FORMAT_I40A: /* four planes: full width, half width, half width, full width */
+		case VIDEO_FORMAT_I42A:
+			linesize[0] = width;
+			linesize[1] = HALF(width);
+			linesize[2] = HALF(width);
+			linesize[3] = width;
+			break;
+
+		case VIDEO_FORMAT_YVYU: /* one plane: double width */
+		case VIDEO_FORMAT_YUY2:
+		case VIDEO_FORMAT_UYVY:
+			linesize[0] = width * 2;
+			break;
+		case VIDEO_FORMAT_P010: /* two planes: all double width */
+		case VIDEO_FORMAT_P216:
+			linesize[0] = width * 2;
+			linesize[1] = width * 2;
+			break;
+		case VIDEO_FORMAT_I412: /* three planes: all double width */
+			linesize[0] = width * 2;
+			linesize[1] = width * 2;
+			linesize[2] = width * 2;
+			break;
+		case VIDEO_FORMAT_YA2L: /* four planes: all double width */
+			linesize[0] = width * 2;
+			linesize[1] = width * 2;
+			linesize[2] = width * 2;
+			linesize[3] = width * 2;
+			break;
+
+		case VIDEO_FORMAT_Y800: /* one plane: full width */
+			linesize[0] = width;
+			break;
+		case VIDEO_FORMAT_NV12: /* two planes: all full width */
+			linesize[0] = width;
+			linesize[1] = width;
+			break;
+		case VIDEO_FORMAT_I444: /* three planes: all full width */
+			linesize[0] = width;
+			linesize[1] = width;
+			linesize[2] = width;
+			break;
+		case VIDEO_FORMAT_YUVA: /* four planes: all full width */
+			linesize[0] = width;
+			linesize[1] = width;
+			linesize[2] = width;
+			linesize[3] = width;
+			break;
+
+		case VIDEO_FORMAT_V210: { /* one plane: bruh (Little Endian Compressed) */
+			align_uint32(&width, 48);
+			linesize[0] = ((width + 5) / 6) * 16;
+			break;
+		}
+	}
+}
+
+void video_frame_get_plane_heights(uint32_t heights[MAX_AV_PLANES], enum video_format format, uint32_t height)
+{
+	switch (format) {
+		default:
+		case VIDEO_FORMAT_NONE:
+			return;
+
+		case VIDEO_FORMAT_I420: /* three planes: full height, half height, half height */
+		case VIDEO_FORMAT_I010:
+			heights[0] = height;
+			heights[1] = height / 2;
+			heights[2] = height / 2;
+			break;
+
+		case VIDEO_FORMAT_NV12: /* two planes: full height, half height */
+		case VIDEO_FORMAT_P010:
+			heights[0] = height;
+			heights[1] = height / 2;
+			break;
+
+		case VIDEO_FORMAT_Y800: /* one plane: full height */
+		case VIDEO_FORMAT_YVYU:
+		case VIDEO_FORMAT_YUY2:
+		case VIDEO_FORMAT_UYVY:
+		case VIDEO_FORMAT_RGBA:
+		case VIDEO_FORMAT_BGRA:
+		case VIDEO_FORMAT_BGRX:
+		case VIDEO_FORMAT_BGR3:
+		case VIDEO_FORMAT_AYUV:
+		case VIDEO_FORMAT_V210:
+		case VIDEO_FORMAT_R10L:
+			heights[0] = height;
+			break;
+
+		case VIDEO_FORMAT_I444: /* three planes: all full height */
+		case VIDEO_FORMAT_I422:
+		case VIDEO_FORMAT_I210:
+		case VIDEO_FORMAT_I412:
+			heights[0] = height;
+			heights[1] = height;
+			heights[2] = height;
+			break;
+
+		case VIDEO_FORMAT_I40A: /* four planes: full height, half height, half height, full height */
+			heights[0] = height;
+			heights[1] = height / 2;
+			heights[2] = height / 2;
+			heights[0] = height;
+			break;
+
+		case VIDEO_FORMAT_I42A: /* four planes: all full height */
+		case VIDEO_FORMAT_YUVA:
+		case VIDEO_FORMAT_YA2L:
+			heights[0] = height;
+			heights[1] = height;
+			heights[2] = height;
+			heights[3] = height;
+			break;
+
+		case VIDEO_FORMAT_P216: /* two planes: all full height */
+		case VIDEO_FORMAT_P416:
+			heights[0] = height;
+			heights[1] = height;
+			break;
+	}
+}
+
+void video_frame_init(struct video_frame *frame, enum video_format format, uint32_t width, uint32_t height)
+{
+	size_t size = 0;
+	uint32_t linesizes[MAX_AV_PLANES];
+	uint32_t heights[MAX_AV_PLANES];
+	size_t offsets[MAX_AV_PLANES - 1];
 	int alignment = base_get_alignment();
 
 	if (!frame)
 		return;
 
 	memset(frame, 0, sizeof(struct video_frame));
+	memset(linesizes, 0, sizeof(linesizes));
+	memset(heights, 0, sizeof(heights));
 	memset(offsets, 0, sizeof(offsets));
 
-	switch (format) {
-	case VIDEO_FORMAT_NONE:
-		return;
+	/* determine linesizes for each plane */
+	video_frame_get_linesizes(linesizes, format, width);
 
-	case VIDEO_FORMAT_I420: {
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_height = (height + 1) / 2;
-		const uint32_t quarter_area = half_width * half_height;
-		size += quarter_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += quarter_area;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->linesize[0] = width;
-		frame->linesize[1] = half_width;
-		frame->linesize[2] = half_width;
-		break;
-	}
+	/* determine line count for each plane */
+	video_frame_get_plane_heights(heights, format, height);
 
-	case VIDEO_FORMAT_NV12: {
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t cbcr_width = (width + 1) & (UINT32_MAX - 1);
-		size += cbcr_width * ((height + 1) / 2);
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->linesize[0] = width;
-		frame->linesize[1] = cbcr_width;
-		break;
-	}
-
-	case VIDEO_FORMAT_Y800:
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = width;
-		break;
-
-	case VIDEO_FORMAT_YVYU:
-	case VIDEO_FORMAT_YUY2:
-	case VIDEO_FORMAT_UYVY: {
-		const uint32_t double_width =
-			((width + 1) & (UINT32_MAX - 1)) * 2;
-		size = double_width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = double_width;
-		break;
-	}
-
-	case VIDEO_FORMAT_RGBA:
-	case VIDEO_FORMAT_BGRA:
-	case VIDEO_FORMAT_BGRX:
-	case VIDEO_FORMAT_AYUV:
-		size = width * height * 4;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = width * 4;
-		break;
-
-	case VIDEO_FORMAT_I444:
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size * 3);
-		frame->data[1] = (uint8_t *)frame->data[0] + size;
-		frame->data[2] = (uint8_t *)frame->data[1] + size;
-		frame->linesize[0] = width;
-		frame->linesize[1] = width;
-		frame->linesize[2] = width;
-		break;
-
-	case VIDEO_FORMAT_I412:
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size * 3);
-		frame->data[1] = (uint8_t *)frame->data[0] + size;
-		frame->data[2] = (uint8_t *)frame->data[1] + size;
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = width * 2;
-		frame->linesize[2] = width * 2;
-		break;
-
-	case VIDEO_FORMAT_BGR3:
-		size = width * height * 3;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = width * 3;
-		break;
-
-	case VIDEO_FORMAT_I422: {
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_area = half_width * height;
-		size += half_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += half_area;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->linesize[0] = width;
-		frame->linesize[1] = half_width;
-		frame->linesize[2] = half_width;
-		break;
-	}
-
-	case VIDEO_FORMAT_I210: {
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_area = half_width * height;
-		const uint32_t half_area_size = 2 * half_area;
-		size += half_area_size;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += half_area_size;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = half_width * 2;
-		frame->linesize[2] = half_width * 2;
-		break;
-	}
-
-	case VIDEO_FORMAT_I40A: {
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_height = (height + 1) / 2;
-		const uint32_t quarter_area = half_width * half_height;
-		size += quarter_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += quarter_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[2] = size;
-		size += width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
-		frame->linesize[0] = width;
-		frame->linesize[1] = half_width;
-		frame->linesize[2] = half_width;
-		frame->linesize[3] = width;
-		break;
-	}
-
-	case VIDEO_FORMAT_I42A: {
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_area = half_width * height;
-		size += half_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += half_area;
-		ALIGN_SIZE(size, alignment);
-		offsets[2] = size;
-		size += width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
-		frame->linesize[0] = width;
-		frame->linesize[1] = half_width;
-		frame->linesize[2] = half_width;
-		frame->linesize[3] = width;
-		break;
-	}
-
-	case VIDEO_FORMAT_YUVA:
-		size = width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		size += width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += width * height;
-		ALIGN_SIZE(size, alignment);
-		offsets[2] = size;
-		size += width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
-		frame->linesize[0] = width;
-		frame->linesize[1] = width;
-		frame->linesize[2] = width;
-		frame->linesize[3] = width;
-		break;
-
-	case VIDEO_FORMAT_YA2L: {
-		const uint32_t linesize = width * 2;
-		const uint32_t plane_size = linesize * height;
-		size = plane_size;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
+	/* calculate total buffer required */
+	for (uint32_t i = 0; i < MAX_AV_PLANES; i++) {
+		if (!linesizes[i] || !heights[i])
+			continue;
+		size_t plane_size = (size_t)linesizes[i] * (size_t)heights[i];
+		align_size(&plane_size, alignment);
 		size += plane_size;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += plane_size;
-		ALIGN_SIZE(size, alignment);
-		offsets[2] = size;
-		size += plane_size;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->data[3] = (uint8_t *)frame->data[0] + offsets[2];
-		frame->linesize[0] = linesize;
-		frame->linesize[1] = linesize;
-		frame->linesize[2] = linesize;
-		frame->linesize[3] = linesize;
-		break;
+		offsets[i] = size;
 	}
 
-	case VIDEO_FORMAT_I010: {
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t half_width = (width + 1) / 2;
-		const uint32_t half_height = (height + 1) / 2;
-		const uint32_t quarter_area = half_width * half_height;
-		size += quarter_area * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[1] = size;
-		size += quarter_area * 2;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->data[2] = (uint8_t *)frame->data[0] + offsets[1];
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = half_width * 2;
-		frame->linesize[2] = half_width * 2;
-		break;
+	/* allocate memory */
+	frame->data[0] = bmalloc(size);
+	frame->linesize[0] = linesizes[0];
+
+	/* apply plane data pointers according to offsets */
+	for (uint32_t i = 1; i < MAX_AV_PLANES; i++) {
+		if (!linesizes[i] || !heights[i])
+			continue;
+		frame->data[i] = frame->data[0] + offsets[i - 1];
+		frame->linesize[i] = linesizes[i];
 	}
 
-	case VIDEO_FORMAT_P010: {
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t cbcr_width = (width + 1) & (UINT32_MAX - 1);
-		size += cbcr_width * ((height + 1) / 2) * 2;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = cbcr_width * 2;
-		break;
-	}
-
-	case VIDEO_FORMAT_P216: {
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		const uint32_t cbcr_width = (width + 1) & (UINT32_MAX - 1);
-		size += cbcr_width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = cbcr_width * 2;
-		break;
-	}
-
-	case VIDEO_FORMAT_P416: {
-		size = width * height * 2;
-		ALIGN_SIZE(size, alignment);
-		offsets[0] = size;
-		size += width * height * 4;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->data[1] = (uint8_t *)frame->data[0] + offsets[0];
-		frame->linesize[0] = width * 2;
-		frame->linesize[1] = width * 4;
-		break;
-	}
-
-	case VIDEO_FORMAT_V210: {
-		const uint32_t adjusted_width = ((width + 5) / 6) * 16;
-		size = adjusted_width * height;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = adjusted_width;
-		break;
-	}
-
-	case VIDEO_FORMAT_R10L:
-		size = width * height * 4;
-		ALIGN_SIZE(size, alignment);
-		frame->data[0] = bmalloc(size);
-		frame->linesize[0] = width * 4;
-		break;
-	}
+	assert(((uintptr_t)frame->data[i] % alignment) == 0);
 }
 
 void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 		      enum video_format format, uint32_t cy)
 {
-	switch (format) {
-	case VIDEO_FORMAT_NONE:
-		return;
+	uint32_t heights[MAX_AV_PLANES];
 
-	case VIDEO_FORMAT_I420:
-	case VIDEO_FORMAT_I010:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy / 2);
-		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy / 2);
-		break;
+	memset(heights, 0, sizeof(heights));
 
-	case VIDEO_FORMAT_NV12:
-	case VIDEO_FORMAT_P010:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy / 2);
-		break;
+	/* determine line count for each plane */
+	video_frame_get_plane_heights(heights, format, cy);
 
-	case VIDEO_FORMAT_Y800:
-	case VIDEO_FORMAT_YVYU:
-	case VIDEO_FORMAT_YUY2:
-	case VIDEO_FORMAT_UYVY:
-	case VIDEO_FORMAT_RGBA:
-	case VIDEO_FORMAT_BGRA:
-	case VIDEO_FORMAT_BGRX:
-	case VIDEO_FORMAT_BGR3:
-	case VIDEO_FORMAT_AYUV:
-	case VIDEO_FORMAT_V210:
-	case VIDEO_FORMAT_R10L:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		break;
-
-	case VIDEO_FORMAT_I444:
-	case VIDEO_FORMAT_I422:
-	case VIDEO_FORMAT_I210:
-	case VIDEO_FORMAT_I412:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
-		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy);
-		break;
-
-	case VIDEO_FORMAT_I40A:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy / 2);
-		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy / 2);
-		memcpy(dst->data[3], src->data[3], src->linesize[3] * cy);
-		break;
-
-	case VIDEO_FORMAT_I42A:
-	case VIDEO_FORMAT_YUVA:
-	case VIDEO_FORMAT_YA2L:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
-		memcpy(dst->data[2], src->data[2], src->linesize[2] * cy);
-		memcpy(dst->data[3], src->data[3], src->linesize[3] * cy);
-		break;
-
-	case VIDEO_FORMAT_P216:
-	case VIDEO_FORMAT_P416:
-		memcpy(dst->data[0], src->data[0], src->linesize[0] * cy);
-		memcpy(dst->data[1], src->data[1], src->linesize[1] * cy);
-		break;
+	/* copy each plane */
+	for (uint32_t i = 0; i < MAX_AV_PLANES; i++) {
+		if (!heights[i])
+			continue;
+		if (src->linesize[i] == dst->linesize[i]) {
+			memcpy(dst->data[i], src->data[i], src->linesize[i] * heights[i]);
+		} else { /* linesizes which do not match must be copied line-by-line */
+			size_t src_linesize = src->linesize[i];
+			size_t dst_linesize = dst->linesize[i];
+			/* determine how much we can write (frames with different line sizes require more )*/
+			size_t linesize = src_linesize < dst_linesize ? src_linesize : dst_linesize;
+			for (uint32_t i = 0; i < heights[i]; i++) {
+				uint8_t *src_pos = src->data[i] + (src_linesize * i);
+				uint8_t *dst_pos = dst->data[i] + (dst_linesize * i);
+				memcpy(dst_pos, src_pos, linesize);
+			}
+		}
 	}
 }

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -94,6 +94,8 @@ enum video_format {
 
 	/* packed uncompressed 10-bit format */
 	VIDEO_FORMAT_R10L,
+	/* two-plane, packed luma/chroma like UYVY and then alpha plane */
+	VIDEO_FORMAT_UYVA,
 };
 
 enum video_trc {
@@ -148,6 +150,7 @@ static inline bool format_is_yuv(enum video_format format)
 	case VIDEO_FORMAT_YVYU:
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:
+	case VIDEO_FORMAT_UYVA:
 	case VIDEO_FORMAT_I444:
 	case VIDEO_FORMAT_I412:
 	case VIDEO_FORMAT_I40A:
@@ -191,6 +194,8 @@ static inline const char *get_video_format_name(enum video_format format)
 		return "YUY2";
 	case VIDEO_FORMAT_UYVY:
 		return "UYVY";
+	case VIDEO_FORMAT_UYVA:
+		return "UYVA";
 	case VIDEO_FORMAT_RGBA:
 		return "RGBA";
 	case VIDEO_FORMAT_BGRA:

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -976,6 +976,7 @@ convert_video_format(enum video_format format, enum video_trc trc)
 		case VIDEO_FORMAT_I42A:
 		case VIDEO_FORMAT_YUVA:
 		case VIDEO_FORMAT_AYUV:
+		case VIDEO_FORMAT_UYVA:
 			return GS_BGRA;
 		case VIDEO_FORMAT_I010:
 		case VIDEO_FORMAT_P010:

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1640,6 +1640,7 @@ enum convert_type {
 	CONVERT_422P10LE,
 	CONVERT_422_A,
 	CONVERT_422_PACK,
+	CONVERT_422_PACK_A,
 	CONVERT_444,
 	CONVERT_444P12LE,
 	CONVERT_444_A,
@@ -1675,6 +1676,9 @@ static inline enum convert_type get_convert_type(enum video_format format,
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:
 		return CONVERT_422_PACK;
+
+	case VIDEO_FORMAT_UYVA:
+		return CONVERT_422_PACK_A;
 
 	case VIDEO_FORMAT_Y800:
 		return CONVERT_800;
@@ -1734,6 +1738,23 @@ static inline bool set_packed422_sizes(struct obs_source *source,
 	source->async_convert_height[0] = height;
 	source->async_texture_formats[0] = GS_BGRA;
 	source->async_channel_count = 1;
+	return true;
+}
+
+static inline bool
+set_packed422_sep_alpha_sizes(struct obs_source *source,
+			      const struct obs_source_frame *frame)
+{
+	const uint32_t width = frame->width;
+	const uint32_t height = frame->height;
+	const uint32_t half_width = (width + 1) / 2;
+	source->async_convert_width[0] = half_width;
+	source->async_convert_height[0] = height;
+	source->async_texture_formats[0] = GS_BGRA;
+	source->async_convert_width[1] = width;
+	source->async_convert_height[1] = height;
+	source->async_texture_formats[1] = GS_R8;
+	source->async_channel_count = 2;
 	return true;
 }
 
@@ -2039,6 +2060,8 @@ static inline bool init_gpu_conversion(struct obs_source *source,
 				 frame->trc)) {
 	case CONVERT_422_PACK:
 		return set_packed422_sizes(source, frame);
+	case CONVERT_422_PACK_A:
+		return set_packed422_sep_alpha_sizes(source, frame);
 
 	case CONVERT_420:
 	case CONVERT_420_PQ:
@@ -2170,6 +2193,7 @@ static void upload_raw_frame(gs_texture_t *tex[MAX_AV_PLANES],
 	switch (get_convert_type(frame->format, frame->full_range,
 				 frame->trc)) {
 	case CONVERT_422_PACK:
+	case CONVERT_422_PACK_A:
 	case CONVERT_800:
 	case CONVERT_RGB_LIMITED:
 	case CONVERT_BGR3:
@@ -2208,6 +2232,8 @@ static const char *select_conversion_technique(enum video_format format,
 	switch (format) {
 	case VIDEO_FORMAT_UYVY:
 		return "UYVY_Reverse";
+	case VIDEO_FORMAT_UYVA:
+		return "UYVA_Reverse";
 
 	case VIDEO_FORMAT_YUY2:
 		switch (trc) {
@@ -3555,6 +3581,11 @@ static void copy_frame_data(struct obs_source_frame *dst,
 	case VIDEO_FORMAT_V210:
 	case VIDEO_FORMAT_R10L:
 		copy_frame_data_plane(dst, src, 0, dst->height);
+		break;
+
+	case VIDEO_FORMAT_UYVA:
+		copy_frame_data_plane(dst, src, 0, dst->height);
+		copy_frame_data_plane(dst, src, 1, dst->height);
 		break;
 
 	case VIDEO_FORMAT_I40A: {

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -816,6 +816,7 @@ static void set_gpu_converted_data(struct video_frame *output,
 	case VIDEO_FORMAT_YVYU:
 	case VIDEO_FORMAT_YUY2:
 	case VIDEO_FORMAT_UYVY:
+	case VIDEO_FORMAT_UYVA:
 	case VIDEO_FORMAT_RGBA:
 	case VIDEO_FORMAT_BGRA:
 	case VIDEO_FORMAT_BGRX:


### PR DESCRIPTION
### Description
This change adds the YUVA pixel format, which is a 4:2:2:4 semi-planar with packed YUV data in one place and a second plane with only alpha data as documented here: https://docs.ndi.video/docs/sdk/frame-types
Note that best I can tell, NDI is the only software that uses this pixel format, and other software may use YUVA to refer to a different format.  I am open to suggestions of alternative names for this format in OBS.

### Motivation and Context
NDI uses an unusual format for pixel data with transparency, and obs-ndi was silently ignoring the alpha plane of that format leading to these bug reports :https://github.com/obs-ndi/obs-ndi/issues/937 and https://github.com/obs-ndi/obs-ndi/issues/983 

### How Has This Been Tested?
This has been tested on Windows and macOS using one OBS instance sending a source with transparency over NDI (which already worked correctly) and another instance receiving (along with a small patch to obs-ndi to use the new format which I will submit as a PR on that side after this has been merged)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
