### PR TITLE
UI:Implement drag-and-drop from sources to scenes

### DIFF
--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -1,19 +1,13 @@
-#include "obs-frontend-api.h"
-#include "obs-source.h"
-#include "obs.h"
 #include "scene-tree.hpp"
-#include <obs-module.h>
+#include "obs.h"
 
-#include <QDropEvent>
-#include <QMimeData>
-#include <QPushButton>
-#include <QScrollBar>
 #include <QSizePolicy>
+#include <QScrollBar>
+#include <QDropEvent>
+#include <QPushButton>
 #include <QTimer>
 #include <cmath>
-
-
-OBS_DECLARE_MODULE()
+#include <QMimeData>
 
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
@@ -113,9 +107,9 @@ void SceneTree::startDrag(Qt::DropActions supportedActions)
 
 void SceneTree::dropEvent(QDropEvent *event)
 {
-	 if (event->mimeData()->hasFormat("application/indexes")) {
-		QByteArray encodedData = event->mimeData()->data(
-			"application/indexes");
+	if (event->mimeData()->hasFormat("application/indexes")) {
+		QByteArray encodedData =
+			event->mimeData()->data("application/indexes");
 		QDataStream stream(&encodedData, QIODevice::ReadOnly);
 
 		QStringList sourceNames;
@@ -138,7 +132,7 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 		event->setDropAction(Qt::MoveAction);
 		event->accept();
-	 }
+	}
 
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
@@ -195,7 +189,7 @@ void SceneTree::addSourceToScene(const QString &sourceName,
 
 	obs_scene_t *scene = obs_scene_from_source(sceneSource);
 	if (!scene) {
-		obs_source_release(source);      
+		obs_source_release(source);
 		obs_source_release(sceneSource);
 		return;
 	}
@@ -205,7 +199,6 @@ void SceneTree::addSourceToScene(const QString &sourceName,
 	obs_source_release(source);
 	obs_source_release(sceneSource);
 }
-
 
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
 {

--- a/UI/scene-tree.hpp
+++ b/UI/scene-tree.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <QListWidget>
 #include <QEvent>
 #include <QItemDelegate>
+#include <QListWidget>
 
 class SceneTree : public QListWidget {
 	Q_OBJECT
@@ -26,6 +26,11 @@ public:
 
 	explicit SceneTree(QWidget *parent = nullptr);
 
+	QString GetSceneNameFromDrop(QDropEvent *event);
+	void handleDropEvent(const QString &sceneName);
+	void addSourceToScene(const QString &sourceName,
+			      const QString &sceneName);
+
 private:
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
 
@@ -36,6 +41,7 @@ protected:
 	virtual void dropEvent(QDropEvent *event) override;
 	virtual void dragMoveEvent(QDragMoveEvent *event) override;
 	virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
+	virtual void dragEnterEvent(QDragEnterEvent *event) override;
 	virtual void rowsInserted(const QModelIndex &parent, int start,
 				  int end) override;
 #if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)

--- a/UI/scene-tree.hpp
+++ b/UI/scene-tree.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <QListWidget>
 #include <QEvent>
 #include <QItemDelegate>
-#include <QListWidget>
 
 class SceneTree : public QListWidget {
 	Q_OBJECT

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -1,29 +1,28 @@
-#include "obs-app.hpp"
-#include "platform.hpp"
-#include "qt-wrappers.hpp"
-#include "source-tree.hpp"
 #include "window-basic-main.hpp"
+#include "obs-app.hpp"
+#include "source-tree.hpp"
+#include "qt-wrappers.hpp"
+#include "platform.hpp"
+#include "source-label.hpp"
 
 #include <obs-frontend-api.h>
 #include <obs.h>
-#include <obs.hpp>
 
 #include <string>
 
-#include <QAccessible>
-#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
-#include <QMouseEvent>
-#include <QPushButton>
 #include <QSpacerItem>
+#include <QPushButton>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QMouseEvent>
+#include <QAccessible>
 
-#include <QDrag>
-#include <QMimeData>
 #include <QStylePainter>
 #include <QStyleOptionFocusRect>
-
+#include <QDrag>
+#include <QMimeData>
 
 static inline OBSScene GetCurrentScene()
 {
@@ -1186,11 +1185,10 @@ void SourceTree::startDrag(Qt::DropActions supportedActions)
 	drag->setPixmap(blueBox);
 	drag->setHotSpot(dragStartPosition - boundingRect.topLeft());
 
-	Qt::DropAction dropAction = drag->exec(supportedActions);
+	drag->exec(supportedActions);
 }
 
-
-bool SourceTree::get_selected_source_names(obs_scene_t *scene,
+bool SourceTree::get_selected_source_names(obs_scene_t * /*scene*/,
 					   obs_sceneitem_t *sceneitem,
 					   void *param)
 {
@@ -1208,6 +1206,7 @@ bool SourceTree::get_selected_source_names(obs_scene_t *scene,
 	}
 	return true;
 }
+
 
 void SourceTree::SetIconsVisible(bool visible)
 {
@@ -1761,7 +1760,6 @@ void SourceTree::Remove(OBSSceneItem item, OBSScene scene)
 	QString sceneName = QString::fromUtf8(obs_source_get_name(sceneSource));
 
 	removeSourceFromScene(sourceName, sceneName);
-
 }
 
 void SourceTree::removeSourceFromScene(const QString &sourceName,
@@ -1803,7 +1801,6 @@ void SourceTree::removeSourceFromScene(const QString &sourceName,
 	obs_source_release(source);
 	obs_source_release(sceneSource);
 }
-
 
 void SourceTree::GroupSelectedItems()
 {

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -1,19 +1,20 @@
 #pragma once
 
-#include <QList>
-#include <QVector>
-#include <QPointer>
-#include <QListView>
-#include <QCheckBox>
-#include <QStaticText>
-#include <QSvgRenderer>
-#include <QAbstractListModel>
-#include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
+#include <obs.h>
+
+#include <QAbstractListModel>
+#include <QCheckBox>
+#include <QList>
+#include <QListView>
+#include <QPointer>
+#include <QStaticText>
+#include <QStyledItemDelegate>
+#include <QSvgRenderer>
+#include <QVector>
 
 class QLabel;
-class OBSSourceLabel;
 class QCheckBox;
 class QLineEdit;
 class SourceTree;
@@ -58,7 +59,7 @@ private:
 	QCheckBox *vis = nullptr;
 	QCheckBox *lock = nullptr;
 	QHBoxLayout *boxLayout = nullptr;
-	OBSSourceLabel *label = nullptr;
+	QLabel *label = nullptr;
 
 	QLineEdit *editor = nullptr;
 
@@ -80,6 +81,7 @@ private slots:
 
 	void VisibilityChanged(bool visible);
 	void LockedChanged(bool locked);
+	void Renamed(const QString &name);
 
 	void ExpandClicked(bool checked);
 
@@ -172,6 +174,13 @@ public:
 
 	void SelectItem(obs_sceneitem_t *sceneitem, bool select);
 
+	static bool get_selected_source_names(obs_scene_t *scene,
+					      obs_sceneitem_t *sceneitem,
+					      void *param);
+	void removeSourceFromScene(const QString &sourceName,
+				   const QString &sceneName);
+
+
 	bool MultipleBaseSelected() const;
 	bool GroupsSelected() const;
 	bool GroupedItemsSelected() const;
@@ -193,10 +202,17 @@ protected:
 	virtual void mouseDoubleClickEvent(QMouseEvent *event) override;
 	virtual void dropEvent(QDropEvent *event) override;
 	virtual void paintEvent(QPaintEvent *event) override;
+	virtual void mousePressEvent(QMouseEvent *event) override;
+	virtual void startDrag(Qt::DropActions supportedActions) override;
 
 	virtual void
 	selectionChanged(const QItemSelection &selected,
 			 const QItemSelection &deselected) override;
+	virtual void dragMoveEvent(QDragMoveEvent *event) override;
+	virtual void dragEnterEvent(QDragEnterEvent *event) override;
+
+private:
+	QPoint dragStartPosition;
 };
 
 class SourceTreeDelegate : public QStyledItemDelegate {

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -1,18 +1,16 @@
 #pragma once
 
+#include <QList>
+#include <QVector>
+#include <QPointer>
+#include <QListView>
+#include <QCheckBox>
+#include <QStaticText>
+#include <QSvgRenderer>
+#include <QAbstractListModel>
+#include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
-#include <obs.h>
-
-#include <QAbstractListModel>
-#include <QCheckBox>
-#include <QList>
-#include <QListView>
-#include <QPointer>
-#include <QStaticText>
-#include <QStyledItemDelegate>
-#include <QSvgRenderer>
-#include <QVector>
 
 class QLabel;
 class QCheckBox;
@@ -142,6 +140,7 @@ class SourceTree : public QListView {
 	QSvgRenderer iconNoSources;
 
 	OBSData undoSceneData;
+	QPoint dragStartPosition;
 
 	bool iconsVisible = true;
 
@@ -177,9 +176,9 @@ public:
 	static bool get_selected_source_names(obs_scene_t *scene,
 					      obs_sceneitem_t *sceneitem,
 					      void *param);
+
 	void removeSourceFromScene(const QString &sourceName,
 				   const QString &sceneName);
-
 
 	bool MultipleBaseSelected() const;
 	bool GroupsSelected() const;
@@ -210,9 +209,6 @@ protected:
 			 const QItemSelection &deselected) override;
 	virtual void dragMoveEvent(QDragMoveEvent *event) override;
 	virtual void dragEnterEvent(QDragEnterEvent *event) override;
-
-private:
-	QPoint dragStartPosition;
 };
 
 class SourceTreeDelegate : public QStyledItemDelegate {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Drag-and-Drop feature allows users to effortlessly move sources or groups of sources into scenes within the user interface. This intuitive functionality enhances user interaction by providing a visual and interactive way to organize and customize content.

The feature mimics the behaviour of a copy and paste. For example if we drag a "Input Audio Device" from Scene 1 to Scene 2, after the event, both Scene 1 and Scene 2 will have the "Input Audio Device" source.

Start:
State of Scene 1 and Scene 2
![image](https://github.com/obsproject/obs-studio/assets/75538603/0d8368f1-3ca8-4f54-9c00-b133b8557e10)
![image](https://github.com/obsproject/obs-studio/assets/75538603/0bb627ea-97f9-4afc-bbd7-8bf6b4b79098)

During the Drag and Drop from the "Audio Input Capture" from Scene 1 to Scene 2:
![Imagem WhatsApp 2024-05-23 às 12 20 10_d1a6b6ce](https://github.com/obsproject/obs-studio/assets/75538603/c942af01-4891-4666-a56c-571bfe916c32)

After the drag and drop operation:
![image](https://github.com/obsproject/obs-studio/assets/75538603/4dfd7a32-0ebd-4efd-9c17-e7ed23802506)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

As live streaming and digital content creation grow, efficient tools are essential. The Drag-and-Drop feature in OBS simplifies the organization of sources, mimicking copy-and-paste behavior. By allowing users to easily duplicate sources between scenes, it improves workflow and ensures consistency, making OBS even more user-friendly and effective.

We got this feature idea from the Ideas page, and here is the link to the post: https://ideas.obsproject.com/posts/225/drag-and-drop-sources-into-other-scenes

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
We conducted extensive manual testing to ensure the reliability and functionality of the Drag-and-Drop feature. The testing process was carried out on Windows 11 to verify compatibility and performance, ensuring a seamless user experience across different scenarios.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
