### PR TITLE
CI: Rewrite obs-crowdin-sync in Python & add to repository

### DIFF
--- a/.github/actions/update-crowdin-locales/action.yaml
+++ b/.github/actions/update-crowdin-locales/action.yaml
@@ -1,0 +1,24 @@
+name: Update locales on Crowdin
+description: Updates the US English locales on Crowdin.
+runs:
+  using: composite
+  steps:
+    - name: Check Runner Operating System 🏃‍♂️
+      if: runner.os != 'Linux'
+      shell: bash
+      run: |
+        echo "::warning::Action requires Linux-based runner."
+        exit 2
+
+    - name: Install and Configure Python 🐍
+      shell: bash
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        python3 -m pip install crowdin-api-client
+
+    - name: Update Locales on Crowdin 🇺🇸
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python3 .github/scripts/utils.py/update-crowdin-locales.py

--- a/.github/actions/update-translations/action.yaml
+++ b/.github/actions/update-translations/action.yaml
@@ -1,0 +1,41 @@
+name: Update Translations and AUTHORS
+description: Creates a Pull Request updating translations and AUTHORS.
+runs:
+  using: composite
+  steps:
+    - name: Check Runner Operating System 🏃‍♂️
+      if: runner.os != 'Linux'
+      shell: bash
+      run: |
+        echo "::warning::Action requires Linux-based runner."
+        exit 2
+
+    - name: Install and Configure Python 🐍
+      shell: bash
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        python3 -m pip install lxml requests crowdin-api-client
+
+    - name: Update Translations 🌐
+      shell: bash
+      run: |
+        source .venv/bin/activate
+        python3 .github/scripts/utils.py/update-translations.py
+
+    - name: Create Pull Request 🔧
+      uses: peter-evans/create-pull-request@6ce4eca6b6db0ff4f4d1b542dce50e785446dc27
+      with:
+        author: Translation Updater <commits@obsproject.com>
+        commit-message: Update Translations and AUTHORS
+        title: Update Translations and AUTHORS
+        branch: automated/update-translations
+        body: |
+          This updates all translations and the `AUTHORS` file.
+
+          Translations are pulled from https://crowdin.com/project/obs-studio.
+          Top translators are pulled from https://crowdin.com/project/obs-studio/reports/top-members.
+          Top Git contributors are generated using `git shortlog --all -sn --no-merges`
+
+          The creation of this Pull Request was triggered manually.
+        delete-branch: true

