### PR TITLE
libobs: Set channel layout for remux output

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -152,6 +152,18 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 			// Otherwise tag 0 to let FFmpeg automatically select the appropriate tag
 			out_stream->codecpar->codec_tag = 0;
 		}
+
+		if (in_stream->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(59, 24, 100)
+			out_stream->codecpar->channel_layout =
+				av_get_default_channel_layout(
+					in_stream->codecpar->channels);
+#else
+			av_channel_layout_default(
+				&out_stream->codecpar->ch_layout,
+				in_stream->codecpar->ch_layout.nb_channels);
+#endif
+		}
 	}
 
 #ifndef NDEBUG


### PR DESCRIPTION
### Description

Set the channel layout when remuxing.

### Motivation and Context

Fixes muxing PCM in MP4 failing.

Fixes #10384

### How Has This Been Tested?

Remuxed file that previously failed.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
