### PR TITLE
UI: Adjust appearance of multiview borders and labels

### DIFF
--- a/UI/multiview.cpp
+++ b/UI/multiview.cpp
@@ -34,9 +34,9 @@ static OBSSource CreateLabel(const char *name, size_t h)
 	OBSDataAutoRelease font = obs_data_create();
 
 	std::string text;
-	text += " ";
+	text += "  ";
 	text += name;
-	text += " ";
+	text += "  ";
 
 #if defined(_WIN32)
 	obs_data_set_string(font, "face", "Arial");
@@ -51,6 +51,7 @@ static OBSSource CreateLabel(const char *name, size_t h)
 	obs_data_set_obj(settings, "font", font);
 	obs_data_set_string(settings, "text", text.c_str());
 	obs_data_set_bool(settings, "outline", false);
+	obs_data_set_int(settings, "opacity", 50);
 
 #ifdef _WIN32
 	const char *text_source_id = "text_gdiplus";

--- a/UI/multiview.cpp
+++ b/UI/multiview.cpp
@@ -34,9 +34,9 @@ static OBSSource CreateLabel(const char *name, size_t h)
 	OBSDataAutoRelease font = obs_data_create();
 
 	std::string text;
-	text += "  ";
+	text += " ";
 	text += name;
-	text += "  ";
+	text += " ";
 
 #if defined(_WIN32)
 	obs_data_set_string(font, "face", "Arial");
@@ -320,7 +320,7 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 			sourceX = thickness + pvwprgCX / 2;
 			sourceY = thickness;
 			labelX = offset + pvwprgCX / 2;
