### PR TITLE
UI: Reformat .ui files with Qt Designer

### DIFF
--- a/UI/forms/AutoConfigStreamPage.ui
+++ b/UI/forms/AutoConfigStreamPage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>692</width>
+    <width>726</width>
     <height>407</height>
    </rect>
   </property>

--- a/UI/forms/OBSAdvAudio.ui
+++ b/UI/forms/OBSAdvAudio.ui
@@ -97,8 +97,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1346</width>
-        <height>254</height>
+        <width>1157</width>
+        <height>262</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_3">
@@ -143,7 +143,6 @@
             <widget class="QLabel" name="label_2">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -162,7 +161,6 @@
              </property>
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -175,7 +173,6 @@
             <widget class="QLabel" name="label_3">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -188,7 +185,6 @@
             <widget class="QLabel" name="label_5">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -201,7 +197,6 @@
             <widget class="QLabel" name="label">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -214,7 +209,6 @@
             <widget class="QLabel" name="label_4">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -227,7 +221,6 @@
             <widget class="QLabel" name="label_6">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -263,7 +256,6 @@
                  <widget class="QLabel" name="label_9">
                   <property name="font">
                    <font>
-                    <weight>75</weight>
                     <bold>true</bold>
                    </font>
                   </property>
@@ -276,7 +268,6 @@
                  <widget class="QCheckBox" name="usePercent">
                   <property name="font">
                    <font>
-                    <weight>75</weight>
                     <bold>true</bold>
                    </font>
                   </property>

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -7,7 +7,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1079</width>
+    <width>1086</width>
     <height>729</height>
    </rect>
   </property>
@@ -176,7 +176,7 @@
            </widget>
           </item>
           <item>
-           <widget class="OBSBasicPreview" name="preview">
+           <widget class="OBSBasicPreview" name="preview" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -486,8 +486,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1079</width>
-     <height>21</height>
+     <width>1086</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -677,6 +677,11 @@
      <addaction name="actionSceneListMode"/>
      <addaction name="actionSceneGridMode"/>
     </widget>
+    <widget class="QMenu" name="multiviewProjectorMenu">
+     <property name="title">
+      <string>MultiviewProjector</string>
+     </property>
+    </widget>
     <action name="resetUI">
      <property name="text">
       <string>Basic.MainMenu.View.ResetUI</string>
@@ -706,11 +711,6 @@
     <addaction name="separator"/>
     <addaction name="actionAlwaysOnTop"/>
    </widget>
-   <widget class="QMenu" name="multiviewProjectorMenu">
-    <property name="title">
-     <string>MultiviewProjector</string>
-    </property>
-   </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
      <string>Basic.MainMenu.Tools</string>
@@ -739,7 +739,7 @@
   <widget class="OBSBasicStatusBar" name="statusbar"/>
   <widget class="OBSDock" name="scenesDock">
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Scenes</string>
@@ -808,9 +808,6 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="spacing">
-           <number>0</number>
-          </property>
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>
@@ -831,6 +828,9 @@
           </property>
           <property name="defaultDropAction">
            <enum>Qt::TargetMoveAction</enum>
+          </property>
+          <property name="spacing">
+           <number>0</number>
           </property>
           <addaction name="actionRemoveScene"/>
          </widget>
@@ -879,7 +879,7 @@
   </widget>
   <widget class="OBSDock" name="sourcesDock">
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Sources</string>
@@ -948,9 +948,6 @@
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <property name="spacing">
-           <number>0</number>
-          </property>
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>
@@ -971,6 +968,9 @@
           </property>
           <property name="selectionMode">
            <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+          <property name="spacing">
+           <number>0</number>
           </property>
           <addaction name="actionRemoveSource"/>
          </widget>
@@ -1019,7 +1019,7 @@
   </widget>
   <widget class="OBSDock" name="mixerDock">
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
     <string>Mixer</string>
@@ -1094,7 +1094,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>74</width>
+              <width>217</width>
               <height>16</height>
              </rect>
             </property>
