### PR TITLE
libobs/media-io: Fix copying different line-size video frame

### DIFF
--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -261,11 +261,11 @@ void video_frame_copy(struct video_frame *dst, const struct video_frame *src,
 			size_t linesize = src_linesize < dst_linesize
 						  ? src_linesize
 						  : dst_linesize;
-			for (uint32_t i = 0; i < heights[i]; i++) {
+			for (uint32_t y = 0; y < heights[i]; y++) {
 				uint8_t *src_pos =
-					src->data[i] + (src_linesize * i);
+					src->data[i] + (src_linesize * y);
 				uint8_t *dst_pos =
-					dst->data[i] + (dst_linesize * i);
+					dst->data[i] + (dst_linesize * y);
 				memcpy(dst_pos, src_pos, linesize);
 			}
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The outer `for` loop defines a variable `i` to indicate the index of the plane, which is as expected.

The inner `for` loop should use a different name variable. I renamed the variable to `y` to indicate the line index of the iteration.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The PR #10139 implemented to copy a video frame into a different line-size video frame. However, when the line-size was different, the frame was not correctly copied.

I was writing a unit test to cover the new branch introduced by the PR #10139 and realized the bug. Fortunately, the bug has not been released yet.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 38
Tested with a code below.
```c
static void memset_rand(void *dst, size_t size)
{
        long *buf = dst;
        for (size_t i = 0; i < size; i += sizeof(long))
                buf[i] = random();
}
static void video_frame_line_by_line_test(void **state)
{
        UNUSED_PARAMETER(state);

        const int width = 320;
        const int height = 180;
        const int linesize = 328;

        struct video_frame *frame1 = video_frame_create(VIDEO_FORMAT_Y800, width, height);
        struct video_frame frame2 = {0};
        frame2.data[0] = bmalloc(linesize * height);
        frame2.linesize[0] = linesize;

        memset_rand(frame1->data[0], frame1->linesize[0] * height);

        video_frame_copy(&frame2, frame1, VIDEO_FORMAT_Y800, height);

        for (int y = 0; y < height; y++) {
                assert_memory_equal(frame2.data[0] + frame2.linesize[0] * y, frame1->data[0] + frame1->linesize[0] * y, width);
        }

        bfree(frame2.data[0]);
        video_frame_destroy(frame1);

        assert_int_equal(bnum_allocs(), 0);
}
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
