### PR TITLE
UI: Change how the status bar gets weak stream output

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -518,7 +518,7 @@ void OBSBasicStatusBar::StreamDelayStarting(int sec)
 		return;
 
 	OBSOutputAutoRelease output = obs_frontend_get_streaming_output();
-	streamOutput = obs_output_get_weak_output(output);
+	streamOutput = OBSGetWeakRef(output);
 
 	delaySecTotal = delaySecStarting = sec;
 	UpdateDelayMsg();
@@ -533,7 +533,7 @@ void OBSBasicStatusBar::StreamDelayStopping(int sec)
 
 void OBSBasicStatusBar::StreamStarted(obs_output_t *output)
 {
-	streamOutput = obs_output_get_weak_output(output);
+	streamOutput = OBSGetWeakRef(output);
 
 	streamSigs.emplace_back(obs_output_get_signal_handler(output),
 				"reconnect", OBSOutputReconnect, this);


### PR DESCRIPTION
### Description
The changes obs_output_get_weak_output to OBSGetWeakRef to be consistent with the other UI code.

### Motivation and Context
Consistent code

### How Has This Been Tested?
Ran stream and nothing broke

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
