### PR TITLE
mac-avcapture: Improve av_capture_sync_info formatting

### DIFF
--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -284,23 +284,22 @@ bool obs_module_load(void)
 
     obs_register_source(&av_capture_info);
 
-    struct obs_source_info av_capture_sync_info = {.id = "macos-avcapture-fast",
-                                                   .type = OBS_SOURCE_TYPE_INPUT,
-                                                   .output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW |
-                                                                   OBS_SOURCE_AUDIO | OBS_SOURCE_SRGB |
-                                                                   OBS_SOURCE_DO_NOT_DUPLICATE,
-                                                   .create = av_fast_capture_create,
-                                                   .get_name = av_fast_capture_get_name,
-                                                   .get_defaults = av_fast_capture_set_defaults,
-                                                   .get_properties = av_capture_properties,
-                                                   .update = av_capture_update,
-                                                   .destroy = av_capture_destroy,
-                                                   .video_tick = av_fast_capture_tick,
-                                                   .video_render = av_fast_capture_render,
-                                                   .get_width = av_fast_capture_get_width,
-                                                   .get_height = av_fast_capture_get_height,
-                                                   .icon_type = OBS_ICON_TYPE_CAMERA
-
+    struct obs_source_info av_capture_sync_info = {
+        .id = "macos-avcapture-fast",
+        .type = OBS_SOURCE_TYPE_INPUT,
+        .output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_CUSTOM_DRAW | OBS_SOURCE_AUDIO | OBS_SOURCE_SRGB |
+                        OBS_SOURCE_DO_NOT_DUPLICATE,
+        .create = av_fast_capture_create,
+        .get_name = av_fast_capture_get_name,
+        .get_defaults = av_fast_capture_set_defaults,
+        .get_properties = av_capture_properties,
+        .update = av_capture_update,
+        .destroy = av_capture_destroy,
+        .video_tick = av_fast_capture_tick,
+        .video_render = av_fast_capture_render,
+        .get_width = av_fast_capture_get_width,
+        .get_height = av_fast_capture_get_height,
+        .icon_type = OBS_ICON_TYPE_CAMERA,
     };
 
     obs_register_source(&av_capture_sync_info);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds a comma to the end of the definition to improve on an... *interesting* formatting choice by clang-format.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this when working on something else, it made my eyes hurt.
A comma at the end is established practice in the rest of the code base.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran clang-format to get this new formatting.
Shouldn't have

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
