### PR TITLE
UI: Fix volume control button styling

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -1187,9 +1187,10 @@ QSlider::handle:disabled {
 /* Volume Control */
 
 #stackedMixerArea QPushButton {
+    width: var(--icon_base);
+    height: var(--icon_base);
     background-color: var(--button_bg);
-    min-width: var(--icon_base);
-    padding: var(--padding_small) var(--padding_base);
+    padding: var(--padding_base_border) var(--padding_base_border);
     margin: 0px var(--spacing_base);
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -263,9 +263,6 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	if (showConfig) {
 		config = new QPushButton(this);
 		config->setProperty("themeID", "menuIconSmall");
-		config->setSizePolicy(QSizePolicy::Maximum,
-				      QSizePolicy::Maximum);
-		config->setMaximumSize(22, 22);
 		config->setAutoDefault(false);
 
 		config->setAccessibleName(


### PR DESCRIPTION
### Description
The config button and mute checkbox were different sizes.

Before:
![Screenshot from 2024-04-29 02-15-28](https://github.com/obsproject/obs-studio/assets/19962531/26fd99f2-6399-4997-b08d-630d909175b2)

After:
![Screenshot from 2024-04-29 02-21-06](https://github.com/obsproject/obs-studio/assets/19962531/c81df381-224f-444d-ac36-b6cdc07c1efd)

### Motivation and Context
Fixes Yami styling

### How Has This Been Tested?
Looked at volume controls to make sure the buttons were consistent.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
