### PR TITLE
obs-webrtc: Adjust RtcpNackResponder from bitrate

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -21,6 +21,9 @@ const uint8_t audio_payload_type = 111;
 const char *video_mid = "1";
 const uint8_t video_payload_type = 96;
 
+// ~3 seconds of 8.5 Megabit video
+const int video_nack_buffer_size = 4000;
+
 WHIPOutput::WHIPOutput(obs_data_t *, obs_output_t *output)
 	: output(output),
 	  endpoint_url(),
@@ -181,7 +184,8 @@ void WHIPOutput::ConfigureVideoTrack(std::string media_stream_id,
 
 	video_sr_reporter = std::make_shared<rtc::RtcpSrReporter>(rtp_config);
 	packetizer->addToChain(video_sr_reporter);
-	packetizer->addToChain(std::make_shared<rtc::RtcpNackResponder>());
+	packetizer->addToChain(std::make_shared<rtc::RtcpNackResponder>(
+		video_nack_buffer_size));
 
 	video_track = peer_connection->addTrack(video_description);
 	video_track->setMediaHandler(packetizer);


### PR DESCRIPTION
### Description
Adjust RtcpNackResponder from bitrate

### Motivation and Context
At higher bitrates the cache would be undersized. Because of the undersized cache we wouldn't have enough NACK history to fix the stream.

### How Has This Been Tested?
Against Broadcast Box with a packet loss percentage of 1%

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
