### PR TITLE
UI: Refactor system tray

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -211,6 +211,8 @@ target_sources(
           spinbox-ignorewheel.hpp
           source-tree.cpp
           source-tree.hpp
+          system-tray-icon.cpp
+          system-tray-icon.hpp
           url-push-button.cpp
           url-push-button.hpp
           undo-stack-obs.cpp

--- a/UI/cmake/ui-elements.cmake
+++ b/UI/cmake/ui-elements.cmake
@@ -20,6 +20,8 @@ target_sources(
             slider-ignorewheel.hpp
             spinbox-ignorewheel.cpp
             spinbox-ignorewheel.hpp
+            system-tray-icon.cpp
+            system-tray-icon.hpp
             vertical-scroll-area.cpp
             vertical-scroll-area.hpp)
 

--- a/UI/system-tray-icon.cpp
+++ b/UI/system-tray-icon.cpp
@@ -1,0 +1,319 @@
+#include "system-tray-icon.hpp"
+#include "window-basic-main.hpp"
+
+#include <QAction>
+
+OBSSystemTrayIcon::OBSSystemTrayIcon(QWidget *parent) : QSystemTrayIcon(parent)
+{
+#ifdef __APPLE__
+	QIcon trayIconFile = QIcon(":/res/images/obs_macos.svg");
+	trayIconFile.setIsMask(true);
+#else
+	QIcon trayIconFile = QIcon(":/res/images/obs.png");
+#endif
+	setIcon(QIcon::fromTheme("obs-tray", trayIconFile));
+	setToolTip("OBS Studio");
+
+	OBSBasic *main = OBSBasic::Get();
+	menu.reset(new QMenu());
+
+	showHide = menu->addAction(main->isVisible()
+					   ? QTStr("Basic.SystemTray.Hide")
+					   : QTStr("Basic.SystemTray.Show"),
+				   this, &OBSSystemTrayIcon::ToggleVisibility);
+	menu->addSeparator();
+
+	previewProjector = new QMenu(QTStr("PreviewProjector"));
+	studioProgramProjector = new QMenu(QTStr("StudioProgramProjector"));
+
+	main->AddProjectorMenuMonitors(previewProjector, main,
+				       &OBSBasic::OpenPreviewProjector);
+	main->AddProjectorMenuMonitors(studioProgramProjector, main,
+				       &OBSBasic::OpenStudioProgramProjector);
+	menu->addMenu(previewProjector);
+	menu->addMenu(studioProgramProjector);
+	menu->addSeparator();
+
+	stream = menu->addAction(obs_frontend_streaming_active()
+					 ? QTStr("Basic.Main.StopStreaming")
+					 : QTStr("Basic.Main.StartStreaming"),
+				 main, &OBSBasic::on_streamButton_clicked);
+	record = menu->addAction(obs_frontend_recording_active()
+					 ? QTStr("Basic.Main.StopRecording")
+					 : QTStr("Basic.Main.StartRecording"),
+				 main, &OBSBasic::on_recordButton_clicked);
+	replay = menu->addAction(
+		obs_frontend_replay_buffer_active()
+			? QTStr("Basic.Main.StopReplayBuffer")
+			: QTStr("Basic.Main.StartReplayBuffer"));
+	virtualCam =
+		menu->addAction(obs_frontend_virtualcam_active()
+					? QTStr("Basic.Main.StopVirtualCam")
+					: QTStr("Basic.Main.StartVirtualCam"));
+	menu->addSeparator();
+	menu->addAction(QTStr("Exit"), main, &OBSBasic::close);
+
+	setContextMenu(menu.data());
+
+	UpdateReplayBuffer();
+
+	OBSOutputAutoRelease vcamOutput = obs_frontend_get_virtualcam_output();
+	virtualCam->setEnabled(!!vcamOutput);
+
+	if (Active())
+		OnActivate(true);
+
+	connect(this, &QSystemTrayIcon::activated, this,
+		&OBSSystemTrayIcon::IconActivated);
+
+	obs_frontend_add_event_callback(OnEvent, this);
+	show();
+}
+
+OBSSystemTrayIcon::~OBSSystemTrayIcon()
+{
+	delete previewProjector;
+	delete studioProgramProjector;
+
+	obs_frontend_remove_event_callback(OnEvent, this);
+}
+
+void OBSSystemTrayIcon::OnEvent(enum obs_frontend_event event, void *data)
+{
+	OBSSystemTrayIcon *sysTray = static_cast<OBSSystemTrayIcon *>(data);
+
+	switch (event) {
+	// Streaming
+	case OBS_FRONTEND_EVENT_STREAMING_STARTING:
+		sysTray->StreamStarting();
+		break;
+	case OBS_FRONTEND_EVENT_STREAMING_STARTED:
+		sysTray->StreamStarted();
+		break;
+	case OBS_FRONTEND_EVENT_STREAMING_STOPPING:
+		sysTray->StreamStopping();
+		break;
+	case OBS_FRONTEND_EVENT_STREAMING_STOPPED:
+		sysTray->StreamStopped();
+		break;
+
+	// Recording
+	case OBS_FRONTEND_EVENT_RECORDING_STARTED:
+		sysTray->RecordingStarted();
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_STOPPING:
+		sysTray->RecordingStopping();
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
+		sysTray->RecordingStopped();
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_PAUSED:
+		sysTray->RecordingPaused();
+		break;
+	case OBS_FRONTEND_EVENT_RECORDING_UNPAUSED:
+		sysTray->RecordingUnpaused();
+		break;
+
+	// Replay Buffer
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED:
+		sysTray->ReplayStarted();
+		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING:
+		sysTray->ReplayStopping();
+		break;
+	case OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED:
+		sysTray->ReplayStopped();
+		break;
+
+	// Virtual Camera
+	case OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED:
+		sysTray->VirtualCamStarted();
+		break;
+	case OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED:
+		sysTray->VirtualCamStopped();
+		break;
+
+	default:
+		break;
+	}
+}
+
+bool OBSSystemTrayIcon::Active()
+{
+	return obs_frontend_streaming_active() ||
+	       obs_frontend_recording_active() ||
+	       obs_frontend_replay_buffer_active() ||
+	       obs_frontend_virtualcam_active();
+}
+
+void OBSSystemTrayIcon::OnActivate(bool force)
+{
+	if (!force && Active())
+		return;
+
+#ifdef __APPLE__
+	QIcon trayIconFile = QIcon(":/res/images/tray_active_macos.svg");
+	trayIconFile.setIsMask(true);
+#else
+	QIcon trayIconFile = QIcon(":/res/images/tray_active.png");
+#endif
+	setIcon(QIcon::fromTheme("obs-tray-active", trayIconFile));
+}
+
+void OBSSystemTrayIcon::OnDeactivate()
+{
+	if (!Active())
+		return;
+
+#ifdef __APPLE__
+	QIcon trayIconFile = QIcon(":/res/images/obs_macos.svg");
+	trayIconFile.setIsMask(true);
+#else
+	QIcon trayIconFile = QIcon(":/res/images/obs.png");
+#endif
+	setIcon(QIcon::fromTheme("obs-tray", trayIconFile));
+}
+
+void OBSSystemTrayIcon::ToggleVisibility()
+{
+	OBSBasic *main = OBSBasic::Get();
+	main->ToggleShowHide();
+
+	QTimer::singleShot(0, [this, main] {
+		showHide->setText(main->isVisible()
+					  ? QTStr("Basic.SystemTray.Hide")
+					  : QTStr("Basic.SystemTray.Show"));
+	});
+}
+
+// Streaming
+void OBSSystemTrayIcon::StreamStarting()
+{
+	stream->setText(QTStr("Basic.Main.Connecting"));
+	stream->setEnabled(false);
+}
+
+void OBSSystemTrayIcon::StreamStarted()
+{
+	stream->setEnabled(true);
+	stream->setText(QTStr("Basic.Main.StopStreaming"));
+	OnActivate();
+}
+
+void OBSSystemTrayIcon::StreamStopping()
+{
+	stream->setText(QTStr("Basic.Main.StoppingStreaming"));
+}
+
+void OBSSystemTrayIcon::StreamStopped()
+{
+	stream->setText(QTStr("Basic.Main.StartStreaming"));
+	OnDeactivate();
+}
+
+// Recording
+void OBSSystemTrayIcon::RecordingStarted()
+{
+	record->setText(QTStr("Basic.Main.StopRecording"));
+	OnActivate();
+}
+
+void OBSSystemTrayIcon::RecordingStopping()
+{
+	record->setText(QTStr("Basic.Main.StoppingRecording"));
+}
+
+void OBSSystemTrayIcon::RecordingStopped()
+{
+	record->setText(QTStr("Basic.Main.StartRecording"));
+	OnDeactivate();
+}
+
+void OBSSystemTrayIcon::RecordingPaused()
+{
+#ifdef __APPLE__
+	QIcon trayIconFile = QIcon(":/res/images/obs_paused_macos.svg");
+	trayIconFile.setIsMask(true);
+#else
+	QIcon trayIconFile = QIcon(":/res/images/obs_paused.png");
+#endif
+	setIcon(QIcon::fromTheme("obs-tray-paused", trayIconFile));
+}
+
+void OBSSystemTrayIcon::RecordingUnpaused()
+{
+#ifdef __APPLE__
+	QIcon trayIconFile = QIcon(":/res/images/tray_active_macos.svg");
+	trayIconFile.setIsMask(true);
+#else
+	QIcon trayIconFile = QIcon(":/res/images/tray_active.png");
+#endif
+	setIcon(QIcon::fromTheme("obs-tray-active", trayIconFile));
+}
+
+// Replay Buffer
+void OBSSystemTrayIcon::UpdateReplayBuffer()
+{
+	OBSOutputAutoRelease replayOutput =
+		obs_frontend_get_replay_buffer_output();
+	replay->setEnabled(!!replayOutput);
+}
+
+void OBSSystemTrayIcon::ReplayStarted()
+{
+	replay->setText(QTStr("Basic.Main.StopReplayBuffer"));
+	OnActivate();
+}
+
+void OBSSystemTrayIcon::ReplayStopping()
+{
+	replay->setText(QTStr("Basic.Main.StoppingReplayBuffer"));
+}
+
+void OBSSystemTrayIcon::ReplayStopped()
+{
+	replay->setText(QTStr("Basic.Main.StartReplayBuffer"));
+	OnDeactivate();
+}
+
+// Virtual Camera
+void OBSSystemTrayIcon::VirtualCamStarted()
+{
+	virtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
+	OnActivate();
+}
+
+void OBSSystemTrayIcon::VirtualCamStopped()
+{
+	virtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
+	OnDeactivate();
+}
+
+void OBSSystemTrayIcon::IconActivated(QSystemTrayIcon::ActivationReason reason)
+{
+	OBSBasic *main = OBSBasic::Get();
+
+	// Refresh projector list
+	previewProjector->clear();
+	studioProgramProjector->clear();
+	main->AddProjectorMenuMonitors(previewProjector, main,
+				       &OBSBasic::OpenPreviewProjector);
+	main->AddProjectorMenuMonitors(studioProgramProjector, main,
+				       &OBSBasic::OpenStudioProgramProjector);
+
+#ifdef __APPLE__
+	UNUSED_PARAMETER(reason);
+#else
+	if (reason == QSystemTrayIcon::Trigger)
+		ToggleVisibility();
+#endif
+}
+
+void OBSSystemTrayIcon::ShowNotification(const QString &text,
+					 QSystemTrayIcon::MessageIcon n)
+{
+	if (!supportsMessages())
+		return;
+
+	showMessage("OBS Studio", text, n, 10000);
+}

--- a/UI/system-tray-icon.hpp
+++ b/UI/system-tray-icon.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <QSystemTrayIcon>
+#include <QPointer>
+#include <obs-frontend-api.h>
+
+class QAction;
+
+class OBSSystemTrayIcon : public QSystemTrayIcon {
+	Q_OBJECT
+
+private:
+	QScopedPointer<QMenu> menu;
+	QPointer<QAction> showHide;
+	QPointer<QAction> stream;
+	QPointer<QAction> record;
+	QPointer<QAction> replay;
+	QPointer<QAction> virtualCam;
+	QPointer<QMenu> previewProjector;
+	QPointer<QMenu> studioProgramProjector;
+
+	static void OnEvent(enum obs_frontend_event event, void *data);
+	bool Active();
+	void OnActivate(bool force = false);
+	void OnDeactivate();
+
+	void StreamStarting();
+	void StreamStarted();
+	void StreamStopping();
+	void StreamStopped();
+
+	void RecordingStarted();
+	void RecordingStopping();
+	void RecordingStopped();
+	void RecordingPaused();
+	void RecordingUnpaused();
+
+	void ReplayStarted();
+	void ReplayStopping();
+	void ReplayStopped();
+
+	void VirtualCamStarted();
+	void VirtualCamStopped();
+
+private slots:
+	void ToggleVisibility();
+	void IconActivated(QSystemTrayIcon::ActivationReason reason);
+
+public:
+	OBSSystemTrayIcon(QWidget *parent = nullptr);
+	~OBSSystemTrayIcon();
+
+	void ShowNotification(const QString &text,
+			      QSystemTrayIcon::MessageIcon n);
+	void UpdateReplayBuffer();
+};

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -56,6 +56,7 @@ class QListWidgetItem;
 class VolControl;
 class OBSBasicStats;
 class OBSBasicVCamConfig;
+class OBSSystemTrayIcon;
 
 #include "ui_OBSBasic.h"
 #include "ui_ColorSelect.h"
@@ -198,6 +199,7 @@ class OBSBasic : public OBSMainWindow {
 	friend struct BasicOutputHandler;
 	friend struct OBSStudioAPI;
 	friend class ScreenshotObj;
+	friend class OBSSystemTrayIcon;
 
 	enum class MoveDir { Up, Down, Left, Right };
 
@@ -327,14 +329,7 @@ private:
 	bool vcamEnabled = false;
 	VCamConfig vcamConfig;
 
-	QScopedPointer<QSystemTrayIcon> trayIcon;
-	QPointer<QAction> sysTrayStream;
-	QPointer<QAction> sysTrayRecord;
-	QPointer<QAction> sysTrayReplayBuffer;
-	QPointer<QAction> sysTrayVirtualCam;
-	QPointer<QAction> showHide;
-	QPointer<QAction> exit;
-	QPointer<QMenu> trayMenu;
+	QScopedPointer<OBSSystemTrayIcon> trayIcon;
 	QPointer<QMenu> previewProjector;
 	QPointer<QMenu> studioProgramProjector;
 	QPointer<QMenu> previewProjectorSource;
@@ -783,7 +778,6 @@ private slots:
 	void SetBlendingMethod();
 	void SetBlendingMode();
 
-	void IconActivated(QSystemTrayIcon::ActivationReason reason);
 	void SetShowing(bool showing);
 
 	void ToggleShowHide();


### PR DESCRIPTION
### Description
This moves the system tray to its own file.

### Motivation and Context
Instead of being strewn all over OBSBasic, the system tray code is now consolidated into its own file, making it easier to maintain.

### How Has This Been Tested?
Used system tray to perform actions in OBS.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
