### PR TITLE
cmake: Fix MSVC runtime selection for win-dshow and win-capture targets

### DIFF
--- a/plugins/win-capture/get-graphics-offsets/cmake/32bit-build.cmake
+++ b/plugins/win-capture/get-graphics-offsets/cmake/32bit-build.cmake
@@ -2,4 +2,7 @@ project(get-graphics-offsets)
 
 add_executable(get-graphics-offsets)
 target_link_libraries(get-graphics-offsets PRIVATE _get-graphics-offsets)
-set_property(TARGET get-graphics-offsets PROPERTY OUTPUT_NAME get-graphics-offsets32)
+
+# cmake-format: off
+set_target_properties(get-graphics-offsets PROPERTIES OUTPUT_NAME get-graphics-offsets32 MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# cmake-format: on

--- a/plugins/win-capture/graphics-hook/cmake/32bit-build.cmake
+++ b/plugins/win-capture/graphics-hook/cmake/32bit-build.cmake
@@ -6,4 +6,7 @@ endif()
 
 add_library(graphics-hook MODULE)
 target_link_libraries(graphics-hook PRIVATE _graphics-hook)
-set_property(TARGET graphics-hook PROPERTY OUTPUT_NAME graphics-hook32)
+
+# cmake-format: off
+set_target_properties(graphics-hook PROPERTIES OUTPUT_NAME graphics-hook32 MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# cmake-format: on

--- a/plugins/win-capture/inject-helper/cmake/32bit-build.cmake
+++ b/plugins/win-capture/inject-helper/cmake/32bit-build.cmake
@@ -2,4 +2,7 @@ project(inject-helper)
 
 add_executable(inject-helper)
 target_link_libraries(inject-helper PRIVATE _inject-helper)
-set_property(TARGET inject-helper PROPERTY OUTPUT_NAME inject-helper32)
+
+# cmake-format: off
+set_target_properties(inject-helper PROPERTIES OUTPUT_NAME inject-helper32 MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# cmake-format: on

--- a/plugins/win-dshow/virtualcam-module/CMakeLists.txt
+++ b/plugins/win-dshow/virtualcam-module/CMakeLists.txt
@@ -69,7 +69,6 @@ if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
               virtualcam-module.cpp)
   target_include_directories(_virtualcam INTERFACE "${CMAKE_CURRENT_BINARY_DIR}")
   target_compile_definitions(_virtualcam INTERFACE VIRTUALCAM_AVAILABLE)
-  set_property(TARGET _virtualcam PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
   target_link_libraries(
     _virtualcam
@@ -89,6 +88,8 @@ add_library(OBS::virtualcam ALIAS obs-virtualcam-module)
 
 target_sources(obs-virtualcam-module PRIVATE cmake/windows/virtualcam-module64.def)
 target_link_libraries(obs-virtualcam-module PRIVATE _virtualcam)
+
+set_property(TARGET obs-virtualcam-module PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 configure_file(virtualcam-install.bat.in virtualcam-install.bat)
 target_add_resource(obs-virtualcam-module "${CMAKE_CURRENT_BINARY_DIR}/virtualcam-install.bat"

--- a/plugins/win-dshow/virtualcam-module/cmake/32bit-build.cmake
+++ b/plugins/win-dshow/virtualcam-module/cmake/32bit-build.cmake
@@ -46,4 +46,6 @@ add_library(OBS::virtualcam ALIAS obs-virtualcam-module)
 target_sources(obs-virtualcam-module PRIVATE cmake/windows/virtualcam-module32.def)
 target_link_libraries(obs-virtualcam-module PRIVATE _virtualcam)
 
+set_property(TARGET obs-virtualcam-module PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 set_property(TARGET obs-virtualcam-module PROPERTY OUTPUT_NAME obs-virtualcam-module32)


### PR DESCRIPTION
### Description
Adds the missing explicit MSVC runtime selection to the the 32-bit `win-capture` target and also moves the same selection out of the shared virtual cam interface library to the actual architecture-specific targets.

### Motivation and Context
The `MSVC_RUNTIME_LIBRARY` target property when set on an `INTERFACE` type library is not inherited by targets which consume the library, thus their property is set automatically set by CMake.

This affected the virtual camera target which uses an `INTERFACE` library for sources and settings shared between its 64-bit and 32-bit variants.

The PR sets the property directly on the "final" output targets to fix this.

### How Has This Been Tested?
Needs to be tested on an Intel-based Windows installation.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
