### PR TITLE
UI: Support portable config mode on linux with new cmake version

### DIFF
--- a/UI/cmake/os-linux.cmake
+++ b/UI/cmake/os-linux.cmake
@@ -1,5 +1,6 @@
 target_sources(obs-studio PRIVATE platform-x11.cpp)
-target_compile_definitions(obs-studio PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
+target_compile_definitions(obs-studio PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}"
+                                              "$<$<BOOL:${ENABLE_RELOCATABLE}>:ENABLE_RELOCATABLE>")
 target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate)
 
 if(TARGET OBS::python)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2738,7 +2738,7 @@ static void load_debug_privilege(void)
 
 #define CONFIG_PATH BASE_PATH "/config"
 
-#if defined(LINUX_PORTABLE) || defined(_WIN32)
+#if defined(LINUX_PORTABLE) || defined(ENABLE_RELOCATABLE) || defined(_WIN32)
 #define ALLOW_PORTABLE_MODE 1
 #else
 #define ALLOW_PORTABLE_MODE 0


### PR DESCRIPTION
### Description

This adds support for the `--portable` command line parameter when using the new cmake version on linux

I chose to only enable this when building with `ENABLE_RELOCATABLE` enabled because non-relocatable builds are most likely installed in a root owned directory (not writable for normal users). This mirrors how the `LINUX_PORTABLE` option behaved with the old cmake version

### Motivation and Context

The portable mode is missing since building with the new cmake version

### How Has This Been Tested?

- Built OBS with `OBS_CMAKE_VERSION=3` and `ENABLE_RELOCATABLE`
- Ran `obs --help` to check if the `--portable` option is available
- Executed OBS with the `--portable` option and checked where it places the config dir

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