--- a/.github/scripts/utils.py/update-crowdin-locales.py
+++ b/.github/scripts/utils.py/update-crowdin-locales.py
@@ -1,0 +1,101 @@
+import os
+import subprocess
+import logging
+
+from crowdin_api import CrowdinClient
+from fnmatch import fnmatch
+
+
+CROWDIN_PROJECT_ID = 51028
+CROWDIN_API_TOKEN = os.environ["CROWDIN_PAT"]
+DEFAULT_LOCALE = "en-US"
+
+crowdin_api = CrowdinClient(token=CROWDIN_API_TOKEN, project_id=CROWDIN_PROJECT_ID, page_size=500)
+
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def get_updated_locales(cwd=".") -> list[str]:
+    COMMITS_TO_CHECK = f"{os.environ['GITHUB_EVENT_BEFORE']}..{os.environ['GITHUB_SHA']}"
+    updated_locales = subprocess.check_output(["git", "diff", "--name-only", COMMITS_TO_CHECK], cwd=cwd)
+    updated_locales = updated_locales.decode().strip().splitlines()
+    updated_locales = [updated_locale for updated_locale in updated_locales if updated_locale.endswith(f"/{DEFAULT_LOCALE}.ini")]
+
+    return updated_locales
+
+
+def get_dir_id(name: str) -> int:
+    crowdin_api.source_files.list_directories(filter=name)["data"][0]["data"]["id"]
+
+
+def add_to_crowdin_storage(file_path: str) -> int:
+    return crowdin_api.storages.add_storage(open(file_path))["data"]["id"]
+
+
+def update_crowdin_file(file_id: int, file_path: str) -> None:
+    storage_id = add_to_crowdin_storage(file_path)
+    crowdin_api.source_files.update_file(file_id, storage_id)
+
+    logger.info(f"{file_path} updated on Crowdin.")
+
+
+def create_crowdin_file(file_path: str, name: str, directory_name: str, export_pattern: str):
+    storage_id = add_to_crowdin_storage(file_path)
+
+    crowdin_api.source_files.add_file(storage_id,
+                                      name,
+                                      directoryId=get_dir_id(directory_name),
+                                      exportOptions={"exportPattern": export_pattern})
+
+    logger.info(f"{file_path} created on Crowdin in {directory_name} as {name}.")
+
+
+def upload(updated_locales: list[str]) -> None:
+    export_paths_map = dict()
+
+    for source_file_data in crowdin_api.source_files.list_files()["data"]:
+        source_file = source_file_data["data"]
+
+        if "exportOptions" not in source_file:
+            continue
+
+        export_path: str = source_file["exportOptions"]["exportPattern"]
+        export_path = export_path[1:]
+        export_path = export_path.replace("%file_name%", os.path.basename(source_file["name"]).split(".")[0])
+        export_path = export_path.replace("%locale%", DEFAULT_LOCALE)
+
+        export_paths_map[export_path] = source_file["id"]
+
+    for file_path in updated_locales:
+        if not os.path.exists(file_path):
+            logger.warning(f"Unable to find {file_path} in working directory.")
+            continue
+
+        path_parts = file_path.split("/")
+
+        if file_path in export_paths_map:
+            crowdin_file_id = export_paths_map[file_path]
+            update_crowdin_file(crowdin_file_id, file_path)
+        elif fnmatch(file_path, f"plugins/*/data/locale/{DEFAULT_LOCALE}.ini"):
+            create_crowdin_file(file_path, f"{path_parts[1]}.ini",
+                                path_parts[0], "/plugins/%file_name%/data/locale/%locale%.ini")
+        elif fnmatch(file_path, f"UI/frontend-plugins/*/data/locale/{DEFAULT_LOCALE}.ini"):
+            create_crowdin_file(file_path, f"{path_parts[2]}.ini",
+                                path_parts[1], "/UI/frontend-plugins/%file_name%/data/locale/%locale%.ini")
+        else:
+            logger.error(f"Unable to create {file_path} on Crowdin due to its unexpected location.")
+
+
+updated_locales = [str]
+
+if "SUBMODULE_NAME" in os.environ:
+    updated_locales = get_updated_locales(f"plugins/{os.environ['SUBMODULE_NAME']}")
+else:
+    updated_locales = get_updated_locales()
+
+if len(updated_locales) != 0:
+    upload(updated_locales)
+else:
+    logger.error("Unable to find updated locales.")

