### PR TITLE
docs: Document obs_frontend_recording_add_chapter()

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -647,6 +647,17 @@ Functions
 
 ---------------------------------------
 
+.. function:: bool obs_frontend_recording_add_chapter(const char *name)
+
+   Asks OBS to insert a chapter marker at the current output time into the recording.
+
+   :param name: The name for the chapter, may be *NULL* to use an automatically generated name ("Unnamed <Chapter number>" or localized equivalent).
+   :return: *true* if insertion was successful, *false* if recording is inactive, paused, or if chapter insertion is not supported by the current output.
+
+   .. versionadded:: 30.2
+
+---------------------------------------
+
 .. function:: void obs_frontend_replay_buffer_start(void)
 
    Starts the replay buffer.


### PR DESCRIPTION
### Description

Adds documentation for `obs_frontend_recording_add_chapter()`.

### Motivation and Context

This was missing from #10608 

### How Has This Been Tested?

N/A

### Types of changes

- Documentation (a change to documentation pages)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
