### PR TITLE
plugins: Set keyframe flag on encoded audio packets

### DIFF
--- a/plugins/coreaudio-encoder/encoder.cpp
+++ b/plugins/coreaudio-encoder/encoder.cpp
@@ -775,6 +775,7 @@ static bool aac_encode(void *data, struct encoder_frame *frame,
 	packet->timebase_num = 1;
 	packet->timebase_den = (uint32_t)ca->samples_per_second;
 	packet->type = OBS_ENCODER_AUDIO;
+	packet->keyframe = true;
 	packet->size = out_desc.mDataByteSize;
 	packet->data = (uint8_t *)buffer_list.mBuffers[0].mData +
 		       out_desc.mStartOffset;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -442,6 +442,7 @@ static bool do_encode(struct enc_encoder *enc, struct encoder_packet *packet,
 	packet->data = enc->packet_buffer.array;
 	packet->size = avpacket.size;
 	packet->type = OBS_ENCODER_AUDIO;
+	packet->keyframe = true;
 	packet->timebase_num = 1;
 	packet->timebase_den = (int32_t)enc->context->sample_rate;
 	av_packet_unref(&avpacket);

--- a/plugins/obs-libfdk/obs-libfdk.c
+++ b/plugins/obs-libfdk/obs-libfdk.c
@@ -273,6 +273,7 @@ static bool libfdk_encode(void *data, struct encoder_frame *frame,
 	packet->data = enc->packet_buffer;
 	packet->size = out_args.numOutBytes;
 	packet->type = OBS_ENCODER_AUDIO;
+	packet->keyframe = true;
 	packet->timebase_num = 1;
 	packet->timebase_den = enc->sample_rate;
 


### PR DESCRIPTION
### Description
Not strictly necessary, and does not fix any bug. This just corrects a nitpick that technically audio encoder packets are start points, but that they aren't being labeled accordingly as keyframes.

### Motivation and Context
It would be nice to portray accurate metadata in encoder packets, even if things work regardless of what is set. The documentation does not specify this flag as being relevant only to video, so it might as well be "implemented."

### How Has This Been Tested?
Started up OBS and tested some streams and observed no difference in behavior.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
