### PR TITLE
UI: Use shared cookie manager for YT Control Panel

### DIFF
--- a/UI/window-dock-youtube-app.cpp
+++ b/UI/window-dock-youtube-app.cpp
@@ -33,20 +33,11 @@ static constexpr const char *INGESTION_STOPPED = "INGESTION_STOPPED";
 
 YouTubeAppDock::YouTubeAppDock(const QString &title)
 	: BrowserDock(title),
-	  dockBrowser(nullptr),
-	  cookieManager(nullptr)
+	  dockBrowser(nullptr)
 {
 	cef->init_browser();
 	OBSBasic::InitBrowserPanelSafeBlock();
 	AddYouTubeAppDock();
-}
-
-YouTubeAppDock::~YouTubeAppDock()
-{
-	if (cookieManager) {
-		cookieManager->FlushStore();
-		delete cookieManager;
-	}
 }
 
 bool YouTubeAppDock::IsYTServiceSelected()
@@ -78,9 +69,12 @@ void YouTubeAppDock::SettingsUpdated(bool cleanup)
 
 	// definitely cleanup if YT switched off
 	if (!ytservice || cleanup) {
-		if (cookieManager)
-			cookieManager->DeleteCookies("", "");
+		if (panel_cookies) {
+			panel_cookies->DeleteCookies("youtube.com", "");
+			panel_cookies->DeleteCookies("google.com", "");
+		}
 	}
+
 	if (ytservice)
 		Update();
 }
@@ -135,16 +129,9 @@ void YouTubeAppDock::AddYouTubeAppDock()
 
 void YouTubeAppDock::CreateBrowserWidget(const std::string &url)
 {
-	std::string dir_name = std::string("obs_profile_cookies_youtube/") +
-			       config_get_string(OBSBasic::Get()->Config(),
-						 "Panels", "CookieId");
-	if (cookieManager)
-		delete cookieManager;
-	cookieManager = cef->create_cookie_manager(dir_name, true);
-
 	if (dockBrowser)
 		delete dockBrowser;
-	dockBrowser = cef->create_widget(this, url, cookieManager);
+	dockBrowser = cef->create_widget(this, url, panel_cookies);
 	if (!dockBrowser)
 		return;
 

--- a/UI/window-dock-youtube-app.hpp
+++ b/UI/window-dock-youtube-app.hpp
@@ -11,7 +11,6 @@ class YouTubeAppDock : public BrowserDock {
 
 public:
 	YouTubeAppDock(const QString &title);
-	~YouTubeAppDock();
 
 	enum streaming_mode_t { YTSM_ACCOUNT, YTSM_STREAM_KEY };
 
@@ -49,5 +48,4 @@ private:
 
 	QString channelId;
 	QPointer<QCefWidget> dockBrowser;
-	QCefCookieManager *cookieManager; // is not a Qt object
 };


### PR DESCRIPTION
### Description
Use the cookie manager shared by service integration browser docks for YouTube Control Panel.

NOTE: This commit does not have any migration logic for existing logged-in users of YTCP, they will need to sign-in again. Based on usage stats, this is not going to affect a large fraction of OBS users.

### Motivation and Context
This will enable users of the YouTube Chat panel have a better (creator facing) experience for observed chat message latency, for those users who sign-in to the YouTube Control Panel or YouTube Live Chat.

### How Has This Been Tested?
Built OBS locally on Linux workstation, verified existing functionality for YouTube Control Panel continues to work.
* Sign-in provides access to the control panel with stream stats and controls.
* Sign-in improves chat message latency when Chat panel is open (since it shares the cookies).
* Sign-out clears cookies from the shared cookie manager. 

### Types of changes
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
