### PR TITLE
CI: Generate/Verify Attestation for Windows builds

### DIFF
--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -33,8 +33,9 @@ runs:
       run: |
         # Download OBS release
         . ${env:GITHUB_ACTION_PATH}\Invoke-External.ps1
-        Invoke-External gh release download "${{ inputs.tagName }}" -p "*-Windows.zip"
-        Expand-Archive -Path "*-Windows.zip" -DestinationPath "${{ github.workspace }}/build"
+        Invoke-External gh release download "${{ inputs.tagName }}" -p "OBS-Studio-${{ inputs.tagName }}-Windows.zip"
+        Invoke-External gh attestation verify "OBS-Studio-${{ inputs.tagName }}-Windows.zip" --owner obsproject
+        Expand-Archive -Path "OBS-Studio-${{ inputs.tagName }}-Windows.zip" -DestinationPath "${{ github.workspace }}/build"
 
     - name: Setup bouf
       shell: pwsh

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,12 +207,13 @@ jobs:
 
   sign-windows-build:
     name: Windows Signing ✍️
-    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@d7bf65a80b40bec6446dcb4a2f03629fb74cc3f9
+    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@b5b457d7b059397b70f6e3dd09b65e172ad734c3
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
     needs: build-project
     permissions:
       contents: 'read'
       id-token: 'write'
+      attestations: 'write'
     secrets: inherit
 
   create-release:

--- a/.github/workflows/sign-windows.yaml
+++ b/.github/workflows/sign-windows.yaml
@@ -52,6 +52,11 @@ jobs:
           version: ${{ github.ref_name }}
           channel: ${{ steps.setup.outputs.channel }}
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ github.workspace }}/output/*-x64.zip
+
       - name: Upload Signed Build
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description

Adds [GitHub's new attestation feature](https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/) to Windows release workflows.

### Motivation and Context

This ensures that the artifact used to generate delta updates has been generated on CI and has not been altered before the patch workflow runs.

### How Has This Been Tested?

Tested on my fork.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