--- a/.github/scripts/utils.py/update-translations.py
+++ b/.github/scripts/utils.py/update-translations.py
@@ -1,0 +1,292 @@
+import time
+import requests
+import fnmatch
+import logging
+import subprocess
+import os
+
+from lxml import etree
+from io import BytesIO
+from crowdin_api import CrowdinClient
+from zipfile import ZipFile
+from typing import NewType
+
+CrowdinBuild = NewType("CrowdinBuild", dict[str, dict[str, str]])  # file path mapped to string keys & translations
+
+CROWDIN_PROJECT_ID = 51028
+CROWDIN_API_TOKEN = os.environ["CROWDIN_PAT"]
+
+crowdin_api = CrowdinClient(token=CROWDIN_API_TOKEN, project_id=CROWDIN_PROJECT_ID, page_size=500)
+
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def generate_build() -> int:
+    build_res = crowdin_api.translations.build_project_translation(dict({"skipUntranslatedStrings": True}))["data"]
+
+    is_finished = build_res["status"] == "finished"
+    while not is_finished:
+        time.sleep(5.0)
+        is_finished = crowdin_api.translations.check_project_build_status(build_res["id"])["data"]["status"] == "finished"
+
+    return build_res["id"]
+
+
+def download_build(build_id: int) -> CrowdinBuild:
+    download_url = crowdin_api.translations.download_project_translations(build_id)["data"]["url"]
+    build_download_req = requests.get(download_url)
+    build: CrowdinBuild = dict()
+
+    with ZipFile(BytesIO(build_download_req.content)) as build_zip:
+        file_list = build_zip.namelist()
+        file_list.sort()
+
+        for file_name in file_list:
+            if not file_name.endswith(".ini"):
+                continue
+
+            content = build_zip.read(file_name).decode()
+
+            content = content.strip()
+            if content == "":
+                continue
+
+            content = content.replace("\r\n", "\n")
+            content = content.replace("\r", "\n")
+
+            while "\n\n" in content:
+                content = content.replace("\n\n", "\n")
+
+            # Manually placed linebreaks in translations break the parsing
+            fixed_linebreaks = ""
+            previous_line = ""
+
+            for line in content.splitlines():
+                if '="' in line and not line.endswith('="'):
+                    fixed_linebreaks += "\n"
+                else:
+                    logger.warning(f"{file_name} contains manually placed linebreak which should be fixed on Crowdin. Line: {previous_line}")
+                fixed_linebreaks += line
+
+                previous_line = line
+
+            fixed_linebreaks = fixed_linebreaks.strip()
+
+            # Parse to CrowdinBuild
+            build[file_name] = {line[:line.index("=")]: line[line.index('"') + 1:-1] for line in fixed_linebreaks.splitlines()}
+
+    return build
+
+
+def get_locale_from_path(file_path: str) -> str:
+    return file_path[file_path.rindex("/")+1:file_path.rindex(".")]
+
+
+def filter_build(build: CrowdinBuild, patterns: list[str]) -> CrowdinBuild:
+    filtered_build: CrowdinBuild = dict()
+
+    for pattern in patterns:
+        filtered_build = filtered_build | {key: build[key] for key in fnmatch.filter(list(build), pattern)}
+
+    return filtered_build
+
+
+def write_core_translations(build: CrowdinBuild) -> None:
+    for file_path, translations in build.items():
+        with open(file_path, "w") as file:
+            output = ""
+            for key, translation in translations.items():
+                output += f'{key}="{translation}"\n'
+            file.write(output)
+
+
+def write_locale_file(build: CrowdinBuild) -> None:
+    FILE_PATH = "UI/data/locale.ini"
+    DEFAULT_LANGUAGE_NAME = "English (USA)"
+    DEFAULT_LOCALE = "en-US"
+    LANGUAGE_PROGRESS_THRESHOLD = 35  # Required percentage of language progress for a language to be added to the locale.ini
+
+    locales_to_write: list[str] = []
+
+    with open(FILE_PATH, encoding="utf-8") as file:
+        for line in file:
+            line = line.strip()
+            if line.startswith("["):
+                locales_to_write.append(line[1:-1])
+
+    for progress_data in crowdin_api.translation_status.get_project_progress()["data"]:
+        locale = progress_data["data"]["language"]["locale"]
+        if not locale in locales_to_write:
+            if progress_data["data"]["translationProgress"] >= LANGUAGE_PROGRESS_THRESHOLD:
+                locales_to_write.append(locale)
+
+    build[f"language-name/{DEFAULT_LOCALE}.ini"] = {"Language": DEFAULT_LANGUAGE_NAME}
+    if not DEFAULT_LOCALE in locales_to_write:
+        locales_to_write.append(DEFAULT_LOCALE)
+
+    locales_to_write.sort()  # Sort again because we manually inserted en-US
+    output = ""
+
+    for locale in locales_to_write:
+        file_path = f"language-name/{locale}.ini"
+        if not file_path in build:
+            logger.warning(f"Unable to add {locale} to locale.ini because it is missing the translation file.")
+            continue
+
+        translations = build[file_path]
+
+        if not "Language" in translations:
+            logger.warning(f"Unable to add {locale} to locale.ini because it is missing the language name.")
+            continue
+
+        output += f"[{locale}]\n"
+        output += f'Name={translations["Language"]}\n'
+        output += "\n"
+
+    output = output[:-1]
+    with open(FILE_PATH, "w", encoding="utf-8") as file:
+        file.write(output)
+
+
+def write_desktop_entry(build: CrowdinBuild) -> None:
+    FILE_PATH = "UI/xdg-data/com.obsproject.Studio.desktop"
+
+    content = ""
+
+    with open(FILE_PATH, encoding="utf-8") as file:
+        # Remove previous translations
+        content = file.read().split("\n\n")[0]
+
+    content += "\n\n"
+
+    for file_path, translations in build.items():
+        locale = get_locale_from_path(file_path)
+
+        for key, translation in translations.items():
+            content += f'{key}[{locale}]={translation}\n'
+
+    with open(FILE_PATH, "w", encoding="utf-8") as file:
+        file.write(content)
+
+
+def write_meta_info(build: CrowdinBuild) -> None:
+    FILE_PATH = "UI/xdg-data/com.obsproject.Studio.metainfo.xml.in"
+    FILE_ID = 758  # id of the file probably called "Metadata"
+    LANGUAGE_CODE_MAP = {"en_GB": "en-GB", "nb": "nb-NO", "pt_BR": "pt-BR"}  # Flathub and Crowdin don't share exactly the same language codes
+
+    source_strings_data = crowdin_api.source_strings.list_strings(fileId=FILE_ID)["data"]
+    xpath_list = [string["data"]["identifier"] for string in source_strings_data]
+
+    read_file = ""
+    with open(FILE_PATH, encoding="utf-8") as file:
+        for line in file.read().splitlines():
+            if ' xml:lang="' in line:
+                continue
+
+            read_file += line
+
+    xml_tree = etree.ElementTree(etree.fromstring(read_file.encode()))
+
+    for xpath in reversed(xpath_list):
+        for file_path, translations in reversed(build.items()):
+            if not xpath in translations:
+                continue
+
+            source_element = xml_tree.find(f".{xpath}")
+
+            if source_element is None:
+                logger.warning(f"Unable to find {xpath} from {file_path} in meta-info.")
+                continue
+
+            translated_element = etree.Element(source_element.tag)
+            translated_element.text = translations[xpath]
+
+            locale = get_locale_from_path(file_path)
+
+            if locale in LANGUAGE_CODE_MAP:
+                locale = LANGUAGE_CODE_MAP[locale]
+
+            translated_element.set("xmllang", locale)
+            source_element.addnext(translated_element)
+
+    etree.indent(xml_tree)
+
+    output = '<?xml version="1.0" encoding="UTF-8"?>\n'
+    output += etree.tostring(xml_tree, encoding="utf-8").decode()
+    output = output.replace(' xmllang="', ' xml:lang="')
+    output += "\n"
+
+    with open(FILE_PATH, "w", encoding="utf-8") as file:
+        file.write(output)
+
+
+def write_authors() -> None:
+    FILE_PATH = "AUTHORS"
+    EXCLUDED_COMMITERS = ["Translation Updater", "Service Checker"]
+
+    output = "Original Author: Lain Bailey\n\nContributors are sorted by their amount of commits / translated words.\n\n"
+    output += "Git Contributors:\n"
+
+    git_output = subprocess.check_output(["git", "shortlog", "--all", "-sn", "--no-merges"]).decode()
+    for line in git_output.splitlines():
+        committer_name = line.split("\t")[1]
+        if committer_name not in EXCLUDED_COMMITERS:
+            output += f" {committer_name}\n"
+
+    output += "\nTranslators:\n"
+
+    languages_data = crowdin_api.projects.get_project()["data"]["targetLanguages"]
+    target_languages = {language["name"]: language["id"] for language in languages_data}
+
+    blocked_users_data = crowdin_api.users.list_project_members(role="blocked")["data"]
+    blocked_users_ids = [user["data"]["id"] for user in blocked_users_data]
+
+    for language_name in sorted(target_languages):
+        generate_report_data = crowdin_api.reports.generate_top_members_report(format="json", languageId=target_languages[language_name])["data"]
+
+        report_id = generate_report_data["identifier"]
+        report_finished = generate_report_data["status"] == "finished"
+        while not report_finished:
+            time.sleep(1)
+            report_finished = crowdin_api.reports.check_report_generation_status(report_id)["data"]["status"] == "finished"
+
+        report_download_url = crowdin_api.reports.download_report(report_id)["data"]["url"]
+        report_download_res = requests.get(report_download_url).json()
+
+        if not "data" in report_download_res:
+            continue
+
+        output += f" {language_name}:\n"
+
+        for user_data in report_download_res["data"]:
+            user = user_data["user"]
+            full_name = user["fullName"]
+
+            if full_name == "REMOVED_USER":
+                continue
+
+            if user["id"] in blocked_users_ids:
+                continue
+
+            if user_data["translated"] == 0 and user_data["approved"] == 0:
+                continue
+
+            output += f"  {full_name}\n"
+
+    with open(FILE_PATH, "w", encoding="utf-8") as file:
+        file.write(output)
+
+
+build_id = generate_build()
+build = download_build(build_id)
+
+write_core_translations(filter_build(build, ["UI/data/locale/*.ini",
+                                             "plugins/*/data/locale/*.ini",
+                                             "plugins/mac-virtualcam/src/obs-plugin/data/locale/*.ini",
+                                             "UI/frontend-plugins/*/data/locale/*.ini"]))
+write_locale_file(filter_build(build, ["language-name/*.ini"]))
+write_desktop_entry(filter_build(build, ["desktop-entry/*.ini"]))
+write_meta_info(filter_build(build, ["meta-info/*.ini"]))
+write_authors()

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -51,19 +51,22 @@ jobs:
           runServiceChecks: true
           createPullRequest: true
 
