### PR TITLE
UI: Use selected file path when opening file dialogs

### DIFF
--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -500,7 +500,11 @@ void ImageSourceToolbar::on_browse_clicked()
 	const char *filter = obs_property_path_filter(p);
 	const char *default_path = obs_property_path_default_path(p);
 
-	QString path = OpenFile(this, desc, default_path, filter);
+	QString startDir = ui->path->text();
+	if (startDir.isEmpty())
+		startDir = default_path;
+
+	QString path = OpenFile(this, desc, startDir, filter);
 	if (path.isEmpty()) {
 		return;
 	}

--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1813,17 +1813,21 @@ bool WidgetInfo::PathChanged(const char *setting)
 	obs_path_type type = obs_property_path_type(property);
 	const char *filter = obs_property_path_filter(property);
 	const char *default_path = obs_property_path_default_path(property);
+
+	QLineEdit *edit = static_cast<QLineEdit *>(widget);
+
+	QString startDir = edit->text();
+	if (startDir.isEmpty())
+		startDir = default_path;
+
 	QString path;
 
 	if (type == OBS_PATH_DIRECTORY)
-		path = SelectDirectory(view, QT_UTF8(desc),
-				       QT_UTF8(default_path));
+		path = SelectDirectory(view, QT_UTF8(desc), startDir);
 	else if (type == OBS_PATH_FILE)
-		path = OpenFile(view, QT_UTF8(desc), QT_UTF8(default_path),
-				QT_UTF8(filter));
+		path = OpenFile(view, QT_UTF8(desc), startDir, QT_UTF8(filter));
 	else if (type == OBS_PATH_FILE_SAVE)
-		path = SaveFile(view, QT_UTF8(desc), QT_UTF8(default_path),
-				QT_UTF8(filter));
+		path = SaveFile(view, QT_UTF8(desc), startDir, QT_UTF8(filter));
 
 #ifdef __APPLE__
 	// TODO: Revisit when QTBUG-42661 is fixed
@@ -1833,7 +1837,6 @@ bool WidgetInfo::PathChanged(const char *setting)
 	if (path.isEmpty())
 		return false;
 
-	QLineEdit *edit = static_cast<QLineEdit *>(widget);
 	edit->setText(path);
 	obs_data_set_string(view->settings, setting, QT_TO_UTF8(path));
 	return true;

--- a/plugins/image-source/image-source.c
+++ b/plugins/image-source/image-source.c
@@ -306,28 +306,16 @@ static const char *image_filter =
 
 static obs_properties_t *image_source_properties(void *data)
 {
-	struct image_source *s = data;
-	struct dstr path = {0};
+	UNUSED_PARAMETER(data);
 
 	obs_properties_t *props = obs_properties_create();
 
-	if (s && s->file && *s->file) {
-		const char *slash;
-
-		dstr_copy(&path, s->file);
-		dstr_replace(&path, "\\", "/");
-		slash = strrchr(path.array, '/');
-		if (slash)
-			dstr_resize(&path, slash - path.array + 1);
-	}
-
 	obs_properties_add_path(props, "file", obs_module_text("File"),
-				OBS_PATH_FILE, image_filter, path.array);
+				OBS_PATH_FILE, image_filter, NULL);
 	obs_properties_add_bool(props, "unload",
 				obs_module_text("UnloadWhenNotShowing"));
 	obs_properties_add_bool(props, "linear_alpha",
 				obs_module_text("LinearAlpha"));
-	dstr_free(&path);
 
 	return props;
 }

--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -382,7 +382,7 @@ static void color_grade_filter_defaults(obs_data_t *settings)
 
 static obs_properties_t *color_grade_filter_properties(void *data)
 {
-	struct lut_filter_data *s = data;
+	UNUSED_PARAMETER(data);
 	struct dstr path = {0};
 	const char *slash;
 
@@ -391,14 +391,10 @@ static obs_properties_t *color_grade_filter_properties(void *data)
 
 	dstr_cat(&filter_str, "PNG/Cube (*.cube *.png)");
 
-	if (s && s->file && *s->file) {
-		dstr_copy(&path, s->file);
-	} else {
-		char *lut_dir = obs_module_file("LUTs");
-		dstr_copy(&path, lut_dir);
-		dstr_cat_ch(&path, '/');
-		bfree(lut_dir);
-	}
+	char *lut_dir = obs_module_file("LUTs");
+	dstr_copy(&path, lut_dir);
+	dstr_cat_ch(&path, '/');
+	bfree(lut_dir);
 
 	dstr_replace(&path, "\\", "/");
 	slash = strrchr(path.array, '/');


### PR DESCRIPTION
### Description
Updates the properties view to use the existing path of a selected file when creating file dialogs, rather than relying on logic existing where `obs_properties_add_path` is called.

### Motivation and Context
Fixes #6777 at a deeper level compared to the approach in #6786

Currently, file dialogs for property views reference default_path for their working directory. However, this is set only when the property view is being created. Selecting a file or resetting to defaults does not update this value. Due to most places in the the code having a default_path of NULL, behaviour was _usually_ as expected, as re-opening the file dialog would simply fall back to the last location browsed (on Windows at least).

In the case of the LUT filter, we specify a default_path where the default LUT files are located. This meant that after selecting a LUT file outside that folder, immediately re-opening the file dialog would start in the LUT folder again, rather than the directory of the selected file. The default_path would only get updated to the selected files location when the Filters dialog is re-opened or the filters properties are reloaded via switching off of it and back.

Rather than making sure we update default_path anywhere a file selection can happen, update properties view itself to use the selected path when creating the file dialog, allowing default_path to act strictly as the fallback when there is nothing selected.

### How Has This Been Tested?
Opened the file selectors for the LUT filter, Image slideshow properties, Image source properties, and Image source context bar. Ensured that the file dialog always opened to the location of the specified file if set, the default_path if it's not NULL, and native OS fallback in the case of neither.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
