### PR TITLE
Fix relocatable Linux builds using legacy portable build flag

### DIFF
--- a/UI/platform-x11.cpp
+++ b/UI/platform-x11.cpp
@@ -184,7 +184,7 @@ static inline bool check_path(const char *data, const char *path,
 	return (access(output.c_str(), R_OK) == 0);
 }
 
-#define INSTALL_DATA_PATH OBS_INSTALL_PREFIX OBS_DATA_PATH "/obs-studio/"
+#define INSTALL_DATA_PATH OBS_INSTALL_PREFIX "/" OBS_DATA_PATH "/obs-studio/"
 
 bool GetDataFilePath(const char *data, string &output)
 {
@@ -200,7 +200,10 @@ bool GetDataFilePath(const char *data, string &output)
 	if (relative_data_path) {
 		bool result = check_path(data, relative_data_path, output);
 		bfree(relative_data_path);
-		return result;
+
+		if (result) {
+			return true;
+		}
 	}
 
 	if (check_path(data, OBS_DATA_PATH "/obs-studio/", output))

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -56,7 +56,7 @@ static const char *module_bin[] = {
 };
 
 static const char *module_data[] = {
-	OBS_DATA_PATH "/%module%",
+	OBS_DATA_PATH "/obs-plugins/%module%",
 	OBS_INSTALL_DATA_PATH "/obs-plugins/%module%",
 	FLATPAK_PLUGIN_PATH "/share/obs/obs-plugins/%module%",
 };
@@ -76,7 +76,9 @@ void add_default_module_paths(void)
 	if (module_bin_path && module_data_path) {
 		char *abs_module_bin_path =
 			os_get_abs_path_ptr(module_bin_path);
-		if (strcmp(abs_module_bin_path, OBS_INSTALL_PREFIX
+
+		if (abs_module_bin_path &&
+		    strcmp(abs_module_bin_path, OBS_INSTALL_PREFIX
 			   "/" OBS_PLUGIN_DESTINATION) != 0) {
 			obs_add_module_path(module_bin_path, module_data_path);
 		}


### PR DESCRIPTION
### Description
Fixes Linux builds using the legacy `LINUX_PORTABLE` flag.

### Motivation and Context
The updated Linux build system uses the same directory structure for both fixed and relocatable builds (so all files are in the same locations relative to the main binary, libraries, or modules).

The legacy portable build variant used a different directory structure, so the existing guards and checks would not work anymore.

### How Has This Been Tested?
Tested on Ubuntu 23.10:

* Built and ran OBS Studio with legacy build system and `LINUX_PORTABLE` disabled
  * Used `LD_LIBRARY_PATH` to enable running from custom install location
* Built and ran OBS Studio with legacy build system and `LINUX_PORTABLE` enabled
* Built and ran OBS Studio with updated build system and `ENABLE_RELOCATABLE` disabled
  * Used `LD_LIBRARY_PATH` to enable running from custom install location
* Built and ran OBS Studio with updated build system and `ENABLE_RELOCATABLE` enabled


### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
