### PR TITLE
UI: Adjust font size on macOS

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -100,6 +100,9 @@
     --border_highlight: "transparent"; /* TODO: Better Accessibility focus state */
     /* TODO: Move Accessibilty Colors to Theme config system */
 
+    /* OS Fixes */
+    --os_mac_font_base_value: 12;
+
     --font_base: calc(1pt * var(--font_base_value));
     --font_small: calc(0.9pt * var(--font_base_value));
     --font_large: calc(1.1pt * var(--font_base_value));

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -28,6 +28,9 @@
     --spacing_base_value: 2;
     --padding_base_value: 0.25;
 
+    /* OS Fixes */
+    --os_mac_font_base_value: 11;
+
     --icon_base: calc(6px + var(--font_base_value));
 
     --padding_wide: calc(18px + calc(0.25 * var(--padding_base_value)));


### PR DESCRIPTION
### Description
Changes the font size on macOS to be more appropriate

Depends on #10661, supersedes #10660
Closes #10660

### Motivation and Context
10pt font is smaller on macOS than other operating systems. We increase it only on macOS

### How Has This Been Tested?
It has not

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
