### PR TITLE
obs-webrtc: Various WHIP patches

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -583,12 +583,12 @@ void WHIPOutput::Send(void *data, uintptr_t size, uint64_t duration,
 	// Set new timestamp
 	rtp_config->timestamp = rtp_config->timestamp + elapsed_timestamp;
 
-	// get elapsed time in clock rate from last RTCP sender report
+	// Get elapsed time in clock rate from last RTCP sender report
 	auto report_elapsed_timestamp =
 		rtp_config->timestamp -
 		rtcp_sr_reporter->lastReportedTimestamp();
 
-	// check if last report was at least 1 second ago
+	// Check if last report was at least 1 second ago
 	if (rtp_config->timestampToSeconds(report_elapsed_timestamp) > 1)
 		rtcp_sr_reporter->setNeedsToReport();
 

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -604,6 +604,13 @@ void register_whip_output()
 {
 	const uint32_t base_flags = OBS_OUTPUT_ENCODED | OBS_OUTPUT_SERVICE;
 
+	const char *audio_codecs = "opus";
+#ifdef ENABLE_HEVC
+	const char *video_codecs = "h264;hevc;av1";
+#else
+	const char *video_codecs = "h264;av1";
+#endif
+
 	struct obs_output_info info = {};
 	info.id = "whip_output";
 	info.flags = OBS_OUTPUT_AV | base_flags;
@@ -638,21 +645,20 @@ void register_whip_output()
 	info.get_connect_time_ms = [](void *priv_data) -> int {
 		return static_cast<WHIPOutput *>(priv_data)->GetConnectTime();
 	};
-#ifdef ENABLE_HEVC
-	info.encoded_video_codecs = "h264;hevc;av1";
-#else
-	info.encoded_video_codecs = "h264;av1";
-#endif
-	info.encoded_audio_codecs = "opus";
+	info.encoded_video_codecs = video_codecs;
+	info.encoded_audio_codecs = audio_codecs;
 	info.protocols = "WHIP";
 
 	obs_register_output(&info);
 
 	info.id = "whip_output_video";
 	info.flags = OBS_OUTPUT_VIDEO | base_flags;
+	info.encoded_audio_codecs = nullptr;
 	obs_register_output(&info);
 
 	info.id = "whip_output_audio";
 	info.flags = OBS_OUTPUT_AUDIO | base_flags;
+	info.encoded_video_codecs = nullptr;
+	info.encoded_audio_codecs = audio_codecs;
 	obs_register_output(&info);
 }

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -162,7 +162,7 @@ void WHIPOutput::ConfigureVideoTrack(std::string media_stream_id,
 		packetizer = std::make_shared<rtc::H264RtpPacketizer>(
 			rtc::H264RtpPacketizer::Separator::StartSequence,
 			rtp_config, MAX_VIDEO_FRAGMENT_SIZE);
-#if ENABLE_HEVC
+#ifdef ENABLE_HEVC
 	} else if (strcmp("hevc", codec) == 0) {
 		video_description.addH265Codec(video_payload_type);
 		packetizer = std::make_shared<rtc::H265RtpPacketizer>(
@@ -638,7 +638,11 @@ void register_whip_output()
 	info.get_connect_time_ms = [](void *priv_data) -> int {
 		return static_cast<WHIPOutput *>(priv_data)->GetConnectTime();
 	};
+#ifdef ENABLE_HEVC
+	info.encoded_video_codecs = "h264;hevc;av1";
+#else
 	info.encoded_video_codecs = "h264;av1";
+#endif
 	info.encoded_audio_codecs = "opus";
 	info.protocols = "WHIP";
 


### PR DESCRIPTION
### Description
- Fixes ifdef guards for HEVC
- Fixes a capitalization of a few comments
- Only advertises relevant codecs in audio-only and video-only outputs

### Motivation and Context
Clean things up and improve standards

### How Has This Been Tested?
OBS compiles

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
