### PR TITLE
text-freetype2: Use cached glyph advances

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -570,12 +570,17 @@ uint32_t get_ft2_text_width(wchar_t *text, struct ft2_source *srcdata)
 		const FT_UInt glyph_index =
 			FT_Get_Char_Index(srcdata->font_face, text[i]);
 
-		load_glyph(srcdata, glyph_index, get_render_mode(srcdata));
-
 		if (text[i] == L'\n')
 			w = 0;
 		else {
-			w += slot->advance.x >> 6;
+			if (src_glyph) {
+				// Use the cached values.
+				w += src_glyph->xadv;
+			} else {
+				load_glyph(srcdata, glyph_index,
+					   get_render_mode(srcdata));
+				w += slot->advance.x >> 6;
+			}
 			if (w > max_w)
 				max_w = w;
 		}


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
We had these advances laying around but didnt use them here. Loading the glyphs from the fonts is extremely slow, so lets avoid that since we take the time to cache these already.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Makes this function ~4000x times faster. Everyone loves fast.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
It didnt crash, but also this is used in the other width computation so it should be fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
