### PR TITLE
UI: Add system tray actions for pausing and replay saving

### DIFF
--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -329,7 +329,9 @@ private:
 	QScopedPointer<QSystemTrayIcon> trayIcon;
 	QPointer<QAction> sysTrayStream;
 	QPointer<QAction> sysTrayRecord;
+	QPointer<QAction> sysTrayPause;
 	QPointer<QAction> sysTrayReplayBuffer;
+	QPointer<QAction> sysTraySaveReplay;
 	QPointer<QAction> sysTrayVirtualCam;
 	QPointer<QAction> showHide;
 	QPointer<QAction> exit;


### PR DESCRIPTION
### Description
This adds actions to the system tray to pause/unpause recordings and saving replays.

### Motivation and Context
https://ideas.obsproject.com/posts/1582/add-pause-menu-entry-to-tray-while-recording

Also noticed saving replays was also not in the system tray menu.

### How Has This Been Tested?
Clicked on actions in system tray

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
