### PR TITLE
UI: Adjust preview scrolling clamp values

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2678,6 +2678,9 @@ void OBSBasicPreview::ClampScrollingOffsets()
 	vec3_mulf(&offset, &offset, 0.5f);
 	vec3_maxf(&offset, &offset, 0.0f);
 
+	vec3_divf(&target, &target, 2.0f);
+	vec3_add(&offset, &offset, &target);
+
 	scrollingOffset.x = std::clamp(scrollingOffset.x, -offset.x, offset.x);
 	scrollingOffset.y = std::clamp(scrollingOffset.y, -offset.y, offset.y);
 }


### PR DESCRIPTION
### Description
Changes the math for the preview clamp values to allow the zoomed in preview to be moved further inwards.

### Motivation and Context
The current preview clamp values are overly restrictive and can make it difficult to edit things close to the edges of the canvas when zoomed in.

### How Has This Been Tested?
Zoomed in, zoomed out, panned around

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