-  download-language-files:
-    name: Download Language Files 🌐
+  update-language-files:
+    name: Update Language Files 🌐
     if: github.repository_owner == 'obsproject' && inputs.job == 'translations'
     runs-on: ubuntu-22.04
-    env:
-      CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.CROWDIN_SYNC_GITHUB_PAT }}
           fetch-depth: 0
-      - uses: obsproject/obs-crowdin-sync/download@30b5446e3b5eb19595aa68a81ddf896a857302cf
+      - name: Update Language Files 🌐
+        uses: ./.github/actions/update-translations
+        env:
+          CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
 
   steam-upload:
     name: Upload Steam Builds 🚂

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -88,8 +88,8 @@ jobs:
     needs: cache-cleanup
     secrets: inherit
 
-  upload-language-files:
-    name: Upload Language Files 🌐
+  update-crowdin-locales:
+    name: Update Locales on Crowdin 🇺🇸
     if: github.repository_owner == 'obsproject' && github.ref_name == 'master'
     runs-on: ubuntu-22.04
     steps:
@@ -123,9 +123,9 @@ jobs:
           baseRef: ${{ steps.nightly-checks.outputs.lastNightly }}
           checkGlob: '**/en-US.ini'
 
-      - name: Upload US English Language Files 🇺🇸
+      - name: Update Locales on Crowdin 🇺🇸
         if: fromJSON(steps.nightly-checks.outputs.passed) && steps.checks.outputs.passed == 'true'
