### PR TITLE
UI: Reset YT Live Chat dock on StreamingStop.

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -211,6 +211,7 @@ void YoutubeAuth::ResetChat()
 {
 #ifdef BROWSER_AVAILABLE
 	if (chat && chat->cefWidget) {
+		chat->SetApiChatId("");
 		chat->cefWidget->setURL(YOUTUBE_CHAT_PLACEHOLDER_URL);
 	}
 #endif

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -7531,6 +7531,11 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 #ifdef YOUTUBE_ENABLED
 	if (YouTubeAppDock::IsYTServiceSelected())
 		youtubeAppDock->IngestionStopped();
+	std::shared_ptr<YoutubeApiWrappers> ytAuth =
+		dynamic_pointer_cast<YoutubeApiWrappers>(auth);
+	if (ytAuth.get()) {
+		ytAuth->ResetChat();
+	}
 #endif
 
 	blog(LOG_INFO, STREAMING_STOP);


### PR DESCRIPTION
### Description
This will use the same placeholder URL that is used before a stream is started.

### Motivation and Context
When a stream ends, the input bar for sending chat messages should no longer
be active. It wouldn't work even if it was active.

### How Has This Been Tested?
Built OBS locally on Linux workstation, started and stopped a live stream.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