@@ -1202,7 +1202,7 @@
   </widget>
   <widget class="OBSDock" name="transitionsDock">
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.SceneTransitions</string>
@@ -1348,7 +1348,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="obs.qrc">
               <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
             </property>
             <property name="flat">
@@ -1380,7 +1380,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="obs.qrc">
               <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
             </property>
             <property name="flat">
@@ -1412,7 +1412,7 @@
              <string notr="true"/>
             </property>
             <property name="icon">
-             <iconset>
+             <iconset resource="obs.qrc">
               <normaloff>:/settings/images/settings/general.svg</normaloff>:/settings/images/settings/general.svg</iconset>
             </property>
             <property name="flat">
@@ -1449,7 +1449,7 @@
   </widget>
   <widget class="OBSDock" name="controlsDock">
    <property name="features">
-    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetMovable|QDockWidget::DockWidgetFloatable</set>
+    <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Controls</string>
@@ -1650,7 +1650,7 @@
   </widget>
   <action name="actionAddScene">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
    </property>
    <property name="text">
@@ -1665,7 +1665,7 @@
   </action>
   <action name="actionAddSource">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
    </property>
    <property name="text">
@@ -1680,7 +1680,7 @@
   </action>
   <action name="actionRemoveScene">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
    </property>
    <property name="text">
@@ -1704,7 +1704,7 @@
   </action>
   <action name="actionRemoveSource">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
    </property>
    <property name="text">
@@ -1731,7 +1731,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/settings/images/settings/general.svg</normaloff>:/settings/images/settings/general.svg</iconset>
    </property>
    <property name="text">
@@ -1746,7 +1746,7 @@
   </action>
   <action name="actionSceneUp">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
    </property>
    <property name="text">
@@ -1764,7 +1764,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
    </property>
    <property name="text">
@@ -1779,7 +1779,7 @@
   </action>
   <action name="actionSceneDown">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
    </property>
    <property name="text">
@@ -1797,7 +1797,7 @@
     <bool>true</bool>
    </property>
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
    </property>
    <property name="text">
@@ -2013,11 +2013,11 @@
    </property>
   </action>
   <action name="actionReleaseNotes">
-   <property name="visible">
-    <bool>false</bool>
-   </property>
    <property name="text">
     <string>Basic.MainMenu.Help.ReleaseNotes</string>
+   </property>
+   <property name="visible">
+    <bool>false</bool>
    </property>
   </action>
   <action name="actionInteract">

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -69,9 +69,6 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
-            <property name="spacing">
-             <number>1</number>
-            </property>
             <property name="dragEnabled">
              <bool>true</bool>
             </property>
@@ -80,6 +77,9 @@
             </property>
             <property name="defaultDropAction">
              <enum>Qt::TargetMoveAction</enum>
+            </property>
+            <property name="spacing">
+             <number>1</number>
             </property>
            </widget>
           </item>
@@ -116,7 +116,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -145,7 +145,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -174,7 +174,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -203,7 +203,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -291,9 +291,6 @@
             <property name="contextMenuPolicy">
              <enum>Qt::CustomContextMenu</enum>
             </property>
-            <property name="spacing">
-             <number>1</number>
-            </property>
             <property name="dragEnabled">
              <bool>true</bool>
             </property>
@@ -302,6 +299,9 @@
             </property>
             <property name="defaultDropAction">
              <enum>Qt::TargetMoveAction</enum>
+            </property>
+            <property name="spacing">
+             <number>1</number>
             </property>
            </widget>
           </item>
@@ -338,7 +338,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -367,7 +367,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -396,7 +396,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -425,7 +425,7 @@
                 <string notr="true"/>
                </property>
                <property name="icon">
-                <iconset>
+                <iconset resource="obs.qrc">
                  <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
                </property>
                <property name="autoDefault">
@@ -606,7 +606,7 @@
   </layout>
   <action name="actionRemoveFilter">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
    </property>
    <property name="text">
