### PR TITLE
UI: Reset duration when removing show/hide transition

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1183,6 +1183,8 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 		if (id.isNull() || id.isEmpty()) {
 			obs_sceneitem_set_transition(sceneItem, visible,
 						     nullptr);
+			obs_sceneitem_set_transition_duration(sceneItem,
+							      visible, 0);
 		} else {
 			OBSSource tr = obs_sceneitem_get_transition(sceneItem,
 								    visible);


### PR DESCRIPTION
### Description
Reset a scene items show/hide transition duration to 0 when selecting the 'None' option.

### Motivation and Context
We currently treat the globally set transition time as a default when configuring a scene item Show/Hide transition. Once a show/hide transition gets set on a scene item, it is never cleared, meaning if a show/hide transition is removed by setting it to `None`, it will retain that duration if a transition is later set again, instead of using the global duration again.

### How Has This Been Tested?
Configured show/hide transitions on multiple sources and ensured the main window global duration is only used as a default. Ensured that this value is properly reset when selecting `None` as a transition.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
