### PR TITLE
UI: Give private spacing helper sources names

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <graphics/vec4.h>
 #include <graphics/matrix4.h>
+#include <util/dstr.hpp>
 #include "window-basic-preview.hpp"
 #include "window-basic-main.hpp"
 #include "obs-app.hpp"
@@ -2331,7 +2332,7 @@ OBSBasicPreview *OBSBasicPreview::Get()
 	return OBSBasic::Get()->ui->preview;
 }
 
-static obs_source_t *CreateLabel(float pixelRatio)
+static obs_source_t *CreateLabel(float pixelRatio, int i)
 {
 	OBSDataAutoRelease settings = obs_data_create();
 	OBSDataAutoRelease font = obs_data_create();
@@ -2357,7 +2358,9 @@ static obs_source_t *CreateLabel(float pixelRatio)
 	const char *text_source_id = "text_ft2_source";
 #endif
 
-	return obs_source_create_private(text_source_id, NULL, settings);
+	DStr name;
+	dstr_printf(name, "Preview spacing label %d", i);
+	return obs_source_create_private(text_source_id, name, settings);
 }
 
 static void SetLabelText(int sourceIndex, int px)
@@ -2639,7 +2642,7 @@ void OBSBasicPreview::DrawSpacingHelpers()
 	float pixelRatio = main->GetDevicePixelRatio();
 	for (int i = 0; i < 4; i++) {
 		if (!spacerLabel[i])
-			spacerLabel[i] = CreateLabel(pixelRatio);
+			spacerLabel[i] = CreateLabel(pixelRatio, i);
 	}
 
 	vec3_set(&start, top.x, 0.0f, 1.0f);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Gives names to the spacing helper label private text sources in the preview, to make the log a bit nicer.

If people think the `dstr` is overkill (I'm a bit torn on that) I'd also be happy to change it to a generic `Preview spacing label` instead.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When you click on a scene item for the first time in a program run, you get this log:
```
debug: private source '(null)' (text_ft2_source) created
debug: private source '(null)' (text_ft2_source) created
debug: private source '(null)' (text_ft2_source) created
debug: private source '(null)' (text_ft2_source) created
```

While this obviously isn't a huge issue I think it's nicer to have debug lines that actually say something, so with this PR you get this:
```
debug: private source 'Preview spacing label 0' (text_ft2_source) created
debug: private source 'Preview spacing label 1' (text_ft2_source) created
debug: private source 'Preview spacing label 2' (text_ft2_source) created
debug: private source 'Preview spacing label 3' (text_ft2_source) created
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.4.1
Ran OBS, clicked a scene item. Observed the log above.
Also created a normal source called `Preview spacing label 0` to be 100% sure that the private source names don't cause collisions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
