### PR TITLE
UI: Update media source time labels while seeking

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -160,6 +160,7 @@ void MediaControls::MediaSliderReleased()
 			obs_source_media_set_time(source, GetSliderTime(seek));
 		}
 
+		UpdateLabels(seek);
 		seek = lastSeek = -1;
 	}
 
@@ -179,6 +180,7 @@ void MediaControls::MediaSliderMoved(int val)
 {
 	if (seekTimer.isActive()) {
 		seek = val;
+		UpdateLabels(seek);
 	}
 }
 
@@ -358,16 +360,7 @@ void MediaControls::SetSliderPosition()
 		sliderPosition = 0.0f;
 
 	ui->slider->setValue((int)sliderPosition);
-
-	ui->timerLabel->setText(FormatSeconds((int)(time / 1000.0f)));
-
-	if (!countDownTimer)
-		ui->durationLabel->setText(
-			FormatSeconds((int)(duration / 1000.0f)));
-	else
-		ui->durationLabel->setText(
-			QString("-") +
-			FormatSeconds((int)((duration - time) / 1000.0f)));
+	UpdateLabels((int)sliderPosition);
 }
 
 QString MediaControls::FormatSeconds(int totalSeconds)
@@ -534,4 +527,27 @@ void MediaControls::UpdateSlideCounter()
 		ui->timerLabel->setText("-");
 		ui->durationLabel->setText("-");
 	}
+}
+
+void MediaControls::UpdateLabels(int val)
+{
+	OBSSource source = OBSGetStrongRef(weakSource);
+	if (!source) {
+		return;
+	}
+
+	float duration = (float)obs_source_media_get_duration(source);
+	float percent = (float)val / (float)ui->slider->maximum();
+
+	float time = percent * duration;
+
+	ui->timerLabel->setText(FormatSeconds((int)(time / 1000.0f)));
+
+	if (!countDownTimer)
+		ui->durationLabel->setText(
+			FormatSeconds((int)(duration / 1000.0f)));
+	else
+		ui->durationLabel->setText(
+			QString("-") +
+			FormatSeconds((int)((duration - time) / 1000.0f)));
 }

--- a/UI/media-controls.hpp
+++ b/UI/media-controls.hpp
@@ -64,6 +64,7 @@ private slots:
 	void MoveSliderBackwards(int seconds = 5);
 
 	void UpdateSlideCounter();
+	void UpdateLabels(int val);
 
 public slots:
 	void PlayMedia();


### PR DESCRIPTION
### Description
Update the time and duration labels in the context bar when changing the seek position

https://github.com/obsproject/obs-studio/assets/1554753/a044da07-351e-43e5-9cf2-681e42236f7e

### Motivation and Context
Better feedback of user interaction

### How Has This Been Tested?
Seeked back and forth through multiple media files.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
