### PR TITLE
obs-webrtc: Add null terminator to codec array

### DIFF
--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -1,7 +1,7 @@
 #include "whip-service.h"
 
-const char *audio_codecs[MAX_CODECS] = {"opus"};
-const char *video_codecs[MAX_CODECS] = {"h264", "hevc", "av1"};
+const char *audio_codecs[] = {"opus", nullptr};
+const char *video_codecs[] = {"h264", "hevc", "av1", nullptr};
 
 WHIPService::WHIPService(obs_data_t *settings, obs_service_t *)
 	: server(),

--- a/plugins/obs-webrtc/whip-service.h
+++ b/plugins/obs-webrtc/whip-service.h
@@ -2,8 +2,6 @@
 #include <obs-module.h>
 #include <string>
 
-#define MAX_CODECS 3
-
 struct WHIPService {
 	std::string server;
 	std::string bearer_token;


### PR DESCRIPTION
This fixes an issue where when the MAX_CODECS length was equal to the amount of supported codecs (3), it would leave the list without a null terminator and crash when iterating over the elements.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Addresses a bug where a non-null terminated list of strings was iterated over into invalid memory

### Motivation and Context
Crashes on some machines depending on if the memory layout had a null accidentally after the list.

### How Has This Been Tested?
Tested on Mac and Windows, no longer crashes in release mode.

### Types of changes
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
