### PR TITLE
CI: Use phased group rollouts for Sparkle stable channel updates

### DIFF
--- a/.github/actions/sparkle-appcast/action.yaml
+++ b/.github/actions/sparkle-appcast/action.yaml
@@ -160,6 +160,10 @@ runs:
           --channel '${{ inputs.channel }}'
         )
 
+        if [[ '${{ inputs.channel }}' == 'stable' ]] {
+          sparkle_options+=(--phased-rollout-interval 86400)
+        }
+
         Sparkle/bin/generate_appcast \
           ${sparkle_options} \
           builds

--- a/.github/actions/sparkle-appcast/action.yaml
+++ b/.github/actions/sparkle-appcast/action.yaml
@@ -150,15 +150,18 @@ runs:
         print -n '${{ inputs.sparklePrivateKey }}' >> eddsa_private.key
         local feed_url='${{ steps.builds.outputs.feedUrl }}'
         local arch=${${${(s:_:)feed_url:t}[2]}//x86/x86_64}
+        local sparkle_options=(
+          --verbose
+          --ed-key-file eddsa_private.key
+          --download-url-prefix '${{ inputs.urlPrefix }}/'
+          --full-release-notes-url "${feed_url//updates_*/notes_${{ inputs.channel }}.html}"
+          --maximum-versions 0
+          --maximum-deltas '${{ inputs.count }}'
+          --channel '${{ inputs.channel }}'
+        )
 
         Sparkle/bin/generate_appcast \
-          --verbose \
-          --ed-key-file eddsa_private.key \
-          --download-url-prefix '${{ inputs.urlPrefix }}/' \
-          --full-release-notes-url "${feed_url//updates_*/notes_${{ inputs.channel }}.html}" \
-          --maximum-versions 0 \
-          --maximum-deltas ${{ inputs.count }} \
-          --channel '${{ inputs.channel }}' \
+          ${sparkle_options} \
           builds
 
         local -a deltas=(builds/*.delta(N))


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Instead of pushing the Sparkle update to all macOS users at once, use Sparkle's "phased group rollouts" ("phased rollout interval") feature to split the notifications up into 7 groups separated by 1 day intervals. This potentially allows us to catch critical issues before all macOS users get the update notification.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We had a critical issue with OBS Studio 30.0.1 that we had to hotfix that day with OBS Studio 30.0.2. At the time, we considered the possibility of if we could have a more gradual rollout of macOS updates. This is possible with Sparkle's phased group rollouts.

https://sparkle-project.org/documentation/publishing/#phased-group-rollouts

It's possible that we conclude that this isn't worth the added complexity, but I wanted to get the code changes done so that we didn't have to worry about _if_ it was possible, only if we wanted to actually try it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested the changes locally to make sure that the CI scripts should still work and produce valid appcasts. I did not test the subsequently produced appcast files in any way other than checking them visually.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
