### PR TITLE
obs-ffmpeg: Fix output path logging

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -306,6 +306,7 @@ static void build_command_line(struct ffmpeg_muxer *stream,
 	*args = os_process_args_create(exe);
 	bfree(exe);
 
+	dstr_copy(&stream->path, path);
 	os_process_args_add_arg(*args, path);
 	os_process_args_add_argf(*args, "%d", vencoder ? 1 : 0);
 	os_process_args_add_argf(*args, "%d", num_tracks);


### PR DESCRIPTION
### Description

Fixes issue introduced in #10101 that would result in the output file path being empty.

### Motivation and Context

Fix bug.

### How Has This Been Tested?

Recorded file.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
