### PR TITLE
UI: Fix styling of appearance tab

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -936,6 +936,15 @@
              <item>
               <widget class="QFrame" name="appearanceFrame">
                <layout class="QVBoxLayout" name="verticalLayout_30">
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
                 <item>
                  <widget class="QGroupBox" name="appearanceGeneral">
                   <property name="title">
@@ -945,6 +954,12 @@
                    <bool>false</bool>
                   </property>
                   <layout class="QFormLayout" name="formLayout_37">
+                   <property name="labelAlignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                   <property name="topMargin">
+                    <number>2</number>
+                   </property>
                    <item row="0" column="0">
                     <widget class="QLabel" name="label_45">
                      <property name="text">
@@ -973,6 +988,19 @@
                    </item>
                   </layout>
                  </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_8">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
               </widget>


### PR DESCRIPTION
### Description
This makes the appearance tab look the same as other settings tabs.

Before:
![Screenshot from 2024-04-29 02-05-04](https://github.com/obsproject/obs-studio/assets/19962531/be3c9b3e-0d95-4809-b683-9d94393bf3e7)

After:
![Screenshot from 2024-04-29 03-27-46](https://github.com/obsproject/obs-studio/assets/19962531/7f02c288-0c69-435c-89d6-d3f4c28be89f)

### Motivation and Context
Makes appearance tab look better

### How Has This Been Tested?
Looked at appearance tab

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
