### PR TITLE
UI: Add support for additional canvases to multitrack video output

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -628,9 +628,9 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	}
 
 	void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-						    multitrack_video_stop_cb stop_video, void *param) override
+						    multitrack_video_stop_cb stop_video, void *private_data) override
 	{
-		main->MultitrackVideoRegister(name, start_video, stop_video, param);
+		main->MultitrackVideoRegister(name, start_video, stop_video, private_data);
 	}
 
 	void obs_frontend_multitrack_video_unregister(const char *name) override

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -626,6 +626,17 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 			cb.callback(event, cb.private_data);
 		}
 	}
+
+	void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
+						    multitrack_video_stop_cb stop_video, void *param) override
+	{
+		main->MultitrackVideoRegister(name, start_video, stop_video, param);
+	}
+
+	void obs_frontend_multitrack_video_unregister(const char *name) override
+	{
+		main->MultitrackVideoUnregister(name);
+	}
 };
 
 obs_frontend_callbacks *InitializeAPIInterface(OBSBasic *main)

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -627,8 +627,10 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 		}
 	}
 
-	void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-						    multitrack_video_stop_cb stop_video, void *private_data) override
+	void obs_frontend_multitrack_video_register(const char *name,
+						    obs_frontend_multitrack_video_start_cb start_video,
+						    obs_frontend_multitrack_video_stop_cb stop_video,
+						    void *private_data) override
 	{
 		main->MultitrackVideoRegister(name, start_video, stop_video, private_data);
 	}

--- a/UI/goliveapi-postdata.cpp
+++ b/UI/goliveapi-postdata.cpp
@@ -7,7 +7,8 @@
 #include "models/multitrack-video.hpp"
 
 GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
-					const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled)
+					const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled,
+					const std::map<std::string, video_t *> &extra_views)
 {
 	GoLiveApi::PostData post_data{};
 	post_data.service = "IVS";
@@ -43,6 +44,22 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 #endif
 		} else if (qstricmp(codec, "av1")) {
 			add_codec("av1");
+		}
+	}
+
+	if (!extra_views.empty()) {
+		auto &extra_views_capability = *post_data.capabilities.extra_views;
+		extra_views_capability.reserve(extra_views.size());
+		for (auto &view : extra_views) {
+			video_t *video = view.second;
+			if (!video)
+				continue;
+			const struct video_output_info *voi = video_output_get_info(video);
+			if (!voi)
+				continue;
+			extra_views_capability.push_back(
+				GoLiveApi::ExtraView{view.first, voi->width, voi->height,
+						     media_frames_per_second{voi->fps_num, voi->fps_den}});
 		}
 	}
 

--- a/UI/goliveapi-postdata.cpp
+++ b/UI/goliveapi-postdata.cpp
@@ -48,6 +48,7 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 	}
 
 	if (!extra_views.empty()) {
+		post_data.capabilities.extra_views.emplace();
 		auto &extra_views_capability = *post_data.capabilities.extra_views;
 		extra_views_capability.reserve(extra_views.size());
 		for (auto &view : extra_views) {

--- a/UI/goliveapi-postdata.hpp
+++ b/UI/goliveapi-postdata.hpp
@@ -2,8 +2,10 @@
 
 #include <obs.hpp>
 #include <optional>
+#include <map>
 #include <QString>
 #include "models/multitrack-video.hpp"
 
 GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<uint64_t> &maximum_aggregate_bitrate,
-					const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled);
+					const std::optional<uint32_t> &maximum_video_tracks, bool vod_track_enabled,
+					const std::map<std::string, video_t *> &extra_views);

--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -124,14 +124,24 @@ struct System {
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(System, version, name, build, release, revision, bits, arm, armEmulation)
 };
 
