### PR TITLE
rtmp-services: Add Amazon IVS service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 254,
+    "version": 255,
     "files": [
         {
             "name": "services.json",
-            "version": 254
+            "version": 255
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2903,6 +2903,25 @@
                 "x264opts": "scenecut=0",
                 "output": "rtmp_output"
             }
+        },
+        {
+            "name": "Amazon IVS",
+            "supported video codecs": ["h264"],
+            "servers": [
+                {
+                    "name": "Global (RTMPS, recommended)",
+                    "url": "rtmps://ingest.global-contribute.live-video.net:443/app"
+                },
+                {
+                    "name": "Global (RTMP)",
+                    "url": "rtmp://ingest.global-contribute.live-video.net/app"
+                }
+            ],
+            "multitrack_video_configuration_url": "https://ingest.contribute.live-video.net/api/v3/GetClientConfiguration",
+            "recommended": {
+                "keyint": 2,
+                "x264opts": "scenecut=0"
+            }
         }
     ]
 }


### PR DESCRIPTION
This is a smaller version of https://github.com/obsproject/obs-studio/pull/10634

### Description
Add Amazon IVS service entry with global DNS names

### Motivation and Context
Currently users of Amazon IVS customers have to use the custom service entry and enter both a URL and their stream key; with multitrack video they'd also have to enter a config URL (which is currently not exposed in the custom service UI)

With these changes users will generally only have to enter their stream key (and select "Global (RTMPS, recommended)" or "Global (RTMP)" depending on whichever the Amazon IVS customer wants their users to use)

### How Has This Been Tested?
Tested using various IVS channels created for testing purposes, some of which were allowlisted for multitrack video

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
