### PR TITLE
UI: Fix duplicate appearance of the discarded screen recorder

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -546,7 +546,7 @@ bool OBSBasicProperties::ConfirmQuit()
 		// Do nothing because the settings are already updated
 		break;
 	case QMessageBox::Discard:
-		obs_source_update(source, oldSettings);
+		obs_source_reset_settings(source, oldSettings);
 		break;
 	case QMessageBox::Cancel:
 		return false;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When I created a new screen recorder and clicked "accept," after that, I clicked on the cross and selected "Discard," but the pop-up appeared again. Now, it is solved because the update function wouldn't do what's most suitable for the need, but rather the function that resets to the settings prior to the discard.
<!--- Describe your changes in detail. -->

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This change fixes the issue reported on: https://github.com/obsproject/obs-studio/issues/10333, where the discard button was pressed and the screen recorded opened anyway. With this fix, the discard button only appears once and disappears once clicked.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

The testing environment was Windows 11, replicating the observed behavior. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
 Bug fix (non-breaking change which fixes an issue)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
