### PR TITLE
libobs: Add buffered file serializer to legacy cmake

### DIFF
--- a/libobs/cmake/legacy.cmake
+++ b/libobs/cmake/legacy.cmake
@@ -176,6 +176,8 @@ target_sources(
           util/bitstream.h
           util/bmem.c
           util/bmem.h
+          util/buffered-file-serializer.c
+          util/buffered-file-serializer.h
           util/c99defs.h
           util/cf-lexer.c
           util/cf-lexer.h


### PR DESCRIPTION
### Description

Adds buffered file serializer to legacy CMake.

### Motivation and Context

Fix #10764 ...again

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