+struct ExtraView {
+	string name;
+	uint32_t canvas_width;
+	uint32_t canvas_height;
+	media_frames_per_second framerate;
+
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(ExtraView, name, canvas_width, canvas_height, framerate)
+};
+
 struct Capabilities {
 	Cpu cpu;
 	Memory memory;
 	optional<GamingFeatures> gaming_features;
 	System system;
 	optional<std::vector<Gpu>> gpu;
+	optional<std::vector<ExtraView>> extra_views;
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Capabilities, cpu, memory, gaming_features, system, gpu)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Capabilities, cpu, memory, gaming_features, system, gpu, extra_views)
 };
 
 struct Preferences {
@@ -206,10 +216,11 @@ struct VideoEncoderConfiguration {
 	uint32_t height;
 	optional<media_frames_per_second> framerate;
 	optional<obs_scale_type> gpu_scale_type;
+	optional<string> view;
 	json settings;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(VideoEncoderConfiguration, type, width, height, framerate,
-						    gpu_scale_type, settings)
+						    gpu_scale_type, view, settings)
 };
 
 struct AudioEncoderConfiguration {

--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -37,6 +37,7 @@
 #include "goliveapi-network.hpp"
 #include "multitrack-video-error.hpp"
 #include "models/multitrack-video.hpp"
+#include "window-basic-main.hpp"
 
 Qt::ConnectionType BlockingConnectionTypeFor(QObject *object)
 {
@@ -168,21 +169,23 @@ static OBSOutputAutoRelease create_recording_output(obs_data_t *settings)
 	return output;
 }
 
-static void adjust_video_encoder_scaling(const obs_video_info &ovi, obs_encoder_t *video_encoder,
+static void adjust_video_encoder_scaling(const char *view_name, const obs_video_info *ovi, const video_output_info *voi,
+					 obs_encoder_t *video_encoder,
 					 const GoLiveApi::VideoEncoderConfiguration &encoder_config,
 					 size_t encoder_index)
 {
 	auto requested_width = encoder_config.width;
 	auto requested_height = encoder_config.height;
 
-	if (ovi.output_width == requested_width || ovi.output_height == requested_height)
-		return;
+	auto width = ovi ? ovi->base_width : voi->width;
+	auto height = ovi ? ovi->base_height : voi->height;
 
-	if (ovi.base_width < requested_width || ovi.base_height < requested_height) {
+	if (width < requested_width || height < requested_height) {
 		blog(LOG_WARNING,
 		     "Requested resolution exceeds canvas/available resolution for encoder %zu: %" PRIu32 "x%" PRIu32
-		     " > %" PRIu32 "x%" PRIu32,
-		     encoder_index, requested_width, requested_height, ovi.base_width, ovi.base_height);
+		     " > %" PRIu32 "x%" PRIu32 " (canvas: %s)",
+		     encoder_index, requested_width, requested_height, width, height,
+		     view_name ? view_name : "obs_base");
 	}
 
 	obs_encoder_set_scaled_size(video_encoder, requested_width, requested_height);
@@ -231,7 +234,8 @@ static bool encoder_available(const char *type)
 }
 
 static OBSEncoderAutoRelease create_video_encoder(DStr &name_buffer, size_t encoder_index,
-						  const GoLiveApi::VideoEncoderConfiguration &encoder_config)
+						  const GoLiveApi::VideoEncoderConfiguration &encoder_config,
+						  const std::map<std::string, video_t *> &extra_views)
 {
 	auto encoder_type = encoder_config.type.c_str();
 	if (!encoder_available(encoder_type)) {
@@ -251,17 +255,31 @@ static OBSEncoderAutoRelease create_video_encoder(DStr &name_buffer, size_t enco
 		throw MultitrackVideoError::warning(
 			QTStr("FailedToStartStream.FailedToCreateVideoEncoder").arg(name_buffer->array, encoder_type));
 	}
-	obs_encoder_set_video(video_encoder, obs_get_video());
 
-	obs_video_info ovi;
-	if (!obs_get_video_info(&ovi)) {
+	obs_video_info ovi_storage;
+	if (!obs_get_video_info(&ovi_storage)) {
 		blog(LOG_WARNING, "Failed to get obs_video_info while creating encoder %zu", encoder_index);
 		throw MultitrackVideoError::warning(
 			QTStr("FailedToStartStream.FailedToGetOBSVideoInfo").arg(name_buffer->array, encoder_type));
 	}
+	obs_video_info *ovi = &ovi_storage;
 
-	adjust_video_encoder_scaling(ovi, video_encoder, encoder_config, encoder_index);
-	adjust_encoder_frame_rate_divisor(ovi, video_encoder, encoder_config, encoder_index);
+	const char *view_name = nullptr;
+	video_t *video = nullptr;
+	if (encoder_config.view.has_value()) {
+		view_name = encoder_config.view->c_str();
+		auto it = extra_views.find(view_name);
+		if (it != extra_views.end()) {
+			video = it->second;
+			ovi = nullptr;
+		}
+	}
+
+	obs_encoder_set_video(video_encoder, video ? video : obs_get_video());
+
+	auto voi = video ? video_output_get_info(video) : nullptr;
+	adjust_video_encoder_scaling(view_name, ovi, voi, video_encoder, encoder_config, encoder_index);
+	adjust_encoder_frame_rate_divisor(ovi_storage, video_encoder, encoder_config, encoder_index);
 
 	return video_encoder;
 }
@@ -288,7 +306,8 @@ static OBSOutputs SetupOBSOutput(QWidget *parent, const QString &multitrack_vide
 				 std::vector<OBSEncoderAutoRelease> &audio_encoders,
 				 std::shared_ptr<obs_encoder_group_t> &video_encoder_group,
 				 const char *audio_encoder_id, size_t main_audio_mixer,
-				 std::optional<size_t> vod_track_mixer);
+				 std::optional<size_t> vod_track_mixer,
+				 const std::map<std::string, video_t *> &extra_views);
 static void SetupSignalHandlers(bool recording, MultitrackVideoOutput *self, obs_output_t *output, OBSSignal &start,
 				OBSSignal &stop, OBSSignal &deactivate);
 
@@ -340,13 +359,21 @@ void MultitrackVideoOutput::PrepareStreaming(
 	     rtmp_url.has_value() ? rtmp_url->c_str() : "",
 	     vod_track_info_storage->array ? vod_track_info_storage->array : "No");
 
+	auto extra_views = std::make_shared<ExtraViewsGuard>();
+	for (auto &video_output : OBSBasic::Get()->GetAdditionalMultitrackVideoViews()) {
+		video_t *video = video_output.start_video(video_output.param);
+		if (!video)
+			continue;
+		extra_views->views_[video_output.name] = video;
+	}
+
 	const bool custom_config_only = auto_config_url.isEmpty() && MultitrackVideoDeveloperModeEnabled() &&
 					custom_config.has_value() &&
 					strcmp(obs_service_get_id(service), "rtmp_custom") == 0;
 
 	if (!custom_config_only) {
 		auto go_live_post = constructGoLivePost(stream_key, maximum_aggregate_bitrate, maximum_video_tracks,
-							vod_track_mixer.has_value());
+							vod_track_mixer.has_value(), extra_views->views_);
 
 		go_live_config = DownloadGoLiveConfig(parent, auto_config_url, go_live_post, multitrack_video_name);
 	}
@@ -389,7 +416,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 	std::shared_ptr<obs_encoder_group_t> video_encoder_group;
 	auto outputs = SetupOBSOutput(parent, multitrack_video_name, dump_stream_to_file_config, output_config,
 				      audio_encoders, video_encoder_group, audio_encoder_id, main_audio_mixer,
-				      vod_track_mixer);
+				      vod_track_mixer, extra_views->views_);
 	auto output = std::move(outputs.output);
 	auto recording_output = std::move(outputs.recording_output);
 	if (!output)
