### PR TITLE
UI,docs: Send a custom event to the dock widget when closing

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -329,6 +329,8 @@ OBSBasic::OBSBasic(QWidget *parent)
 
 	setContextMenuPolicy(Qt::CustomContextMenu);
 
+	QEvent::registerEventType(QEvent::User + QEvent::Close);
+
 	api = InitializeAPIInterface(this);
 
 	ui->setupUi(this);

--- a/UI/window-dock.cpp
+++ b/UI/window-dock.cpp
@@ -34,6 +34,11 @@ void OBSDock::closeEvent(QCloseEvent *event)
 	}
 
 	QDockWidget::closeEvent(event);
+
+	if (widget() && event->isAccepted()) {
+		QEvent widgetEvent(QEvent::Type(QEvent::User + QEvent::Close));
+		qApp->sendEvent(widget(), &widgetEvent);
+	}
 }
 
 void OBSDock::showEvent(QShowEvent *event)

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -480,6 +480,12 @@ Functions
    Adds a dock with the widget to the UI with a toggle in the Docks
    menu.
 
+   When the dock is closed, a custom QEvent of type `QEvent::User + QEvent::Close`
+   is sent to the widget to enable it to react to the event (e.g., unload elements
+   to save resources).
+   A generic QShowEvent is already sent by default when the widget is being
+   shown (e.g., dock opened).
+
    Note: Use :c:func:`obs_frontend_remove_dock` to remove the dock
          and the id from the UI.
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Send a custom event to the OBSDock widget when the dock (from `obs_frontend_add_dock_by_id`) is closed, which allow plugin authors to potentially save resources while the dock is closed.

A QShowEvent is already sent to the widget when the dock is (re-)opened.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Motivation related to:
- https://github.com/obsproject/obs-browser/pull/431

Enabling a way closing browser from a plugin dock when the said dock is closed, since OBS Studio completely owns the access to the dock object.

So in a scenario like separating service integration, beside randomly guessing we can't know when close browsers to save resources.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Disabled the `closeBrowser()` call in BrowserDock `closeEvent()` impl and added the following to QCefWidgetInternal for testing purpose:
```cpp
bool QCefWidgetInternal::event(QEvent *event)
{
	if (event->type() == (QEvent::User + QEvent::Close))
	{
		closeBrowser();
		return true;
	}

	return QCefWidget::event(event);
}
```
The browser is closed when the dock is closed thanks to the event as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
