### PR TITLE
UI: Adjust button order in vertical mixer

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -306,7 +306,6 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 			controlLayout->setAlignment(config, Qt::AlignVCenter);
 		}
 
-		controlLayout->addItem(new QSpacerItem(3, 0));
 		// Add Headphone (audio monitoring) widget here
 		controlLayout->addWidget(mute);
 		controlLayout->setAlignment(mute, Qt::AlignVCenter);

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -301,14 +301,14 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		controlLayout->setContentsMargins(0, 0, 0, 0);
 		controlLayout->setSpacing(0);
 
+		controlLayout->addWidget(mute);
+		controlLayout->setAlignment(mute, Qt::AlignVCenter);
+		// Add Headphone (audio monitoring) widget here
+
 		if (showConfig) {
 			controlLayout->addWidget(config);
 			controlLayout->setAlignment(config, Qt::AlignVCenter);
 		}
-
-		// Add Headphone (audio monitoring) widget here
-		controlLayout->addWidget(mute);
-		controlLayout->setAlignment(mute, Qt::AlignVCenter);
 
 		meterLayout->setContentsMargins(0, 0, 0, 0);
 		meterLayout->setSpacing(0);


### PR DESCRIPTION
### Description
Moves the mute button before the config menu button in vertical mixer layout.

### Motivation and Context
Any action with a dedicated button has a dedicated button because we consider it important or frequent. Additional config/options should always be the last button entry. This also matches the button order in horizontal layout.

### How Has This Been Tested?
![image](https://github.com/obsproject/obs-studio/assets/1554753/d7457f4d-d1e9-4291-86c3-ca8dfdc8556a)


### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
