### PR TITLE
obs-qsv11: Fix QSV failing on multi-vendor multi-GPU systems

### DIFF
--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -33,26 +33,31 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession,
 	obs_video_info ovi;
 	obs_get_video_info(&ovi);
 	mfxU32 adapter_idx = ovi.adapter;
+	mfxU32 idx_adjustment = 0;
 
 	// Select current adapter - will be iGPU if exists due to adapter reordering
 	if (codec == QSV_CODEC_AV1 && !adapters[adapter_idx].supports_av1) {
-		for (mfxU32 i = 0; i < 4; i++) {
+		for (mfxU32 i = 0; i < MAX_ADAPTERS; i++) {
+			if (!adapters[i].is_intel) {
+				idx_adjustment++;
+				continue;
+			}
 			if (adapters[i].supports_av1) {
 				adapter_idx = i;
 				break;
 			}
 		}
 	} else if (!adapters[adapter_idx].is_intel) {
-		for (mfxU32 i = 0; i < 4; i++) {
+		for (mfxU32 i = 0; i < MAX_ADAPTERS; i++) {
 			if (adapters[i].is_intel) {
 				adapter_idx = i;
 				break;
 			}
+			idx_adjustment++;
 		}
 	}
 
-	adapter_index = adapter_idx;
-
+	adapter_idx -= idx_adjustment;
 	mfxStatus sts = MFX_ERR_NONE;
 	mfxVariant impl;
 


### PR DESCRIPTION
### Description

Fixes Intel QSV not working on setups where the Intel GPU is not idx 0.

### Motivation and Context

QSV started failing on my NVIDIA dGPU+Intel dGPU system with https://github.com/obsproject/obs-studio/commit/4c6e2a6722de4ed923cf29bc0bf65ddd8f45a2cf applied.

The IDX fed into `MFXCreateSession()` only counts Intel GPUs, so we need to adjust the index down if there are non-Intel GPUs earlier in the list.

This is already done in the QSV test app, but was missing here: https://github.com/obsproject/obs-studio/blob/master/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp#L73-L86

### How Has This Been Tested?

Tested on system with RTX 4090 and Arc A750.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
