### PR TITLE
libobs & obs-ffmpeg: Surround sound fixes

### DIFF
--- a/libobs/media-io/media-remux.c
+++ b/libobs/media-io/media-remux.c
@@ -158,10 +158,23 @@ static inline bool init_output(media_remux_job_t job, const char *out_filename)
 			out_stream->codecpar->channel_layout =
 				av_get_default_channel_layout(
 					in_stream->codecpar->channels);
+			/* The avutil default channel layout for 5 channels is
+			 * 5.0, which OBS does not support. Manually set 5
+			 * channels to 4.1. */
+			if (in_stream->codecpar->channels == 5)
+				out_stream->codecpar->channel_layout =
+					av_get_channel_layout("4.1");
 #else
 			av_channel_layout_default(
 				&out_stream->codecpar->ch_layout,
 				in_stream->codecpar->ch_layout.nb_channels);
+			/* The avutil default channel layout for 5 channels is
+			 * 5.0, which OBS does not support. Manually set 5
+			 * channels to 4.1. */
+			if (in_stream->codecpar->ch_layout.nb_channels == 5)
+				out_stream->codecpar->ch_layout =
+					(AVChannelLayout)
+						AV_CHANNEL_LAYOUT_4POINT1;
 #endif
 		}
 	}

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -271,12 +271,21 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 #else
 	av_channel_layout_default(&enc->context->ch_layout,
 				  (int)audio_output_get_channels(audio));
+	/* The avutil default channel layout for 5 channels is 5.0, which OBS
+	 * does not support. Manually set 5 channels to 4.1. */
 	if (aoi->speakers == SPEAKERS_4POINT1)
 		enc->context->ch_layout =
 			(AVChannelLayout)AV_CHANNEL_LAYOUT_4POINT1;
+	/* AAC, ALAC, & FLAC default to 3.0 for 3 channels instead of 2.1.
+	 * Tell the encoder to deal with 2.1 as if it were 3.0. */
 	if (aoi->speakers == SPEAKERS_2POINT1)
 		enc->context->ch_layout =
 			(AVChannelLayout)AV_CHANNEL_LAYOUT_SURROUND;
+	// ALAC supports 7.1 wide instead of regular 7.1.
+	if (aoi->speakers == SPEAKERS_7POINT1 &&
+	    astrcmpi(enc->type, "alac") == 0)
+		enc->context->ch_layout =
+			(AVChannelLayout)AV_CHANNEL_LAYOUT_7POINT1_WIDE_BACK;
 #endif
 
 	enc->context->sample_rate = audio_output_get_sample_rate(audio);


### PR DESCRIPTION
### Description
This fixes two bugs with surround sound (blame Rodney !).
(1)
Commit [1] added ALAC & PCM support.
But 7.1 ALAC encoding fails.
This fixes the issue by assigning the correct 7.1 layout supported by FFmpeg ALAC encoder (7.1(wide)).

[1] https://github.com/obsproject/obs-studio/commit/3ae98511d09f1ebaf5c9cc005a285efd1a26aeff

(2) This commit [2] uses the av_channel_layout_default & av_get_default_channel_layout which set 5.0
as layout for 5 audio channels; but obs sets 4.1 speaker layout for 5 channels.
The second commit of this PR fixes that.

[2] https://github.com/obsproject/obs-studio/commit/567e35ac693ca0e97e0e74d4f7649fea7501d3ad

### Motivation and Context
Fix a bug.
I came upon this bug while reviewing Rodney's hybrid mp4 muxer.
https://github.com/obsproject/obs-studio/pull/10608
The bug is due to the fact that FFmpeg ALAC encoder uses 7.1(wide) layout which changes the back speakers
to side ones.
@derrod  pointed out then that probably his commit [2] above would need some fixing.
@norihiro also suggested that there might be fixes needed elsewhere.
That was a correct expectation.

### How Has This Been Tested?
There's no error popup anymore, the recording works fine.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
