### PR TITLE
UI: Enable custom server entry for Amazon IVS

### DIFF
--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -802,7 +802,7 @@ void OBSBasicSettings::UpdateServerList()
 		ui->server->addItem(name, server);
 	}
 
-	if (serviceName == "Twitch") {
+	if (serviceName == "Twitch" || serviceName == "Amazon IVS") {
 		ui->server->addItem(
 			QTStr("Basic.Settings.Stream.SpecifyCustomServer"),
 			CustomServerUUID());


### PR DESCRIPTION
### Description
Add Amazon IVS service entry with global DNS names

### Motivation and Context
Currently users of Amazon IVS customers have to use the custom service entry and enter both a URL and their stream key; with multitrack video they'd also have to enter a config URL (which is currently not exposed in the custom service UI)

With these changes users will generally only have to enter their stream key (and select "Global (RTMPS, recommended)" or "Global (RTMP)" depending on whichever the Amazon IVS customer wants their users to use)

Additionally, this enables the "custom server" settings entry for Amazon IVS

### How Has This Been Tested?
Tested using various IVS channels created for testing purposes, some of which were allowlisted for multitrack video

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
