### PR TITLE
UI: Change advanced audio controls to use audio_active

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -54,6 +54,10 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	activateSignal.Connect(handler, "activate", OBSSourceActivated, this);
 	deactivateSignal.Connect(handler, "deactivate", OBSSourceDeactivated,
 				 this);
+	audioActivateSignal.Connect(handler, "audio_activate",
+				    OBSSourceActivated, this);
+	audioDeactivateSignal.Connect(handler, "audio_deactivate",
+				      OBSSourceDeactivated, this);
 	volChangedSignal.Connect(handler, "volume", OBSSourceVolumeChanged,
 				 this);
 	syncOffsetSignal.Connect(handler, "audio_sync", OBSSourceSyncChanged,
@@ -92,7 +96,8 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	SetSourceName(sourceName);
 	nameLabel->setAlignment(Qt::AlignVCenter);
 
-	bool isActive = obs_source_active(source);
+	bool isActive = obs_source_active(source) &&
+			obs_source_audio_active(source);
 	active->setText(isActive ? QTStr("Basic.Stats.Status.Active")
 				 : QTStr("Basic.Stats.Status.Inactive"));
 	if (isActive)
@@ -369,7 +374,7 @@ static inline void setCheckboxState(QCheckBox *checkbox, bool checked)
 
 void OBSAdvAudioCtrl::SourceActiveChanged(bool isActive)
 {
-	if (isActive) {
+	if (isActive && obs_source_audio_active(source)) {
 		active->setText(QTStr("Basic.Stats.Status.Active"));
 		setThemeID(active, "error");
 	} else {

--- a/UI/adv-audio-control.hpp
+++ b/UI/adv-audio-control.hpp
@@ -53,6 +53,8 @@ private:
 	OBSSignal mixersSignal;
 	OBSSignal activateSignal;
 	OBSSignal deactivateSignal;
+	OBSSignal audioActivateSignal;
+	OBSSignal audioDeactivateSignal;
 	OBSSignal balChangedSignal;
 	OBSSignal renameSignal;
 

--- a/UI/window-basic-adv-audio.hpp
+++ b/UI/window-basic-adv-audio.hpp
@@ -16,6 +16,8 @@ class OBSBasicAdvAudio : public QDialog {
 private:
 	OBSSignal sourceAddedSignal;
 	OBSSignal sourceRemovedSignal;
+	OBSSignal sourceActivatedSignal;
+	OBSSignal sourceDeactivatedSignal;
 	bool showInactive;
 	bool showVisible;
 
@@ -27,6 +29,7 @@ private:
 
 	static void OBSSourceAdded(void *param, calldata_t *calldata);
 	static void OBSSourceRemoved(void *param, calldata_t *calldata);
+	static void OBSSourceActivated(void *param, calldata_t *calldata);
 
 	std::unique_ptr<Ui_OBSAdvAudio> ui;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This changes the active/inactive status in the advanced audio properties dialog to be based on the audio_active status of the source instead of its active status.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With the addition of audio capture to game and window capture in 30.1, those sources would appear in the advanced audio properties regardless of whether said audio capture was enabled or not. This can quickly clutter the dialog with sources who aren't actually capturing any audio. This change will hide those by default, by marking them as inactive if the audio capture is not enabled, while still allowing them to be shown by ticking "Show inactive".

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tried every case of making sources active/inactive, verified that all was showing correctly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
