### PR TITLE
deps/media-playback: Fix hardware decoding of streams

### DIFF
--- a/deps/media-playback/media-playback/decode.c
+++ b/deps/media-playback/media-playback/decode.c
@@ -338,15 +338,12 @@ static int decode_packet(struct mp_decode *d, int *got_frame)
 		}
 
 		int err = av_hwframe_transfer_data(d->sw_frame, d->hw_frame, 0);
+		if (err == 0) {
+			err = av_frame_copy_props(d->sw_frame, d->hw_frame);
+		}
 		if (err) {
 			ret = 0;
 			*got_frame = false;
-		} else {
-			d->sw_frame->color_range = d->hw_frame->color_range;
-			d->sw_frame->color_primaries =
-				d->hw_frame->color_primaries;
-			d->sw_frame->color_trc = d->hw_frame->color_trc;
-			d->sw_frame->colorspace = d->hw_frame->colorspace;
 		}
 	}
 


### PR DESCRIPTION
### Description
Fixes #10369.
Since the update to FFmpeg 6.1, streams to a Media Source are broken if hardware decoding is enabled (both RTMP or SRT have been reported). The video is black although the audio is decoded fine. The manual copy of metadata introduced in commit [1] does not work any more for some unfathomable reasons.
As a fix we call instead the av_frame_copy_props function used in FFmpeg app in a similar context (hardware decoding) [2].
The metadata are copied without issues.
There is no need to guard the use of that function since it was introduced 9 years ago in avutil/frame.c.

[1] https://github.com/obsproject/obs-studio/commit/22fde5cdcd1c784cd60b8a8cd50af02e7e537182
[2] https://github.com/FFmpeg/FFmpeg/master/fftools/ffmpeg_dec.c

NB: on FFmpeg master as of today (3/15/24), the relevant line I've copied is 
https://github.com/FFmpeg/FFmpeg/blame/master/fftools/ffmpeg_dec.c#L336

### Motivation and Context
Bugfix.

### How Has This Been Tested?
HW decoding works again with Media Source when one plays an RTMP stream.
HW decoding still works for local media files.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
