### PR TITLE
cmake,UI: Fix SOVERSION on Linux

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -97,8 +97,11 @@ endif()
 foreach(graphics_library IN ITEMS opengl metal d3d11)
   string(TOUPPER ${graphics_library} graphics_library_U)
   if(TARGET OBS::libobs-${graphics_library})
-    target_compile_definitions(obs-studio
-                               PRIVATE DL_${graphics_library_U}="$<TARGET_FILE_NAME:OBS::libobs-${graphics_library}>")
+    target_compile_definitions(
+      obs-studio
+      PRIVATE
+        DL_${graphics_library_U}="$<$<IF:$<PLATFORM_ID:Windows>,TARGET_FILE_NAME,TARGET_SONAME_FILE_NAME>:OBS::libobs-${graphics_library}>"
+    )
   else()
     target_compile_definitions(obs-studio PRIVATE DL_${graphics_library_U}="")
   endif()

--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -55,8 +55,8 @@ function(set_target_properties_obs target)
   elseif(target_type STREQUAL SHARED_LIBRARY)
     set_target_properties(
       ${target}
-      PROPERTIES VERSION ${OBS_VERSION_MAJOR}
-                 SOVERSION ${OBS_VERSION_CANONICAL}
+      PROPERTIES VERSION ${OBS_VERSION_CANONICAL}
+                 SOVERSION ${OBS_VERSION_MAJOR}
                  BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
                  INSTALL_RPATH "${OBS_LIBRARY_RPATH}")
 
@@ -98,12 +98,12 @@ function(set_target_properties_obs target)
 
   elseif(target_type STREQUAL MODULE_LIBRARY)
     if(target STREQUAL obs-browser)
-      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION ${OBS_VERSION_CANONICAL})
+      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION ${OBS_VERSION_MAJOR})
     else()
       set_target_properties(
         ${target}
         PROPERTIES VERSION 0
-                   SOVERSION ${OBS_VERSION_CANONICAL}
+                   SOVERSION ${OBS_VERSION_MAJOR}
                    BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
                    INSTALL_RPATH "${OBS_MODULE_RPATH}")
     endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #10737
Supersedes #10739

SOVERSION is either the major number of a semver or an arbitrary number incremented at each API/ABI break.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

CMake 3 does not apply RPATH like CMake 2 so it unraveled this issue.

We didn't released a CMake 3.0 Linux build, so no breaking change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Build and installed the Flatpak locally and OBS finds `libobs-opengl.so.30`.

Non-Flatpak local build seems to work too.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
