### PR TITLE
libobs: Fix missing started signal upon second start of delayed output

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -3002,8 +3002,6 @@ void obs_output_signal_stop(obs_output_t *output, int code)
 		obs_output_end_data_capture_internal(output, false);
 		output_reconnect(output);
 	} else {
-		if (delay_active(output))
-			os_atomic_set_bool(&output->delay_active, false);
 		obs_output_end_data_capture(output);
 	}
 }


### PR DESCRIPTION
### Description
If an output has delay enabled and is gracefully stopped once, upon startup a second time, it will not send the `started` signal. This is due to `obs_output_signal_stop()` pre-emtively setting `delay_active` to false. It is later set to `false` in
`obs_output_end_data_capture_internal()`, so this logic is not needed anyway.

When the encoder is then started a second time, `output->delay_capturing` will still be true, resulting in `begin_delayed_capture()` returning early and not firing the `started` signal.

### Motivation and Context
I was testing other changes and measuring the various signals of outputs, and noticed that when I performed the reproduction steps above, I wasn't getting a `started` signal.

### How Has This Been Tested?
Ubuntu 22.04
WHIP output

Tested every combination of:
- starting/stopping stream
- enabling/disabling stream delay

Repro steps:
- Configure delayed RTMP stream encoder in OBS
- Enable obs-websocket debug logging
- Start stream to a server
  - You should see a `starting` then a `started` event
- Stop stream gracefully (allowing delay to play out before stopping)
- Start stream again
  - You should see a `starting` event but no `started` event

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
