### PR TITLE
rtmp-services: Add Rooter to ingest list

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 248,
+    "version": 249,
     "files": [
         {
             "name": "services.json",
-            "version": 248
+            "version": 249
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2822,6 +2822,27 @@
                 "max audio bitrate": 320,
                 "bframes": 0
             }
+        },
+        {
+            "name": "Rooter",
+            "stream_key_link": "https://www.rooter.gg/studio",
+            "servers": [
+                {
+                    "name": "Server 1",
+                    "url": "rtmps://c2ee45b2888d.global-contribute.live-video.net:443/app/"
+                },
+                {
+                    "name": "Server 2",
+                    "url": "rtmps://rtmp-mumbai-in.rooter.io:443/show"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 8000
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Adding Rooter's Rtmp ingest servers to the services list.
Website link: https://www.rooter.gg

### Motivation and Context
Rooter is the biggest esports platform in India. 
To make to the user flow simpler, we are adding the ingest servers to the list.

### How Has This Been Tested?
After adding ingest servers to the services file and updating version in package.json, 
I build it on my Apple M1 Pro. I verified that we can see our newly added Rooter service in the list
when I select Service dropdown menu from obs studio.


### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x ] My code is not on the master branch.
- [x ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.