### PR TITLE
rtmp-services: Add Rooter to ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 247,
+    "version": 248,
     "files": [
         {
             "name": "services.json",
-            "version": 247
+            "version": 248
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2799,6 +2799,27 @@
                 "max video bitrate": 12000,
                 "max audio bitrate": 320
             }
+        },
+        {
+            "name": "Rooter",
+            "stream_key_link": "https://www.rooter.gg/studio",
+            "servers": [
+                {
+                    "name": "Server 1",
+                    "url": "rtmps://c2ee45b2888d.global-contribute.live-video.net:443/app/"
+                },
+                {
+                    "name": "Server 2",
+                    "url": "rtmps://rtmp-mumbai-in.rooter.io:443/show"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 7000
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
**Adding support for Rooter to OBS:**
Rooter is a leading game streaming platform in India. 

Added rooter.gg ingests urls and recommended configuration to the service list.
Incremented rtmp-services version in package.json.