### PR TITLE
CI: Update formatting actions to use git diff filter before formatting 

### DIFF
--- a/.github/actions/check-changes/action.yaml
+++ b/.github/actions/check-changes/action.yaml
@@ -3,7 +3,7 @@ description: Checks for changed files compared to specific git reference and glo
 inputs:
   baseRef:
     description: Git reference to check against
-    required: true
+    required: false
   ref:
     description: Git reference to check with
     required: false
@@ -15,12 +15,16 @@ inputs:
     description: Use fallback compare against prior commit
     required: false
     default: 'true'
+  diffFilter:
+    description: git diff-filter string to use
+    required: false
+    default: ''
 outputs:
   hasChangedFiles:
     value: ${{ steps.checks.outputs.hasChangedFiles }}
     description: True if specified files were changed in comparison to specified git reference
   changedFiles:
-    value: ${{ toJSON(steps.checks.outputs.changedFiles) }}
+    value: ${{ steps.checks.outputs.changedFiles }}
     description: List of changed files
 runs:
   using: composite
@@ -31,26 +35,42 @@ runs:
       env:
         GIT_BASE_REF: ${{ inputs.baseRef }}
         GIT_REF: ${{ inputs.ref }}
+        GITHUB_EVENT_FORCED: ${{ github.event.forced }}
+        GITHUB_REF_BEFORE: ${{ github.event.before }}
         USE_FALLBACK: ${{ inputs.useFallback }}
+        DIFF_FILTER: ${{ inputs.diffFilter }}
       run: |
         : Check for Changed Files ✅
         if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
         shopt -s extglob
         shopt -s dotglob
 
-        if ! git cat-file -e "${GIT_BASE_REF}" &> /dev/null; then
-          echo "::warning::Provided base reference ${GIT_BASE_REF} is invalid"
-          if [[ "${USE_FALLBACK}" == 'true' ]]; then
-            GIT_BASE_REF='HEAD~1'
+        if [[ "${GIT_BASE_REF}" ]]; then
+          if ! git cat-file -e "${GIT_BASE_REF}" &> /dev/null; then
+            echo "::warning::Provided base reference ${GIT_BASE_REF} is invalid"
+            if [[ "${USE_FALLBACK}" == 'true' ]]; then
+              GIT_BASE_REF='HEAD~1'
+            fi
           fi
+        else
+          if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
+            GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+          fi
+
+          GIT_BASE_REF='HEAD~1'
+          case "${GITHUB_EVENT_NAME}" in
+            pull_request) GIT_BASE_REF="origin/${GITHUB_BASE_REF}" ;;
+            push) if [[ "${GITHUB_EVENT_FORCED}" != 'true' ]]; then GIT_BASE_REF="${GITHUB_REF_BEFORE}"; fi ;;
+            *) ;;
+          esac
         fi
 
-        changes=($(git diff --name-only ${GIT_BASE_REF} ${GIT_REF} -- ${{ inputs.checkGlob }}))
+        changes=($(git diff --name-only --diff-filter="${DIFF_FILTER}" ${GIT_BASE_REF} ${GIT_REF} -- ${{ inputs.checkGlob }}))
 
         if (( ${#changes[@]} )); then
           file_string="${changes[*]}"
           echo "hasChangedFiles=true" >> $GITHUB_OUTPUT
-          echo "changedFiles=[${file_string// /,}]" >> GITHUB_OUTPUT
+          echo "changedFiles=[\"${file_string// /\",\"}\"]" >> $GITHUB_OUTPUT
         else
           echo "hasChangedFiles=false" >> $GITHUB_OUTPUT
           echo "changedFiles=[]" >> GITHUB_OUTPUT

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -20,8 +20,15 @@ runs:
         echo "::notice::run-clang-format action requires a macOS-based or Linux-based runner."
         exit 2
 
+    - name: Check for Changed Files ✅
+      uses: ./.github/actions/check-changes
+      id: checks
+      with:
+        checkGlob: "'*.c' '*.h' '*.cpp' '*.hpp' '*.m' '*.mm'"
+        diffFilter: 'ACM'
+
     - name: Install Dependencies 🛍️
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && fromJSON(steps.checks.outputs.hasChangedFiles)
       shell: bash
       run: |
         : Install Dependencies 🛍️
@@ -33,33 +40,21 @@ runs:
         echo ::endgroup::
 
     - name: Run clang-format 🐉
+      if: fromJSON(steps.checks.outputs.hasChangedFiles)
       id: result
       shell: zsh --no-rcs --errexit --pipefail {0}
       working-directory: ${{ inputs.workingDirectory }}
       env:
-        GITHUB_EVENT_FORCED: ${{ github.event.forced }}
-        GITHUB_REF_BEFORE: ${{ github.event.before }}
+        CHANGED_FILES: ${{ steps.checks.outputs.changedFiles }}
       run: |
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+        
+        print ::group::Install clang-format-17
+        brew install --quiet obsproject/tools/clang-format@17
+        print ::endgroup::
 
-        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
-          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-        fi
-
-        local -a changes=($(git diff --name-only HEAD~1 HEAD))
-        case ${GITHUB_EVENT_NAME} {
-          pull_request) changes=($(git diff --name-only origin/${GITHUB_BASE_REF} HEAD)) ;;
-          push) if [[ ${GITHUB_EVENT_FORCED} != true ]] changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD)) ;;
-          *) ;;
-        }
-
-        if (( ${changes[(I)(*.c|*.h|*.cpp|*.hpp|*.m|*.mm)]} )) {
-          print ::group::Install clang-format-17
-          brew install --quiet obsproject/tools/clang-format@17
-          print ::endgroup::
-
-          print ::group::Run clang-format-17
-          ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.c|*.h|*.cpp|*.hpp|*.m|*.mm)}
-          print ::endgroup::
-        }
+        print ::group::Run clang-format-17
+        local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
+        ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
+        print ::endgroup::

