### PR TITLE
text-freetype2: Fix bug with null characters

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -424,6 +424,8 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	FILE *tmp_file = NULL;
 	uint32_t filesize = 0;
 	char *tmp_read = NULL;
+	char *sanitized = NULL;
+	size_t sanitized_length = 0;
 	uint16_t header = 0;
 	size_t bytes_read;
 
@@ -458,19 +460,28 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	fseek(tmp_file, 0, SEEK_SET);
 
 	tmp_read = bzalloc(filesize + 1);
-	bytes_read = fread(tmp_read, filesize, 1, tmp_file);
+	bytes_read = fread(tmp_read, 1, filesize, tmp_file);
 	fclose(tmp_file);
 
+	sanitized = bzalloc(bytes_read + 1);
+	for (size_t i = 0; i < bytes_read; i++) {
+		if (tmp_read[i] != '\0') {
+			sanitized[sanitized_length] = tmp_read[i];
+			sanitized_length++;
+		}
+	}
+	sanitized[sanitized_length] = '\0';
 	if (srcdata->text != NULL) {
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text,
-		       (strlen(tmp_read) + 1));
+	srcdata->text = bzalloc((sanitized_length + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(sanitized, sanitized_length, srcdata->text,
+		       (sanitized_length + 1));
 
 	remove_cr(srcdata->text);
 	bfree(tmp_read);
+	bfree(sanitized);
 }
 
 void read_from_end(struct ft2_source *srcdata, const char *filename)


### PR DESCRIPTION
When uploading a file containing null characters only the characters before the first null character would be rendered. Fixed by sanitizing the null characters from the bytes read from the uploaded file.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sanitize null characters from the bytes read from an uploaded file. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change fixes the issue reported on: [obs-studio/issues#7595](https://github.com/obsproject/obs-studio/issues/7595), where when a user uploaded a file containing null characters, only the characters prior to the first null character would be rendered. With this fix, the correct text from the file is rendered.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The changes were tested by uploading a file containing null characters.
The testing environment is macOS Sonoma 14.3.1

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
