### PR TITLE
UI: Adjust styling of QTabBar tabs

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -165,14 +165,14 @@
     --button_border_hover: var(--grey1);
     --button_border_focus: var(--grey1);
 
-    --tab_bg: var(--input_bg);
-    --tab_bg_hover: var(--grey3);
-    --tab_bg_down: var(--grey7);
-    --tab_bg_disabled: var(--grey6);
+    --tab_bg: var(--button_bg_disabled);
+    --tab_bg_hover: var(--button_bg_hover);
+    --tab_bg_down: var(--primary);
+    --tab_bg_disabled: var(--button_bg_disabled);
 
-    --tab_border: var(--grey1);
-    --tab_border_hover: var(--grey1);
-    --tab_border_focus: var(--grey1);
+    --tab_border: var(--border_color);
+    --tab_border_hover: var(--button_border_hover);
+    --tab_border_focus: var(--button_border_focus);
     --tab_border_selected: var(--primary);
 
     --scrollbar: var(--grey4);
@@ -718,7 +718,7 @@ QToolBarExtension {
 /* Tab Widget */
 
 QTabWidget::pane { /* The tab widget frame */
-    border-top: 4px solid var(--bg_base);
+    border-top: 4px solid var(--tab_bg);
 }
 
 QTabWidget::tab-bar {
@@ -771,17 +771,13 @@ QTabBar::tab:selected {
 }
 
 QTabBar::tab:top {
-}
-
-QTabBar::tab:top:selected {
-    border-bottom: 2px solid var(--tab_border_selected);
+    border-bottom: 0px solid transparent;
+    margin-bottom: 0px;
 }
 
 QTabBar::tab:bottom {
-}
-
-QTabBar::tab:bottom:selected {
-    border-top: 2px solid var(--tab_border_selected);
+    border-top: 0px solid transparent;
+    margin-top: 0px;
 }
 
 QTabBar QToolButton {

--- a/UI/data/themes/Yami_Acri.ovt
+++ b/UI/data/themes/Yami_Acri.ovt
@@ -48,15 +48,11 @@
     --button_border_hover: var(--button_bg_hover);
     --button_border_focus: var(--button_bg_hover);
 
-    --tab_bg: var(--input_bg);
-    --tab_bg_hover: var(--grey3);
-    --tab_bg_down: var(--grey7);
-    --tab_bg_disabled: var(--grey6);
+    --tab_bg_down: #162458;
 
-    --tab_border: var(--grey3);
-    --tab_border_hover: var(--grey1);
-    --tab_border_focus: var(--grey1);
-    --tab_border_selected: var(--primary_light);
+    --tab_border_hover: var(--primary_light);
+    --tab_border_focus: var(--input_border_focus);
+    --tab_border_selected: var(--primary);
 
     --scrollbar: var(--grey5);
     --scrollbar_hover: var(--primary_light);


### PR DESCRIPTION
### Description
Adjusts the appearance of tabs in tab bar widgets such as the Output tab and stacked docks.

Before:
![image](https://github.com/obsproject/obs-studio/assets/1554753/40a7f3c0-e510-4624-933c-adf7e1964776)


After:
![image](https://github.com/obsproject/obs-studio/assets/1554753/f9bf2bb7-99bc-4e60-8417-8db3fb9a963c)


### Motivation and Context
Feedback on Discord

### How Has This Been Tested?
👁

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