@@ -434,6 +461,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 				std::move(start_recording),
 				std::move(stop_recording),
 				std::move(deactivate_recording),
+				extra_views,
 			});
 		}
 	}
@@ -447,6 +475,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 		std::move(start_streaming),
 		std::move(stop_streaming),
 		std::move(deactivate_stream),
+		extra_views,
 	});
 }
 
@@ -584,7 +613,7 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 
 static bool create_video_encoders(const GoLiveApi::Config &go_live_config,
 				  std::shared_ptr<obs_encoder_group_t> &video_encoder_group, obs_output_t *output,
-				  obs_output_t *recording_output)
+				  obs_output_t *recording_output, const std::map<std::string, video_t *> &extra_views)
 {
 	DStr video_encoder_name_buffer;
 	if (go_live_config.encoder_configurations.empty()) {
@@ -597,8 +626,8 @@ static bool create_video_encoders(const GoLiveApi::Config &go_live_config,
 		return false;
 
 	for (size_t i = 0; i < go_live_config.encoder_configurations.size(); i++) {
-		auto encoder =
-			create_video_encoder(video_encoder_name_buffer, i, go_live_config.encoder_configurations[i]);
+		auto encoder = create_video_encoder(video_encoder_name_buffer, i,
+						    go_live_config.encoder_configurations[i], extra_views);
 		if (!encoder)
 			return false;
 
@@ -759,14 +788,15 @@ static OBSOutputs SetupOBSOutput(QWidget *parent, const QString &multitrack_vide
 				 std::vector<OBSEncoderAutoRelease> &audio_encoders,
 				 std::shared_ptr<obs_encoder_group_t> &video_encoder_group,
 				 const char *audio_encoder_id, size_t main_audio_mixer,
-				 std::optional<size_t> vod_track_mixer)
+				 std::optional<size_t> vod_track_mixer,
+				 const std::map<std::string, video_t *> &extra_views)
 {
 	auto output = create_output();
 	OBSOutputAutoRelease recording_output;
 	if (dump_stream_to_file_config)
 		recording_output = create_recording_output(dump_stream_to_file_config);
 
-	if (!create_video_encoders(go_live_config, video_encoder_group, output, recording_output))
+	if (!create_video_encoders(go_live_config, video_encoder_group, output, recording_output, extra_views))
 		return {nullptr, nullptr};
 
 	std::vector<speaker_layout> requested_speaker_layouts;
@@ -875,4 +905,17 @@ void RecordingDeactivateHandler(void *arg, calldata_t * /*data*/)
 {
 	auto self = static_cast<MultitrackVideoOutput *>(arg);
 	MultitrackVideoOutput::ReleaseOnMainThread(self->take_current_stream_dump());
+}
+
+MultitrackVideoOutput::ExtraViewsGuard::~ExtraViewsGuard()
+{
+	auto additional_views = OBSBasic::Get()->GetAdditionalMultitrackVideoViews();
+	for (auto &view : views_) {
+		for (auto &v : additional_views) {
+			if (v.name != view.first)
+				continue;
+
+			v.stop_video(view.second, v.param);
+		}
+	}
 }

--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -361,7 +361,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 
 	auto extra_views = std::make_shared<ExtraViewsGuard>();
 	for (auto &video_output : OBSBasic::Get()->GetAdditionalMultitrackVideoViews()) {
-		video_t *video = video_output.start_video(video_output.param);
+		video_t *video = video_output.start_video(video_output.name.c_str(), video_output.param);
 		if (!video)
 			continue;
 		extra_views->views_[video_output.name] = video;
@@ -915,7 +915,7 @@ MultitrackVideoOutput::ExtraViewsGuard::~ExtraViewsGuard()
 			if (v.name != view.first)
 				continue;
 
-			v.stop_video(view.second, v.param);
+			v.stop_video(v.name.c_str(), view.second, v.param);
 		}
 	}
 }

--- a/UI/multitrack-video-output.hpp
+++ b/UI/multitrack-video-output.hpp
@@ -44,12 +44,19 @@ public:
 	}
 
 private:
+	struct ExtraViewsGuard {
+		std::map<std::string, video_t *> views_;
+
+		~ExtraViewsGuard();
+	};
+
 	struct OBSOutputObjects {
 		OBSOutputAutoRelease output_;
 		std::shared_ptr<obs_encoder_group_t> video_encoder_group_;
 		std::vector<OBSEncoderAutoRelease> audio_encoders_;
 		OBSServiceAutoRelease multitrack_video_service_;
 		OBSSignal start_signal, stop_signal, deactivate_signal;
+		std::shared_ptr<ExtraViewsGuard> extra_views_;
 	};
 
 	std::optional<OBSOutputObjects> take_current();

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -599,10 +599,10 @@ void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo
 }
 
 void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-					    multitrack_video_stop_cb stop_video, void *param)
