### PR TITLE
cmake: Remove more Qt 5 code

### DIFF
--- a/cmake/common/helpers_common.cmake
+++ b/cmake/common/helpers_common.cmake
@@ -255,10 +255,8 @@ function(find_qt_plugins)
   # cmake-format: off
   list(APPEND qt_plugins_Core platforms printsupport styles imageformats iconengines)
   # cmake-format: on
-  list(APPEND qt_plugins_Gui platforminputcontexts virtualkeyboard)
-  list(APPEND qt_plugins_Network bearer)
+  list(APPEND qt_plugins_Gui platforminputcontexts)
   list(APPEND qt_plugins_Sql sqldrivers)
-  list(APPEND qt_plugins_Multimedia mediaservice audio)
   list(APPEND qt_plugins_3dRender sceneparsers geometryloaders)
   list(APPEND qt_plugins_3dQuickRender renderplugins)
   list(APPEND qt_plugins_Positioning position)

--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -450,7 +450,7 @@ function(_bundle_dependencies target)
         continue()
       endif()
 
-      if(library MATCHES "Qt[56]?::.+")
+      if(library MATCHES "Qt6?::.+")
         find_qt_plugins(COMPONENT ${library} TARGET ${target} FOUND_VAR plugins_list)
       endif()
       list(APPEND library_paths ${library_location})

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -402,7 +402,7 @@ function(_bundle_dependencies target)
         endif()
       endforeach()
 
-      if(library MATCHES "Qt[56]?::.+")
+      if(library MATCHES "Qt6?::.+")
         find_qt_plugins(COMPONENT ${library} TARGET ${target} FOUND_VAR plugins_list)
       endif()
     endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Qt Gui virtualkeyboard plugin was removed in Qt 6.x.
Qt Network Bearer Management was removed in Qt 6.0.
Qt Multimedia mediaservice and audio plugins were removed in Qt 6.x.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We don't support building with Qt 5 anymore, so we can remove Qt5-isms.

https://doc.qt.io/qt-5/bearer-management.html
https://github.com/qt/qtmultimedia/commit/98148969b112f82d2b49e77950ea5f6d8b37b8b2
https://github.com/qt/qtmultimedia/commit/762eff8c15aa8cbb6962c2893ff792ab172783ee
https://github.com/qt/qtmultimedia/commit/b4d331d08b48698c15d7b52da469341bf8dcfbca
https://doc.qt.io/qt-5/qtvirtualkeyboard-deployment-guide.html
https://doc.qt.io/qt-6/qtvirtualkeyboard-deployment-guide.html

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
