### PR TITLE
aja: Call CNTV2Card::ApplySignalRoute with a CNTV2SignalRouter instance

### DIFF
--- a/plugins/aja/aja-routing.cpp
+++ b/plugins/aja/aja-routing.cpp
@@ -295,7 +295,9 @@ bool Routing::ConfigureSourceRoute(const SourceProps &props, NTV2Mode mode,
 	if (!ParseRouteString(route_string, cnx))
 		return false;
 
-	card->ApplySignalRoute(cnx, false);
+	CNTV2SignalRouter sr;
+	sr.ResetFrom(cnx);
+	card->ApplySignalRoute(sr, false);
 
 	// Apply SDI widget settings
 	start_channel_index = GetIndexForNTV2Channel(init_channel);
@@ -441,7 +443,9 @@ bool Routing::ConfigureOutputRoute(const OutputProps &props, NTV2Mode mode,
 	if (!ParseRouteString(route_string, cnx))
 		return false;
 
-	card->ApplySignalRoute(cnx, false);
+	CNTV2SignalRouter sr;
+	sr.ResetFrom(cnx);
+	card->ApplySignalRoute(sr, false);
 
 	// Apply SDI widget settings
 	if (props.ioSelect != IOSelection::HDMIMonitorOut ||


### PR DESCRIPTION
The version of the `CNTV2Card::ApplySignalRoute` API which accepts a const ref to `NTV2XptConnections` results in additional crosspoint connection validation before `CNTV2Card::Connect` calls are made. If the validation logic fails under this version of the API, the `Connect` calls will also fail.

This PR switches to the version of `CNTV2Card::ApplySignalRoute` which accepts a const ref to a `CNTV2SignalRouter` instance. This API still performs the crosspoint validation but will not prevent the `Connect` calls. It is perfectly safe to call Connect even if the crosspoint connections are actually invalid, so there is really no reason to use the validation step unless writing code that explicitly needs to check its result.

Crosspoint validation is an entirely optional step and is performed via a "CanConnect" ROM table in the firmware. In rare cases where the table contains a bug, the SDK will prevent the crosspoints from connecting, even though the firmware can physically connect them. In other words, a bad entry in the CanConnect table can prevent the ability to connect a perfectly valid signal route, when using the `NTV2XptConnections` version of `CNTV2Card::ApplySignalRoute`.

As an example, here is a screenshot of the NTV2 Watcher application showing a case where the CanConnect ROM reports that a particular crosspoint connection (SDI4A => TSIMux2B, highlighted in red) is invalid even though the route is physically valid in the FPGA fabric:
![image](https://github.com/obsproject/obs-studio/assets/78836538/510c0a74-78af-4570-b02a-c29c145f6ff3)

The TSIMux2 widget and subsequent Framestore2 widgets light up in blue as there is actually a valid signal between those connections.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Switch to the version of `CNTV2Card::ApplySignalRoute` which accepts a `const CNTV2SignalRouter&` instance. This change allows crosspoint connections to be made even if the optional validation step fails, due to a rare firmware bug.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We recently found that some older Kona5 firmwares had a bug in their "CanConnect" ROM table, which is used by the ajantv2 SDK for crosspoint connection validation. The crosspoint connection validation step is entirely optional but is used by the version of the `CNTV2Card::ApplySignalRoute` API which takes a `const NTV2XptConnections&`. In this rare situation it will prevent the ability to connect otherwise physically legal connections.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with a known buggy Kona5 retail firmware, which had a couple of incorrect crosspoint "CanConnect" entries.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
