### PR TITLE
UI: Retain existing last output resolution

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1306,6 +1306,15 @@ retryScene:
 		vcamConfig.source = obs_data_get_string(obj, "source");
 	}
 
+	if (obs_data_has_user_value(data, "resolution")) {
+		OBSDataAutoRelease res = obs_data_get_obj(data, "resolution");
+		if (obs_data_has_user_value(res, "x") &&
+		    obs_data_has_user_value(res, "y")) {
+			lastOutputResolution = {obs_data_get_int(res, "x"),
+						obs_data_get_int(res, "y")};
+		}
+	}
+
 	/* ---------------------- */
 
 	if (api)


### PR DESCRIPTION
### Description

Save last output resolution if it was specified in the loaded scene collection.

### Motivation and Context

Amendment to #10018 that was missed originally, resulting in the data being lost if the collection was ever loaded and saved without the output being started in between.

### How Has This Been Tested?

Verified resolution remains in JSON.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