+					    multitrack_video_stop_cb stop_video, void *private_data)
 {
 	if (callbacks_valid())
-		c->obs_frontend_multitrack_video_register(name, start_video, stop_video, param);
+		c->obs_frontend_multitrack_video_register(name, start_video, stop_video, private_data);
 }
 
 void obs_frontend_multitrack_video_unregister(const char *name)

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -597,3 +597,16 @@ void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo
 	if (callbacks_valid())
 		c->obs_frontend_add_undo_redo_action(name, undo, redo, undo_data, redo_data, repeatable);
 }
+
+void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
+					    multitrack_video_stop_cb stop_video, void *param)
+{
+	if (callbacks_valid())
+		c->obs_frontend_multitrack_video_register(name, start_video, stop_video, param);
+}
+
+void obs_frontend_multitrack_video_unregister(const char *name)
+{
+	if (callbacks_valid())
+		c->obs_frontend_multitrack_video_unregister(name);
+}

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -598,8 +598,8 @@ void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo
 		c->obs_frontend_add_undo_redo_action(name, undo, redo, undo_data, redo_data, repeatable);
 }
 
-void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-					    multitrack_video_stop_cb stop_video, void *private_data)
+void obs_frontend_multitrack_video_register(const char *name, obs_frontend_multitrack_video_start_cb start_video,
+					    obs_frontend_multitrack_video_stop_cb stop_video, void *private_data)
 {
 	if (callbacks_valid())
 		c->obs_frontend_multitrack_video_register(name, start_video, stop_video, private_data);

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -238,8 +238,8 @@ typedef void (*undo_redo_cb)(const char *data);
 EXPORT void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					      const char *undo_data, const char *redo_data, bool repeatable);
 
