### PR TITLE
CI: Ignore PVS-Studio's license close to expiry error code

### DIFF
--- a/.github/actions/windows-analysis/action.yaml
+++ b/.github/actions/windows-analysis/action.yaml
@@ -55,8 +55,8 @@ runs:
         )
         & "C:\Program Files (x86)\PVS-Studio\PVS-Studio_Cmd.exe" @pvsParams
         
-        # Success and CodeErrorsFound are fine as error codes, we only care if it is anything but those
-        $pvs_result = $LASTEXITCODE -band (-bnot [PVSErrorCodes]::CodeErrorsFound)
+        # Success, LicenseExpiringSoon, and CodeErrorsFound are fine as error codes, we only care if it is anything but those
+        $pvs_result = $LASTEXITCODE -band (-bnot ([PVSErrorCodes]::CodeErrorsFound -bor [PVSErrorCodes]::LicenseExpiringSoon))
         if ($pvs_result -ne 0) {
             Write-Output "PVS-Studio Errors: $([PVSErrorCodes]$pvs_result)"
         }


### PR DESCRIPTION
### Description

Adds the error code indicating the licence is expiring soon to the ignored ones.

### Motivation and Context

Want to avoid failure if there isn't one.

This shouldn't be required as we set `--disableLicenseExpirationCheck` check but here we are.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
