### PR TITLE
libobs: Use floating point textures when loading floating point image files

### DIFF
--- a/libobs/graphics/graphics-ffmpeg.c
+++ b/libobs/graphics/graphics-ffmpeg.c
@@ -370,6 +370,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 
 	if (info->format == AV_PIX_FMT_BGR0) {
 		data = ffmpeg_image_copy_data_straight(info, frame);
+
 	} else if (info->format == AV_PIX_FMT_RGBA ||
 		   info->format == AV_PIX_FMT_BGRA) {
 		if (alpha_mode == GS_IMAGE_ALPHA_STRAIGHT) {
@@ -401,6 +402,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 				}
 			}
 		}
+
 	} else if (info->format == AV_PIX_FMT_RGBA64BE) {
 		const size_t dst_linesize = (size_t)info->cx * 4;
 		data = bmalloc(info->cy * dst_linesize);
@@ -413,6 +415,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 		const uint8_t *src = frame->data[0];
 		uint16_t value[4];
 		float f[4];
+
 		if (alpha_mode == GS_IMAGE_ALPHA_STRAIGHT) {
 			for (int y = 0; y < info->cy; y++) {
 				for (size_t x = 0; x < row_elements; ++x) {
@@ -432,6 +435,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 
 				src += src_linesize - src_min_line;
 			}
+
 		} else if (alpha_mode == GS_IMAGE_ALPHA_PREMULTIPLY_SRGB) {
 			for (int y = 0; y < info->cy; y++) {
 				for (size_t x = 0; x < row_elements; ++x) {
@@ -454,6 +458,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 
 				src += src_linesize - src_min_line;
 			}
+
 		} else if (alpha_mode == GS_IMAGE_ALPHA_PREMULTIPLY) {
 			for (int y = 0; y < info->cy; y++) {
 				for (size_t x = 0; x < row_elements; ++x) {
@@ -477,6 +482,7 @@ static void *ffmpeg_image_reformat_frame(struct ffmpeg_image *info,
 		}
 
 		info->format = AV_PIX_FMT_RGBA;
+
 	} else {
 		static const enum AVPixelFormat format = AV_PIX_FMT_BGRA;
 


### PR DESCRIPTION
### Description
Allows the ability to open image files with floating point precision as floating point textures without unnecessarily downsampling to unsigned 8bit integer precision.

### Motivation and Context
Someone told me that they were trying to load an image file with 32bit floating point precision per channel to do some sort of advanced shader stuff, and that important precision information was being lost. They didn't know why. I noticed that they were being converted away to 8bit unsigned integer RGBA unnecessarily despite the fact that we supported the texture format natively, so I just fixed it in like 5 minutes.

### How Has This Been Tested?
Tested it with a .tiff file containing 32bit floating point precision RGBA file, opened it with an image source, checked the debugger to make sure the code path was being executed, checked the visible result, everything checked out.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
