### PR TITLE
rtmp-services: Update Joystick.TV servers and recommended settings

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 252,
+    "version": 253,
     "files": [
         {
             "name": "services.json",
-            "version": 252
+            "version": 253
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2523,21 +2523,26 @@
         },
         {
             "name": "Joystick.TV",
-            "more_info_link": "https://support.joystick.tv/support/creator-support/setting-up-your-stream/",
+            "more_info_link": "https://support.joystick.tv/live_streaming/",
             "stream_key_link": "https://joystick.tv/stream-settings",
             "servers": [
                 {
-                    "name": "RTMP",
+                    "name": "North America",
                     "url": "rtmp://live.joystick.tv/live/"
+                },
+                {
+                    "name": "Europe",
+                    "url": "rtmp://eu.live.joystick.tv/live/"
                 }
             ],
             "recommended": {
                 "keyint": 2,
                 "max video bitrate": 7500,
                 "max audio bitrate": 192,
+                "max fps": 60,
                 "profile": "main",
                 "bframes": 0,
-                "x264opts": "tune=zerolatency"
+                "x264opts": "tune=zerolatency scenecut=0"
             },
             "supported video codecs": [
                 "h264"


### PR DESCRIPTION
### Description
Updated the Joystick.TV RTMP service with
* a new `more_info_link`. Previous URL still 301 redirects for backwards compatibility
* Added a new Ingest server for Europe
* Renamed the North American server from "RTMP" to "North America" to be more explicit in the location
* Added recommended "max fps" setting
* Updated `x264opts` with `scenecut=0`

### Motivation and Context
We recently launched a new ingest server in the EU for all of our European Streamers. This gives them easier access to setup OBS using the new EU servers.

The recommended settings are updates to help stability when streamers use the "Simple" format.

### How Has This Been Tested?
Replaced `/home/jeremy/.var/app/com.obsproject.Studio/config/obs-studio/plugin_config/rtmp-services/services.json` with the updated file, and streamed in to the site.

### Types of changes
RTMP service update. (update to existing RTMP service)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
