### PR TITLE
libobs: Add support for multitrack, AV1, and HEVC captions

### DIFF
--- a/libobs/obs-av1.h
+++ b/libobs/obs-av1.h
@@ -30,6 +30,10 @@ EXPORT void obs_extract_av1_headers(const uint8_t *packet, size_t size,
 				    size_t *new_packet_size,
 				    uint8_t **header_data, size_t *header_size);
 
+EXPORT void metadata_obu_itu_t35(const uint8_t *itut_t35_buffer,
+				 size_t itut_bufsize, uint8_t **out_buffer,
+				 size_t *outbuf_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1076,6 +1076,15 @@ struct caption_text {
 	struct caption_text *next;
 };
 
+struct caption_track_data {
+	struct caption_text *caption_head;
+	struct caption_text *caption_tail;
+	pthread_mutex_t caption_mutex;
+	double caption_timestamp;
+	double last_caption_timestamp;
+	struct deque caption_data;
+};
+
 struct pause_data {
 	pthread_mutex_t mutex;
 	uint64_t last_video_ts;
@@ -1152,12 +1161,8 @@ struct obs_output {
 	struct video_scale_info video_conversion;
 	struct audio_convert_info audio_conversion;
 
-	pthread_mutex_t caption_mutex;
-	double caption_timestamp;
-	struct caption_text *caption_head;
-	struct caption_text *caption_tail;
-
-	struct deque caption_data;
+	// captions are output per track
+	struct caption_track_data *caption_tracks[MAX_OUTPUT_VIDEO_ENCODERS];
 
 	bool valid;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -21,6 +21,7 @@
 #include "graphics/math-extra.h"
 #include "obs.h"
 #include "obs-internal.h"
+#include "obs-av1.h"
 
 #include <caption/caption.h>
 #include <caption/mpeg.h>
@@ -1506,17 +1507,33 @@ static inline bool has_higher_opposing_ts(struct obs_output *output,
 			  output->highest_audio_ts > packet->dts_usec);
 }
 
-static const uint8_t nal_start[4] = {0, 0, 0, 1};
+static size_t extract_itut_t35_buffer_from_sei(sei_t *sei, uint8_t **data_out)
+{
+	if (!sei || !sei->head) {
+		return 0;
+	}
+	/* We should only need to get one payload, because the SEI that was 
+	 * generated should only have one message, so no need to iterate. If
+	 * we did iterate, we would need to generate multiple OBUs. */
+	sei_message_t *msg = sei_message_head(sei);
+	int payload_size = (int)sei_message_size(msg);
+	uint8_t *payload_data = sei_message_data(msg);
+	*data_out = malloc(payload_size);
+	memcpy(*data_out, payload_data, payload_size);
+	return payload_size;
+}
 
+static const uint8_t nal_start[4] = {0, 0, 0, 1};
 static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 {
 	struct encoder_packet backup = *out;
 	sei_t sei;
-	uint8_t *data;
+	uint8_t *data = NULL;
 	size_t size;
 	long ref = 1;
 	bool avc = false;
 	bool hevc = false;
+	bool av1 = false;
 
 	/* Instead of exiting early for unsupported codecs, we will continue
 	 * processing to allow the freeing of caption data even if the captions
@@ -1524,6 +1541,8 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 	 * the given codec. */
 	if (strcmp(out->encoder->info.codec, "h264") == 0) {
 		avc = true;
+	} else if (strcmp(out->encoder->info.codec, "av1") == 0) {
+		av1 = true;
 #ifdef ENABLE_HEVC
 	} else if (strcmp(out->encoder->info.codec, "hevc") == 0) {
 		hevc = true;
@@ -1632,9 +1651,19 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 		ctrack->caption_head = next;
 	}
 
-	if (avc || hevc) {
-		data = malloc(sei_render_size(&sei));
-		size = sei_render(&sei, data);
+	if (avc || hevc || av1) {
+		if (avc || hevc) {
+			data = malloc(sei_render_size(&sei));
+			size = sei_render(&sei, data);
+		}
+		/* In each of these specs there is an identical structure that
+		 * carries caption information. It is named slightly differently
+		 * in each one. The metadata_itut_t35 in AV1 or the
+		 * user_data_registered_itu_t_t35 in HEVC/AVC. We have an AVC
+		 * SEI wrapped version of that here. We will strip it out and
+		 * repackage it slightly to fit the different codec carrying
+		 * mechanisms. A slightly modified SEI for HEVC and a metadata
+		 * OBU for AV1. */
 		if (avc) {
 			/* TODO: SEI should come after AUD/SPS/PPS,
 			 * but before any VCL */
@@ -1642,8 +1671,8 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 			da_push_back_array(out_data, data, size);
 #ifdef ENABLE_HEVC
 		} else if (hevc) {
-			/* Only first NAL, VPS/PPS/SPS should use the 4 byte
-				start code, SEIs use 3 byte version */
+			/* Only first NAL (VPS/PPS/SPS) should use the 4 byte
+			 * start code. SEIs use 3 byte version */
 			da_push_back_array(out_data, nal_start + 1, 3);
 			/* nal_unit_header( ) {
 			 * forbidden_zero_bit       f(1)
@@ -1665,20 +1694,29 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 			da_push_back_array(out_data, hevc_nal_header, 2);
 			da_push_back_array(out_data, &data[1], size - 1);
 #endif
+		} else if (av1) {
+			uint8_t *obu_buffer = NULL;
+			size_t obu_buffer_size = 0;
+			size = extract_itut_t35_buffer_from_sei(&sei, &data);
+			metadata_obu_itu_t35(data, size, &obu_buffer,
+					     &obu_buffer_size);
+			if (obu_buffer) {
+				da_push_back_array(out_data, obu_buffer,
+						   obu_buffer_size);
+				bfree(obu_buffer);
+			}
 		}
-		free(data);
+		if (data) {
+			free(data);
+		}
+		obs_encoder_packet_release(out);
+
+		*out = backup;
+		out->data = (uint8_t *)out_data.array + sizeof(ref);
+		out->size = out_data.num - sizeof(ref);
 	}
-
-	obs_encoder_packet_release(out);
-
-	*out = backup;
-	out->data = (uint8_t *)out_data.array + sizeof(ref);
-	out->size = out_data.num - sizeof(ref);
 	sei_free(&sei);
-	if (avc || hevc) {
-		return true;
-	}
-	return false;
+	return avc || hevc || av1;
 }
 
 static inline void send_interleaved(struct obs_output *output)

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1518,7 +1518,7 @@ static size_t extract_itut_t35_buffer_from_sei(sei_t *sei, uint8_t **data_out)
 	sei_message_t *msg = sei_message_head(sei);
 	int payload_size = (int)sei_message_size(msg);
 	uint8_t *payload_data = sei_message_data(msg);
-	*data_out = malloc(payload_size);
+	*data_out = bmalloc(payload_size);
 	memcpy(*data_out, payload_data, payload_size);
 	return payload_size;
 }
@@ -1653,7 +1653,7 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 
 	if (avc || hevc || av1) {
 		if (avc || hevc) {
-			data = malloc(sei_render_size(&sei));
+			data = bmalloc(sei_render_size(&sei));
 			size = sei_render(&sei, data);
 		}
 		/* In each of these specs there is an identical structure that
@@ -1707,7 +1707,7 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 			}
 		}
 		if (data) {
-			free(data);
+			bfree(data);
 		}
 		obs_encoder_packet_release(out);
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -175,14 +175,11 @@ obs_output_t *obs_output_create(const char *id, const char *name,
 	output = bzalloc(sizeof(struct obs_output));
 	pthread_mutex_init_value(&output->interleaved_mutex);
 	pthread_mutex_init_value(&output->delay_mutex);
-	pthread_mutex_init_value(&output->caption_mutex);
 	pthread_mutex_init_value(&output->pause.mutex);
 
 	if (pthread_mutex_init(&output->interleaved_mutex, NULL) != 0)
 		goto fail;
 	if (pthread_mutex_init(&output->delay_mutex, NULL) != 0)
-		goto fail;
-	if (pthread_mutex_init(&output->caption_mutex, NULL) != 0)
 		goto fail;
 	if (pthread_mutex_init(&output->pause.mutex, NULL) != 0)
 		goto fail;
@@ -255,6 +252,18 @@ static inline void clear_raw_audio_buffers(obs_output_t *output)
 	}
 }
 
+static void destroy_caption_track(struct caption_track_data **ctrack_ptr)
+{
+	if (!ctrack_ptr || !*ctrack_ptr) {
+		return;
+	}
+	struct caption_track_data *ctrack = *ctrack_ptr;
+	pthread_mutex_destroy(&ctrack->caption_mutex);
+	deque_free(&ctrack->caption_data);
+	bfree(ctrack);
+	*ctrack_ptr = NULL;
+}
+
 void obs_output_destroy(obs_output_t *output)
 {
 	if (output) {
@@ -281,6 +290,10 @@ void obs_output_destroy(obs_output_t *output)
 				obs_encoder_remove_output(
 					output->video_encoders[i], output);
 			}
+			if (output->caption_tracks[i]) {
+				destroy_caption_track(
+					&output->caption_tracks[i]);
+			}
 		}
 
 		for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
@@ -294,13 +307,11 @@ void obs_output_destroy(obs_output_t *output)
 
 		os_event_destroy(output->stopping_event);
 		pthread_mutex_destroy(&output->pause.mutex);
-		pthread_mutex_destroy(&output->caption_mutex);
 		pthread_mutex_destroy(&output->interleaved_mutex);
 		pthread_mutex_destroy(&output->delay_mutex);
 		os_event_destroy(output->reconnect_stop_event);
 		obs_context_data_free(&output->context);
 		deque_free(&output->delay_data);
-		deque_free(&output->caption_data);
 		if (output->owns_info_id)
 			bfree((void *)output->info.id);
 		if (output->last_error_message)
@@ -338,11 +349,17 @@ bool obs_output_actual_start(obs_output_t *output)
 	if (os_atomic_load_long(&output->delay_restart_refs))
 		os_atomic_dec_long(&output->delay_restart_refs);
 
-	output->caption_timestamp = 0;
-
-	deque_free(&output->caption_data);
-	deque_init(&output->caption_data);
-
+	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		struct caption_track_data *ctrack = output->caption_tracks[i];
+		if (!ctrack) {
+			continue;
+		}
+		pthread_mutex_lock(&ctrack->caption_mutex);
+		ctrack->caption_timestamp = 0;
+		deque_free(&ctrack->caption_data);
+		deque_init(&ctrack->caption_data);
+		pthread_mutex_unlock(&ctrack->caption_mutex);
+	}
 	return success;
 }
 
@@ -470,10 +487,16 @@ void obs_output_actual_stop(obs_output_t *output, bool force, uint64_t ts)
 		os_event_signal(output->stopping_event);
 	}
 
-	while (output->caption_head) {
-		output->caption_tail = output->caption_head->next;
-		bfree(output->caption_head);
-		output->caption_head = output->caption_tail;
+	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		struct caption_track_data *ctrack = output->caption_tracks[i];
+		if (!ctrack) {
+			continue;
+		}
+		while (ctrack->caption_head) {
+			ctrack->caption_tail = ctrack->caption_head->next;
+			bfree(ctrack->caption_head);
+			ctrack->caption_head = ctrack->caption_tail;
+		}
 	}
 }
 
@@ -965,6 +988,19 @@ void obs_output_remove_encoder(struct obs_output *output,
 	obs_output_remove_encoder_internal(output, encoder);
 }
 
+static struct caption_track_data *create_caption_track()
+{
+	struct caption_track_data *rval =
+		bzalloc(sizeof(struct caption_track_data));
+	pthread_mutex_init_value(&rval->caption_mutex);
+
+	if (pthread_mutex_init(&rval->caption_mutex, NULL) != 0) {
+		bfree(rval);
+		rval = NULL;
+	}
+	return rval;
+}
+
 void obs_output_set_video_encoder2(obs_output_t *output, obs_encoder_t *encoder,
 				   size_t idx)
 {
@@ -1002,6 +1038,13 @@ void obs_output_set_video_encoder2(obs_output_t *output, obs_encoder_t *encoder,
 	obs_encoder_remove_output(output->video_encoders[idx], output);
 	obs_encoder_add_output(encoder, output);
 	output->video_encoders[idx] = encoder;
+
+	destroy_caption_track(&output->caption_tracks[idx]);
+	if (encoder != NULL) {
+		output->caption_tracks[idx] = create_caption_track();
+	} else {
+		output->caption_tracks[idx] = NULL;
+	}
 
 	// Set preferred resolution on the default index to preserve old behavior
 	if (idx == 0) {
@@ -1478,20 +1521,29 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 	if (out->priority > 1)
 		return false;
 
+	struct caption_track_data *ctrack =
+		output->caption_tracks[out->track_idx];
+	if (!ctrack) {
+		blog(LOG_DEBUG,
+		     "Caption track for index: %lu has not been initialized",
+		     out->track_idx);
+		return false;
+	}
+
 	sei_init(&sei, 0.0);
 
 	da_init(out_data);
 	da_push_back_array(out_data, (uint8_t *)&ref, sizeof(ref));
 	da_push_back_array(out_data, out->data, out->size);
 
-	if (output->caption_data.size > 0) {
+	if (ctrack->caption_data.size > 0) {
 
 		cea708_t cea708;
 		cea708_init(&cea708, 0); // set up a new popon frame
 		void *caption_buf = bzalloc(3 * sizeof(uint8_t));
 
-		while (output->caption_data.size > 0) {
-			deque_pop_front(&output->caption_data, caption_buf,
+		while (ctrack->caption_data.size > 0) {
+			deque_pop_front(&ctrack->caption_data, caption_buf,
 					3 * sizeof(uint8_t));
 
 			if ((((uint8_t *)caption_buf)[0] & 0x3) != 0) {
@@ -1529,16 +1581,16 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 		msg->size = cea708_render(&cea708, sei_message_data(msg),
 					  sei_message_size(msg));
 		sei_message_append(&sei, msg);
-	} else if (output->caption_head) {
+	} else if (ctrack->caption_head) {
 		caption_frame_t cf;
 		caption_frame_init(&cf);
-		caption_frame_from_text(&cf, &output->caption_head->text[0]);
+		caption_frame_from_text(&cf, &ctrack->caption_head->text[0]);
 
 		sei_from_caption_frame(&sei, &cf);
 
-		struct caption_text *next = output->caption_head->next;
-		bfree(output->caption_head);
-		output->caption_head = next;
+		struct caption_text *next = ctrack->caption_head->next;
+		bfree(ctrack->caption_head);
+		ctrack->caption_head = next;
 	}
 
 	data = malloc(sei_render_size(&sei));
@@ -1559,8 +1611,6 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 	return true;
 }
 
-double last_caption_timestamp = 0;
-
 static inline void send_interleaved(struct obs_output *output)
 {
 	struct encoder_packet out = output->interleaved_packets.array[0];
@@ -1576,33 +1626,37 @@ static inline void send_interleaved(struct obs_output *output)
 	if (out.type == OBS_ENCODER_VIDEO) {
 		output->total_frames++;
 
-		pthread_mutex_lock(&output->caption_mutex);
+		pthread_mutex_lock(
+			&output->caption_tracks[out.track_idx]->caption_mutex);
 
 		double frame_timestamp =
 			(out.pts * out.timebase_num) / (double)out.timebase_den;
 
-		if (output->caption_head &&
-		    output->caption_timestamp <= frame_timestamp) {
+		struct caption_track_data *ctrack =
+			output->caption_tracks[out.track_idx];
+
+		if (ctrack->caption_head &&
+		    ctrack->caption_timestamp <= frame_timestamp) {
 			blog(LOG_DEBUG, "Sending caption: %f \"%s\"",
-			     frame_timestamp, &output->caption_head->text[0]);
+			     frame_timestamp, &ctrack->caption_head->text[0]);
 
 			double display_duration =
-				output->caption_head->display_duration;
+				ctrack->caption_head->display_duration;
 
 			if (add_caption(output, &out)) {
-				output->caption_timestamp =
+				ctrack->caption_timestamp =
 					frame_timestamp + display_duration;
 			}
 		}
 
-		if (output->caption_data.size > 0) {
-			if (last_caption_timestamp < frame_timestamp) {
-				last_caption_timestamp = frame_timestamp;
+		if (ctrack->caption_data.size > 0) {
+			if (ctrack->last_caption_timestamp < frame_timestamp) {
+				ctrack->last_caption_timestamp =
+					frame_timestamp;
 				add_caption(output, &out);
 			}
 		}
-
-		pthread_mutex_unlock(&output->caption_mutex);
+		pthread_mutex_unlock(&ctrack->caption_mutex);
 	}
 
 	output->info.encoded_packet(output->context.data, &out);
@@ -2853,12 +2907,19 @@ const char *obs_output_get_id(const obs_output_t *output)
 void obs_output_caption(obs_output_t *output,
 			const struct obs_source_cea_708 *captions)
 {
-	pthread_mutex_lock(&output->caption_mutex);
-	for (size_t i = 0; i < captions->packets; i++) {
-		deque_push_back(&output->caption_data, captions->data + (i * 3),
-				3 * sizeof(uint8_t));
+	for (int i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		struct caption_track_data *ctrack = output->caption_tracks[i];
+		if (!ctrack) {
+			continue;
+		}
+		pthread_mutex_lock(&ctrack->caption_mutex);
+		for (size_t i = 0; i < captions->packets; i++) {
+			deque_push_back(&ctrack->caption_data,
+					captions->data + (i * 3),
+					3 * sizeof(uint8_t));
+		}
+		pthread_mutex_unlock(&ctrack->caption_mutex);
 	}
-	pthread_mutex_unlock(&output->caption_mutex);
 }
 
 static struct caption_text *caption_text_new(const char *text, size_t bytes,
@@ -2899,13 +2960,20 @@ void obs_output_output_caption_text2(obs_output_t *output, const char *text,
 	int size = (int)strlen(text);
 	blog(LOG_DEBUG, "Caption text: %s", text);
 
-	pthread_mutex_lock(&output->caption_mutex);
+	for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
+		struct caption_track_data *ctrack = output->caption_tracks[i];
+		if (!ctrack) {
+			continue;
+		}
+		pthread_mutex_lock(&ctrack->caption_mutex);
 
-	output->caption_tail =
-		caption_text_new(text, size, output->caption_tail,
-				 &output->caption_head, display_duration);
+		ctrack->caption_tail = caption_text_new(text, size,
+							ctrack->caption_tail,
+							&ctrack->caption_head,
+							display_duration);
 
-	pthread_mutex_unlock(&output->caption_mutex);
+		pthread_mutex_unlock(&ctrack->caption_mutex);
+	}
 }
 
 float obs_output_get_congestion(obs_output_t *output)

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1515,6 +1515,15 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 	uint8_t *data;
 	size_t size;
 	long ref = 1;
+	bool avc = false;
+
+	/* Instead of exiting early for unsupported codecs, we will continue
+	 * processing to allow the freeing of caption data even if the captions
+	 * will not be included in the bitstream due to being unimplemented in
+	 * the given codec. */
+	if (strcmp(out->encoder->info.codec, "h264") == 0) {
+		avc = true;
+	}
 
 	DARRAY(uint8_t) out_data;
 
@@ -1593,22 +1602,26 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 		ctrack->caption_head = next;
 	}
 
-	data = malloc(sei_render_size(&sei));
-	size = sei_render(&sei, data);
-	/* TODO SEI should come after AUD/SPS/PPS, but before any VCL */
-	da_push_back_array(out_data, nal_start, 4);
-	da_push_back_array(out_data, data, size);
-	free(data);
+	if (avc) {
+		data = malloc(sei_render_size(&sei));
+		size = sei_render(&sei, data);
+		/* TODO: SEI should come after AUD/SPS/PPS,
+		 * but before any VCL */
+		da_push_back_array(out_data, nal_start, 4);
+		da_push_back_array(out_data, data, size);
+		free(data);
+	}
 
 	obs_encoder_packet_release(out);
 
 	*out = backup;
 	out->data = (uint8_t *)out_data.array + sizeof(ref);
 	out->size = out_data.num - sizeof(ref);
-
 	sei_free(&sei);
-
-	return true;
+	if (avc) {
+		return true;
+	}
+	return false;
 }
 
 static inline void send_interleaved(struct obs_output *output)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Main components of this change

1 - We will now keep a per track list of caption data. When caption insertion is triggered we will add that to the list for each actively encoding video track. When doing interleaved sending we will pull the data from the caption data for the corresponding video. This ensures that captions get copied to all video tracks.

2 - Captions were always being inserted as AVC SEIs regardless of the codec being used for encoding. This would corrupt anything other than AVC. This type of caption insertion must be handled on a codec by codec basis, and if a codec isn't handled explicitly, no caption insertion will be attempted. This was tested by streaming to twitch with a popular caption plugin enabled, while having enhanced broadcasting configured with HEVC and AVC streams. The HEVC stream had no captions, while AVC showed all captions.

3 - Explicit handling for HEVC caption insertion. HEVC is very close to AVC, both use NALs, and a SEI NAL to add caption data. We simply need to add a 2 byte HEVC NAL header where there is a one byte AVC NAL header. I tested the same way I tested item number two, but this time was able to see captions on the HEVC stream that was sent to Twitch. I also recorded a stream that I was able to process with FFmpeg. Tracing headers showed the same number of user data registered ITUT-35 SEI NALs. Notably no errors from FFmpeg occurred processing the HEVC stream.

4 - Explicit handing for AV1 caption insertion. The data structure that is used to hold caption data is reference in the AV1 spec "5.8.2 - Metadata ITUT T35 Syntax". This defines a structure that has no differences from the HEVC/AVC structures for holding caption data, (See "D.1.6" User data registered by rec. ITU-T T.35 SEI message syntax" in the AVC spec, or D.2.6 in the HEVC spec). This structure is extracted from the SEI data and wrapped in a metadata OBU and inserted into the bitstream. Testing involved streaming AV1 to twitch and validating no video corruption. The twitch player has not yet implemented AV1 captions (as AV1 is not yet officially supported), but recording of the FLV and processing with FFmpeg shows no errors. You can find the itut t35 metadata OBUs while tracing headers with FFmpeg, showing that that data has been properly inserted into the stream.

### Motivation and Context
1 - Multitrack captioning was broken. 
2 - Captioning on any track other than H.264 would cause bitstream corruption.  There doesn't appear to be an open bug for this, but it was clearly a bug.

### How Has This Been Tested?
Being tested in the Twitch enhanced broadcasting beta currently. Details of dev testing which was done prior to releasing to the beta cohort can be found in this document:
https://www.dropbox.com/scl/fi/v5yku0a1j1m01fpk1xggo/OBS-Multitrack-Embedded-Caption-Support-Testing.paper?rlkey=yfv37vx7zs2d9m8bug9o6la2y&dl=0)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
