### PR TITLE
UI: Fix incompatible settings message when streaming Multitrack Video

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -398,9 +398,9 @@ void MultitrackVideoOutput::PrepareStreaming(
 	auto multitrack_video_name =
 		QTStr("Basic.Settings.Stream.MultitrackVideoLabel");
 	if (obs_data_has_user_value(service_settings,
-				    "ertmp_multitrack_video_name")) {
+				    "multitrack_video_name")) {
 		multitrack_video_name = obs_data_get_string(
-			service_settings, "ertmp_multitrack_video_name");
+			service_settings, "multitrack_video_name");
 	}
 
 	auto auto_config_url_data = auto_config_url.toUtf8();
@@ -637,7 +637,7 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(
 			QString(" %1. %2\n").arg(num).arg(QTStr(name));
 
 		where_to_disable +=
-			QString(" %1. [%2 > %3 > %4]\n")
+			QString(" %1. [%2 → %3 → %4]\n")
 				.arg(num)
 				.arg(QTStr("Settings"))
 				.arg(QTStr("Basic.Settings.Advanced"))
@@ -667,12 +667,11 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(
 	QMessageBox mb(parent);
 	mb.setIcon(QMessageBox::Critical);
 	mb.setWindowTitle(QTStr("MultitrackVideo.IncompatibleSettings.Title"));
-	mb.setText(
-		QString(QTStr("MultitrackVideo.IncompatibleSettings.Text"))
-			.arg(obs_data_get_string(service_settings,
-						 "ertmp_multitrack_video_name"))
-			.arg(incompatible_settings)
-			.arg(where_to_disable));
+	mb.setText(QString(QTStr("MultitrackVideo.IncompatibleSettings.Text"))
+			   .arg(obs_data_get_string(service_settings,
+						    "multitrack_video_name"))
+			   .arg(incompatible_settings)
+			   .arg(where_to_disable));
 	auto this_stream = mb.addButton(
 		QTStr("MultitrackVideo.IncompatibleSettings.DisableAndStartStreaming"),
 		QMessageBox::AcceptRole);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Fix incompatible settings message when streaming Multitrack Video

When streaming with Multitrack Video (Enhanced Broadcasting) and incompatible settings, the warning message was missing parts of the string due to incorrect translation string keys.

Additionally, use Unicode arrows to direct users through UI elements.

The bulk of the diff is just clang-format rearranging lines.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want warning/error messages to be readable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
