### PR TITLE
Make Flatpak use CMake build framework 3.0

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -75,7 +75,8 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DOBS_CMAKE_VERSION=3",
                 "-DENABLE_WAYLAND=ON",
                 "-DENABLE_BROWSER=ON",
                 "-DCEF_ROOT_DIR=/app/cef",
@@ -83,7 +84,6 @@
                 "-DENABLE_ALSA=OFF",
                 "-DENABLE_PULSEAUDIO=ON",
                 "-DENABLE_JACK=ON",
-                "-DENABLE_RTMPS=ON",
                 "-DENABLE_VLC=OFF",
                 "-DENABLE_AJA=ON",
                 "-DENABLE_LIBFDK=ON",

--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -1109,7 +1109,6 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings,
 static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 			     int bf, bool compatibility)
 {
-	const char *rc = obs_data_get_string(settings, "rate_control");
 	int keyint_sec = (int)obs_data_get_int(settings, "keyint_sec");
 	bool lossless;
 
@@ -1117,7 +1116,6 @@ static bool init_encoder_av1(struct nvenc_data *enc, obs_data_t *settings,
 		return false;
 	}
 
-	NV_ENC_INITIALIZE_PARAMS *params = &enc->params;
 	NV_ENC_CONFIG *config = &enc->config;
 	NV_ENC_CONFIG_AV1 *av1_config = &config->encodeCodecConfig.av1Config;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

- Fix unused variable in NVENC native to enable the next point
- Make Flatpak use CMake build framework 3.0
  - Also change CMake build type to RelWithDebInfo which is the preferred build type in Freedesktop SDK environments, dependencies will not be touched in this PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Move things forward to deprecate CMake 2.0 and battletest CMake 3.0.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Local build

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
