### PR TITLE
UI: Make disabled tool buttons consistent with push buttons

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -1099,7 +1099,7 @@ QPushButton:disabled {
 QToolButton:disabled,
 QPushButton[toolButton="true"]:disabled {
     background-color: var(--button_bg_disabled);
-    border-color: transparent;
+    border-color: var(--button_border);
 }
 
 QPushButton::menu-indicator {


### PR DESCRIPTION
### Description
This makes the borders the same color when tool buttons and push buttons are disabled.

Before:
![Screenshot from 2024-04-29 02-15-28](https://github.com/obsproject/obs-studio/assets/19962531/708853f1-7583-4419-afaa-67a2f1dcd1ac)

After:
![Screenshot from 2024-04-29 02-37-45](https://github.com/obsproject/obs-studio/assets/19962531/bca90300-8e1f-45b6-90b5-a3e57a2f7fda)

### Motivation and Context
I don't know if this was intentional or not, but IMO I think the tool buttons having the disabled border looks better.

### How Has This Been Tested?
Looked at tool buttons

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
