### PR TITLE
libobs: Save default values in obs_data JSON serialisation

### DIFF
--- a/libobs/obs-data.c
+++ b/libobs/obs-data.c
@@ -593,9 +593,6 @@ static json_t *obs_data_to_json(obs_data_t *data)
 		enum obs_data_type type = obs_data_item_gettype(item);
 		const char *name = get_item_name(item);
 
-		if (!obs_data_item_has_user_value(item))
-			continue;
-
 		if (type == OBS_DATA_STRING)
 			set_json_string(json, name, item);
 		else if (type == OBS_DATA_NUMBER)


### PR DESCRIPTION
### Description

Serialise default values when converting `obs_data` to JSON.

### Motivation and Context

Pretty much the same as #8205, if we change defaults we have to write migration code and sometimes try to infer what the default should have been to explicitly set it, if we just save the defaults at the time the user created the config in the first place we don't have to worry about it.

### How Has This Been Tested?

Ran OBS, played around, seems to work fine.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
