### PR TITLE
libobs: Ensure audio offsets are positive

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2063,7 +2063,7 @@ static bool initialize_interleaved_packets(struct obs_output *output)
 		}
 	}
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		if (output->audio_encoders[i]) {
+		if (output->audio_encoders[i] && audio[i]->dts > 0) {
 			output->audio_offsets[i] = audio[i]->dts;
 		}
 	}


### PR DESCRIPTION
### Description

Only set audio offset if current DTS is positive.

### Motivation and Context

DTS/PTS can be negative for "priming" samples produced by AAC/Opus encoders, currently this would result in the DTS/PTS being corrected to 0, which causes A/V desync by making the silent priming samples part of the actual presentation.

By leaving the negative DTS/PTS the FFmpeg muxer (and #10608) can correctly set the encoder delay and ensure synced playback.

### How Has This Been Tested?

Recorded a few videos of the Twitch sync test and validated that sync is now equivalent to PCM (there still seems to be one frame of delay somewhere in OBS).

![Resolve Comparison](https://github.com/obsproject/obs-studio/assets/3123295/cf9fae90-6d3e-46da-b886-45ea2b7a768b)

(Note: #10690 was included here)

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
