### PR TITLE
UI: Clean up main window dock structure

### DIFF
--- a/UI/data/themes/Acri.qss
+++ b/UI/data/themes/Acri.qss
@@ -284,24 +284,12 @@ OBSDock > QWidget {
     border-bottom-right-radius: 4px;
 }
 
-OBSDock QFrame {
-    background: palette(dark);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-#transitionsContainer QPushButton {
-    margin: 0px 0px;
-    padding: 4px 6px;
-}
-
 OBSDock QLabel {
     background: transparent;
 }
 
-OBSDock QComboBox,
-OBSDock QPushButton {
-    margin: 1px 2px;
+#transitionsFrame {
+    padding: 4px 8px;
 }
 
 QDockWidget {
@@ -774,8 +762,12 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 
 
 /* Controls Dock */
-#controlsDock QPushButton {
-    margin: 1px;
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 2px 1px;
 }
 
 #streamButton,

--- a/UI/data/themes/Dark.qss
+++ b/UI/data/themes/Dark.qss
@@ -131,6 +131,27 @@ QMainWindow::separator {
 
 /* Dock Widget */
 
+OBSDock > QWidget {
+    border: 1px solid palette(base);
+    border-top: none;
+}
+
+#transitionsFrame {
+    padding: 4px;
+}
+
+#transitionsFrame > QWidget {
+    margin-bottom: 2px;
+}
+
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 1px 1px;
+}
+
 QDockWidget {
     titlebar-close-icon: url(theme:Dark/close.svg);
     titlebar-normal-icon: url(theme:Dark/popout.svg);

--- a/UI/data/themes/Grey.qss
+++ b/UI/data/themes/Grey.qss
@@ -284,24 +284,12 @@ OBSDock > QWidget {
     border-bottom-right-radius: 4px;
 }
 
-OBSDock QFrame {
-    background: palette(dark);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-#transitionsContainer QPushButton {
-    margin: 0px 0px;
-    padding: 4px 6px;
-}
-
 OBSDock QLabel {
     background: transparent;
 }
 
-OBSDock QComboBox,
-OBSDock QPushButton {
-    margin: 1px 2px;
+#transitionsFrame {
+    padding: 4px 8px;
 }
 
 QDockWidget {
@@ -772,8 +760,12 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 
 
 /* Controls Dock */
-#controlsDock QPushButton {
-    margin: 1px;
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 2px 1px;
 }
 
 #streamButton,

--- a/UI/data/themes/Light.qss
+++ b/UI/data/themes/Light.qss
@@ -284,24 +284,12 @@ OBSDock > QWidget {
     border-bottom-right-radius: 4px;
 }
 
-OBSDock QFrame {
-    background: palette(dark);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-#transitionsContainer QPushButton {
-    margin: 0px 0px;
-    padding: 4px 6px;
-}
-
 OBSDock QLabel {
     background: transparent;
 }
 
-OBSDock QComboBox,
-OBSDock QPushButton {
-    margin: 1px 2px;
+#transitionsFrame {
+    padding: 4px 8px;
 }
 
 QDockWidget {
@@ -772,8 +760,12 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 
 
 /* Controls Dock */
-#controlsDock QPushButton {
-    margin: 1px;
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 2px 1px;
 }
 
 #streamButton,

--- a/UI/data/themes/Rachni.qss
+++ b/UI/data/themes/Rachni.qss
@@ -282,24 +282,12 @@ OBSDock > QWidget {
     border-bottom-right-radius: 4px;
 }
 
-OBSDock QFrame {
-    background: palette(dark);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-#transitionsContainer QPushButton {
-    margin: 0px 0px;
-    padding: 4px 6px;
-}
-
 OBSDock QLabel {
     background: transparent;
 }
 
-OBSDock QComboBox,
-OBSDock QPushButton {
-    margin: 1px 2px;
+#transitionsFrame {
+    padding: 4px 8px;
 }
 
 QDockWidget {
@@ -772,8 +760,12 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
 
 
 /* Controls Dock */
-#controlsDock QPushButton {
-    margin: 1px;
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 2px 1px;
 }
 
 #streamButton,

--- a/UI/data/themes/Yami.qss
+++ b/UI/data/themes/Yami.qss
@@ -288,24 +288,12 @@ OBSDock > QWidget {
     border-bottom-right-radius: 4px;
 }
 
-OBSDock QFrame {
-    background: palette(dark);
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-}
-
-#transitionsContainer QPushButton {
-    margin: 0px 0px;
-    padding: 4px 6px;
-}
-
 OBSDock QLabel {
     background: transparent;
 }
 
-OBSDock QComboBox,
-OBSDock QPushButton {
-    margin: 1px 2px;
+#transitionsFrame {
+    padding: 4px 8px;
 }
 
 QDockWidget {
@@ -387,7 +375,7 @@ QGroupBox::title {
 }
 
 QScrollBar:vertical {
-    background-color: transparent;
+    background-color: #1F212A;
     width: 14px;
     margin: 0px;
 }
@@ -405,7 +393,7 @@ QScrollBar::up-arrow:vertical, QScrollBar::down-arrow:vertical, QScrollBar::add-
 }
 
 QScrollBar:horizontal {
-    background-color: transparent;
+    background: #1F212A;
     height: 14px;
     margin: 0px;
 }
