### PR TITLE
UI: Fix double confirmation dialog while discarding source change

### DIFF
--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -476,18 +476,9 @@ void OBSBasicProperties::reject()
 
 void OBSBasicProperties::closeEvent(QCloseEvent *event)
 {
-	if (!acceptClicked && (CheckSettings() != 0)) {
-		if (!ConfirmQuit()) {
-			event->ignore();
-			return;
-		}
-	}
-
 	QDialog::closeEvent(event);
-	if (!event->isAccepted())
-		return;
-
-	Cleanup();
+	if (event->isAccepted())
+		Cleanup();
 }
 
 bool OBSBasicProperties::nativeEvent(const QByteArray &, void *message,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->

- Fixes #10333
- Supersedes #10446

`QDialog::closeEvent()` already calls the `reject()` function, the override of the former function was actually allowing a first confirmation dialog which once discarded gets re-openned by `QDialog::closeEvent()`.

Removing most of the closeEvent() override code is enough to fix the issue since reject() will be called showing the confirmation dialog.

<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix a bug

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I happen to be able to reproduce the bug with some of my sources, once the fix applied none of them add double dialog.

And the properties dialog behaves as before but without the bug.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
