### PR TITLE
UI: Fix Auto-Config Wizard for custom server with no stream key

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -852,11 +852,11 @@ void AutoConfigStreamPage::UpdateServerList()
 
 void AutoConfigStreamPage::UpdateCompleted()
 {
+	const bool custom = IsCustomService();
 	if (ui->stackedWidget->currentIndex() == (int)Section::Connect ||
-	    (ui->key->text().isEmpty() && !auth)) {
+	    (ui->key->text().isEmpty() && !auth && !custom)) {
 		ready = false;
 	} else {
-		bool custom = IsCustomService();
 		if (custom) {
 			ready = !ui->customServer->text().isEmpty();
 		} else {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The issue reported on GitHub involves the OBS Studio Auto-Configuration Wizard becoming non-functional when a custom server is selected without requiring a stream key, preventing further progress. To address this, I included the !custom constraint in the if condition within the UpdateCompleted() function, aiming to handle cases where a custom server is used without a stream key, thereby allowing the wizard to proceed as expected.

### Motivation and Context
This change improves the user experience in OBS Studio, especially for those utilizing custom streaming services. It solves the problem outlined in this issue: [obsproject/obs-studio#10087](https://github.com/obsproject/obs-studio/issues/10087), where the setup wizard would inaccurately report readiness due to not considering custom services without a provided stream key.

Fixes #10087

### How Has This Been Tested?
This has been tested using a macOS environment.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
