### PR TITLE
obs-outputs: Add native mp4 output to legacy cmake

### DIFF
--- a/plugins/obs-outputs/cmake/legacy.cmake
+++ b/plugins/obs-outputs/cmake/legacy.cmake
@@ -20,6 +20,10 @@ target_sources(
           flv-mux.c
           flv-mux.h
           flv-output.c
+          mp4-mux-internal.h
+          mp4-mux.c
+          mp4-mux.h
+          mp4-output.c
           net-if.c
           net-if.h
           null-output.c
@@ -51,7 +55,7 @@ if(ENABLE_HEVC)
   target_sources(obs-outputs PRIVATE rtmp-hevc.c rtmp-hevc.h)
 endif()
 
-target_link_libraries(obs-outputs PRIVATE OBS::libobs OBS::happy-eyeballs)
+target_link_libraries(obs-outputs PRIVATE OBS::libobs OBS::happy-eyeballs OBS::opts-parser)
 
 set_target_properties(obs-outputs PROPERTIES FOLDER "plugins" PREFIX "")
 


### PR DESCRIPTION
### Description

Adds the new hybrid MP4 output added in #10608 to legacy cmake.

### Motivation and Context

Fixes #10764 

### How Has This Been Tested?

Built with legacy cmake on Linux, confirmed OBS no longer crashes.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
