### PR TITLE
UI: Fix Qt 6.7 checkbox signal deprecations

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -273,7 +273,11 @@ QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
 
 	QCheckBox *checkbox = new QCheckBox(QT_UTF8(desc));
 	checkbox->setCheckState(val ? Qt::Checked : Qt::Unchecked);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	return NewWidget(prop, checkbox, &QCheckBox::checkStateChanged);
+#else
 	return NewWidget(prop, checkbox, &QCheckBox::stateChanged);
+#endif
 }
 
 QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -790,8 +790,13 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		&OBSBasicSettings::SimpleReplayBufferChanged);
 	connect(ui->simpleRBSecMax, &QSpinBox::valueChanged, this,
 		&OBSBasicSettings::SimpleReplayBufferChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(ui->advOutSplitFile, &QCheckBox::checkStateChanged, this,
+		&OBSBasicSettings::AdvOutSplitFileChanged);
+#else
 	connect(ui->advOutSplitFile, &QCheckBox::stateChanged, this,
 		&OBSBasicSettings::AdvOutSplitFileChanged);
+#endif
 	connect(ui->advOutSplitFileType, &QComboBox::currentIndexChanged, this,
 		&OBSBasicSettings::AdvOutSplitFileChanged);
 	connect(ui->advReplayBuf, &QCheckBox::toggled, this,
@@ -1360,8 +1365,13 @@ void OBSBasicSettings::LoadGeneralSettings()
 					"HideOBSWindowsFromCapture");
 		ui->hideOBSFromCapture->setChecked(hideWindowFromCapture);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+		connect(ui->hideOBSFromCapture, &QCheckBox::checkStateChanged,
+			this, &OBSBasicSettings::HideOBSWindowWarning);
+#else
 		connect(ui->hideOBSFromCapture, &QCheckBox::stateChanged, this,
 			&OBSBasicSettings::HideOBSWindowWarning);
+#endif
 	}
 #endif
 
@@ -4713,7 +4723,11 @@ void OBSBasicSettings::SpeakerLayoutChanged(int idx)
 	UpdateAudioWarnings();
 }
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+void OBSBasicSettings::HideOBSWindowWarning(Qt::CheckState state)
+#else
 void OBSBasicSettings::HideOBSWindowWarning(int state)
+#endif
 {
 	if (loading || state == Qt::Unchecked)
 		return;

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -454,7 +454,12 @@ private slots:
 	void on_colorPreset_currentIndexChanged(int idx);
 
 	void GeneralChanged();
+
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	void HideOBSWindowWarning(Qt::CheckState state);
+#else
 	void HideOBSWindowWarning(int state);
+#endif
 	void AudioChanged();
 	void AudioChangedRestart();
 	void ReloadAudioSources();

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -71,9 +71,13 @@ OBSBasicTransform::OBSBasicTransform(OBSSceneItem item, OBSBasic *parent)
 		   &OBSBasicTransform::OnCropChanged);
 	HookWidget(ui->cropBottom, ISCROLL_CHANGED,
 		   &OBSBasicTransform::OnCropChanged);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	HookWidget(ui->cropToBounds, &QCheckBox::checkStateChanged,
+		   &OBSBasicTransform::OnControlChanged);
+#else
 	HookWidget(ui->cropToBounds, &QCheckBox::stateChanged,
 		   &OBSBasicTransform::OnControlChanged);
-
+#endif
 	ui->buttonBox->button(QDialogButtonBox::Close)->setDefault(true);
 
 	connect(ui->buttonBox->button(QDialogButtonBox::Reset),

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -67,10 +67,17 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth,
 		[](const QString &link) { QDesktopServices::openUrl(link); });
 
 	ui->scheduledTime->setVisible(false);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+	connect(ui->checkScheduledLater, &QCheckBox::checkStateChanged, this,
+		[&](Qt::CheckState state)
+#else
 	connect(ui->checkScheduledLater, &QCheckBox::stateChanged, this,
-		[&](int state) {
-			ui->scheduledTime->setVisible(state);
-			if (state) {
+		[&](int state)
+#endif
+		{
+			const bool checked = (state == Qt::Checked);
+			ui->scheduledTime->setVisible(checked);
+			if (checked) {
 				ui->checkAutoStart->setVisible(true);
 				ui->checkAutoStop->setVisible(true);
 				ui->helpAutoStartStop->setVisible(true);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
qt/qtbase@3512fb1ec5ff088772170540c4e91b1886fbea45 (also cherry-picked to https://github.com/qt/qtbase/commit/02ba4b14dc1c0cee802d8d840315833fda2449b4) deprecated the stateChanged signal of QCheckBoxes in favor of a new checkStateChanged signal. The signals are the same, except that now the enum type is passed explicitly (before the enum was passed as an argument but defined as an int).

The documentation states that it's deprecated for 6.9 but I got the warning now already (dev version appears to be 6.8 currently) and it's also picked to 6.7 and the alternative exists since 6.7 so I'm not 100% what the "real" deprecation version is but 6.7 makes sense.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Got a deprecation warning when compiling against Qt dev branch.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.5 with Qt dev branch.

Tested all the code paths (settings, properties, transform, youtube) except the Windows `HideOBSWindowWarning` one (because I don't have a Windows environment) to see that the signal still gets sent and works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