-typedef video_t *(*obs_frontend_multitrack_video_start_cb)(void *private_data);
-typedef void (*obs_frontend_multitrack_video_stop_cb)(video_t *video, void *private_data);
+typedef video_t *(*obs_frontend_multitrack_video_start_cb)(const char *name, void *private_data);
+typedef void (*obs_frontend_multitrack_video_stop_cb)(const char *name, video_t *video, void *private_data);
 EXPORT void obs_frontend_multitrack_video_register(const char *name, obs_frontend_multitrack_video_start_cb start_video,
 						   obs_frontend_multitrack_video_stop_cb stop_video,
 						   void *private_data);

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -238,6 +238,12 @@ typedef void (*undo_redo_cb)(const char *data);
 EXPORT void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					      const char *undo_data, const char *redo_data, bool repeatable);
 
+typedef video_t *(*multitrack_video_start_cb)(void *param);
+typedef void (*multitrack_video_stop_cb)(video_t *video, void *param);
+EXPORT void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
+						   multitrack_video_stop_cb stop_video, void *param);
+EXPORT void obs_frontend_multitrack_video_unregister(const char *name);
+
 /* ------------------------------------------------------------------------- */
 
 #ifdef __cplusplus

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -238,10 +238,11 @@ typedef void (*undo_redo_cb)(const char *data);
 EXPORT void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					      const char *undo_data, const char *redo_data, bool repeatable);
 