@@ -621,7 +621,7 @@
   </action>
   <action name="actionMoveUp">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/up.svg</normaloff>:/res/images/up.svg</iconset>
    </property>
    <property name="text">
@@ -633,7 +633,7 @@
   </action>
   <action name="actionMoveDown">
    <property name="icon">
-    <iconset>
+    <iconset resource="obs.qrc">
      <normaloff>:/res/images/down.svg</normaloff>:/res/images/down.svg</iconset>
    </property>
    <property name="text">

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -169,8 +169,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>767</width>
-              <height>1326</height>
+              <width>764</width>
+              <height>1298</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -281,11 +281,11 @@
                    <string>Basic.Settings.General.Updater</string>
                   </property>
                   <layout class="QFormLayout" name="formLayout_20">
-                   <property name="labelAlignment">
-                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                   </property>
                    <property name="fieldGrowthPolicy">
                     <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                   </property>
+                   <property name="labelAlignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                    </property>
                    <item row="0" column="0">
                     <widget class="QLabel" name="updateChannelLabel">
@@ -1571,8 +1571,8 @@
                     <rect>
                      <x>0</x>
                      <y>0</y>
-                     <width>772</width>
-                     <height>651</height>
+                     <width>518</width>
+                     <height>609</height>
                     </rect>
                    </property>
                    <property name="sizePolicy">
@@ -2167,14 +2167,14 @@
                     </item>
                     <item>
                      <widget class="QGroupBox" name="simpleReplayBuf">
+                      <property name="title">
+                       <string>ReplayBuffer</string>
+                      </property>
                       <property name="checkable">
                        <bool>true</bool>
                       </property>
                       <property name="checked">
                        <bool>true</bool>
-                      </property>
-                      <property name="title">
-                       <string>ReplayBuffer</string>
                       </property>
                       <layout class="QFormLayout" name="formLayout_24">
                        <property name="fieldGrowthPolicy">
@@ -2368,8 +2368,8 @@
                         <rect>
                          <x>0</x>
                          <y>0</y>
-                         <width>759</width>
-                         <height>616</height>
+                         <width>431</width>
+                         <height>180</height>
                         </rect>
                        </property>
                        <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -2485,7 +2485,7 @@
                                   <string notr="true">3</string>
                                  </property>
                                 </widget>
-                              </item>
+                               </item>
                                <item>
                                 <widget class="QRadioButton" name="advOutTrack4">
                                  <property name="text">
@@ -2510,64 +2510,64 @@
                               </layout>
                              </widget>
                              <widget class="QWidget" name="streamMultiTracks">
-                               <layout class="QHBoxLayout" name="horizontalLayout_multitrack">
-                                <property name="leftMargin">
-                                 <number>0</number>
-                                </property>
-                                <property name="topMargin">
-                                 <number>0</number>
-                                </property>
-                                <property name="rightMargin">
-                                 <number>0</number>
-                                </property>
-                                <property name="bottomMargin">
-                                 <number>0</number>
-                                </property>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack1">
-                                  <property name="text">
-                                   <string notr="true">1</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack2">
-                                  <property name="text">
-                                   <string notr="true">2</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack3">
-                                  <property name="text">
-                                   <string notr="true">3</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack4">
-                                  <property name="text">
-                                   <string notr="true">4</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack5">
-                                  <property name="text">
-                                   <string notr="true">5</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                                <item>
-                                 <widget class="QCheckBox" name="advOutMultiTrack6">
-                                  <property name="text">
-                                   <string notr="true">6</string>
-                                  </property>
-                                 </widget>
-                                </item>
-                               </layout>
-                              </widget>
-			    </widget>
+                              <layout class="QHBoxLayout" name="horizontalLayout_multitrack">
+                               <property name="leftMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="topMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="rightMargin">
+                                <number>0</number>
+                               </property>
+                               <property name="bottomMargin">
+                                <number>0</number>
+                               </property>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack1">
+                                 <property name="text">
+                                  <string notr="true">1</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack2">
+                                 <property name="text">
+                                  <string notr="true">2</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack3">
+                                 <property name="text">
+                                  <string notr="true">3</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack4">
+                                 <property name="text">
+                                  <string notr="true">4</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack5">
+                                 <property name="text">
+                                  <string notr="true">5</string>
+                                 </property>
+                                </widget>
+                               </item>
+                               <item>
+                                <widget class="QCheckBox" name="advOutMultiTrack6">
+                                 <property name="text">
+                                  <string notr="true">6</string>
+                                 </property>
+                                </widget>
+                               </item>
+                              </layout>
+                             </widget>
+                            </widget>
                            </item>
                            <item row="2" column="0">
                             <widget class="QLabel" name="advOutAEncLabel">
