### PR TITLE
libobs: Export NV12/P010 functions

### DIFF
--- a/libobs/graphics/device-exports.h
+++ b/libobs/graphics/device-exports.h
@@ -180,6 +180,8 @@ EXPORT void device_debug_marker_begin(gs_device_t *device,
 EXPORT void device_debug_marker_end(gs_device_t *device);
 EXPORT bool device_is_monitor_hdr(gs_device_t *device, void *monitor);
 EXPORT bool device_shared_texture_available(void);
+EXPORT bool device_nv12_available(gs_device_t *device);
+EXPORT bool device_p010_available(gs_device_t *device);
 
 #ifdef __APPLE__
 EXPORT gs_texture_t *device_texture_create_from_iosurface(gs_device_t *device,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
nv12 and p010 device functions were not exported on all platforms.    
Windows was exporting from C files instead. After CMake 3.0 we started     
hiding symbols and resolution failed. 

This resulted in obs crashing since fallback encoders were not used.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes texture encoders on opengl

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Launched a texture encoder.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
