### PR TITLE
Fix compiling with FFmpeg 7

### DIFF
--- a/plugins/linux-v4l2/v4l2-decoder.c
+++ b/plugins/linux-v4l2/v4l2-decoder.c
@@ -78,7 +78,9 @@ void v4l2_destroy_decoder(struct v4l2_decoder *decoder)
 	}
 
 	if (decoder->context) {
+#if LIBAVCODEC_VERSION_MAJOR < 61
 		avcodec_close(decoder->context);
+#endif
 		avcodec_free_context(&decoder->context);
 	}
 }

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -886,7 +886,12 @@ static int64_t ffmpeg_mux_seek_av_buffer(void *opaque, int64_t offset,
 	return 0;
 }
 
+#if LIBAVFORMAT_VERSION_MAJOR >= 61
+static int ffmpeg_mux_write_av_buffer(void *opaque, const uint8_t *buf,
+				      int buf_size)
+#else
 static int ffmpeg_mux_write_av_buffer(void *opaque, uint8_t *buf, int buf_size)
+#endif
 {
 	struct ffmpeg_mux *ffm = opaque;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix errors introduced by building OBS Studio with FFmpeg 7.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

FFmpeg 7 is out, and Arch Linux will not wait for us…

And since the errors looked easy to fix, so I made the PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Not tested, I'll maybe try to on my side (at least the v4l2 path)…

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
