### PR TITLE
UI: Fix scene rename on tab

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10662,10 +10662,16 @@ bool SceneRenameDelegate::eventFilter(QObject *editor, QEvent *event)
 {
 	if (event->type() == QEvent::KeyPress) {
 		QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
-		if (keyEvent->key() == Qt::Key_Escape) {
+		switch (keyEvent->key()) {
+		case Qt::Key_Escape: {
 			QLineEdit *lineEdit = qobject_cast<QLineEdit *>(editor);
 			if (lineEdit)
 				lineEdit->undo();
+			break;
+		}
+		case Qt::Key_Tab:
+		case Qt::Key_Backtab:
+			return false;
 		}
 	}
 


### PR DESCRIPTION
### Description
Tab key press event was triggering default Qt behavior and selecting next item in scene list before rename event could complete. This caused the incorrect scene to become the target of the rename method. Consumed the tab key event and observed that tab now completes the edit and leaves the current scene selected. This is in alignment with how tabbing away from a rename affects renaming of sources.

### Motivation and Context
Fixes #10090

### How Has This Been Tested?
Built and ran locally on Windows 11 machine before code change, observed incorrect behavior tabbing from rename. Modified code, observed tabbing from rename completes edit as expected.


### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
