### PR TITLE
mac-avcapture: Add pointer check for outputting NULL video frames

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -359,7 +359,9 @@
             self.captureInfo->previousSurface = NULL;
         }
     } else {
-        obs_source_output_video(self.captureInfo->source, NULL);
+        if (self.captureInfo->source) {
+            obs_source_output_video(self.captureInfo->source, NULL);
+        }
     }
 }
 


### PR DESCRIPTION
### Description
Add a null pointer check for the source pointer in the source info struct before using it to output an empty `NULL` frame for a possibly stopped capture device.

### Motivation and Context
When a capture card or video capture source is contained in the scene collection's list of sources, but the source is not a part of any scene, it will be first created but then destroyed again in a deferred fashion (as it has no strong references to it anymore).

This will happen before the capture source has finished its own initialization, hence why the source pointer can be invalid at that point.

### How Has This Been Tested?
* Tested on macOS 14 with a bespoke scene collection to trigger the issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