-			labelY = pvwprgCY * 0.85f;
+			labelY = pvwprgCY;
 			if (program) {
 				sourceX += pvwprgCX;
 				labelX += pvwprgCX;
@@ -330,27 +330,27 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 			sourceX = thickness;
 			sourceY = pvwprgCY + thickness;
 			labelX = offset;
-			labelY = pvwprgCY * 1.85f;
+			labelY = pvwprgCY * 2;
 			if (program) {
 				sourceY = thickness;
-				labelY = pvwprgCY * 0.85f;
+				labelY = pvwprgCY;
 			}
 			break;
 		case MultiviewLayout::VERTICAL_RIGHT_8_SCENES:
 			sourceX = pvwprgCX + thickness;
 			sourceY = pvwprgCY + thickness;
 			labelX = pvwprgCX + offset;
-			labelY = pvwprgCY * 1.85f;
+			labelY = pvwprgCY * 2;
 			if (program) {
 				sourceY = thickness;
-				labelY = pvwprgCY * 0.85f;
+				labelY = pvwprgCY;
 			}
 			break;
 		case MultiviewLayout::HORIZONTAL_BOTTOM_8_SCENES:
 			sourceX = thickness;
 			sourceY = pvwprgCY + thickness;
 			labelX = offset;
-			labelY = pvwprgCY * 1.85f;
+			labelY = pvwprgCY * 2;
 			if (program) {
 				sourceX += pvwprgCX;
 				labelX += pvwprgCX;
@@ -367,7 +367,7 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 			sourceX = thickness;
 			sourceY = thickness;
 			labelX = offset;
-			labelY = pvwprgCY * 0.85f;
+			labelY = pvwprgCY;
 			if (program) {
 				sourceX += pvwprgCX;
 				labelX += pvwprgCX;
@@ -444,12 +444,16 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 		offset = labelOffset(multiviewLayout, label, scenesCX);
 
 		gs_matrix_push();
-		gs_matrix_translate3f(sourceX + offset,
-				      (scenesCY * 0.85f) + sourceY, 0.0f);
+		gs_matrix_translate3f(
+			sourceX + offset,
+			sourceY + scenesCY -
+				(obs_source_get_height(label) * ppiScaleY) -
+				(thickness * 3),
+			0.0f);
 		gs_matrix_scale3f(ppiScaleX, ppiScaleY, 1.0f);
 		drawBox(obs_source_get_width(label),
-			obs_source_get_height(label) + int(sourceY * 0.015f),
-			labelColor);
+			obs_source_get_height(label) + thicknessx2, labelColor);
+		gs_matrix_translate3f(0, thickness, 0.0f);
 		obs_source_video_render(label);
 		gs_matrix_pop();
 	}
@@ -499,12 +503,18 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 	// Draw the Label
 	if (drawLabel) {
 		gs_matrix_push();
-		gs_matrix_translate3f(labelX, labelY, 0.0f);
+		gs_matrix_translate3f(
+			labelX,
+			labelY -
+				(obs_source_get_height(previewLabel) *
+				 ppiScaleY) -
+				(thickness * 3),
+			0.0f);
 		gs_matrix_scale3f(ppiScaleX, ppiScaleY, 1.0f);
 		drawBox(obs_source_get_width(previewLabel),
-			obs_source_get_height(previewLabel) +
-				int(pvwprgCX * 0.015f),
+			obs_source_get_height(previewLabel) + thicknessx2,
 			labelColor);
+		gs_matrix_translate3f(0, thickness, 0.0f);
 		obs_source_video_render(previewLabel);
 		gs_matrix_pop();
 	}
@@ -532,12 +542,18 @@ void Multiview::Render(uint32_t cx, uint32_t cy)
 	// Draw the Label
 	if (drawLabel) {
 		gs_matrix_push();
-		gs_matrix_translate3f(labelX, labelY, 0.0f);
+		gs_matrix_translate3f(
+			labelX,
+			labelY -
+				(obs_source_get_height(programLabel) *
+				 ppiScaleY) -
+				(thickness * 3),
+			0.0f);
 		gs_matrix_scale3f(ppiScaleX, ppiScaleY, 1.0f);
 		drawBox(obs_source_get_width(programLabel),
-			obs_source_get_height(programLabel) +
-				int(pvwprgCX * 0.015f),
+			obs_source_get_height(programLabel) + thicknessx2,
 			labelColor);
+		gs_matrix_translate3f(0, thickness, 0.0f);
 		obs_source_video_render(programLabel);
 		gs_matrix_pop();
 	}

--- a/UI/multiview.hpp
+++ b/UI/multiview.hpp
@@ -40,7 +40,7 @@ private:
 	std::vector<OBSSource> multiviewLabels;
 
 	// Multiview position helpers
-	float thickness = 4;
+	float thickness = 6;
 	float offset, thicknessx2 = thickness * 2, pvwprgCX, pvwprgCY, sourceX,
 		      sourceY, labelX, labelY, scenesCX, scenesCY, ppiCX, ppiCY,
 		      siX, siY, siCX, siCY, ppiScaleX, ppiScaleY, siScaleX,

--- a/UI/multiview.hpp
+++ b/UI/multiview.hpp
@@ -47,8 +47,8 @@ private:
 		      siScaleY, fw, fh, ratio;
 
 	// argb colors
-	static const uint32_t outerColor = 0xFFD0D0D0;
-	static const uint32_t labelColor = 0xD91F1F1F;
+	static const uint32_t outerColor = 0xFF999999;
+	static const uint32_t labelColor = 0x33000000;
 	static const uint32_t backgroundColor = 0xFF000000;
 	static const uint32_t previewColor = 0xFF00D000;
 	static const uint32_t programColor = 0xFFD00000;


### PR DESCRIPTION
### Description
Adjusts the size of multiview borders and the label styling to be less opaque to avoid covering actual scene content.

**Before**
![obs64_fuz6xrIlx1](https://github.com/obsproject/obs-studio/assets/1554753/a2d5e349-10af-49e8-a70e-18d8afe175a0)

**After**
![image](https://github.com/obsproject/obs-studio/assets/1554753/af3e335d-91d6-4ae1-8b98-57524f35933d)


Preview/Program indicator borders are important information, so increasing the border width greatly improves their readability in some multiview layouts and display sizes/resolutions.

The size and position of the label box is adjusted to be based off the label's height plus the border width to look more consistent and fix the text not being vertically centered.

The background and label text are made less opaque to ensure they don't completely block visual content.

-----

### Motivation and Context

Many hardware multiviews either place the labels outside/around the content, or on top with no background. BlackMagic ATEM is only of the only examples that places a black background behind the label and even in that case, it is less opaque than our current labels.

![image](https://github.com/obsproject/obs-studio/assets/1554753/8c60b06c-ec9f-4506-928c-c213268d4801)
![image](https://github.com/obsproject/obs-studio/assets/1554753/3e4cc1df-62ea-423a-ba52-63ff9911d8b1)
![image](https://github.com/obsproject/obs-studio/assets/1554753/413f8671-87ef-43cc-b22e-6e464bbd914a)
![image](https://github.com/obsproject/obs-studio/assets/1554753/ee4449e2-f510-42b2-9aae-41ff431de61a)


### How Has This Been Tested?
Tested all multiview layouts on multiple different sized displays at different resolutions.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
