### PR TITLE
UI: Fix filter undo action using UUID instead of name

### DIFF
--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -202,6 +202,7 @@ void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings,
 {
 	obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
 	const char *source_uuid = obs_source_get_uuid(source);
+	const char *name = obs_source_get_name(source);
 	OBSBasic *main = OBSBasic::Get();
 
 	OBSDataAutoRelease redo_wrapper = obs_data_create();
@@ -235,8 +236,8 @@ void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings,
 
 	std::string undo_data = obs_data_get_json(undo_wrapper);
 	std::string redo_data = obs_data_get_json(redo_wrapper);
-	main->undo_s.add_action(QTStr("Undo.Filters").arg(source_uuid),
-				undo_redo, undo_redo, undo_data, redo_data);
+	main->undo_s.add_action(QTStr("Undo.Filters").arg(name), undo_redo,
+				undo_redo, undo_data, redo_data);
 
 	obs_source_update(source, new_settings);
 }


### PR DESCRIPTION
### Description

Fixes undo action display text using the source UUID instead of name.

### Motivation and Context

Users don't know what UUID maps to what source.

### How Has This Been Tested?

Hasn't

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
