### PR TITLE
libobs: Add keyframe aligned encoder groups

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1094,6 +1094,20 @@ extern bool audio_pause_check(struct pause_data *pause, struct audio_data *data,
 			      size_t sample_rate);
 extern void pause_reset(struct pause_data *pause);
 
+enum keyframe_group_track_status {
+	KEYFRAME_TRACK_STATUS_NOT_SEEN = 0,
+	KEYFRAME_TRACK_STATUS_SEEN = 1,
+	KEYFRAME_TRACK_STATUS_SKIPPED = 2,
+};
+
+struct keyframe_group_data {
+	uintptr_t group_id;
+	int64_t pts;
+	uint32_t required_tracks;
+	enum keyframe_group_track_status
+		seen_on_track[MAX_OUTPUT_VIDEO_ENCODERS];
+};
+
 struct obs_output {
 	struct obs_context_data context;
 	struct obs_output_info info;
@@ -1102,6 +1116,7 @@ struct obs_output {
 	bool owns_info_id;
 
 	bool received_video[MAX_OUTPUT_VIDEO_ENCODERS];
+	DARRAY(struct keyframe_group_data) keyframe_group_tracking;
 	bool received_audio;
 	volatile bool data_active;
 	volatile bool end_data_capture_thread_active;

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -91,6 +91,17 @@ static void *gpu_encode_thread(void *data)
 			pkt.timebase_den = encoder->timebase_den;
 			pkt.encoder = encoder;
 
+			if (encoder->encoder_group && !encoder->start_ts) {
+				struct encoder_group *group =
+					encoder->encoder_group;
+				bool ready = false;
+				pthread_mutex_lock(&group->mutex);
+				ready = group->start_timestamp == timestamp;
+				pthread_mutex_unlock(&group->mutex);
+				if (!ready)
+					continue;
+			}
+
 			if (!encoder->first_received && num_paired) {
 				bool wait_for_audio = false;
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2600,6 +2600,11 @@ EXPORT void obs_encoder_set_last_error(obs_encoder_t *encoder,
 
 EXPORT uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder);
 
+EXPORT bool obs_encoder_group_keyframe_aligned_encoders(
+	obs_encoder_t *encoder, obs_encoder_t *encoder_to_be_grouped);
+EXPORT bool obs_encoder_group_remove_keyframe_aligned_encoder(
+	obs_encoder_t *encoder, obs_encoder_t *encoder_to_be_ungrouped);
+
 /* ------------------------------------------------------------------------- */
 /* Stream Services */
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is meant to allow grouping encoders for e.g. eRTMP multitrack video (<=> Twitch Enhanced Broadcasting) such that IDR frames are aligned for seamless rendition switching when transmuxing the overall output stream into e.g. HLS or similar multi rendition formats

### Motivation and Context
Without this change, encoders aren't guaranteed to start on the same frame even if started "at the same time" due to encoder startup not being synchronized with the video thread; e.g. in practice we've observed a one frame offset that sometimes happens between encoders, though the offset can be arbitrarily high potentially due to lack of synchronization

With this there's explicit synchronization, so all encoders start on the same frame (and get the "same stream" of frames fed to them)

### How Has This Been Tested?
This code has been deployed in the Twitch Enhanced Broadcasting beta since January, and its effects can be observed when disabling the check in `receive_video` while using multitrack video outputs (and logging which input frame is first sent to encoders)

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
