### PR TITLE
obs-outputs: Adjust HEVCDecoderConfigurationRecord for hvc1 tag

### DIFF
--- a/plugins/obs-outputs/rtmp-hevc.c
+++ b/plugins/obs-outputs/rtmp-hevc.c
@@ -852,7 +852,7 @@ size_t obs_parse_hevc_header(uint8_t **header, const uint8_t *data, size_t size)
 				OBS_HEVC_NAL_SEI_SUFFIX};
 
 			if (type == array_idx_to_type[i]) {
-				int ps_array_completeness = 0;
+				int ps_array_completeness = 1;
 				int ret = hvcc_add_nal_unit(
 					buf, len, ps_array_completeness, &hvcc,
 					i);


### PR DESCRIPTION
### Description

Sets `ps_array_completeness` when creating the HEVC Decoder Configuration Record to 1.

### Motivation and Context

The `hvc1` tag is used in Enhanced FLV/RTMP and the native MP4 muxer (#10608) because Apple for some reason does not support the more permissive `hev1` tag, and one of the requirements laid out in the specification (ISO/IEC 14496-15) is that for `hvc1` the `array_completeness` value for parameter sets needs to be `1`.

FFmpeg also just sets this to 1 if the tag is `hvc1` without any additional checks for bitstream modification and I checked playback of these files on Windows and macOS with various players and browsers so it's probably fine.

As far as I can tell this really just means that all SPS/VPS/PPS need to be inside the `HEVCDecoderConfigurationRecord` present in the `moov` atom, which is what we do anyways.

### How Has This Been Tested?

Tested as part of #10608.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
