### PR TITLE
obs-ffmpeg: Fix HDR metadata not being written when using FFmpeg 6.1+

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -491,6 +491,11 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 #endif
 	ffm->video_stream->avg_frame_rate = av_inv_q(context->time_base);
 
+	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
+		context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+
+	avcodec_parameters_from_context(ffm->video_stream->codecpar, context);
+
 	const int max_luminance = ffm->params.max_luminance;
 	if (max_luminance > 0) {
 		size_t content_size;
@@ -537,11 +542,6 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 			(uint8_t *)mastering, sizeof(*mastering), 0);
 #endif
 	}
-
-	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)
-		context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
-
-	avcodec_parameters_from_context(ffm->video_stream->codecpar, context);
 
 	ffm->video_ctx = context;
 }


### PR DESCRIPTION
### Description

The newer FFmpeg API requires us to set the mastering display and content light level metadata on the codec parameters rather than the stream, as those get overwritten/reset by `avcodec_parameters_from_context()` we need to move things around so they are added *after* the codec parameters are initialised.

This mainly affects NVENC HEVC/AV1 and the software AV1 encoders, as those do not seem to add this data to the bitstream on their own (AMF/QSV do).

### Motivation and Context

Fixes issue introduced in #9935
Fixes #10363

### How Has This Been Tested?

Recorded some HDR video, confirmed everything is correct.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
