### PR TITLE
libobs: Fix missing w32-pthreads dependency when building without UI

### DIFF
--- a/libobs/cmake/os-windows.cmake
+++ b/libobs/cmake/os-windows.cmake
@@ -1,3 +1,7 @@
+if(NOT TARGET OBS::w32-pthreads)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/deps/w32-pthreads" "${CMAKE_BINARY_DIR}/deps/w32-pthreads")
+endif()
+
 configure_file(cmake/windows/obs-module.rc.in libobs.rc)
 
 add_library(obs-obfuscate INTERFACE)


### PR DESCRIPTION
### Description
Adds w32-pthreads to CMake project if target is not available already when `libobs` is being configured.

### Motivation and Context
w32-pthreads is not correctly added to the generated CMake project if the UI subdirectory is not also included, which leads to builds configured without UI to fail.

Fixes #10347.

### How Has This Been Tested?
Tested on Windows 11 using `cmake --preset windows-x64 --fresh -DENABLE_UI=OFF`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
