### PR TITLE
obs-ffmpeg: Fix NVENC API compatibility with old drivers/hardware

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -32,6 +32,8 @@
 	 ((ver) << 16) | (0x7 << 28))
 
 #define NV_ENC_CONFIG_COMPAT_VER (NVENCAPI_STRUCT_VERSION(7) | (1 << 31))
+#define NV_ENC_INITIALIZE_PARAMS_COMPAT_VER \
+	(NVENCAPI_STRUCT_VERSION(5) | (1 << 31))
 #define NV_ENC_PIC_PARAMS_COMPAT_VER (NVENCAPI_STRUCT_VERSION(4) | (1 << 31))
 #define NV_ENC_LOCK_BITSTREAM_COMPAT_VER NVENCAPI_STRUCT_VERSION(1)
 #define NV_ENC_REGISTER_RESOURCE_COMPAT_VER NVENCAPI_STRUCT_VERSION(3)
@@ -387,7 +389,9 @@ static void initialize_params(struct nvenc_data *enc, const GUID *nv_preset,
 
 	NV_ENC_INITIALIZE_PARAMS *params = &enc->params;
 	memset(params, 0, sizeof(*params));
-	params->version = NV_ENC_INITIALIZE_PARAMS_VER;
+	params->version = enc->needs_compat_ver
+				  ? NV_ENC_INITIALIZE_PARAMS_COMPAT_VER
+				  : NV_ENC_INITIALIZE_PARAMS_VER;
 	params->encodeGUID = enc->codec_guid;
 	params->presetGUID = *nv_preset;
 	params->encodeWidth = width;

--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -1105,6 +1105,9 @@ static void *nvenc_create_internal(enum codec_type codec, obs_data_t *settings,
 	enc->codec = codec;
 	enc->first_packet = true;
 
+	if (get_nvenc_ver() == COMPATIBILITY_VERSION) {
+		enc->needs_compat_ver = true;
+	}
 	NV_ENCODE_API_FUNCTION_LIST init = {NV_ENCODE_API_FUNCTION_LIST_VER};
 
 	switch (enc->codec) {
@@ -1127,9 +1130,6 @@ static void *nvenc_create_internal(enum codec_type codec, obs_data_t *settings,
 	}
 	if (!init_d3d11(enc, settings)) {
 		goto fail;
-	}
-	if (get_nvenc_ver() == COMPATIBILITY_VERSION) {
-		enc->needs_compat_ver = true;
 	}
 	if (!init_session(enc)) {
 		goto fail;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This fixes NVENC for NVIDIA devices stuck on pre-531.61 drivers, such as Kepler devices which can only update to 474.82. We didn't intentionally break this, so we should fix it until we remove the compatibility hacks that we currently use.

For the record we _will_ be officially dropping Kepler at some point, which we will attempt to communicate in advance.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix an unintentional breakage.

Fixes #10431

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I tested this on a GTX 1060 with driver 512.15 to simulate the scenario of being on an SDK 11.1 driver (on Windows, 471.41 or newer but older than 522.25; on Linux, 470.57.02 and newer but older than 520.56.06). Will seek additional testing on actual Kepler hardware.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
