### PR TITLE
libobs-winrt: Remove interop code now provided by Windows SDK

### DIFF
--- a/libobs-winrt/CMakeLists.txt
+++ b/libobs-winrt/CMakeLists.txt
@@ -22,6 +22,7 @@ target_precompile_headers(
   <obs-module.h>
   <util/windows/ComPtr.hpp>
   <Windows.Graphics.Capture.Interop.h>
+  <windows.graphics.directx.direct3d11.interop.h>
   <winrt/Windows.Foundation.Metadata.h>
   <winrt/Windows.Graphics.Capture.h>
   <winrt/Windows.System.h>)

--- a/libobs-winrt/cmake/legacy.cmake
+++ b/libobs-winrt/cmake/legacy.cmake
@@ -14,6 +14,7 @@ target_precompile_headers(
   <DispatcherQueue.h>
   <dwmapi.h>
   <Windows.Graphics.Capture.Interop.h>
+  <windows.graphics.directx.direct3d11.interop.h>
   <winrt/Windows.Foundation.Metadata.h>
   <winrt/Windows.Graphics.Capture.h>
   <winrt/Windows.System.h>)

--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -1,19 +1,5 @@
 #include "winrt-capture.h"
 
-extern "C" {
-HRESULT __stdcall CreateDirect3D11DeviceFromDXGIDevice(
-	::IDXGIDevice *dxgiDevice, ::IInspectable **graphicsDevice);
-
-HRESULT __stdcall CreateDirect3D11SurfaceFromDXGISurface(
-	::IDXGISurface *dgxiSurface, ::IInspectable **graphicsSurface);
-}
-
-struct __declspec(uuid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1"))
-	IDirect3DDxgiInterfaceAccess : ::IUnknown {
-	virtual HRESULT __stdcall GetInterface(GUID const &id,
-					       void **object) = 0;
-};
-
 extern "C" EXPORT BOOL winrt_capture_supported()
 try {
 	/* no contract for IGraphicsCaptureItemInterop, verify 10.0.18362.0 */
@@ -50,7 +36,8 @@ template<typename T>
 static winrt::com_ptr<T> GetDXGIInterfaceFromObject(
 	winrt::Windows::Foundation::IInspectable const &object)
 {
-	auto access = object.as<IDirect3DDxgiInterfaceAccess>();
+	auto access = object.as<Windows::Graphics::DirectX::Direct3D11::
+					IDirect3DDxgiInterfaceAccess>();
 	winrt::com_ptr<T> result;
 	winrt::check_hresult(
 		access->GetInterface(winrt::guid_of<T>(), result.put_void()));


### PR DESCRIPTION
### Description
Remove the custom declarations of the external 
functions _CreateDirect3D11DeviceFromDXGIDevice_ and 
_CreateDirect3D11SurfaceFromDXGISurface_, as well as the 
_IDirect3DDxgiInterfaceAccess_ interface. 

Add WinSDK interop header:
_windows.graphics.directx.direct3d11.interop.h_

### Motivation and Context
This cleanup simplifies our codebase and ensures we're 
utilizing the standard, up-to-date definitions provided by the 
Windows SDK.

### How Has This Been Tested?
Tested AMD Windows 11 with WinSDK 10.0.22621.0.  Header file exists
in WinSDK 10.0.20348.0 as well, with same code definitions.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.