### PR TITLE
UI: Size the abstract-socket address properly

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -67,12 +67,13 @@ void CheckIfAlreadyRunning(bool &already_running)
 	struct sockaddr_un bindInfo;
 	memset(&bindInfo, 0, sizeof(sockaddr_un));
 	bindInfo.sun_family = AF_LOCAL;
-	snprintf(bindInfo.sun_path + 1, sizeof(bindInfo.sun_path) - 1,
-		 "%s %d %s", "/com/obsproject", getpid(),
-		 App()->GetVersionString().c_str());
+	auto bindInfoStrlen = snprintf(bindInfo.sun_path + 1,
+				       sizeof(bindInfo.sun_path) - 1,
+				       "%s %d %s", "/com/obsproject", getpid(),
+				       App()->GetVersionString().c_str());
 
 	int bindErr = bind(uniq, (struct sockaddr *)&bindInfo,
-			   sizeof(struct sockaddr_un));
+			   sizeof(sa_family_t) + 1 + bindInfoStrlen);
 	already_running = bindErr == 0 ? 0 : 1;
 
 	if (already_running) {


### PR DESCRIPTION
### Description
Unlike filesystem addresses, which are paths, abstract addresses are blobs.

### Motivation and Context
This means that the address wasn't "\0/com/obsproject 2413747 version", but rather "\0/com/obsproject 2402613 version\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"; this is reflected in both /proc/net/unix:
```
000000001bf56057: 00000002 00000000 00000000 0002 01 56719817 @/com/obsproject 2402613 version@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
000000003e897b41: 00000002 00000000 00000000 0002 01 56730132 @/com/obsproject 2413747 version
```
and ss -l:
![](https://github.com/obsproject/obs-studio/assets/6709544/4b20fe3c-570f-407e-8e1a-7d1e033b7354)
extending the whole address column to the point of unusability.

This size calculation follows trivially from the manual, and naturally behaves correctly, as above.

This is the same issue as nfs-utils fsidd: https://lore.kernel.org/linux-nfs/b38ecca96762d939d377c381bf34521ee5945129.1700601199.git.nabijaczleweli@nabijaczleweli.xyz/T/#u

### How Has This Been Tested?
Ex-situ.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
