### PR TITLE
cmake: Deprecate legacy CMake for all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,21 +34,19 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "(Darwin)" OR OBS_CMAKE_VERSION VERSION_GREATE
   return()
 endif()
 
-if(CMAKE_HOST_SYSTEM_NAME MATCHES "(Windows|Darwin)")
-  message(
-    DEPRECATION
-      "\n"
-      "============ LEGACY BUILD SYSTEM IS DEPRECATED ============"
-      "\n"
-      "You are using the legacy build system to build OBS Studio. "
-      "The legacy build system is unsupported and will be removed in the near future."
-      "\n"
-      "To migrate to the new build system, familiarize yourself with CMake presets "
-      "(https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) and create "
-      "a user preset with your customized build settings, inheriting from one of the default presets."
-      "\n"
-      "============ LEGACY BUILD SYSTEM IS DEPRECATED ============")
-endif()
+message(
+  DEPRECATION
+    "\n"
+    "============ LEGACY BUILD SYSTEM IS DEPRECATED ============"
+    "\n"
+    "You are using the legacy build system to build OBS Studio. "
+    "The legacy build system is unsupported and will be removed in the near future."
+    "\n"
+    "To migrate to the new build system, familiarize yourself with CMake presets "
+    "(https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) and create "
+    "a user preset with your customized build settings, inheriting from one of the default presets."
+    "\n"
+    "============ LEGACY BUILD SYSTEM IS DEPRECATED ============")
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/Modules")
 include(VersionConfig)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
We now support the new, modern CMake path on all platforms. Encourage everyone to migrate by deprecating the legacy CMake path. The legacy CMake path will be removed in a future update.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to give notice that the legacy CMake is deprecated.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 to check that the deprecation warning was clearly displayed in the CMake log output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
