### PR TITLE
UI: Set dock floating after hiding it

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -416,8 +416,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 		main->AddDockWidget(dock, Qt::RightDockWidgetArea);
 
-		dock->setFloating(true);
 		dock->setVisible(false);
+		dock->setFloating(true);
 
 		return true;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Setting the dock floating before hiding it created a transparent window on X11.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
On X11 (Fedora 38, XFCE4), an undrawn window was created at the top-left corner of the screen by this API if the dock added by this API is hidden at the beginning.

The window mostly held the background image like the screenshot below.
![dock](https://github.com/obsproject/obs-studio/assets/780600/4e358799-50f0-4c0c-9618-125015f0aacd)

The `statsDock` has the order `setVisible(false)` then `setFloating(true)`, which causes no issue so far.
https://github.com/obsproject/obs-studio/blob/83383c13bc5657fb7ef071d6e250a66d66cdcc95/UI/window-basic-main.cpp#L9621-L9622

The implementation of `QDockWidget::setFloating` has a branch condition involving `isVisible()` so I suspected the order mattered.
https://github.com/qt/qtbase/blob/a78938e0f686263540e06d923f2949169f3219e4/src/widgets/widgets/qdockwidget.cpp#L1448-L1468

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Fedora 38, XFCE4
- Plugin: [obs-loudness-dock](https://github.com/norihiro/obs-loudness-dock/)

Should be tested on Windows and macOS but I have not.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
