### PR TITLE
obs-ffmpeg: Fix deadlock on shutting down muxer

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -686,9 +686,9 @@ static void *ffmpeg_mux_io_thread(void *data)
 
 		// Loop to write in chunk_size chunks
 		for (;;) {
-			shutting_down = os_atomic_load_bool(&ffm->io.shutdown_requested);
-
 			pthread_mutex_lock(&ffm->io.data_mutex);
+
+			shutting_down = os_atomic_load_bool(&ffm->io.shutdown_requested);
 
 			// Fetch as many writes as possible from the deque
 			// and fill up our local chunk. This may involve seeking


### PR DESCRIPTION
### Description
The things that happen to get this deadlock:
- the io thread reads `shutdown_requested` as false
- the main thread sets `shutdown_requested` to true
- the main thread gets the `data_mutex`
- the main thread signals `new_data_available_event`
- the main thread releases the `data_mutex`
- the main thread waits for the io thread to exit
- the io thread gets the `data_mutex`
- the io thread resets `new_data_available_event` because `chunk_used < 65536 && !shutting_down`
- the io thread releases the `data_mutex`
- the io thread waits for `new_data_available_event`

with the changes the `new_data_available_event` cannot be send from the main thread between the reading of `shutdown_requested` the getting of the  `data_mutex` in the io thread

### Motivation and Context
Got a memory dump Fenrir from a muxer that was stuck.
the main thread is in `ffmpeg_mux_free` waiting for the io thread to close.
the io thread is waiting for `new_data_available_event`

### How Has This Been Tested?
Muxer still works as expected 

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.