### PR TITLE
libobs: Mix audio of each source in a scene only once

### DIFF
--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -93,6 +93,15 @@ struct obs_scene_item {
 	struct obs_scene_item *next;
 };
 
+struct scene_source_mix {
+	obs_source_t *source;
+	obs_source_t *transition;
+	size_t pos;
+	size_t count;
+	bool apply_buf;
+	float buf[AUDIO_OUTPUT_FRAMES];
+};
+
 struct obs_scene {
 	struct obs_source *source;
 
@@ -106,4 +115,6 @@ struct obs_scene {
 	pthread_mutex_t video_mutex;
 	pthread_mutex_t audio_mutex;
 	struct obs_scene_item *first_item;
+
+	DARRAY(struct scene_source_mix) mix_sources;
 };


### PR DESCRIPTION
### Description

Only mix audio of each unique source in a scene once.

### Motivation and Context

Fixes a common pitfall as the constructive interference due to multiple scene items using the same source is not visible anywhere.

Based on discussions this should not happen.

### How Has This Been Tested?

Pure sine wave media source and ffmpeg `volumedetect` to make sure recordings after this fix have the same volume as a recording with only one scene item.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