-typedef video_t *(*multitrack_video_start_cb)(void *private_data);
-typedef void (*multitrack_video_stop_cb)(video_t *video, void *private_data);
-EXPORT void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-						   multitrack_video_stop_cb stop_video, void *private_data);
+typedef video_t *(*obs_frontend_multitrack_video_start_cb)(void *private_data);
+typedef void (*obs_frontend_multitrack_video_stop_cb)(video_t *video, void *private_data);
+EXPORT void obs_frontend_multitrack_video_register(const char *name, obs_frontend_multitrack_video_start_cb start_video,
+						   obs_frontend_multitrack_video_stop_cb stop_video,
+						   void *private_data);
 EXPORT void obs_frontend_multitrack_video_unregister(const char *name);
 
 /* ------------------------------------------------------------------------- */

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -238,10 +238,10 @@ typedef void (*undo_redo_cb)(const char *data);
 EXPORT void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					      const char *undo_data, const char *redo_data, bool repeatable);
 
-typedef video_t *(*multitrack_video_start_cb)(void *param);
-typedef void (*multitrack_video_stop_cb)(video_t *video, void *param);
+typedef video_t *(*multitrack_video_start_cb)(void *private_data);
+typedef void (*multitrack_video_stop_cb)(video_t *video, void *private_data);
 EXPORT void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-						   multitrack_video_stop_cb stop_video, void *param);
+						   multitrack_video_stop_cb stop_video, void *private_data);
 EXPORT void obs_frontend_multitrack_video_unregister(const char *name);
 
 /* ------------------------------------------------------------------------- */

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -138,8 +138,9 @@ struct obs_frontend_callbacks {
 						       const undo_redo_cb redo, const char *undo_data,
 						       const char *redo_data, bool repeatable) = 0;
 
-	virtual void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-							    multitrack_video_stop_cb stop_video,
+	virtual void obs_frontend_multitrack_video_register(const char *name,
+							    obs_frontend_multitrack_video_start_cb start_video,
+							    obs_frontend_multitrack_video_stop_cb stop_video,
 							    void *private_data) = 0;
 	virtual void obs_frontend_multitrack_video_unregister(const char *name) = 0;
 };

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -137,6 +137,10 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo,
 						       const undo_redo_cb redo, const char *undo_data,
 						       const char *redo_data, bool repeatable) = 0;
+
+	virtual void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
+							    multitrack_video_stop_cb stop_video, void *param) = 0;
+	virtual void obs_frontend_multitrack_video_unregister(const char *name) = 0;
 };
 
 EXPORT void obs_frontend_set_callbacks_internal(obs_frontend_callbacks *callbacks);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -139,7 +139,8 @@ struct obs_frontend_callbacks {
 						       const char *redo_data, bool repeatable) = 0;
 
 	virtual void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video,
-							    multitrack_video_stop_cb stop_video, void *param) = 0;
+							    multitrack_video_stop_cb stop_video,
+							    void *private_data) = 0;
 	virtual void obs_frontend_multitrack_video_unregister(const char *name) = 0;
 };
 

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -388,8 +388,9 @@ bool AutoConfigStreamPage::validatePage()
 		wiz->testMultitrackVideo = ui->useMultitrackVideo->isChecked();
 
 		if (wiz->testMultitrackVideo) {
+			std::map<std::string, video_t *> extra_views;
 			auto postData = constructGoLivePost(QString::fromStdString(wiz->key), std::nullopt,
-							    std::nullopt, false);
+							    std::nullopt, false, extra_views);
 
 			OBSDataAutoRelease service_settings = obs_service_get_settings(service);
 			auto multitrack_video_name = QTStr("Basic.Settings.Stream.MultitrackVideoLabel");

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10103,10 +10103,10 @@ const std::vector<MultitrackVideoViewInfo> &OBSBasic::GetAdditionalMultitrackVid
 }
 
 void OBSBasic::MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
