### PR TITLE
libobs: Add missing encoder API functions

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -591,6 +591,20 @@ obs_data_t *obs_encoder_get_settings(const obs_encoder_t *encoder)
 	return encoder->context.settings;
 }
 
+signal_handler_t *obs_encoder_get_signal_handler(const obs_encoder_t *encoder)
+{
+	return obs_encoder_valid(encoder, "obs_encoder_get_signal_handler")
+			? encoder->context.signals
+			: NULL;
+}
+
+proc_handler_t *obs_encoder_get_proc_handler(const obs_encoder_t *encoder)
+{
+	return obs_encoder_valid(encoder, "obs_encoder_get_proc_handler")
+			? encoder->context.procs
+			: NULL;
+}
+
 static inline void reset_audio_buffers(struct obs_encoder *encoder)
 {
 	free_audio_buffers(encoder);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2546,6 +2546,14 @@ EXPORT bool obs_encoder_get_extra_data(const obs_encoder_t *encoder,
 /** Returns the current settings for this encoder */
 EXPORT obs_data_t *obs_encoder_get_settings(const obs_encoder_t *encoder);
 
+/** Returns the signal handler for the encoder */
+EXPORT signal_handler_t *obs_encoder_get_signal_handler(const obs_encoder_t
+								*encoder);
+
+/** Returns the procedure handler for the encoder */
+EXPORT proc_handler_t *obs_encoder_get_proc_handler(const obs_encoder_t
+							    *encoder);
+
 /** Sets the video output context to be used with this encoder */
 EXPORT void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video);
 


### PR DESCRIPTION
### Description
Adds the API functions `obs_encoder_get_signal_handler` and `obs_encoder_get_proc_handler`, both of which are mentioned in the API docs but are not actually implemented in the API. Encoders don't use signals for anything, but it was easy enough to include that I didn't see a reason not to.

### Motivation and Context
Was attempting to create a plugin, found `obs_encoder_get_proc_handler` did not actually exist, decided to make a PR to fix that since it's an easy fix.

### How Has This Been Tested?
Created an encoder in a plugin's load function, used function to get its encoder, and found it did correctly return the encoder's proc handler.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
