### PR TITLE
UI: Block Elgato Stream Deck plugin before 5.5.2.0 to avoid crashes

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -183,6 +183,12 @@ static blocked_module_t blocked_modules[] = {
 	// Reference: https://github.com/obsproject/obs-studio/issues/8552
 	{L"\\holisticmotioncapturefilter64bit.dll", 0, 1680044549,
 	 TS_LESS_THAN},
+
+	// Elgato Stream Deck plugin < 2024-02-01
+	// Blocking all previous versions because they have undefined behavior
+	// that results in crashes.
+	// Reference: https://github.com/obsproject/obs-studio/issues/10245
+	{L"\\streamdeckplugin.dll", 0, 1706745600, TS_LESS_THAN},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Elgato Stream Deck plugin older than 5.5.2.0 invokes undefined behavior that results in application crashes. Let's block older versions to prevent the crashes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Requested by @notr1ch . Want less crashes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've built this locally on Windows 11, but I have not tested this, nor am I sure how I would test it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
