### PR TITLE
libobs: Include all audio priming packets if closest is start

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2063,7 +2063,7 @@ static bool initialize_interleaved_packets(struct obs_output *output)
 		}
 	}
 	for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
-		if (output->audio_encoders[i]) {
+		if (output->audio_encoders[i] && audio[i]->dts > 0) {
 			output->audio_offsets[i] = audio[i]->dts;
 		}
 	}

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -1823,7 +1823,26 @@ static size_t get_interleaved_start_idx(struct obs_output *output)
 		}
 	}
 
-	return video_idx < idx ? video_idx : idx;
+	idx = video_idx < idx ? video_idx : idx;
+
+	/* Early AAC/Opus audio packets will be for "priming" the enocder and
+	 * contain silence, but they should not be discarded. So set the idx
+	 * to the first audio packet if closest PTS was <= 0. */
+	size_t first_audio_idx = idx;
+	while (output->interleaved_packets.array[first_audio_idx].type !=
+	       OBS_ENCODER_AUDIO)
+		first_audio_idx++;
+
+	if (output->interleaved_packets.array[first_audio_idx].pts <= 0) {
+		for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+			int audio_idx = find_first_packet_type_idx(
+				output, OBS_ENCODER_AUDIO, i);
+			if (audio_idx >= 0 && (size_t)audio_idx < idx)
+				idx = audio_idx;
+		}
+	}
+
+	return idx;
 }
 
 static int64_t get_encoder_duration(struct obs_encoder *encoder)
@@ -1893,18 +1912,23 @@ static int prune_premature_packets(struct obs_output *output)
 	return diff > duration_usec ? max_idx + 1 : 0;
 }
 
+#define DEBUG_STARTING_PACKETS 0
+
 static void discard_to_idx(struct obs_output *output, size_t idx)
 {
 	for (size_t i = 0; i < idx; i++) {
 		struct encoder_packet *packet =
 			&output->interleaved_packets.array[i];
+#if DEBUG_STARTING_PACKETS == 1
+		blog(LOG_DEBUG, "discarding %s packet, dts: %lld, pts: %lld",
+		     packet->type == OBS_ENCODER_VIDEO ? "video" : "audio",
+		     packet->dts, packet->pts);
+#endif
 		obs_encoder_packet_release(packet);
 	}
 
 	da_erase_range(output->interleaved_packets, 0, idx);
 }
-
-#define DEBUG_STARTING_PACKETS 0
 
 static bool prune_interleaved_packets(struct obs_output *output)
 {


### PR DESCRIPTION
### Description

If the audio packet chosen for A/V sync is the start of the encoded bitstream also include all previous audio packets to ensure all "priming" samples are included.

### Motivation and Context

Same as #10689 but will ensure that all priming samples for AAC are included. This may however require some further thought to ensure multi-track audio/video does not cause issues.

### How Has This Been Tested?

Did some test recordings and looked at the results in Resolve.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
