### PR TITLE
UI: Make status bar record output a weak ref

### DIFF
--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -561,7 +561,7 @@ void OBSBasicStatusBar::StreamStopped()
 
 void OBSBasicStatusBar::RecordingStarted(obs_output_t *output)
 {
-	recordOutput = output;
+	recordOutput = OBSGetWeakRef(output);
 	Activate();
 }
 

--- a/UI/window-basic-status-bar.hpp
+++ b/UI/window-basic-status-bar.hpp
@@ -29,7 +29,7 @@ private:
 
 	OBSWeakOutputAutoRelease streamOutput;
 	std::vector<OBSSignal> streamSigs;
-	obs_output_t *recordOutput = nullptr;
+	OBSWeakOutputAutoRelease recordOutput;
 	bool active = false;
 	bool overloadedNotify = true;
 	bool streamPauseIconToggle = false;


### PR DESCRIPTION
### Description
This changes the status bar record output from a strong reference to a weak one.

### Motivation and Context
Make it consistent with the stream output.

### How Has This Been Tested?
Recorded and made sure status bar still worked as expected.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
