### PR TITLE
mac-capture: Fix string length when duplicated

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -266,7 +266,7 @@ static char **coreaudio_get_channel_names(struct coreaudio_data *ca)
 				    obs_module_text("CoreAudio.Channel.Device"),
 				    i + 1);
 		}
-		channel_names[i] = bstrdup_n(name.array, name.len + 1);
+		channel_names[i] = bstrdup_n(name.array, name.len);
 		dstr_free(&name);
 
 		if (cf_chan_name) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes reading on invalid memory location.

Without this change the call to `bstrdup_n` gives in the string length with zero termination character. However, `bstrdup_n` will handle zero termination by itself and will do a `memcpy` on the given `size + 1`.

This will lead to double-zero terminated strings which get allocated with one byte more than necessary (doh!).
But it will also read from invalid/wrong memory when `memcpy`-ing in case the original string capacity is exactly the size of the string (including zero termination).

E.g.
```C
bstrdup_n("Test", 4 + 1);
  -> bmemdup(str, 5 + 1);
    -> bmalloc(6);
       memcpy(out, ptr, 6); // causing read of 6 of bytes while string buffer is only 5 ("Test\0")
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixing a report from Apple's address sanitizer:
```
=================================================================
==11159==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x00011a15d9b1 at pc 0x000101aeac38 bp 0x00016f955300 sp 0x00016f954ab0
READ of size 18 at 0x00011a15d9b1 thread T0
    #0 0x101aeac34 in wrap_memcpy+0x3fc (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x1ac34)
    #1 0x104806b68 in bmemdup bmem.c:169
    #2 0x138af77fc in bstrdup_n bmem.h:60
    #3 0x138af91ac in coreaudio_get_channel_names mac-audio.c:269
    #4 0x138af8388 in coreaudio_init_format mac-audio.c:311
    #5 0x138af7b58 in coreaudio_init mac-audio.c:748
    #6 0x138af7748 in coreaudio_try_init mac-audio.c:773
    #7 0x138af74ec in coreaudio_create mac-audio.c:939
    #8 0x138af7164 in coreaudio_create_input_capture mac-audio.c:946
    #9 0x1047dce34 in obs_source_create_internal obs-source.c:404
    #10 0x1047dd00c in obs_source_create_set_last_ver obs-source.c:448
    #11 0x1047fc164 in obs_load_source_type obs.c:2270
    #12 0x1047fc04c in obs_load_source obs.c:2379
    #13 0x1006f00d0 in LoadAudioDevice(char const*, int, obs_data*) window-basic-main.cpp:882
    #14 0x1006ef134 in OBSBasic::LoadData(obs_data*, char const*) window-basic-main.cpp:1182
    #15 0x1006eeae0 in OBSBasic::Load(char const*) window-basic-main.cpp:1098
    #16 0x1006f5d30 in OBSBasic::OBSInit() window-basic-main.cpp:2136
    #17 0x100560ee4 in OBSApp::OBSInit() obs-app.cpp:1757
    #18 0x100565f70 in run_program(std::__1::basic_fstream<char, std::__1::char_traits<char>>&, int, char**) obs-app.cpp:2595
    #19 0x100564edc in main obs-app.cpp:3478
    #20 0x194f2e0dc  (<unknown module>)

0x00011a15d9b1 is located 0 bytes after 49-byte region [0x00011a15d980,0x00011a15d9b1)
allocated by thread T0 here:
    #0 0x101b23124 in wrap_malloc+0x94 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x53124)
    #1 0x10480685c in a_malloc bmem.c:55
    #2 0x1048069d0 in a_realloc bmem.c:76
    #3 0x10480695c in brealloc bmem.c:136
    #4 0x10481331c in dstr_ensure_capacity dstr.h:226
    #5 0x104813d34 in dstr_vprintf dstr.c:556
    #6 0x104813cb8 in dstr_printf dstr.c:533
    #7 0x138af9190 in coreaudio_get_channel_names mac-audio.c:265
    #8 0x138af8388 in coreaudio_init_format mac-audio.c:311
    #9 0x138af7b58 in coreaudio_init mac-audio.c:748
    #10 0x138af7748 in coreaudio_try_init mac-audio.c:773
    #11 0x138af74ec in coreaudio_create mac-audio.c:939
    #12 0x138af7164 in coreaudio_create_input_capture mac-audio.c:946
    #13 0x1047dce34 in obs_source_create_internal obs-source.c:404
    #14 0x1047dd00c in obs_source_create_set_last_ver obs-source.c:448
    #15 0x1047fc164 in obs_load_source_type obs.c:2270
    #16 0x1047fc04c in obs_load_source obs.c:2379
    #17 0x1006f00d0 in LoadAudioDevice(char const*, int, obs_data*) window-basic-main.cpp:882
    #18 0x1006ef134 in OBSBasic::LoadData(obs_data*, char const*) window-basic-main.cpp:1182
    #19 0x1006eeae0 in OBSBasic::Load(char const*) window-basic-main.cpp:1098
    #20 0x1006f5d30 in OBSBasic::OBSInit() window-basic-main.cpp:2136
    #21 0x100560ee4 in OBSApp::OBSInit() obs-app.cpp:1757
    #22 0x100565f70 in run_program(std::__1::basic_fstream<char, std::__1::char_traits<char>>&, int, char**) obs-app.cpp:2595
    #23 0x100564edc in main obs-app.cpp:3478
    #24 0x194f2e0dc  (<unknown module>)

SUMMARY: AddressSanitizer: heap-buffer-overflow (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x1ac34) in wrap_memcpy+0x3fc
Shadow bytes around the buggy address:
  0x00011a15d700: fd fd fd fd fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15d780: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15d800: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15d880: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fa
  0x00011a15d900: fa fa fa fa 00 00 00 00 00 00 00 00 fa fa fa fa
=>0x00011a15d980: 00 00 00 00 00 00[01]fa fa fa fa fa 00 00 00 00
  0x00011a15da00: 00 00 02 fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15da80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15db00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15db80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x00011a15dc00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Re-ran with the changed code in the debugger. Duplicated string seems correct and not truncated, and the address sanitizer kept silent.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
