### PR TITLE
obs-qsv11: Check all encoders are Intel devices

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11-plugin-main.c
+++ b/plugins/obs-qsv11/obs-qsv11-plugin-main.c
@@ -84,8 +84,8 @@ bool obs_module_load(void)
 	for (size_t i = 0; i < adapter_count; i++) {
 		struct adapter_info *adapter = &adapters[i];
 		avc_supported |= adapter->is_intel;
-		av1_supported |= adapter->supports_av1;
-		hevc_supported |= adapter->supports_hevc;
+		av1_supported |= adapter->is_intel && adapter->supports_av1;
+		hevc_supported |= adapter->is_intel && adapter->supports_hevc;
 	}
 
 	if (avc_supported) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
On linux we enumerate all VA-API devices, which incorrectly enables QSV AV1/HEVC encoders when an AMD devices reports these capabilities.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
AMD users shouldnt see QSV encoders.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Incorrectly displayed devices on pure amd machine are hidden. When adding an intel device the encoders are presented again.

This shouldnt affect windows as the enumeration skips non-intel devices.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
