### PR TITLE
mac-capture: Replace pragmas with availability markers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -181,7 +181,7 @@ ReferenceAlignment: Right
 RemoveSemicolon: false
 RequiresClausePosition: WithPreceding
 RequiresExpressionIndentation: OuterScope
-SeparateDefinitionBlocks: Always
+SeparateDefinitionBlocks: Leave
 ShortNamespaceLines: 1
 SortIncludes: false
 #SortUsingDeclarations: LexicographicNumeric

--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -5,7 +5,7 @@ const char *sck_audio_capture_getname(void *unused __unused)
     return obs_module_text("SCK.Audio.Name");
 }
 
-static void destroy_audio_screen_stream(struct screen_capture *sc)
+API_AVAILABLE(macos(13.0)) static void destroy_audio_screen_stream(struct screen_capture *sc)
 {
     if (sc->disp && !sc->capture_failed) {
         [sc->disp stopCaptureWithCompletionHandler:^(NSError *_Nullable error) {
@@ -32,7 +32,7 @@ static void destroy_audio_screen_stream(struct screen_capture *sc)
     os_event_destroy(sc->stream_start_completed);
 }
 
-static void sck_audio_capture_destroy(void *data)
+API_AVAILABLE(macos(13.0)) static void sck_audio_capture_destroy(void *data)
 {
     struct screen_capture *sc = data;
 
@@ -57,7 +57,7 @@ static void sck_audio_capture_destroy(void *data)
     bfree(sc);
 }
 
-static bool init_audio_screen_stream(struct screen_capture *sc)
+API_AVAILABLE(macos(13.0)) static bool init_audio_screen_stream(struct screen_capture *sc)
 {
     SCContentFilter *content_filter;
     if (sc->capture_failed) {
@@ -178,7 +178,7 @@ static void sck_audio_capture_defaults(obs_data_t *settings)
     obs_data_set_default_int(settings, "type", ScreenCaptureAudioDesktopStream);
 }
 
-static void *sck_audio_capture_create(obs_data_t *settings, obs_source_t *source)
+API_AVAILABLE(macos(13.0)) static void *sck_audio_capture_create(obs_data_t *settings, obs_source_t *source)
 {
     struct screen_capture *sc = bzalloc(sizeof(struct screen_capture));
 
@@ -209,6 +209,7 @@ fail:
 
 #pragma mark - obs_properties
 
+API_AVAILABLE(macos(13.0))
 static bool audio_capture_method_changed(void *data, obs_properties_t *props, obs_property_t *list __unused,
                                          obs_data_t *settings)
 {
@@ -233,6 +234,7 @@ static bool audio_capture_method_changed(void *data, obs_properties_t *props, ob
     return true;
 }
 
+API_AVAILABLE(macos(13.0))
 static bool reactivate_capture(obs_properties_t *props __unused, obs_property_t *property, void *data)
 {
     struct screen_capture *sc = data;
@@ -248,7 +250,7 @@ static bool reactivate_capture(obs_properties_t *props __unused, obs_property_t 
     return true;
 }
 
-static obs_properties_t *sck_audio_capture_properties(void *data)
+API_AVAILABLE(macos(13.0)) static obs_properties_t *sck_audio_capture_properties(void *data)
 {
     struct screen_capture *sc = data;
 
@@ -284,7 +286,7 @@ static obs_properties_t *sck_audio_capture_properties(void *data)
     return props;
 }
 
-static void sck_audio_capture_update(void *data, obs_data_t *settings)
+API_AVAILABLE(macos(13.0)) static void sck_audio_capture_update(void *data, obs_data_t *settings)
 {
     struct screen_capture *sc = data;
 
@@ -300,6 +302,7 @@ static void sck_audio_capture_update(void *data, obs_data_t *settings)
 
 #pragma mark - obs_source_info
 
+API_AVAILABLE(macos(13.0))
 struct obs_source_info sck_audio_capture_info = {
     .id = "sck_audio_capture",
     .type = OBS_SOURCE_TYPE_INPUT,

--- a/plugins/mac-capture/mac-sck-common.h
+++ b/plugins/mac-capture/mac-sck-common.h
@@ -1,9 +1,6 @@
 #include <AvailabilityMacros.h>
 #include <Cocoa/Cocoa.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-
 #include <stdlib.h>
 #include <obs-module.h>
 #include <util/threading.h>
@@ -28,15 +25,16 @@ typedef enum {
     ScreenCaptureAudioApplicationStream = 1,
 } ScreenCaptureAudioStreamType;
 
-typedef SCDisplay *SCDisplayRef;
+API_AVAILABLE(macos(12.5)) typedef SCDisplay *SCDisplayRef;
 
+API_AVAILABLE(macos(12.5))
 @interface ScreenCaptureDelegate : NSObject <SCStreamOutput, SCStreamDelegate>
 
 @property struct screen_capture *sc;
 
 @end
 
-struct screen_capture {
+struct API_AVAILABLE(macos(12.5)) screen_capture {
     obs_source_t *source;
 
     gs_effect_t *effect;
@@ -71,18 +69,16 @@ struct screen_capture {
 
 bool is_screen_capture_available(void);
 
-void screen_capture_build_content_list(struct screen_capture *sc, bool display_capture);
+API_AVAILABLE(macos(12.5)) void screen_capture_build_content_list(struct screen_capture *sc, bool display_capture);
 
-bool build_display_list(struct screen_capture *sc, obs_properties_t *props);
+API_AVAILABLE(macos(12.5)) bool build_display_list(struct screen_capture *sc, obs_properties_t *props);
 
-bool build_window_list(struct screen_capture *sc, obs_properties_t *props);
+API_AVAILABLE(macos(12.5)) bool build_window_list(struct screen_capture *sc, obs_properties_t *props);
 
-bool build_application_list(struct screen_capture *sc, obs_properties_t *props);
+API_AVAILABLE(macos(12.5)) bool build_application_list(struct screen_capture *sc, obs_properties_t *props);
 
 static const char *screen_capture_getname(void *unused __unused);
 
-void screen_stream_video_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer);
+API_AVAILABLE(macos(12.5)) void screen_stream_video_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer);
 
-void screen_stream_audio_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer);
-
-#pragma clang diagnostic pop
+API_AVAILABLE(macos(12.5)) void screen_stream_audio_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer);

--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -198,7 +198,7 @@ bool build_application_list(struct screen_capture *sc, obs_properties_t *props)
 
 #pragma mark - audio/video
 
-void screen_stream_video_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer)
+API_AVAILABLE(macos(12.5)) void screen_stream_video_update(struct screen_capture *sc, CMSampleBufferRef sample_buffer)
 {
     bool frame_detail_errored = false;
     float scale_factor = 1.0f;

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -1,7 +1,7 @@
 #include "mac-sck-common.h"
 #include "window-utils.h"
 
-static void destroy_screen_stream(struct screen_capture *sc)
+API_AVAILABLE(macos(12.5)) static void destroy_screen_stream(struct screen_capture *sc)
 {
     if (sc->disp && !sc->capture_failed) {
         [sc->disp stopCaptureWithCompletionHandler:^(NSError *_Nullable error) {
@@ -45,7 +45,7 @@ static void destroy_screen_stream(struct screen_capture *sc)
     os_event_destroy(sc->stream_start_completed);
 }
 
-static void sck_video_capture_destroy(void *data)
+API_AVAILABLE(macos(12.5)) static void sck_video_capture_destroy(void *data)
 {
     struct screen_capture *sc = data;
 
@@ -74,7 +74,7 @@ static void sck_video_capture_destroy(void *data)
     bfree(sc);
 }
 
-static bool init_screen_stream(struct screen_capture *sc)
+API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture *sc)
 {
     SCContentFilter *content_filter;
     if (sc->capture_failed) {
@@ -270,7 +270,7 @@ static bool init_screen_stream(struct screen_capture *sc)
     return did_stream_start;
 }
 
-static void *sck_video_capture_create(obs_data_t *settings, obs_source_t *source)
+API_AVAILABLE(macos(12.5)) static void *sck_video_capture_create(obs_data_t *settings, obs_source_t *source)
 {
     struct screen_capture *sc = bzalloc(sizeof(struct screen_capture));
 
@@ -309,7 +309,7 @@ fail:
     return NULL;
 }
 
-static void sck_video_capture_tick(void *data, float seconds __unused)
+API_AVAILABLE(macos(12.5)) static void sck_video_capture_tick(void *data, float seconds __unused)
 {
     struct screen_capture *sc = data;
 
@@ -341,7 +341,7 @@ static void sck_video_capture_tick(void *data, float seconds __unused)
     }
 }
 
-static void sck_video_capture_render(void *data, gs_effect_t *effect __unused)
+API_AVAILABLE(macos(12.5)) static void sck_video_capture_render(void *data, gs_effect_t *effect __unused)
 {
     struct screen_capture *sc = data;
 
@@ -368,14 +368,14 @@ static const char *sck_video_capture_getname(void *unused __unused)
         return obs_module_text("SCK.Name.Beta");
 }
 
-static uint32_t sck_video_capture_getwidth(void *data)
+API_AVAILABLE(macos(12.5)) static uint32_t sck_video_capture_getwidth(void *data)
 {
     struct screen_capture *sc = data;
 
     return (uint32_t) sc->frame.size.width;
 }
 
-static uint32_t sck_video_capture_getheight(void *data)
+API_AVAILABLE(macos(12.5)) static uint32_t sck_video_capture_getheight(void *data)
 {
     struct screen_capture *sc = data;
 
@@ -410,7 +410,7 @@ static void sck_video_capture_defaults(obs_data_t *settings)
     obs_data_set_default_bool(settings, "show_hidden_windows", false);
 }
 
-static void sck_video_capture_update(void *data, obs_data_t *settings)
+API_AVAILABLE(macos(12.5)) static void sck_video_capture_update(void *data, obs_data_t *settings)
 {
     struct screen_capture *sc = data;
 
@@ -472,6 +472,7 @@ static void sck_video_capture_update(void *data, obs_data_t *settings)
 
 #pragma mark - obs_properties
 
+API_AVAILABLE(macos(12.5))
 static bool content_settings_changed(void *data, obs_properties_t *props, obs_property_t *list __unused,
                                      obs_data_t *settings)
 {
@@ -543,6 +544,7 @@ static bool content_settings_changed(void *data, obs_properties_t *props, obs_pr
     return true;
 }
 
+API_AVAILABLE(macos(12.5))
 static bool reactivate_capture(obs_properties_t *props __unused, obs_property_t *property, void *data)
 {
     struct screen_capture *sc = data;
@@ -560,7 +562,7 @@ static bool reactivate_capture(obs_properties_t *props __unused, obs_property_t 
     return true;
 }
 
-static obs_properties_t *sck_video_capture_properties(void *data)
+API_AVAILABLE(macos(12.5)) static obs_properties_t *sck_video_capture_properties(void *data)
 {
     struct screen_capture *sc = data;
 
@@ -693,6 +695,7 @@ enum gs_color_space sck_video_capture_get_color_space(void *data, size_t count,
 
 #pragma mark - obs_source_info
 
+API_AVAILABLE(macos(12.5))
 struct obs_source_info sck_video_capture_info = {
     .id = "screen_capture",
     .type = OBS_SOURCE_TYPE_INPUT,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Replace pragmas silencing `-Wunguarded-availability-new` by availlability markers.

Note: When placing the marker before a function declaration, clang-format can add an empty new line between the marker and the declaration. So markers were put after when it comes to function declaration.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I tried to unvendor simde and discover that `mac-sdk-common.h` pragmas somehow contaminated other `mac-sck-*.mm` files because of our vendored simde.

Simply moving the pragmas like the following allows to fix the contamination:
```diff
diff --git a/plugins/mac-capture/mac-sck-common.h b/plugins/mac-capture/mac-sck-common.h
index 32ca8d246a8a5..e8b1911f6164d 100644
--- a/plugins/mac-capture/mac-sck-common.h
+++ b/plugins/mac-capture/mac-sck-common.h
@@ -1,9 +1,6 @@
 #include <AvailabilityMacros.h>
 #include <Cocoa/Cocoa.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-
 #include <stdlib.h>
 #include <obs-module.h>
 #include <util/threading.h>
@@ -14,6 +11,9 @@
 #include <CoreMedia/CMSampleBuffer.h>
 #include <CoreVideo/CVPixelBuffer.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+
 #define MACCAP_LOG(level, msg, ...) blog(level, "[ mac-screencapture ]: " msg, ##__VA_ARGS__)
 #define MACCAP_ERR(msg, ...)        MACCAP_LOG(LOG_ERROR, msg, ##__VA_ARGS__)
```

Rather than fixing new warnings by adding more pragmas, I tried to find a better way.
And I found `API_AVAILABLE()` and based on [Clang documentation](https://clang.llvm.org/docs/LanguageExtensions.html#objective-c-available):
> If the caller of `my_fun()` already checks that `my_fun()` is only called on 10.12, then add an availability attribute to it, which will also suppress the warning and require that calls to my_fun() are checked

And it seems to work for most of declaration not only functions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Building yes, macOS SCK was not tested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
