### PR TITLE
UI: Selecting multiple sources and applying Show or Hide transitions only affects the first source #10448

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -399,6 +399,7 @@ private:
 
 	OBSSceneItem GetSceneItem(QListWidgetItem *item);
 	OBSSceneItem GetCurrentSceneItem();
+	OBSSceneItem GetSceneItem(int64_t idx);
 
 	bool QueryRemoveSource(obs_source_t *source);
 
@@ -453,6 +454,7 @@ private:
 	void SaveProjectNow();
 
 	int GetTopSelectedSourceItem();
+	int GetSelectedSourceItem(int64_t idx);
 
 	QModelIndexList GetAllSelectedSourceItems();
 
@@ -881,7 +883,6 @@ private:
 	void UpdatePause(bool activate = true);
 	void UpdateReplayBuffer(bool activate = true);
 
-	bool IsFFmpegOutputToURL() const;
 	bool OutputPathValid();
 	void OutputPathInvalidMessage();
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When we try to select multiple sources and change the Transition by going to "Show Transition -> Cut/Fade/etc" it only used to change the topmost source. Issue - [#10448](https://github.com/obsproject/obs-studio/issues/10448)
A video is also attached for the replication steps
I found the root cause and made the changes accordingly which works for both "Show Transition" and "Hide Transition"

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Multiple Source Transition change at once was not possible and was the Transition Change was applicable to the topmost source.
It fixes the issue - [#10448](https://github.com/obsproject/obs-studio/issues/10448)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I ran the tests manually on Windows 11 and everything is working fine. Does not break any feature.
I have added a video link for the confirmation. Here is the [Drive Link](https://drive.google.com/file/d/1hGmo70uGsKmO-iDxNjL1w7scEc1J6FGa/view?usp=sharing) for the video.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


