### PR TITLE
libobs/util: Prevent leaking pipe file descriptors to subprocesses

### DIFF
--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <spawn.h>
+#include <fcntl.h>
 
 #include "bmem.h"
 #include "pipe.h"
@@ -65,6 +66,11 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line,
 
 		return NULL;
 	}
+
+	fcntl(mainfds[0], F_SETFD, FD_CLOEXEC);
+	fcntl(mainfds[1], F_SETFD, FD_CLOEXEC);
+	fcntl(errfds[0], F_SETFD, FD_CLOEXEC);
+	fcntl(errfds[1], F_SETFD, FD_CLOEXEC);
 
 	if (process_pipe.read_pipe) {
 		posix_spawn_file_actions_addclose(&file_actions, mainfds[0]);


### PR DESCRIPTION
### Description
Set `FD_CLOEXEC` file descriptor flag for the pipes created by `os_process_pipe_create`

### Motivation and Context
Since https://github.com/obsproject/obs-studio/pull/10070 obs-ffmpeg-mux can get in a state that it does not close.
`os_process_pipe_destroy` waits till the process ends. The obs-ffmpeg-mux process is terminated when an EOF appears on the
pipe. However, forked process hold the file descriptor of the write-end of the pipe, the EOF won't arrive to the obs-ffmpeg-mux process.
Prevent plugins needing code to close all file descriptors like https://github.com/norihiro/obs-command-source/commit/f4e9b26210d818e4a98c54043b91aa1ff55c06cf

### How Has This Been Tested?
On Mac with the source record plugin

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
