### PR TITLE
obs-ffmpeg: Use video_output_info in amf_create_encoder()

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -991,13 +991,12 @@ try {
 	/* ------------------------------------ */
 	/* get video info                       */
 
-	struct obs_video_info ovi;
-	obs_get_video_info(&ovi);
-
 	struct video_scale_info info;
-	info.format = ovi.output_format;
-	info.colorspace = ovi.colorspace;
-	info.range = ovi.range;
+	video_t *video = obs_encoder_video(enc->encoder);
+	const struct video_output_info *voi = video_output_get_info(video);
+	info.format = voi->format;
+	info.colorspace = voi->colorspace;
+	info.range = voi->range;
 
 	if (enc->fallback) {
 		if (enc->codec == amf_codec_type::AVC)
@@ -1010,9 +1009,9 @@ try {
 
 	enc->cx = obs_encoder_get_width(enc->encoder);
 	enc->cy = obs_encoder_get_height(enc->encoder);
-	enc->amf_frame_rate = AMFConstructRate(ovi.fps_num, ovi.fps_den);
-	enc->fps_num = (int)ovi.fps_num;
-	enc->fps_den = (int)ovi.fps_den;
+	enc->amf_frame_rate = AMFConstructRate(voi->fps_num, voi->fps_den);
+	enc->fps_num = (int)voi->fps_num;
+	enc->fps_den = (int)voi->fps_den;
 	enc->full_range = info.range == VIDEO_RANGE_FULL;
 
 	switch (info.colorspace) {


### PR DESCRIPTION
### Description
The frame rate used to initialize an AMF encoder should be aligned with the derived frame rate in video_output_info instead of the global obs_video_info structure. With this change, IDRs can be aligned when multiple renditions are being encoded.

Using video_output_info members for the format, colorspace, and range parameters in addition to the frame rate provides a single source for this information and obs_video_info is no longer needed.

### Motivation and Context
IDR frames across segments in multi-track encoding (or eRTMP) must be aligned to allow clean switching in the decoder from one rendition to another. This commit uses the correct frame rate from the video_output_info struct for each encoder, which could be different than the composition frame rate, which allows proper IDR alignment across segments.

### How Has This Been Tested?
The change was tested with a local build of OBS Studio with both Twitch Enhanced Broadcasting (multiple renditions) and non-Enhanced Broadcasting (single stream). Additional details:

- Windows 10 Release 22H2 build 19045
- AMD Ryzen 9 7900 12-core CPU
- 64GB DDR5
- All tests were done with AVC/H.264 codec
- Canvas resolutions tested: 2160p60, 1440p60, 1080p60
- Output resolutions tested: 2160p60 (limited testing), 1440p60, 1080p60
- Enhanced Broadcasting encoder renditions: Primarily: 1080p60, 720p60, 360p30, with spot checking of 1440p30/60 and 720p30 in the mix as well
- AMD GPU's tested: RX550, RX570, RX5700XT, RX6650XT, RX6750XT, RX7700XT, RX7900XT
- 3 iterations of each test for about 10 minutes: Two 3DMark tests (Firestrike Graphics test 1 and 2) and one game-play using Steam WarThunder
- In all cases a test-pattern from a Blackmagic Atem MiniPro with BM Shuttle input was composited with the game, as well as overlaying Task Manager and observing the GPU/CPU/encoder usage
- The stream was broadcast to Twitch, then observed on 2 other PC's for any visual disruption while changing renditions manually and automatically (1 Windows 10, 1 Linux Mint 21.3) using Chrome-based browsers and 1 mobile device (Android-11 based)
- Bitstreams were also captured and inspected with a bitstream analyzer for IDR alignment across renditions 

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
