### PR TITLE
UI: Enable first-party YouTube Chat features in OBS

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -55,6 +55,14 @@ static inline void OpenBrowser(const QString auth_uri)
 	QDesktopServices::openUrl(url);
 }
 
+static void DeleteCookies()
+{
+	if (panel_cookies) {
+		panel_cookies->DeleteCookies("youtube.com", "");
+		panel_cookies->DeleteCookies("google.com", "");
+	}
+}
+
 void RegisterYoutubeAuth()
 {
 	for (auto &service : youtubeServices) {
@@ -64,7 +72,7 @@ void RegisterYoutubeAuth()
 				return std::make_shared<YoutubeApiWrappers>(
 					service);
 			},
-			YoutubeAuth::Login, []() { return; });
+			YoutubeAuth::Login, DeleteCookies);
 	}
 }
 
@@ -212,6 +220,15 @@ void YoutubeAuth::ResetChat()
 #ifdef BROWSER_AVAILABLE
 	if (chat && chat->cefWidget) {
 		chat->cefWidget->setURL(YOUTUBE_CHAT_PLACEHOLDER_URL);
+	}
+#endif
+}
+
+void YoutubeAuth::ReloadChat()
+{
+#ifdef BROWSER_AVAILABLE
+	if (chat && chat->cefWidget) {
+		chat->cefWidget->reloadPage();
 	}
 #endif
 }

--- a/UI/auth-youtube.hpp
+++ b/UI/auth-youtube.hpp
@@ -60,6 +60,7 @@ public:
 
 	void SetChatId(const QString &chat_id, const std::string &api_chat_id);
 	void ResetChat();
+	void ReloadChat();
 
 	static std::shared_ptr<Auth> Login(QWidget *parent,
 					   const std::string &service);

--- a/UI/auth-youtube.hpp
+++ b/UI/auth-youtube.hpp
@@ -16,6 +16,7 @@ class YoutubeChatDock : public BrowserDock {
 
 private:
 	std::string apiChatId;
+	bool isLoggedIn;
 	LineEditAutoResize *lineEdit;
 	QPushButton *sendButton;
 	QHBoxLayout *chatLayout;
@@ -26,9 +27,10 @@ public:
 	void SetApiChatId(const std::string &id);
 
 private slots:
+	void YoutubeCookieCheck();
 	void SendChatMessage();
 	void ShowErrorMessage(const QString &error);
-	void EnableChatInput();
+	void EnableChatInput(bool visible);
 };
 #endif
 

--- a/UI/window-dock-youtube-app.hpp
+++ b/UI/window-dock-youtube-app.hpp
@@ -16,7 +16,6 @@ public:
 
 	void AccountConnected();
 	void AccountDisconnected();
-	void SettingsUpdated(bool cleanup = false);
 	void Update();
 
 	void BroadcastCreated(const char *stream_id);
@@ -27,6 +26,9 @@ public:
 	static bool IsYTServiceSelected();
 	static YoutubeApiWrappers *GetYTApi();
 	static void CleanupYouTubeUrls();
+
+public slots:
+	void SettingsUpdated(bool cleanup = false);
 
 protected:
 	void IngestionStarted(const char *stream_id, streaming_mode_t mode);

--- a/UI/window-dock-youtube-app.hpp
+++ b/UI/window-dock-youtube-app.hpp
@@ -11,7 +11,6 @@ class YouTubeAppDock : public BrowserDock {
 
 public:
 	YouTubeAppDock(const QString &title);
-	~YouTubeAppDock();
 
 	enum streaming_mode_t { YTSM_ACCOUNT, YTSM_STREAM_KEY };
 
@@ -43,11 +42,11 @@ private:
 	void DispatchYTEvent(const char *event, const char *video_id,
 			     streaming_mode_t mode);
 	void UpdateChannelId();
+	void ReloadChatDock();
 	void SetInitEvent(streaming_mode_t mode, const char *event = nullptr,
 			  const char *video_id = nullptr,
 			  const char *channelId = nullptr);
 
 	QString channelId;
 	QPointer<QCefWidget> dockBrowser;
-	QCefCookieManager *cookieManager; // is not a Qt object
 };


### PR DESCRIPTION
### Description
Unlock the full feature set of the YouTube Chat dock in OBS by removing custom scripting/CSS logic. Enable the signed-in experience for live streaming content creators while also sharing login credentials with the YouTube Control panel dock.

### Motivation and Context
This will allow OBS users to utilize features _already_ supported in the YouTube Chat plugin, such as

* creating polls
* managing Q&A sessions
* a rich emoji set in the input panel
* emoji fountains
* moderation tools

and many more. These features are available to users who are logged-in to YouTube Chat and/or the YouTube Control panel.

### How Has This Been Tested?
Built OBS locally on Linux workstation, verified existing functionality for YouTube Chat continues to work in signed-out state. Signing-in to YouTube hides the native Qt input panel in favour of the YouTube native input panel that unlocks all of the first-party functionality for live streaming content creators.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
  Fixes: https://github.com/obsproject/obs-studio/issues/9506
  Fixes: https://github.com/obsproject/obs-studio/issues/7353
- New feature (non-breaking change which adds functionality)
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
