### PR TITLE
win-capture: Always reconfigure audio source when game capture hooks

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1939,9 +1939,7 @@ static void game_capture_tick(void *data, float seconds)
 			signal_handler_signal(sh, "hooked", &data);
 			calldata_free(&data);
 
-			// Update audio capture settings if not in window mode
-			if (gc->audio_source &&
-			    gc->config.mode != CAPTURE_MODE_WINDOW) {
+			if (gc->audio_source) {
 				reconfigure_audio_source(gc->audio_source,
 							 gc->window);
 			}


### PR DESCRIPTION
### Description

Fixes linked audio capture source not re-capturing a window after the game capture source is unhooked.

### Motivation and Context

When the change in #10259 was made I forgot to also update the hook counterpart.

Fixes #10319 

### How Has This Been Tested?

Closed and restarted a game.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
