### PR TITLE
libobs: Fix grouped encoders never starting again after disconnect

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -354,6 +354,9 @@ static void remove_connection(struct obs_encoder *encoder, bool shutdown)
 	if (encoder->encoder_group) {
 		pthread_mutex_lock(&encoder->encoder_group->mutex);
 		encoder->encoder_group->encoders_started -= 1;
+		if (encoder->encoder_group->encoders_started == 0)
+			encoder->encoder_group->start_timestamp = 0;
+
 		pthread_mutex_unlock(&encoder->encoder_group->mutex);
 	}
 


### PR DESCRIPTION
### Description
Fix grouped encoder disconnect/reconnect behavior; this was included in all public Enhanced Broadcasting builds (original commits was <https://github.com/amazon-contributing/upstreaming-to-obs-studio/commit/340c205ce28adad2de103fa99276b9182ce28c38>), but missed in <https://github.com/obsproject/obs-studio/pull/10349>

### Motivation and Context
Follow-up to <https://github.com/obsproject/obs-studio/pull/10349>, fixes encoders never receiving frames again after e.g. the multitrack output disconnected and tries to reconnect

### How Has This Been Tested?
Twitch Enhanced Broadcasting beta

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
