### PR TITLE
libobs/util: Add seeking support to array serializer

### DIFF
--- a/docs/sphinx/reference-libobs-util-serializers.rst
+++ b/docs/sphinx/reference-libobs-util-serializers.rst
@@ -95,6 +95,9 @@ Array Output Serializer
 
 Provides an output serializer used with dynamic arrays.
 
+.. versionchanged:: 30.2
+   Array output serializer now supports seeking.
+
 .. code:: cpp
 
    #include <util/array-serializer.h>
@@ -119,6 +122,13 @@ Array Output Serializer Functions
 
 ---------------------
 
+.. function:: void array_output_serializer_reset(struct array_output_data *data)
+
+   Resets serializer without freeing data.
+
+   .. versionadded:: 30.2
+
+---------------------
 
 File Input/Output Serializers
 =============================

--- a/libobs/util/array-serializer.h
+++ b/libobs/util/array-serializer.h
@@ -25,11 +25,13 @@ extern "C" {
 
 struct array_output_data {
 	DARRAY(uint8_t) bytes;
+	size_t cur_pos;
 };
 
 EXPORT void array_output_serializer_init(struct serializer *s,
 					 struct array_output_data *data);
 EXPORT void array_output_serializer_free(struct array_output_data *data);
+EXPORT void array_output_serializer_reset(struct array_output_data *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

Adds support for the seeking functionality of the OBS serializer API to the array serializer.

Also adds a `reset` function that can be used to avoid reallocating memory when multiple things need to be serialized in one step.

### Motivation and Context

Sometimes you need to be able to seek in memory to make things easier, e.g. to write a size field after the contents have been written.

Split out from #10608 for easier review and slimming down that PR as things get merged.

### How Has This Been Tested?

Tested as part of #10608.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
