### PR TITLE
libobs, plugins: Remove unnecessary output implementation calls

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -912,6 +912,9 @@ Functions used by outputs
    :param flags: Reserved. Set this to 0.
    :return:      *true* if data capture can begin
 
+.. deprecated:: 30.2.0
+   Usage is no longer necessary.
+
 ---------------------
 
 .. function:: bool obs_output_initialize_encoders(obs_output_t *output, int flags)
@@ -923,6 +926,9 @@ Functions used by outputs
    :param output: The output
    :param flags: Reserved. Set this to 0.
    :return:      *true* if successful, *false* otherwise
+
+.. deprecated:: 30.2.0
+   Usage is no longer necessary.
 
 ---------------------
 

--- a/libobs/obs-output-delay.c
+++ b/libobs/obs-output-delay.c
@@ -144,24 +144,11 @@ bool obs_output_delay_start(obs_output_t *output)
 		.ts = os_gettime_ns(),
 	};
 
-	if (!delay_active(output)) {
-		bool can_begin = obs_output_can_begin_data_capture(output, 0);
-		if (!can_begin)
-			return false;
-		if (!obs_output_initialize_encoders(output, 0))
-			return false;
-	}
-
 	pthread_mutex_lock(&output->delay_mutex);
 	deque_push_back(&output->delay_data, &dd, sizeof(dd));
 	pthread_mutex_unlock(&output->delay_mutex);
 
 	os_atomic_inc_long(&output->delay_restart_refs);
-
-	if (delay_active(output)) {
-		do_output_signal(output, "starting");
-		return true;
-	}
 
 	if (!obs_output_begin_data_capture(output, 0)) {
 		obs_output_cleanup_delay(output);

--- a/libobs/obs-output-delay.c
+++ b/libobs/obs-output-delay.c
@@ -137,17 +137,6 @@ void process_delay(void *data, struct encoder_packet *packet)
 		;
 }
 
-void obs_output_signal_delay(obs_output_t *output, const char *signal)
-{
-	struct calldata params;
-	uint8_t stack[128];
-
-	calldata_init_fixed(&params, stack, sizeof(stack));
-	calldata_set_ptr(&params, "output", output);
-	calldata_set_int(&params, "sec", output->active_delay_ns / 1000000000);
-	signal_handler_signal(output->context.signals, signal, &params);
-}
-
 bool obs_output_delay_start(obs_output_t *output)
 {
 	struct delay_data dd = {

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -366,6 +366,10 @@ bool obs_output_actual_start(obs_output_t *output)
 	return success;
 }
 
+static bool can_begin_data_capture(const struct obs_output *output);
+static inline bool initialize_audio_encoders(obs_output_t *output);
+static inline bool initialize_video_encoders(obs_output_t *output);
+
 bool obs_output_start(obs_output_t *output)
 {
 	if (!obs_output_valid(output, "obs_output_start"))
@@ -378,11 +382,22 @@ bool obs_output_start(obs_output_t *output)
 	      obs_service_initialize(output->service, output)))
 		return false;
 
-	if (!obs_output_can_begin_data_capture(output, 0))
-		return false;
+	/* this block of logic is likely flawed. please investigate! */
+	if (!delay_active(output)) {
+		if (active(output))
+			return false;
+		if (data_capture_ending(output))
+			pthread_join(output->end_data_capture_thread, NULL);
+		if (!can_begin_data_capture(output))
+			return false;
+	}
 
-	if (flag_encoded(output) && !obs_output_initialize_encoders(output, 0))
-		return false;
+	if (flag_encoded(output)) {
+		if (flag_audio(output) && !initialize_audio_encoders(output))
+			return false;
+		if (flag_video(output) && !initialize_video_encoders(output))
+			return false;
+	}
 
 	if (output->delay_sec) {
 		return obs_output_delay_start(output);

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -378,6 +378,12 @@ bool obs_output_start(obs_output_t *output)
 	      obs_service_initialize(output->service, output)))
 		return false;
 
