### PR TITLE
libobs: Fix crash when mix is NULL

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -878,13 +878,13 @@ static void obs_free_video(void)
 		obs_free_video_mix(video);
 		obs->video.mixes.array[i] = NULL;
 	}
+	da_free(obs->video.mixes);
 	if (num_views > 0)
 		blog(LOG_WARNING, "Number of remaining views: %ld", num_views);
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
 	pthread_mutex_destroy(&obs->video.mixes_mutex);
 	pthread_mutex_init_value(&obs->video.mixes_mutex);
-	da_free(obs->video.mixes);
 
 	for (size_t i = 0; i < obs->video.ready_encoder_groups.num; i++) {
 		obs_weak_encoder_release(


### PR DESCRIPTION
### Description
When `obs_reset_video` is called, it calls `obs_free_video` that sets the mix to NULL here: https://github.com/obsproject/obs-studio/blob/master/libobs/obs.c#L879

### Motivation and Context
Don't like crashes when switching resolution

### How Has This Been Tested?
On windows by changing the resolution multiple times

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
