### PR TITLE
cmake: Reintroduce macOS font size hack

### DIFF
--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -149,6 +149,13 @@ function(set_target_properties_obs target)
       add_custom_command(
         TARGET ${target}
         POST_BUILD
+        COMMAND /usr/bin/sed -i '' 's/--font_base_value: 10\;/--font_base_value: 12\;/'
+                "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources/themes/Yami.obt"
+        COMMENT "Patch Yami base theme to use larger default font base value on macOS")
+
+      add_custom_command(
+        TARGET ${target}
+        POST_BUILD
         COMMAND /bin/ln -fs obs-frontend-api.dylib libobs-frontend-api.1.dylib
         WORKING_DIRECTORY "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Frameworks"
         COMMENT "Create symlink for legacy obs-frontend-api")


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
eea0e3d2ccd874275f087641b0647d95502bd33c (part of https://github.com/obsproject/obs-studio/pull/9653) removed the equivalent of this as part of the theming overhaul but didn't provide a replacement (or other reasoning), resulting in text being tiny again. Let's add this back, at least until a proper solution is found.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want tiny text.
There has been chatter about potentially adding OS-specific variables or something to the theming system. This however hasn't happened and since [we're already in the deps updating phase](https://github.com/obsproject/obs-studio/pull/10654) it's likely it isn't happening. I don't want to have a beta ship with the tiny text so lets just re-add the hack.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.4.1

See the screenshot of this PR vs current master  vs OBS 30.1 (for reference).
<p>
This PR:
<img width="1340" alt="Bildschirmfoto 2024-05-10 um 20 38 31" src="https://github.com/obsproject/obs-studio/assets/59806498/fd4ce7e7-7602-4332-910b-eb7705a63edb">
Current master branch:
<img width="1340" alt="Bildschirmfoto 2024-05-10 um 20 37 51" src="https://github.com/obsproject/obs-studio/assets/59806498/7dd2db62-a93d-4134-8b40-3e08777dc44c">
30.1:
<img width="1340" alt="Bildschirmfoto 2024-05-10 um 20 36 34" src="https://github.com/obsproject/obs-studio/assets/59806498/7086c9b3-1574-40e3-bacb-70926fa7adae">
</p>

Also went through the program (in particular: Settings, About Dialog, Source Properties, Advanced Audio Properties) to confirm nothing else exploded.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
