### PR TITLE
build-aux: Update Flatpak SVT-AV1 module to 2.0

### DIFF
--- a/build-aux/modules/20-svt-av1.json
+++ b/build-aux/modules/20-svt-av1.json
@@ -18,8 +18,8 @@
         {
             "type": "git",
             "url": "https://gitlab.com/AOMediaCodec/SVT-AV1.git",
-            "tag": "v1.8.0",
-            "commit": "59645eea34e2815b627b8293aa3af254eddd0d69"
+            "tag": "v2.0.0",
+            "commit": "2aeeb4f1a1d495b84bf5c21dbb60ae10e991fada"
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updates the SVT-AV1 encoder included in the Flatpak modules list to the recently released 2.0 version.

### Motivation and Context
The new version of the encoder is more performant and would be nice to have available in OBS.

### How Has This Been Tested?
Lightly tested by:
1. I ran `flatpak-builder builddir --force-clean build-aux/com.obsproject.Studio.json --user --install`.
2. After the build completed successfully, I opened OBS and verified the "SVT-AV1" Video Encoder was available.
3. I closed OBS and ran `flatpak run --command=bash com.obsproject.Studio`.
4. In the new session I ran `ffmpeg -i example-file.mp4 -c:a copy -c:v libsvtav1 out.mp4`.
5. I checked ffmpeg's output and verified the reported `SVT [version]` was listed as `SVT-AV1 Encoder Lib v2.0.0`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
