### PR TITLE
UI: Add OS specific theme variables via prefix

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -317,6 +317,19 @@ static vector<OBSThemeVariable> ParseThemeVariables(const char *themeData)
 		OBSThemeVariable var;
 		var.name = key;
 
+#ifdef _WIN32
+		const QString osPrefix = "os_win_";
+#elif __APPLE__
+		const QString osPrefix = "os_mac_";
+#else
+		const QString osPrefix = "os_lin_";
+#endif
+
+		if (key.startsWith(osPrefix) &&
+		    key.length() > osPrefix.length()) {
+			var.name = key.sliced(osPrefix.length());
+		}
+
 		ret = cf_next_token_should_be(cfp, ":", ";", nullptr);
 		if (ret != PARSE_SUCCESS)
 			continue;


### PR DESCRIPTION
### Description
Allows for themes to define OS specific variables

### Motivation and Context
Mac OS requires a different font size in order to display the way we want. This is a general fix that allows for other OS specific styling changes

### How Has This Been Tested?
Loaded default theme and variants on Windows. Tested variable overrides in base theme and variant themes.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
