### PR TITLE
win-capture: Unhook from hidden windows

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -635,7 +635,8 @@ static void wc_tick(void *data, float seconds)
 	if (!obs_source_showing(wc->source))
 		return;
 
-	if (!wc->window || !IsWindow(wc->window)) {
+	if (!wc->window || !IsWindow(wc->window) ||
+	    !IsWindowVisible(wc->window)) {
 		if (wc->hooked) {
 			wc->hooked = false;
 
@@ -686,7 +687,7 @@ static void wc_tick(void *data, float seconds)
 		wc->previously_failed = false;
 		reset_capture = true;
 
-	} else if (IsIconic(wc->window) || !IsWindowVisible(wc->window)) {
+	} else if (IsIconic(wc->window)) {
 		return; /* If HWND is invisible, WGC module can't be initialized successfully */
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Unhook window-capture from windows that are fully hidden but still alive.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently when a window-capture hooks into a window if the window then becomes hidden it won't unhook. This means we don't recieve an unhooked signal even though the window is effectively inaccessible by the user.

The behaviour for `IsIconic` makes sense to stay hooked because it is still easily accessible by the user.

A common example of an app doing this is Steam, closing steam's main window actually just hides the window rather than destroying it. This then means we don't get an unhooked signal when closing the steam window.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've locally tested these changes against Steam's main window, and this also doesn't affect the normal behaviour of minimised or closed windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