@@ -2608,7 +2608,7 @@
                            <item row="4" column="1">
                             <layout class="QHBoxLayout" name="horizontalLayout_10">
                              <item>
-                              <widget class="QComboBox" name="advOutRescaleFilter" />
+                              <widget class="QComboBox" name="advOutRescaleFilter"/>
                              </item>
                              <item>
                               <widget class="QComboBox" name="advOutRescale">
@@ -2801,8 +2801,8 @@
                             <rect>
                              <x>0</x>
                              <y>0</y>
-                             <width>759</width>
-                             <height>587</height>
+                             <width>518</width>
+                             <height>371</height>
                             </rect>
                            </property>
                            <property name="sizePolicy">
@@ -3238,7 +3238,7 @@
                                    <number>0</number>
                                   </property>
                                   <item>
-                                   <widget class="QComboBox" name="advOutRecRescaleFilter" />
+                                   <widget class="QComboBox" name="advOutRecRescaleFilter"/>
                                   </item>
                                   <item>
                                    <widget class="QComboBox" name="advOutRecRescale">
@@ -3448,8 +3448,8 @@
                             <rect>
                              <x>0</x>
                              <y>0</y>
-                             <width>759</width>
-                             <height>587</height>
+                             <width>634</width>
+                             <height>467</height>
                             </rect>
                            </property>
                            <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -3985,8 +3985,8 @@
                            <rect>
                             <x>0</x>
                             <y>0</y>
-                            <width>759</width>
-                            <height>616</height>
+                            <width>267</width>
+                            <height>510</height>
                            </rect>
                           </property>
                           <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -5058,8 +5058,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>781</width>
-              <height>640</height>
+              <width>608</width>
+              <height>520</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -5991,8 +5991,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>761</width>
-              <height>644</height>
+              <width>196</width>
+              <height>28</height>
              </rect>
             </property>
             <layout class="QFormLayout" name="hotkeyFormLayout">
@@ -6069,8 +6069,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>799</width>
-              <height>666</height>
+              <width>704</width>
+              <height>347</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_42">
@@ -6978,8 +6978,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>826</width>
-              <height>1000</height>
+              <width>713</width>
+              <height>955</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/forms/OBSBasicTransform.ui
+++ b/UI/forms/OBSBasicTransform.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>564</width>
-    <height>313</height>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/UI/forms/OBSBasicVCamConfig.ui
+++ b/UI/forms/OBSBasicVCamConfig.ui
@@ -36,11 +36,11 @@
    </item>
    <item>
     <widget class="QLabel" name="warningLabel">
+     <property name="visible">
+      <bool>false</bool>
+     </property>
      <property name="text">
       <string>Basic.VCam.RestartWarning</string>
-     </property>
-     <property name="visible">
-	<bool>false</bool>
      </property>
     </widget>
    </item>

--- a/UI/forms/OBSExtraBrowsers.ui
+++ b/UI/forms/OBSExtraBrowsers.ui
@@ -42,7 +42,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderDefaultSectionSize">
-      <number>23</number>
+      <number>24</number>
      </attribute>
     </widget>
    </item>

