### PR TITLE
mac-avcapture: Fix possible crash if camera uses BGRA format

### DIFF
--- a/plugins/mac-avcapture/plugin-properties.m
+++ b/plugins/mac-avcapture/plugin-properties.m
@@ -422,10 +422,14 @@ bool properties_update_config(OBSAVCapture *capture, obs_properties_t *propertie
 
             // Only iterate over available framerates if input format, color space, and resolution are matching
             if (hasFoundInputFormat && hasFoundColorSpace && hasFoundResolution) {
+                CFComparisonResult isColorPrimaryMatch = kCFCompareEqualTo;
+
                 CFPropertyListRef colorPrimary = CMFormatDescriptionGetExtension(
                     format.formatDescription, kCMFormatDescriptionExtension_ColorPrimaries);
 
-                CFComparisonResult isColorPrimaryMatch = CFStringCompare(colorPrimary, priorColorPrimary, 0);
+                if (colorPrimary) {
+                    isColorPrimaryMatch = CFStringCompare(colorPrimary, priorColorPrimary, 0);
+                }
 
                 if (isColorPrimaryMatch != kCFCompareEqualTo || !hasFoundFramerate) {
                     for (AVFrameRateRange *range in format.videoSupportedFrameRateRanges.reverseObjectEnumerator) {


### PR DESCRIPTION
### Description
Add check for possible NULL value returned for colour primaries of a capture device' image format.

### Motivation and Context
BGRA or other formats that do not use color primaries will not yield a valid color primary value. Initializing the CFComparisonResult to a default value and replacing it only if a non-NULL color primary value was retrieved avoids a possible crash.

### How Has This Been Tested?
Tested with OBS Virtual Camera which has a BGRA output format, which has no colour primary information attached to it.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
