### PR TITLE
UI: Prevent double scrollbars for encoder properties

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -143,6 +143,9 @@ void OBSPropertiesView::RefreshProperties()
 	adjustSize();
 	SetScrollPos(h, v, hend, vend);
 
+	if (disableScrolling)
+		setMinimumHeight(widget->minimumSizeHint().height());
+
 	lastFocused.clear();
 	if (lastWidget) {
 		lastWidget->setFocus(Qt::OtherFocusReason);

--- a/UI/properties-view.hpp
+++ b/UI/properties-view.hpp
@@ -108,6 +108,7 @@ private:
 	QWidget *lastWidget = nullptr;
 	bool deferUpdate;
 	bool enableDefer = true;
+	bool disableScrolling = false;
 
 	template<typename Sender, typename SenderParent, typename... Args>
 	QWidget *NewWidget(obs_property_t *prop, Sender *widget,
@@ -200,6 +201,12 @@ public:
 	inline void SetDeferrable(bool deferrable) { enableDefer = deferrable; }
 
 	inline OBSObject GetObject() const { return OBSGetStrongRef(weakObj); }
+
+	void setScrolling(bool enabled)
+	{
+		disableScrolling = !enabled;
+		RefreshProperties();
+	}
 
 #define Def_IsObject(type)                                \
 	inline bool IsObject(obs_##type##_t *type) const  \

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2139,6 +2139,7 @@ OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 	view->setFrameShape(QFrame::NoFrame);
 	view->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Minimum);
 	view->setProperty("changed", QVariant(changed));
+	view->setScrolling(false);
 	QObject::connect(view, &OBSPropertiesView::Changed, this,
 			 &OBSBasicSettings::OutputsChanged);
 


### PR DESCRIPTION
### Description

Prevents double scrollbars in advanced output encoder properties by forcing the scroll area to always be full height.

### Motivation and Context

![pictures_say_more_than_a_thousand_words](https://github.com/obsproject/obs-studio/assets/3123295/725f62aa-b80b-4c6c-8f30-e6c8a1314024)

### How Has This Been Tested?

See above.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
