### PR TITLE
libobs: Fix buffer overrun in video_frame_init

### DIFF
--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -196,7 +196,7 @@ void video_frame_init(struct video_frame *frame, enum video_format format,
 	size_t size = 0;
 	uint32_t linesizes[MAX_AV_PLANES];
 	uint32_t heights[MAX_AV_PLANES];
-	size_t offsets[MAX_AV_PLANES - 1];
+	size_t offsets[MAX_AV_PLANES];
 	int alignment = base_get_alignment();
 
 	if (!frame)


### PR DESCRIPTION
### Description

Fixes buffer overrun in `video_frame_init()`

### Motivation and Context

`offsets[]` has size `MAX_AV_PLANES - 1` but the loop would iterate over `MAX_AV_PLANES`, thus resulting in it writing to the memory past the last item.

It is worth noting that in reality this would've never overran, as `MAX_AV_PLANES` is `8`, but the highest amount of planes a video frame can have is 4 (YUV + Alpha).

Found by ~~@notr1ch~~ PVS Studio.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