-        uses: obsproject/obs-crowdin-sync/upload@30b5446e3b5eb19595aa68a81ddf896a857302cf
+        uses: ./.github/actions/update-crowdin-locales
         env:
           CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}
           GITHUB_EVENT_BEFORE: ${{ steps.nightly-checks.outputs.lastNightly }}

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -2,9 +2,6 @@
 # Pull requests for translations outside of Crowdin will not be accepted.
 # Read this forum post for more instructions on submitting translations: https://obsproject.com/forum/threads/how-to-contribute-translations-for-obs.16327/
 
-# Language of this file
-Language="English"
-
 # commonly shared locale
 OK="OK"
 Apply="Apply"

--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1,6 +1,6 @@
-# Note to translators: *DO NOT* translate this file directly. Instead, visit http://crowdin.com/project/obs-studio and submit your translations there.
+# Note to translators: *DO NOT* translate this file directly. Instead, visit https://crowdin.com/project/obs-studio and submit your translations there.
 # Pull requests for translations outside of Crowdin will not be accepted.
-# Read this forum post for more instructions on submitting translations: https://obsproject.com/forum/threads/how-to-contribute-translations-for-obs.16327/
+# Read this forum post for more instructions on submitting translations: https://obsproject.com/wiki/How-To-Contribute-Translations-For-OBS
 
 # commonly shared locale
 OK="OK"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Rewrites the obs-crowdin-sync repository in Python and adds the action to this repository.

Changes that come along with it:
- Translates the `UI/xdg-data/com.obsproject.Studio.metainfo.xml.in` file.
- Creates a pull request instead of pushing directly: https://github.com/Vainock/obs-studio/pull/3
- Changes the name of `English` to `English (USA)` for `en-US`.
- Lowers the requirements for new languages to be added to the `UI/data/locale.ini`.
- Host the `Language` string in a separate `Language Name` file on Crowdin, remove it here.

### Motivation and Context
The obs-crowdin-sync repository was too much for what it solves.

This solution is better for integration testing, easier to extend, easier for error analysis in the log because you don't have a huge bundled script and much cleaner to look at.

Pushing directly to the repo is bad, creating a PR is safer and transparent.

### How Has This Been Tested?
Locally and https://github.com/Vainock/obs-studio/pull/3. The `update-crowdin-locales` action was tested in a obs-browser fork.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
