### PR TITLE
UI: When no source is selected, the text indicating this appears cut off in some languages

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -308,7 +308,7 @@
             </property>
             <property name="maximumSize">
              <size>
-              <width>160</width>
+              <width>200</width>
               <height>22</height>
              </size>
             </property>


### PR DESCRIPTION
### Description
In some languages as Portuguese (PT), Portuguese-Brasil (PT-BR) and Spanish (ES) the last few words dind't appear because they were cut off. The solution was to increase the maximumSize width of the "contextSourceLabel" from 160 to 200. I tested in every single language and it's working fine.

### Motivation and Context
This change fixes the issue reported on: https://github.com/obsproject/obs-studio/issues/7360, where when so source was selected, the text suggesting that appeared cut off in some languages including: Portuguese and Spanish.

### How Has This Been Tested?
The testing environment was Windows 11, replicating the observed behavior in all languages.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