@@ -774,10 +762,13 @@ QSpinBox::down-arrow, QDoubleSpinBox::down-arrow {
     padding: 2px;
 }
 
-
 /* Controls Dock */
-#controlsDock QPushButton {
-    margin: 1px;
+#controlsFrame {
+    padding: 4px 3px;
+}
+
+#controlsFrame QPushButton {
+    margin: 2px 1px;
 }
 
 #streamButton,
@@ -918,7 +909,6 @@ QSlider::handle:disabled {
 }
 
 /* Volume Control */
-
 #stackedMixerArea QPushButton {
     min-width: 16px;
     padding: 4px 8px;

--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -753,37 +753,19 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="bottomMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <item>
       <widget class="QFrame" name="scenesFrame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>160</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
        <layout class="QVBoxLayout" name="verticalLayout_12">
         <property name="spacing">
          <number>0</number>
@@ -893,37 +875,19 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="bottomMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <item>
       <widget class="QFrame" name="sourcesFrame">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>160</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
        <layout class="QVBoxLayout" name="verticalLayout_17">
         <property name="spacing">
          <number>0</number>
@@ -1033,25 +997,19 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="bottomMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <item>
       <widget class="QFrame" name="mixerFrame">
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="spacing">
          <number>0</number>
@@ -1075,10 +1033,10 @@
             <enum>Qt::CustomContextMenu</enum>
            </property>
            <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
+            <enum>QFrame::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
+            <enum>QFrame::Plain</enum>
            </property>
            <property name="verticalScrollBarPolicy">
             <enum>Qt::ScrollBarAsNeeded</enum>
@@ -1094,7 +1052,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>217</width>
+              <width>225</width>
               <height>16</height>
              </rect>
             </property>
@@ -1128,10 +1086,10 @@
             <enum>Qt::CustomContextMenu</enum>
            </property>
            <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
+            <enum>QFrame::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
+            <enum>QFrame::Plain</enum>
            </property>
            <property name="verticalScrollBarPolicy">
             <enum>Qt::ScrollBarAlwaysOff</enum>
@@ -1148,7 +1106,7 @@
               <x>0</x>
               <y>0</y>
               <width>16</width>
-              <height>28</height>
+              <height>192</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -1216,40 +1174,34 @@
       <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="topMargin">
       <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="bottomMargin">
-      <number>0</number>
+      <number>1</number>
      </property>
      <item>
       <widget class="QFrame" name="transitionsFrame">
-       <property name="frameShape">
-        <enum>QFrame::StyledPanel</enum>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Sunken</enum>
-       </property>
        <layout class="QVBoxLayout" name="verticalLayout_8">
         <property name="spacing">
-         <number>2</number>
+         <number>0</number>
         </property>
         <property name="leftMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="topMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="rightMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <property name="bottomMargin">
-         <number>4</number>
+         <number>0</number>
         </property>
         <item>
          <widget class="QComboBox" name="transitions">
@@ -1458,192 +1410,213 @@
     <number>8</number>
    </attribute>
    <widget class="QWidget" name="controlsDockContents">
-    <layout class="QVBoxLayout" name="buttonsVLayout">
+    <layout class="QVBoxLayout" name="verticalLayout_9">
      <property name="spacing">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="leftMargin">
-      <number>4</number>
+      <number>1</number>
      </property>
      <property name="topMargin">
-      <number>4</number>
+      <number>0</number>
      </property>
      <property name="rightMargin">
-      <number>4</number>
+      <number>1</number>
      </property>
      <property name="bottomMargin">
-      <number>4</number>
+      <number>1</number>
      </property>
      <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <widget class="QPushButton" name="streamButton">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Basic.Main.StartStreaming</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="broadcastButton">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>150</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Basic.Main.StartBroadcast</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="recordingLayout">
-       <property name="spacing">
-        <number>2</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="RecordButton" name="recordButton">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Basic.Main.StartRecording</string>
-         </property>
-         <property name="checkable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <widget class="QPushButton" name="modeSwitch">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Basic.TogglePreviewProgramMode</string>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
+      <widget class="QFrame" name="controlsFrame">
+       <layout class="QVBoxLayout" name="buttonsVLayout">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <widget class="QPushButton" name="streamButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Basic.Main.StartStreaming</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="broadcastButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>150</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Basic.Main.StartBroadcast</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="recordingLayout">
+          <property name="spacing">
+           <number>2</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="RecordButton" name="recordButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Basic.Main.StartRecording</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="modeSwitch">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Basic.TogglePreviewProgramMode</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="settingsButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Settings</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="exitButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>150</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Exit</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="expVSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="settingsButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Settings</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="exitButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Exit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="expVSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </widget>


### PR DESCRIPTION
### Description
Clean up the widget properties and general structure of the various main window docks.

### Motivation and Context
The main window OBSDocks have some unnecessary properties explicitly set such as frameStyle or sizePolicy. This also adjusts the Controls dock to have a QFrame around it's contents, to match the other docks.

While it would be possible to _remove_ the QFrame from the other docks, it would lead to a much larger diff and be more restrictive in terms of styling potential. Having a QFrame container within the dock's main QWidget is much more flexible.

### How Has This Been Tested?
Compiled OBS, observed styling, cried because I still have to update like 5 theme files.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