+	if (!obs_output_can_begin_data_capture(output, 0))
+		return false;
+
+	if (flag_encoded(output) && !obs_output_initialize_encoders(output, 0))
+		return false;
+
 	if (output->delay_sec) {
 		return obs_output_delay_start(output);
 	} else {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2346,12 +2346,12 @@ obs_output_set_audio_conversion(obs_output_t *output,
 				const struct audio_convert_info *conversion);
 
 /** Returns whether data capture can begin  */
-EXPORT bool obs_output_can_begin_data_capture(const obs_output_t *output,
-					      uint32_t flags);
+OBS_DEPRECATED EXPORT bool
+obs_output_can_begin_data_capture(const obs_output_t *output, uint32_t flags);
 
 /** Initializes encoders (if any) */
-EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
-					   uint32_t flags);
+OBS_DEPRECATED EXPORT bool obs_output_initialize_encoders(obs_output_t *output,
+							  uint32_t flags);
 
 /**
  * Begins data capture from media/encoders.

--- a/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-hls-mux.c
@@ -118,11 +118,6 @@ bool ffmpeg_hls_mux_start(void *data)
 	obs_data_t *settings;
 	int keyint_sec;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
-
 	service = obs_output_get_service(stream->output);
 	if (!service)
 		return false;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -1049,10 +1049,6 @@ static bool set_config(struct ffmpeg_output *stream)
 		}
 		av_dump_format(ff_data->output, 0, NULL, 1);
 	}
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
 
 	ret = pthread_create(&stream->write_thread, NULL, write_thread, stream);
 	if (ret != 0) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -412,11 +412,6 @@ static inline bool ffmpeg_mux_start_internal(struct ffmpeg_muxer *stream,
 
 	update_encoder_settings(stream, path);
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
-
 	if (stream->is_network) {
 		obs_service_t *service;
 		service = obs_output_get_service(stream->output);
@@ -1040,11 +1035,6 @@ static void replay_buffer_destroy(void *data)
 static bool replay_buffer_start(void *data)
 {
 	struct ffmpeg_muxer *stream = data;
-
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
 
 	obs_data_t *s = obs_output_get_settings(stream->output);
 	stream->max_time = obs_data_get_int(s, "max_time_sec") * 1000000LL;

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -1212,9 +1212,6 @@ static bool try_connect(struct ffmpeg_output *output)
 
 	output->active = true;
 
-	if (!obs_output_can_begin_data_capture(output->output, 0))
-		return false;
-
 	ret = pthread_create(&output->write_thread, NULL, write_thread, output);
 	if (ret != 0) {
 		ffmpeg_log_error(LOG_WARNING, &output->ff_data,

--- a/plugins/obs-outputs/flv-output.c
+++ b/plugins/obs-outputs/flv-output.c
@@ -495,11 +495,6 @@ static bool flv_output_start(void *data)
 	obs_data_t *settings;
 	const char *path;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
-
 	stream->got_first_packet = false;
 	stream->sent_headers = false;
 	os_atomic_set_bool(&stream->stopping, false);

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -251,11 +251,6 @@ static bool mp4_output_start(void *data)
 {
 	struct mp4_output *out = data;
 
-	if (!obs_output_can_begin_data_capture(out->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(out->output, 0))
-		return false;
-
 	os_atomic_set_bool(&out->stopping, false);
 
 	/* get path */

--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -51,11 +51,6 @@ static bool null_output_start(void *data)
 {
 	struct null_output *context = data;
 
-	if (!obs_output_can_begin_data_capture(context->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(context->output, 0))
-		return false;
-
 	if (context->stop_thread_active)
 		pthread_join(context->stop_thread, NULL);
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1479,11 +1479,6 @@ static bool rtmp_stream_start(void *data)
 {
 	struct rtmp_stream *stream = data;
 
-	if (!obs_output_can_begin_data_capture(stream->output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(stream->output, 0))
-		return false;
-
 	os_atomic_set_bool(&stream->connecting, true);
 	return pthread_create(&stream->connect_thread, NULL, connect_thread,
 			      stream) == 0;

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -57,11 +57,6 @@ bool WHIPOutput::Start()
 {
 	std::lock_guard<std::mutex> l(start_stop_mutex);
 
-	if (!obs_output_can_begin_data_capture(output, 0))
-		return false;
-	if (!obs_output_initialize_encoders(output, 0))
-		return false;
-
 	if (start_stop_thread.joinable())
 		start_stop_thread.join();
 	start_stop_thread = std::thread(&WHIPOutput::StartThread, this);


### PR DESCRIPTION
### Description
Moves the initial calling of two output methods to libobs, and deprecates them:
- `obs_output_can_begin_data_capture()`
- `obs_output_initialize_encoders()`

### Motivation and Context
After noticing that every output does effectively the same thing regarding these two functions, I determined that they could actually be moved to libobs entirely without any change in behavior. This cleans up a good amount of code and opens the door for further refactors of the outputs code later down the line.

### How Has This Been Tested?
Ubuntu 22.04

Tested with every combination of:
- Starting/stopping stream
- RTMP, WHIP
- Enabling/disabling stream delay
  - Stopping both forcefully and gracefully
- Streaming to services which deny the incoming connection, causing output failure

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Documentation (a change to documentation pages)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
