### PR TITLE
obs-webrtc: Do not use curl_easy_nextheader

### DIFF
--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -26,6 +26,22 @@ static std::string trim_string(const std::string &source)
 	return ret;
 }
 
+static std::string value_for_header(const std::string &header,
+				    const std::string &val)
+{
+	if (val.size() <= header.size() ||
+	    astrcmpi_n(header.c_str(), val.c_str(), header.size()) != 0) {
+		return "";
+	}
+
+	auto delimiter = val.find_first_of(" ");
+	if (delimiter == std::string::npos) {
+		return "";
+	}
+
+	return val.substr(delimiter + 1);
+}
+
 static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
 				 void *priv_data)
 {
@@ -37,28 +53,12 @@ static size_t curl_writefunction(char *data, size_t size, size_t nmemb,
 	return real_size;
 }
 
-#define LOCATION_HEADER_LENGTH 10
-
-static size_t curl_header_location_function(char *data, size_t size,
-					    size_t nmemb, void *priv_data)
+static size_t curl_header_function(char *data, size_t size, size_t nmemb,
+				   void *priv_data)
 {
 	auto header_buffer = static_cast<std::vector<std::string> *>(priv_data);
-
-	size_t real_size = size * nmemb;
-
-	if (real_size < LOCATION_HEADER_LENGTH)
-		return real_size;
-
-	if (!astrcmpi_n(data, "location: ", LOCATION_HEADER_LENGTH)) {
-		char *val = data + LOCATION_HEADER_LENGTH;
-		auto header_temp =
-			std::string(val, real_size - LOCATION_HEADER_LENGTH);
-
-		header_temp = trim_string(header_temp);
-		header_buffer->push_back(header_temp);
-	}
-
-	return real_size;
+	header_buffer->push_back(trim_string(std::string(data, size * nmemb)));
+	return size * nmemb;
 }
 
 static inline std::string generate_user_agent()


### PR DESCRIPTION
### Description
API not available in Ubuntu 22.04 which ships 7.81 this API was first available in 7.83

### Motivation and Context
Fixes build on Ubuntu 22.04

### How Has This Been Tested?
Tested against WHIP server with TURN
Tested against Broadcast Box
Tested against Twitch

### Types of changes
- Bug fix (non-breaking change which fixes an issue)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
