### PR TITLE
UI: Fix Qt platform override in CMake 3

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -479,16 +479,22 @@ elseif(OS_POSIX)
     target_compile_options(obs PRIVATE -Wno-unqualified-std-cast-call)
   endif()
 
-  if(OS_LINUX AND ENABLE_WHATSNEW)
-    find_package(MbedTLS)
-    find_package(nlohmann_json REQUIRED)
-    if(NOT MBEDTLS_FOUND)
-      obs_status(FATAL_ERROR "mbedTLS not found, but required for WhatsNew support on Linux")
+  if(OS_LINUX)
+    if(USE_XDG)
+      target_compile_definitions(obs PRIVATE USE_XDG)
     endif()
 
-    target_sources(obs PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mbedtls.cpp update/shared-update.cpp
-                               update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
-    target_link_libraries(obs PRIVATE Mbedtls::Mbedtls nlohmann_json::nlohmann_json OBS::blake2)
+    if(ENABLE_WHATSNEW)
+      find_package(MbedTLS)
+      find_package(nlohmann_json REQUIRED)
+      if(NOT MBEDTLS_FOUND)
+        obs_status(FATAL_ERROR "mbedTLS not found, but required for WhatsNew support on Linux")
+      endif()
+
+      target_sources(obs PRIVATE update/crypto-helpers.hpp update/crypto-helpers-mbedtls.cpp update/shared-update.cpp
+                                 update/shared-update.hpp update/update-helpers.cpp update/update-helpers.hpp)
+      target_link_libraries(obs PRIVATE Mbedtls::Mbedtls nlohmann_json::nlohmann_json OBS::blake2)
+    endif()
   endif()
 endif()
 

--- a/UI/cmake/os-linux.cmake
+++ b/UI/cmake/os-linux.cmake
@@ -1,5 +1,5 @@
 target_sources(obs-studio PRIVATE platform-x11.cpp)
-target_compile_definitions(obs-studio PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
+target_compile_definitions(obs-studio PRIVATE USE_XDG OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
 target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus)
 
 if(TARGET OBS::python)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2000,7 +2000,8 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	if (platform_theme && strcmp(platform_theme, "qt5ct") == 0)
 		unsetenv("QT_QPA_PLATFORMTHEME");
 
-#if defined(ENABLE_WAYLAND) && defined(USE_XDG)
+#if defined(ENABLE_WAYLAND) && defined(USE_XDG) && \
+	QT_VERSION < QT_VERSION_CHECK(6, 3, 0)
 	/* NOTE: Qt doesn't use the Wayland platform on GNOME, so we have to
 	 * force it using the QT_QPA_PLATFORM env var. It's still possible to
 	 * use other QPA platforms using this env var, or the -platform command

--- a/UI/ui-config.h.in
+++ b/UI/ui-config.h.in
@@ -1,7 +1,5 @@
 #pragma once
 
-#cmakedefine USE_XDG
-
 #define OAUTH_BASE_URL "@OAUTH_BASE_URL@"
 
 #define TWITCH_CLIENTID "@TWITCH_CLIENTID@"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

USE_XDG definition is missing in CMake 3 code in the UI subdirectory.

This override is still needed until Qt minimum version requirement is increased to at least 6.3.0.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

We still support Qt 6.2 and Ubuntu 22.04.

The override should enforce the Wayland platform where Qt was enforcing the X11 on GNOME Wayland.
The enforce was removed in 6.3.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Not tested.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
