### PR TITLE
coreaudio-encoder: Fix pts/dts not including encoder delay

### DIFF
--- a/plugins/coreaudio-encoder/encoder.cpp
+++ b/plugins/coreaudio-encoder/encoder.cpp
@@ -112,6 +112,7 @@ struct ca_encoder {
 
 	uint64_t total_samples = 0;
 	uint64_t samples_per_second = 0;
+	uint32_t priming_samples = 0;
 
 	vector<uint8_t> extra_data;
 
@@ -595,6 +596,11 @@ static void *aac_create(obs_data_t *settings, obs_encoder_t *encoder)
 		ca->converter, kAudioConverterCurrentOutputStreamDescription,
 		&size, &out));
 
+	AudioConverterPrimeInfo primeInfo;
+	size = sizeof(primeInfo);
+	STATUS_CHECK(AudioConverterGetProperty(
+		ca->converter, kAudioConverterPrimeInfo, &size, &primeInfo));
+
 	/*
 	 * Fix channel map differences between CoreAudio AAC, FFmpeg, Wav
 	 * New channel mappings below assume 2.1, 4.0, 4.1, 5.1, 7.1 resp.
@@ -649,6 +655,7 @@ static void *aac_create(obs_data_t *settings, obs_encoder_t *encoder)
 	ca->in_bytes_required = ca->in_packets * ca->in_frame_size;
 
 	ca->out_frames_per_packet = out.mFramesPerPacket;
+	ca->priming_samples = primeInfo.leadingFrames;
 
 	ca->output_buffer_size = out.mBytesPerPacket;
 
@@ -770,8 +777,8 @@ static bool aac_encode(void *data, struct encoder_frame *frame,
 	if (!(*received_packet = packets > 0))
 		return true;
 
-	packet->pts = ca->total_samples;
-	packet->dts = ca->total_samples;
+	packet->pts = ca->total_samples - ca->priming_samples;
+	packet->dts = ca->total_samples - ca->priming_samples;
 	packet->timebase_num = 1;
 	packet->timebase_den = (uint32_t)ca->samples_per_second;
 	packet->type = OBS_ENCODER_AUDIO;

--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -79,6 +79,12 @@ struct AudioChannelLayout {
 };
 typedef struct AudioChannelLayout AudioChannelLayout;
 
+struct AudioConverterPrimeInfo {
+	UInt32 leadingFrames;
+	UInt32 trailingFrames;
+};
+typedef struct AudioConverterPrimeInfo AudioConverterPrimeInfo;
+
 typedef OSStatus (*AudioConverterComplexInputDataProc)(
 	AudioConverterRef inAudioConverter, UInt32 *ioNumberDataPackets,
 	AudioBufferList *ioData,


### PR DESCRIPTION
### Description

> [!Note]
> Requires #10689 to be fully functional as currently OBS will not treat negative audio timestamps correctly.

CoreAudio - and other AAC encoders - generally have an encoder delay that produces a number of silent "priming" samples. For CoreAudio AAC this is 2112 by default and this needs to be subtracted from the PTS/DTS to ensure that PTS 0 is the actual start of the input audio.

See Apple's documentation for a good explanation of AAC encoder delay and how to deal with it: https://web.archive.org/web/20170912012230/https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFAppenG/QTFFAppenG.html

### Motivation and Context

Want audio to be in sync.

When using FFmpeg encoders libavcodec already handles this for us. This is also already done in the libfdk-aac module: https://github.com/obsproject/obs-studio/blob/master/plugins/obs-libfdk/obs-libfdk.c#L266-L272

### How Has This Been Tested?

Validated on Windows that output DTS/PTS is now correct.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