-				       multitrack_video_stop_cb stop_video, void *param)
+				       multitrack_video_stop_cb stop_video, void *private_data)
 {
 	MultitrackVideoUnregister(name);
-	multitrackVideoViews.push_back({name, start_video, stop_video, param});
+	multitrackVideoViews.push_back({name, start_video, stop_video, private_data});
 }
 
 void OBSBasic::MultitrackVideoUnregister(const char *name)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10097,6 +10097,29 @@ QColor OBSBasic::GetSelectionColor() const
 	}
 }
 
+const std::vector<MultitrackVideoViewInfo> &OBSBasic::GetAdditionalMultitrackVideoViews()
+{
+	return multitrackVideoViews;
+}
+
+void OBSBasic::MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
+				       multitrack_video_stop_cb stop_video, void *param)
+{
+	MultitrackVideoUnregister(name);
+	multitrackVideoViews.push_back({name, start_video, stop_video, param});
+}
+
+void OBSBasic::MultitrackVideoUnregister(const char *name)
+{
+	for (auto it = multitrackVideoViews.begin(); it != multitrackVideoViews.end();) {
+		if (it->name == name) {
+			it = multitrackVideoViews.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
 QColor OBSBasic::GetCropColor() const
 {
 	if (config_get_bool(App()->GetUserConfig(), "Accessibility", "OverrideColors")) {

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -10102,8 +10102,8 @@ const std::vector<MultitrackVideoViewInfo> &OBSBasic::GetAdditionalMultitrackVid
 	return multitrackVideoViews;
 }
 
-void OBSBasic::MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
-				       multitrack_video_stop_cb stop_video, void *private_data)
+void OBSBasic::MultitrackVideoRegister(const char *name, obs_frontend_multitrack_video_start_cb start_video,
+				       obs_frontend_multitrack_video_stop_cb stop_video, void *private_data)
 {
 	MultitrackVideoUnregister(name);
 	multitrackVideoViews.push_back({name, start_video, stop_video, private_data});

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -176,8 +176,8 @@ private:
 
 struct MultitrackVideoViewInfo {
 	std::string name;
-	multitrack_video_start_cb start_video = nullptr;
-	multitrack_video_stop_cb stop_video = nullptr;
+	obs_frontend_multitrack_video_start_cb start_video = nullptr;
+	obs_frontend_multitrack_video_stop_cb stop_video = nullptr;
 	void *param = nullptr;
 };
 
@@ -894,8 +894,8 @@ private:
 
 	float dpi = 1.0;
 
-	void MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
-				     multitrack_video_stop_cb stop_video, void *private_data);
+	void MultitrackVideoRegister(const char *name, obs_frontend_multitrack_video_start_cb start_video,
+				     obs_frontend_multitrack_video_stop_cb stop_video, void *private_data);
 	void MultitrackVideoUnregister(const char *name);
 
 public:

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -174,6 +174,13 @@ private:
 	std::unique_ptr<Ui::ColorSelect> ui;
 };
 
+struct MultitrackVideoViewInfo {
+	std::string name;
+	multitrack_video_start_cb start_video = nullptr;
+	multitrack_video_stop_cb stop_video = nullptr;
+	void *param = nullptr;
+};
+
 class OBSBasic : public OBSMainWindow {
 	Q_OBJECT
 	Q_PROPERTY(QIcon imageIcon READ GetImageIcon WRITE SetImageIcon DESIGNABLE true)
@@ -242,6 +249,8 @@ private:
 	std::vector<VolControl *> volumes;
 
 	std::vector<OBSSignal> signalHandlers;
+
+	std::vector<MultitrackVideoViewInfo> multitrackVideoViews;
 
 	QList<QPointer<QDockWidget>> oldExtraDocks;
 	QStringList oldExtraDockNames;
@@ -885,6 +894,10 @@ private:
 
 	float dpi = 1.0;
 
+	void MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
+				     multitrack_video_stop_cb stop_video, void *param);
+	void MultitrackVideoUnregister(const char *name);
+
 public:
 	OBSSource GetProgramSource();
 	OBSScene GetCurrentScene();
@@ -1017,6 +1030,8 @@ public:
 
 	QColor GetSelectionColor() const;
 	inline bool Closing() { return closing; }
+
+	const std::vector<MultitrackVideoViewInfo> &GetAdditionalMultitrackVideoViews();
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -895,7 +895,7 @@ private:
 	float dpi = 1.0;
 
 	void MultitrackVideoRegister(const char *name, multitrack_video_start_cb start_video,
-				     multitrack_video_stop_cb stop_video, void *param);
+				     multitrack_video_stop_cb stop_video, void *private_data);
 	void MultitrackVideoUnregister(const char *name);
 
 public:

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -239,11 +239,11 @@ Structures/Enumerations
 
    Undo redo callback
 
-.. type:: video_t *(*multitrack_video_start_cb)(void *private_data)
+.. type:: video_t *(*obs_frontend_multitrack_video_start_cb)(const char *name, void *private_data)
 
    Multitrack video start callback
 
-.. type:: void (*multitrack_video_stop_cb)(video_t *video, void *private_data)
+.. type:: void (*obs_frontend_multitrack_video_stop_cb)(const char *name, video_t *video, void *private_data)
 
    Multitrack video stop callback
 
@@ -983,7 +983,7 @@ Functions
 
 ---------------------------------------
 
-.. function:: void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video, multitrack_video_stop_cb stop_video, void *private_data)
+.. function:: void obs_frontend_multitrack_video_register(const char *name, obs_frontend_multitrack_video_start_cb start_video, obs_frontend_multitrack_video_stop_cb stop_video, void *private_data)
 
    :param name: Name to register
    :param start_video: Callback to get video to use

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -239,11 +239,11 @@ Structures/Enumerations
 
    Undo redo callback
 
