### PR TITLE
libobs: Fix image slideshow transitioning from wrong source

### DIFF
--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -402,6 +402,12 @@ bool obs_transition_start(obs_source_t *transition,
 			(uint64_t)duration_ms * 1000000ULL;
 	}
 
+	if (transition->transition_sources[OBS_TRANSITION_SOURCE_B] != NULL)
+		set_source(
+			transition, OBS_TRANSITION_SOURCE_A,
+			transition->transition_sources[OBS_TRANSITION_SOURCE_B],
+			activate_transition);
+
 	set_source(transition, OBS_TRANSITION_SOURCE_B, dest,
 		   activate_transition);
 	if (dest == NULL && same_as_dest && !same_as_source) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
For reference:
- Transition Source 'A' is what we are transitioning _from_
- Transition Source 'B' is what we are transitioning _to_

When transition is started, assign the transition source 'B' to transition source 'A' if transition source 'B' is not NULL. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes obsproject/obs-studio#6320

When an image slideshow is full screened and not selected, transition source 'A' is not updated. 

Investigated how the source is set when image slideshow is working correctly and found that audio rendering calls 'obs_transition_stop' which assigns transition source 'B' to transition source 'A'. This does not get called when reproduction steps are followed because audio is not being rendered for scenes that are not active.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and ran locally on Windows 11 machine before code change. Set up hotkeys for slideshow using arrows to navigate. Created image slideshow, full screened and navigated away from scene containing slideshow. Navigated slide show using hotkeys and observed image slideshow was displaying the wrong image before each transition as described in issue. Modified code and followed reproduction steps. Slides no longer transition from wrong image after following reproduction steps.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
