### PR TITLE
UI: Remove GPU LUID from system info for Multitrack Video

### DIFF
--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -146,13 +146,11 @@ struct Gpu {
 	uint32_t device_id;
 	uint64_t dedicated_video_memory;
 	uint64_t shared_system_memory;
-	string luid;
 	optional<string> driver_version;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Gpu, model, vendor_id, device_id,
 				       dedicated_video_memory,
-				       shared_system_memory, luid,
-				       driver_version)
+				       shared_system_memory, driver_version)
 };
 
 struct GamingFeatures {

--- a/UI/system-info-windows.cpp
+++ b/UI/system-info-windows.cpp
@@ -23,7 +23,6 @@ static std::optional<std::vector<GoLiveApi::Gpu>> system_gpu_data()
 
 	std::vector<GoLiveApi::Gpu> adapter_info;
 
-	DStr luid_buffer;
 	for (i = 0; factory->EnumAdapters1(i, adapter.Assign()) == S_OK; ++i) {
 		DXGI_ADAPTER_DESC desc;
 		char name[512] = "";
@@ -47,11 +46,6 @@ static std::optional<std::vector<GoLiveApi::Gpu>> system_gpu_data()
 
 		data.dedicated_video_memory = desc.DedicatedVideoMemory;
 		data.shared_system_memory = desc.SharedSystemMemory;
-
-		dstr_printf(luid_buffer, "luid_0x%08X_0x%08X",
-			    desc.AdapterLuid.HighPart,
-			    desc.AdapterLuid.LowPart);
-		data.luid = luid_buffer->array;
 
 		/* driver version */
 		LARGE_INTEGER umd;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove GPU LUID from system info for Multitrack Video

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed LUID was sent with the other GPU info. After further review, decided this is not needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built and ran locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
