### PR TITLE
UI,plugin: Refactor virtual camera enablement

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -5,7 +5,7 @@
 #include "audio-encoders.hpp"
 #include "window-basic-main.hpp"
 #include "window-basic-main-outputs.hpp"
-#include "window-basic-vcam-config.hpp"
+#include "window-basic-vcam.hpp"
 
 using namespace std;
 
@@ -289,9 +289,8 @@ static const char *GetStreamOutputType(const obs_service_t *service)
 inline BasicOutputHandler::BasicOutputHandler(OBSBasic *main_) : main(main_)
 {
 	if (main->vcamEnabled) {
-		virtualCam = obs_output_create("virtualcam_output",
-					       "virtualcam_output", nullptr,
-					       nullptr);
+		virtualCam = obs_output_create(
+			VIRTUAL_CAM_ID, "virtualcam_output", nullptr, nullptr);
 
 		signal_handler_t *signal =
 			obs_output_get_signal_handler(virtualCam);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2068,8 +2068,8 @@ void OBSBasic::OBSInit()
 	cef_js_avail = cef && obs_browser_qcef_version() >= 3;
 #endif
 
-	OBSDataAutoRelease obsData = obs_get_private_data();
-	vcamEnabled = obs_data_get_bool(obsData, "vcamEnabled");
+	vcamEnabled =
+		(obs_get_output_flags(VIRTUAL_CAM_ID) & OBS_OUTPUT_VIDEO) != 0;
 	if (vcamEnabled) {
 		AddVCamButton();
 	}

--- a/UI/window-basic-vcam.hpp
+++ b/UI/window-basic-vcam.hpp
@@ -2,6 +2,8 @@
 
 #include <string>
 
+constexpr const char *VIRTUAL_CAM_ID = "virtualcam_output";
+
 enum VCamOutputType {
 	Invalid,
 	SceneOutput,

--- a/plugins/linux-v4l2/linux-v4l2.c
+++ b/plugins/linux-v4l2/linux-v4l2.c
@@ -32,19 +32,12 @@ bool obs_module_load(void)
 {
 	obs_register_source(&v4l2_input);
 
-	obs_data_t *obs_settings = obs_data_create();
-
 	if (loopback_module_available()) {
 		obs_register_output(&virtualcam_info);
-		obs_data_set_bool(obs_settings, "vcamEnabled", true);
 	} else {
-		obs_data_set_bool(obs_settings, "vcamEnabled", false);
 		blog(LOG_WARNING,
-		     "v4l2loopback not installed, virtual camera disabled");
+		     "v4l2loopback not installed, virtual camera not registered");
 	}
-
-	obs_apply_private_data(obs_settings);
-	obs_data_release(obs_settings);
 
 	return true;
 }

--- a/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
+++ b/plugins/mac-virtualcam/src/obs-plugin/plugin-main.mm
@@ -552,10 +552,5 @@ bool obs_module_load(void)
 {
     obs_register_output(&virtualcam_output_info);
 
-    obs_data_t *obs_settings = obs_data_create();
-    obs_data_set_bool(obs_settings, "vcamEnabled", true);
-    obs_apply_private_data(obs_settings);
-    obs_data_release(obs_settings);
-
     return true;
 }

--- a/plugins/win-dshow/dshow-plugin.cpp
+++ b/plugins/win-dshow/dshow-plugin.cpp
@@ -45,17 +45,9 @@ bool obs_module_load(void)
 	RegisterDShowSource();
 	RegisterDShowEncoders();
 #ifdef VIRTUALCAM_AVAILABLE
-	obs_register_output(&virtualcam_info);
-
-	bool installed = vcam_installed(false);
-#else
-	bool installed = false;
+	if (vcam_installed(false))
+		obs_register_output(&virtualcam_info);
 #endif
-
-	obs_data_t *obs_settings = obs_data_create();
-	obs_data_set_bool(obs_settings, "vcamEnabled", installed);
-	obs_apply_private_data(obs_settings);
-	obs_data_release(obs_settings);
 
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Move the whole virtual camera enablement logic in the UI by checking if a the right output id is registered.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Split from #5383, the refactor is not dependent the dual vcam feature.

PipeWire virtual camera is blocked until portals provides a solution.

I just thought that this portion of code can be reviewed separately without waiting that I finally finish my work on portals.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Lightly tested on Linux.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