-.. type:: video_t *(*multitrack_video_start_cb)(void *param)
+.. type:: video_t *(*multitrack_video_start_cb)(void *private_data)
 
    Multitrack video start callback
 
-.. type:: void (*multitrack_video_stop_cb)(video_t *video, void *param)
+.. type:: void (*multitrack_video_stop_cb)(video_t *video, void *private_data)
 
    Multitrack video stop callback
 
@@ -983,7 +983,7 @@ Functions
 
 ---------------------------------------
 
-.. function:: void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video, multitrack_video_stop_cb stop_video, void *param)
+.. function:: void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video, multitrack_video_stop_cb stop_video, void *private_data)
 
    :param name: Name to register
    :param start_video: Callback to get video to use

--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -239,6 +239,14 @@ Structures/Enumerations
 
    Undo redo callback
 
+.. type:: video_t *(*multitrack_video_start_cb)(void *param)
+
+   Multitrack video start callback
+
+.. type:: void (*multitrack_video_stop_cb)(video_t *video, void *param)
+
+   Multitrack video stop callback
+
 
 Functions
 ---------
@@ -972,3 +980,22 @@ Functions
                       This uses the undo action from the first and the redo action from the last action.
 
    .. versionadded:: 29.1
+
+---------------------------------------
+
+.. function:: void obs_frontend_multitrack_video_register(const char *name, multitrack_video_start_cb start_video, multitrack_video_stop_cb stop_video, void *param)
+
+   :param name: Name to register
+   :param start_video: Callback to get video to use
+   :param stop_video: Callback to stop usage of video
+   :param param: Param for the start video and stop video callbacks
+
+   .. versionadded:: 30.2
+
+---------------------------------------
+
+.. function:: void obs_frontend_multitrack_video_unregister(const char *name)
+
+   :param name: name to unregister
+
+   .. versionadded:: 30.2


### PR DESCRIPTION
### Description
Adds frontend API calls to allow plugins to register additional canvases/video outputs that will participate in multitrack video configuration generation and multitrack video streams

### Motivation and Context
Currently additional views/canvases have to use separate rtmp connections or similar to be streamed, where the multitrack video output allows both multiple renditions of the same view and also different views to be streamed

### How Has This Been Tested?
Twitch Enhanced Broadcasting beta

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
