### PR TITLE
libobs: Remove extra gs_flush calls

### DIFF
--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -605,7 +605,6 @@ static inline void render_video(struct obs_core_video_mix *video,
 			copy_surfaces = video->copy_surfaces_encode;
 			channel_count = 1;
 #endif
-			gs_flush();
 		}
 
 		if (video->gpu_conversion) {
@@ -614,7 +613,6 @@ static inline void render_video(struct obs_core_video_mix *video,
 		}
 
 		if (gpu_active) {
-			gs_flush();
 			output_gpu_encoders(video, raw_active);
 		}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
These calls introduce pipeline stalls in OpenGL on low end machines which can contribute to a fairly significant 10-30% of total rendering time. On average (since not every frame stalls) this is ~5% improvement with gpu time decreasing from 6.3ms to 6.0ms when encoders are active.

The driver already needs to synchronize events within the context so these calls are not needed for correctness for OpenGL.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Squeeze out a bit more perf on very low end devices where encoders could go faster if the rendering was faster. It matters more for intel than AMD in my tests but the intel is far weaker than my AMD device.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Rendering vaapi and qsv texture encoders on amd and intel devices and I didnt notice any differences in output.

If I'm reading the D3D11 pages correctly for flush it seems it wont even introduce the gpu-gpu sync that it does on OpenGL so these are only trying to submit commands faster in Windows? I would appreciate testing on windows to know if these were providing any significant performance improvements there.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
