### PR TITLE
UI: Implement DeleteCookies for YT Service dock

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -55,6 +55,14 @@ static inline void OpenBrowser(const QString auth_uri)
 	QDesktopServices::openUrl(url);
 }
 
+static void DeleteCookies()
+{
+	if (panel_cookies) {
+		panel_cookies->DeleteCookies("youtube.com", std::string());
+		panel_cookies->DeleteCookies("google.com", std::string());
+	}
+}
+
 void RegisterYoutubeAuth()
 {
 	for (auto &service : youtubeServices) {
@@ -64,7 +72,7 @@ void RegisterYoutubeAuth()
 				return std::make_shared<YoutubeApiWrappers>(
 					service);
 			},
-			YoutubeAuth::Login, []() { return; });
+			YoutubeAuth::Login, DeleteCookies);
 	}
 }
 


### PR DESCRIPTION
### Description
Implement `DeleteCookies` for YT service integration dock, similar to other service integration docks.

### Motivation and Context
This will enable centralized cookie management for YouTube/Google account logins for other browser docks using the shared cookie manager. The existing YouTube Control Panel browser dock will be migrated to using the shared cookie manager (see https://github.com/obsproject/obs-studio/pull/10747) so that sign-in cookies can be shared between YouTube Control Panel and YouTube Live Chat. This will unlock improved creator-facing experience for OBS users of YouTube Live Chat (such as better chat latency, creation end-points for polls, Q&A, moderation capabilities etc).

### How Has This Been Tested?
Built OBS locally on Linux workstation, connected YouTube account (via OAuth), disconnected YouTube OAuth, verified no cookies were remaining. For purposes of testing, I copied over cookies from the YTCP cookie manager after logging into YouTube Studio.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
