### PR TITLE
obs-ffmpeg: Fix SRT listener bug

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.h
@@ -43,6 +43,8 @@ struct ffmpeg_cfg {
 	const char *password;
 	const char *stream_id;
 	const char *encrypt_passphrase;
+	bool is_srt;
+	bool is_rist;
 };
 
 struct ffmpeg_audio_info {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -150,7 +150,7 @@ static int libsrt_network_wait_fd(URLContext *h, int eid, int write)
 	int ret, len = 1, errlen = 1;
 	SRTSOCKET ready[1];
 	SRTSOCKET error[1];
-
+	SRTContext *s = (SRTContext *)h->priv_data;
 	if (write) {
 		ret = srt_epoll_wait(eid, error, &errlen, ready, &len,
 				     POLLING_TIME, 0, 0, 0, 0);
@@ -158,7 +158,7 @@ static int libsrt_network_wait_fd(URLContext *h, int eid, int write)
 		ret = srt_epoll_wait(eid, ready, &len, error, &errlen,
 				     POLLING_TIME, 0, 0, 0, 0);
 	}
-	if (len == 1 && errlen == 1) {
+	if (len == 1 && errlen == 1 && s->mode == SRT_MODE_CALLER) {
 		/* Socket reported in wsock AND rsock signifies an error. */
 		int reason = srt_getrejectreason(*ready);
 
@@ -232,7 +232,7 @@ static int libsrt_listen(int eid, SRTSOCKET fd, const struct sockaddr *addr,
 	if (srt_listen(fd, 1))
 		return libsrt_neterrno(h);
 
-	ret = libsrt_network_wait_fd_timeout(h, eid, 1, timeout,
+	ret = libsrt_network_wait_fd_timeout(h, eid, 0, timeout,
 					     &h->interrupt_callback);
 	if (ret < 0)
 		return ret;
@@ -462,7 +462,7 @@ static int libsrt_setup(URLContext *h, const char *uri)
 	char hostname[1024], proto[1024], path[1024];
 	char portstr[10];
 	int64_t open_timeout = 0;
-	int eid, write_eid;
+	int eid;
 	struct sockaddr_in la;
 
 	av_url_split(proto, sizeof(proto), NULL, 0, hostname, sizeof(hostname),
@@ -552,20 +552,23 @@ restart:
 		blog(LOG_DEBUG,
 		     "[obs-ffmpeg mpegts muxer / libsrt]: libsrt_socket_nonblock failed");
 
-	ret = write_eid = libsrt_epoll_create(h, fd, 1);
-	if (ret < 0)
-		goto fail1;
 	if (s->mode == SRT_MODE_LISTENER) {
+		int read_eid = ret = libsrt_epoll_create(h, fd, 0);
+		if (ret < 0)
+			goto fail1;
 		// multi-client
-		ret = libsrt_listen(write_eid, fd, cur_ai->ai_addr,
+		ret = libsrt_listen(read_eid, fd, cur_ai->ai_addr,
 				    (socklen_t)cur_ai->ai_addrlen, h,
 				    s->listen_timeout);
-		srt_epoll_release(write_eid);
+		srt_epoll_release(read_eid);
 		if (ret < 0)
 			goto fail1;
 		srt_close(fd);
 		fd = ret;
 	} else {
+		int write_eid = ret = libsrt_epoll_create(h, fd, 1);
+		if (ret < 0)
+			goto fail1;
 		if (s->mode == SRT_MODE_RENDEZVOUS) {
 			if (srt_bind(fd, (struct sockaddr *)&la,
 				     sizeof(struct sockaddr_in))) {
@@ -878,6 +881,8 @@ static int libsrt_write(URLContext *h, const uint8_t *buf, int size)
 static int libsrt_close(URLContext *h)
 {
 	SRTContext *s = (SRTContext *)h->priv_data;
+	if (!s)
+		return 0;
 	if (s->streamid)
 		av_freep(&s->streamid);
 	if (s->passphrase)


### PR DESCRIPTION
### Description
Fixes #10504.
When starting an SRT stream in listener mode, if no connection is made by a client, the socket was not closed when exiting obs. This fixes the issue so that SRT is closed properly.

### Motivation and Context
Bugs are bad.

### How Has This Been Tested?
Bug is fixed.
SRT in caller mode still works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
