### PR TITLE
UI: Use spacers instead of widgets in macOS Permissions UI

### DIFF
--- a/UI/forms/OBSPermissions.ui
+++ b/UI/forms/OBSPermissions.ui
@@ -145,7 +145,17 @@
               <number>25</number>
              </property>
              <item>
-              <widget class="QWidget"/>
+              <spacer name="horizontalSpacer">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
              <item>
               <widget class="QPushButton" name="capturePermissionButton">
@@ -211,7 +221,17 @@
               <number>25</number>
              </property>
              <item>
-              <widget class="QWidget"/>
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
              <item>
               <widget class="QPushButton" name="videoPermissionButton">
@@ -274,7 +294,17 @@
               <number>25</number>
              </property>
              <item>
-              <widget class="QWidget"/>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
              <item>
               <widget class="QPushButton" name="audioPermissionButton">
@@ -340,7 +370,17 @@
               <number>25</number>
              </property>
              <item>
-              <widget class="QWidget"/>
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
              <item>
               <widget class="QPushButton" name="accessibilityPermissionButton">


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The macOS Permissions dialog was using empty widgets to force other widgets into position. Instead, use horizontal spacers.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Noticed when reviewing #10419 that this dialog used blank widgets to help position other elements. Seemed odd. This change should supersede the specific `native="true"` changes to the empty widgets in this file so that that and the duplicate/identical item names are no longer an issue blocking that PR.

Note that I used Qt Creator 12 on Windows 11 to make these changes to the .ui file. Some of the changes made in #10419 do not appear to have been made by Qt Creator 12 when I saved this (notably, the orientation enum namespace), so this file will still need processed again.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and checked the dialog on macOS 13.6.6. The dialog looked the same before and after.

#### Before
<img width="699" alt="Screenshot 2024-04-02 at 7 57 45 PM" src="https://github.com/obsproject/obs-studio/assets/624931/b5f5f4f3-2e7a-4391-9e48-df56fe305492">

#### After
<img width="699" alt="Screenshot 2024-04-02 at 8 11 38 PM" src="https://github.com/obsproject/obs-studio/assets/624931/0a3d642c-0436-4ef8-8acc-79422bd3debe">


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
