### PR TITLE
obs-ffmpeg: Check correct VA-API codec support

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -1074,6 +1074,21 @@ static bool get_device_name_from_pci(struct pci_access *pacc, char *pci_slot,
 	return false;
 }
 
+static bool vaapi_device_codec_supported(const char *path,
+					 enum codec_type codec)
+{
+	switch (codec) {
+	case CODEC_H264:
+		return vaapi_device_h264_supported(path);
+	case CODEC_HEVC:
+		return vaapi_device_hevc_supported(path);
+	case CODEC_AV1:
+		return vaapi_device_av1_supported(path);
+	default:
+		return false;
+	}
+}
+
 static obs_properties_t *vaapi_properties_internal(enum codec_type codec)
 {
 	obs_properties_t *props = obs_properties_create();
@@ -1122,7 +1137,7 @@ static obs_properties_t *vaapi_properties_internal(enum codec_type codec)
 					pacc, pci_slot, namebuf,
 					sizeof(namebuf));
 
-				if (!vaapi_device_h264_supported(path))
+				if (!vaapi_device_codec_supported(path, codec))
 					continue;
 
 				if (!name_found)


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously, we just checked for H264 regardless of which codec was selected. This mostly worked, but on Fedora they ship AV1 without H264 or HEVC. In that case users wont see AV1 as an option.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We really should have been checking the right codec, and users will want to use AV1 without special drivers.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I dont see any changes on my AMD machine. I'll test a fedora machine later.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
