### PR TITLE
UI: Fix audio source insert into invisible group

### DIFF
--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1229,6 +1229,46 @@ void SourceTree::dropEvent(QDropEvent *event)
 	}
 
 	/* --------------------------------------- */
+	/* remember to hide items if dropping on   */
+	/* an invisible group                      */
+
+	bool dropOnInvisible = false;
+	if (dropGroup) {
+		obs_source_t *group = obs_sceneitem_get_source(dropGroup);
+		dropOnInvisible = !obs_source_showing(group);
+	}
+
+	/* --------------------------------------- */
+	/* hide item sources if dropped into an    */
+	/* invisible group and show item sources   */
+	/* if the source is user visible and if it */
+	/* was dragged from an invisible group     */
+	/* into a new visible parent               */
+
+	if (dropOnInvisible) {
+		for (int i = 0; i < indices.size(); i++) {
+			obs_sceneitem_t *item = items[indices[i].row()];
+
+			if (!obs_sceneitem_is_group(item)) {
+				obs_source_t *source =
+					obs_sceneitem_get_source(item);
+
+				if (obs_source_showing(source))
+					obs_source_dec_active(source);
+			}
+		}
+	} else {
+		for (int i = 0; i < indices.size(); i++) {
+			obs_sceneitem_t *item = items[indices[i].row()];
+			obs_source_t *source = obs_sceneitem_get_source(item);
+
+			if (!obs_source_showing(source) &&
+			    obs_sceneitem_visible(item))
+				obs_source_inc_active(source);
+		}
+	}
+
+	/* --------------------------------------- */
 	/* determine if any base group is selected */
 
 	bool hasGroups = false;


### PR DESCRIPTION
### Description
This PR fixes a bug concerning the visualization and release of audio sources when inserted into an invisible group. The bug arises from the fact that when a group is invisible, the audio sources that are dragged into the group are not immediately deactivated, which causes show_refs and activate_refs variables to assume wrong values. As a result, the audio mixers are shown in the UI when in reality they should be hidden; the mixer shows up in other scenes; and, upon deletion, the source is only destroyed if the audio mixer is first marked as hidden.

My approach was to make sure that when these items are dragged into an invisible group, the source is deactivated, which decrements the show_refs and activate_refs variables. By doing this, these variables assume correct values, preventing the described behaviour.

Before (mixer shows up after dragging the source into the invisible group)
![image](https://github.com/obsproject/obs-studio/assets/92863313/2fc3642d-be09-4092-9bef-f7e2c76a744d)

After (mixer is hidden)
![image](https://github.com/obsproject/obs-studio/assets/92863313/e5361ddc-2b0e-489d-b4be-1ad996cec38e)

As a consequence of the above mentionned changes, the PR also ensures that the source audio mixer is displayed when sources are dragged out of an invisible group into a new visible parent. If the audio source is user visible, it is then activated when dragged out of the group and into a visible parent. Otherwise, the source remains deactivated until its visibility is changed. 

This is my first ever open-source contribution, so feel free to suggest any alternative approaches or improvements to my code.

### Motivation and Context
These changes provide a fix for issue #9961

### How Has This Been Tested?
Manual tests were conducted by dragging all types of sources into invisible groups, particularly audio sources, and testing different combinations of group, mixer, and source visibility. Additionally, sources were moved outside of groups with various visibility settings and from invisible groups to visible groups. Finally, testing was done on source deletion following insertion into an invisible group.

#### Testing environment
Windows 11 23H2 (OS Build 22631.3296)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
