### PR TITLE
obs-outputs: Fix FLV muxer tag size logic and file info offset

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -123,7 +123,13 @@ static inline double encoder_video_codec(obs_encoder_t *encoder)
 	return 0.0;
 }
 
-#define FLV_INFO_SIZE_OFFSET 42
+/*
+ * This is based on the position of `duration` and `fileSize` in
+ * `build_flv_meta_data` relative to the beginning of the file
+ * to allow `write_file_info` to overwrite these two fields once
+ * the file is finalized.
+ */
+#define FLV_INFO_SIZE_OFFSET 58
 
 void write_file_info(FILE *file, int64_t duration_ms, int64_t size)
 {

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -212,8 +212,15 @@ static inline void write_previous_tag_size_without_header(struct serializer *s,
 							  uint32_t header_size)
 {
 	assert(serializer_get_pos(s) >= header_size);
-	/* write tag size (starting byte doesn't count) */
-	s_wb32(s, (uint32_t)serializer_get_pos(s) - header_size - 1);
+	assert(serializer_get_pos(s) >= 11);
+
+	/*
+	 * From FLV file format specification version 10:
+	 * Size of previous [current] tag, including its header.
+	 * For FLV version 1 this value is 11 plus the DataSize of
+	 * the previous [current] tag.
+	 */
+	s_wb32(s, (uint32_t)serializer_get_pos(s) - header_size);
 }
 
 static inline void write_previous_tag_size(struct serializer *s)


### PR DESCRIPTION

### Description
This is supposed to make the FLV output emit more compliant FLV files

### Motivation and Context
To prepare eRTMP support there's an upcoming PR that adds "eRTMP" (eFLV?) support to the FLV file output; having eFLV support is generally useful so testing doesn't have to involve RTMP/an actual server, and various tools used at Twitch complained about malformed FLVs (both the off-by-one tag size and the broken header/metadata after FLV files have been finalized)

### How Has This Been Tested?
Verified functionality with https://github.com/kc5nra/ertmp-toolbox and various internal tools

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
