### PR TITLE
UI: Enforce completely Fusion Qt style on Linux

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -930,7 +930,11 @@ static map<string, string> themeMigrations = {
 bool OBSApp::InitTheme()
 {
 	defaultPalette = palette();
+#if !defined(_WIN32) && !defined(__APPLE__)
+	setStyle(new OBSProxyStyle("Fusion"));
+#else
 	setStyle(new OBSProxyStyle());
+#endif
 
 	/* Set search paths for custom 'theme:' URI prefix */
 	string searchDir;

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1987,12 +1987,6 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #endif
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-	/* NOTE: The Breeze Qt style plugin adds frame arround QDockWidget with
-	 * QPainter which can not be modifed. To avoid this the base style is
-	 * enforce to the Qt default style on Linux: Fusion. */
-
-	setenv("QT_STYLE_OVERRIDE", "Fusion", false);
-
 	/* NOTE: Users blindly set this, but this theme is incompatble with Qt6 and
 	 * crashes loading saved geometry. Just turn off this theme and let users complain OBS
 	 * looks ugly instead of crashing. */

--- a/UI/obs-proxy-style.hpp
+++ b/UI/obs-proxy-style.hpp
@@ -4,6 +4,10 @@
 
 class OBSProxyStyle : public QProxyStyle {
 public:
+	OBSProxyStyle() : QProxyStyle() {}
+
+	OBSProxyStyle(const QString &key) : QProxyStyle(key) {}
+
 	int styleHint(StyleHint hint, const QStyleOption *option,
 		      const QWidget *widget,
 		      QStyleHintReturn *returnData) const override;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

As of 8dcfae9a390763645d354700f36caef6b8f482c7, indicating the base style to the proxy is completely functional.

It also bypasses QT_STYLE_OVERRIDE and -style, but since the system theme is no longer available on Linux this is a non-issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Rewrite of #6664 to use the conventional method to enforce a Qt style.

Since #10602, issues with the conventional method were fixed since there is one style for the whole app.

Also #9653 phased out the system theme on Linux and other themes only support Fusion as a base style on Linux.

So the side-effect of #6664 allowing the user to set their own Qt style is mostly unusable and potentially unwanted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Enforced system theme in the config file, and try to ran OBS with Breeze enforced.
With the PR, Fusion was in use and not Breeze.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!-- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