--- a/.github/actions/run-cmake-format/action.yaml
+++ b/.github/actions/run-cmake-format/action.yaml
@@ -20,8 +20,15 @@ runs:
         echo "::notice::run-cmake-format action requires a macOS-based or Linux-based runner."
         exit 2
 
+    - name: Check for Changed Files ✅
+      uses: ./.github/actions/check-changes
+      id: checks
+      with:
+        checkGlob: "'*.cmake' '*CMakeLists.txt'"
+        diffFilter: 'ACM'
+
     - name: Install Dependencies 🛍️
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && fromJSON(steps.checks.outputs.hasChangedFiles)
       shell: bash
       run: |
         : Install Dependencies 🛍️
@@ -32,33 +39,21 @@ runs:
         echo ::endgroup::
 
     - name: Run cmake-format 🎛️
+      if: fromJSON(steps.checks.outputs.hasChangedFiles)
       id: result
       shell: zsh --no-rcs --errexit --pipefail {0}
       working-directory: ${{ github.workspace }}
       env:
-        GITHUB_EVENT_FORCED: ${{ github.event.forced }}
-        GITHUB_REF_BEFORE: ${{ github.event.before }}
+        CHANGED_FILES: ${{ steps.checks.outputs.changedFiles }}
       run: |
         : Run cmake-format 🎛️
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
-          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-        fi
+        print ::group::Install cmakelang
+        pip3 install cmakelang
+        print ::endgroup::
 
-        local -a changes=($(git diff --name-only HEAD~1 HEAD))
-        case ${GITHUB_EVENT_NAME} {
-          pull_request) changes=($(git diff --name-only origin/${GITHUB_BASE_REF} HEAD)) ;;
-          push) if [[ ${GITHUB_EVENT_FORCED} != true ]] changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD)) ;;
-          *) ;;
-        }
-
-        if (( ${changes[(I)*.cmake|*CMakeLists.txt]} )) {
-          print ::group::Install cmakelang
-          pip3 install cmakelang
-          print ::endgroup::
-
-          print ::group::Run cmake-format
-          ./build-aux/run-cmake-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.cmake|*CMakeLists.txt)}
-          print ::endgroup::
-        }
+        print ::group::Run cmake-format
+        local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
+        ./build-aux/run-cmake-format --fail-${{ inputs.failCondition }} --check ${changes}
+        print ::endgroup::

--- a/.github/actions/run-swift-format/action.yaml
+++ b/.github/actions/run-swift-format/action.yaml
@@ -20,8 +20,15 @@ runs:
         echo "::notice::run-swift-format action requires a macOS-based or Linux-based runner."
         exit 2
 
+    - name: Check for Changed Files ✅
+      uses: ./.github/actions/check-changes
+      id: checks
+      with:
+        checkGlob: "'*.swift'"
+        diffFilter: 'ACM'
+
     - name: Install Dependencies 🛍️
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && fromJSON(steps.checks.outputs.hasChangedFiles)
       shell: bash
       run: |
         : Install Dependencies 🛍️
@@ -32,33 +39,21 @@ runs:
         echo ::endgroup::
 
     - name: Run swift-format 🔥
+      if: fromJSON(steps.checks.outputs.hasChangedFiles)
       id: result
       shell: zsh --no-rcs --errexit --pipefail {0}
       working-directory: ${{ github.workspace }}
       env:
-        GITHUB_EVENT_FORCED: ${{ github.event.forced }}
-        GITHUB_REF_BEFORE: ${{ github.event.before }}
+        CHANGED_FILES: ${{ steps.checks.outputs.changedFiles }}
       run: |
         : Run swift-format 🔥
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-        if ! git cat-file -e ${GITHUB_REF_BEFORE} &> /dev/null; then
-          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-        fi
+        print ::group::Install swift-format
+        brew install --quiet swift-format
+        print ::endgroup::
 
-        local -a changes=($(git diff --name-only HEAD~1 HEAD))
-        case ${GITHUB_EVENT_NAME} {
-          pull_request) changes=($(git diff --name-only origin/${GITHUB_BASE_REF} HEAD)) ;;
-          push) if [[ ${GITHUB_EVENT_FORCED} != true ]] changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD)) ;;
-          *) ;;
-        }
-
-        if (( ${changes[(I)*.swift]} )) {
-          print ::group::Install swift-format
-          brew install --quiet swift-format
-          print ::endgroup::
-
-          print ::group::Run swift-format
-          ./build-aux/run-swift-format --fail-${{ inputs.failCondition }} --check ${(M)changes:#(*.swift)}
-          print ::endgroup::
-        }
+        print ::group::Run swift-format
+        local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
+        ./build-aux/run-swift-format --fail-${{ inputs.failCondition }} --check ${changes}
+        print ::endgroup::


### PR DESCRIPTION
### Description
Update code formatting actions to use the `check-changes` action as a trigger for whether or not format checks should actually run and updates that action to pass custom `diff-filter` arguments for `git diff`.

### Motivation and Context
Using git's diff-filter when checking for changed files allows the actions to ignore any deleted files. Combined with explicitly passing glob expressions for source files to git directly allows the command to yield a list of changed files compatible with a given formatter directly.

By updating only the `check-changes` action, the code-formatting actions are able to use that actions as well, reducing code duplication.

### How Has This Been Tested?
Requires CI runs for testing.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
