### PR TITLE
mac-capture: Standardize early return behavior in init_screen_stream()

### DIFF
--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -106,14 +106,14 @@ static bool init_screen_stream(struct screen_capture *sc)
     switch (sc->capture_type) {
         case ScreenCaptureDisplayStream: {
             SCDisplay *target_display = get_target_display();
-
-            if (!target_display) {
+            if (target_display == nil) {
                 MACCAP_ERR("init_screen_stream: Invalid target display ID:  %u\n", sc->display);
-
                 os_sem_post(sc->shareable_content_available);
-                return false;
+                sc->disp = NULL;
+                os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
+                os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
+                return true;
             }
-
             if (sc->hide_obs) {
                 SCRunningApplication *obsApp = nil;
                 NSString *mainBundleIdentifier = [[NSBundle mainBundle] bundleIdentifier];
@@ -149,6 +149,7 @@ static bool init_screen_stream(struct screen_capture *sc)
                 }
             }
             if (target_window == nil) {
+                MACCAP_ERR("init_screen_stream: Invalid target window ID:  %u\n", sc->window);
                 os_sem_post(sc->shareable_content_available);
                 sc->disp = NULL;
                 os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
@@ -167,6 +168,14 @@ static bool init_screen_stream(struct screen_capture *sc)
         } break;
         case ScreenCaptureApplicationStream: {
             SCDisplay *target_display = get_target_display();
+            if (target_display == nil) {
+                MACCAP_ERR("init_screen_stream: Invalid target display ID:  %u\n", sc->display);
+                os_sem_post(sc->shareable_content_available);
+                sc->disp = NULL;
+                os_event_init(&sc->disp_finished, OS_EVENT_TYPE_MANUAL);
+                os_event_init(&sc->stream_start_completed, OS_EVENT_TYPE_MANUAL);
+                return true;
+            }
             SCRunningApplication *target_application = nil;
             for (SCRunningApplication *application in sc->shareable_content.applications) {
                 if ([application.bundleIdentifier isEqualToString:sc->application_id]) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Makes consistent the early return behavior when creating a macOS Screen Capture, such that if the user is creating a capture with an invalid/stale window or display, we abandon initialization properly in all three capture modes.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Per https://github.com/obsproject/obs-studio/issues/10377 as well as lingering reports about stale capture indicators, ScreenCaptureKit still does not behave well if we try to initialize streams with bad parameters, which can cause side effects for other applications relying on replayd. Additionally, the way we are currently early returning from a bad Display Capture, we seem to invalidate the source (making it unmodifiable) for the remainder of that OBS session, which is not desirable.

On 14.4, before these changes, my testing showed that:

1. If initializing a Display Capture with a no-longer-connected display, we could no longer modify that source within that OBS session. Also, replayd crashes.
2. If initializing an Application Capture with a no-longer-connected display, we can still modify the source, but replayd crashes.

With these changes:

1. Initializing a Display Capture with a no-longer-connected display fails, but the source is still modifiable and replayd does not crash.
2. Initializing an Application Capture with a no-longer-connected display, we can still modify the source, and replayd does not crash.

Initializing an Application Capture with an empty application list is supported by SCK and does not crash replayd, so we do not worry about that case.

Fixes https://github.com/obsproject/obs-studio/issues/10377

### How Has This Been Tested?
Tested locally on my 14.4 Apple Silicon machine.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Other

I considered using a `goto`, but I didn't really want to introduce one so I opted not to.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.