--- a/UI/forms/OBSImporter.ui
+++ b/UI/forms/OBSImporter.ui
@@ -53,7 +53,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderDefaultSectionSize">
-      <number>23</number>
+      <number>24</number>
      </attribute>
     </widget>
    </item>

--- a/UI/forms/OBSLogReply.ui
+++ b/UI/forms/OBSLogReply.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>600</width>
-    <height>95</height>
+    <height>96</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/UI/forms/OBSMissingFiles.ui
+++ b/UI/forms/OBSMissingFiles.ui
@@ -59,7 +59,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderDefaultSectionSize">
-      <number>23</number>
+      <number>24</number>
      </attribute>
     </widget>
    </item>

--- a/UI/forms/OBSPermissions.ui
+++ b/UI/forms/OBSPermissions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>550</height>
+    <height>613</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -95,7 +95,7 @@
            <property name="wordWrap">
             <bool>true</bool>
            </property>
-           <property name="bottomMargin">
+           <property name="bottomMargin" stdset="0">
             <number>8</number>
            </property>
           </widget>

--- a/UI/forms/OBSRemux.ui
+++ b/UI/forms/OBSRemux.ui
@@ -53,7 +53,7 @@
       <bool>false</bool>
      </attribute>
      <attribute name="verticalHeaderDefaultSectionSize">
-      <number>23</number>
+      <number>24</number>
      </attribute>
     </widget>
    </item>

--- a/UI/forms/OBSUpdate.ui
+++ b/UI/forms/OBSUpdate.ui
@@ -28,10 +28,13 @@
      </property>
      <property name="html">
       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Segoe UI'; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>

--- a/UI/forms/OBSYoutubeActions.ui
+++ b/UI/forms/OBSYoutubeActions.ui
@@ -82,8 +82,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>783</width>
-            <height>666</height>
+            <width>795</width>
+            <height>657</height>
            </rect>
           </property>
           <layout class="QFormLayout" name="formLayout_2">
@@ -299,7 +299,6 @@
             <widget class="QLabel" name="label_7">
              <property name="font">
               <font>
-               <weight>75</weight>
                <bold>true</bold>
               </font>
              </property>
@@ -522,8 +521,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>218</width>
-            <height>200</height>
+            <width>191</width>
+            <height>216</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -643,11 +642,11 @@
       </property>
       <item row="0" column="0">
        <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,2,0,6">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetNoConstraint</enum>
-        </property>
         <property name="spacing">
          <number>10</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetNoConstraint</enum>
         </property>
         <item>
          <widget class="QPushButton" name="cancelButton">

--- a/UI/forms/source-toolbar/media-controls.ui
+++ b/UI/forms/source-toolbar/media-controls.ui
@@ -295,14 +295,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MediaSlider</class>
-   <extends>QSlider</extends>
-   <header>media-slider.hpp</header>
-  </customwidget>
-  <customwidget>
    <class>ClickableLabel</class>
    <extends>QLabel</extends>
    <header>clickable-label.hpp</header>
+  </customwidget>
+  <customwidget>
+   <class>MediaSlider</class>
+   <extends>QSlider</extends>
+   <header>media-slider.hpp</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/UI/frontend-plugins/frontend-tools/forms/captions.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/captions.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>519</width>
-    <height>152</height>
+    <height>162</height>
    </rect>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
### Description

Reformats all `.ui` files with Qt Designer by opening and re-saving them to update them to the Qt 6 XML format and fix some formatting errors.

This also fixes `multiviewProjectorMenu` being declared in the wrong section.

### Motivation and Context

Every time we edit a `.ui` file with Qt Designer and save it we have to either manually undo these changes or manually stage only the hunks that contain the changes we want. That is silly.

(Qt will randomly change the size values in the file for some reason so we'll still have to skip those if we want to keep diffs down, but those are usually only one or two per file and that's much more managable. But I propose we just ignore those going forward since they're meaningless anyway.)

Replaces #8372 which got stuck in bikeshedding limbo, only covered the main file, and is conflicted.

### How Has This Been Tested?

OBS still compiles and looks the same.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
