### PR TITLE
UI: Address logging buffer size discrepancies

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -350,7 +350,7 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg,
 	static mutex log_mutex;
 	static const char *last_msg_ptr = nullptr;
 	static int last_char_sum = 0;
-	static char cmp_str[4096];
+	static char cmp_str[8192];
 	static int rep_count = 0;
 
 	int new_sum = sum_chars(output_str);
@@ -376,7 +376,8 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg,
 	}
 
 	last_msg_ptr = msg;
-	strcpy(cmp_str, output_str);
+	strncpy(cmp_str, output_str, sizeof(cmp_str));
+	cmp_str[sizeof(cmp_str) - 1] = 0;
 	last_char_sum = new_sum;
 	rep_count = 0;
 

--- a/UI/qt-wrappers.cpp
+++ b/UI/qt-wrappers.cpp
@@ -42,7 +42,7 @@
 
 static inline void OBSErrorBoxva(QWidget *parent, const char *msg, va_list args)
 {
-	char full_message[4096];
+	char full_message[8192];
 	vsnprintf(full_message, sizeof(full_message), msg, args);
 
 	QMessageBox::critical(parent, "Error", full_message);

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -27,7 +27,7 @@ static void *crash_param = NULL;
 static void def_log_handler(int log_level, const char *format, va_list args,
 			    void *param)
 {
-	char out[4096];
+	char out[8192];
 	vsnprintf(out, sizeof(out), format, args);
 
 	switch (log_level) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the remaining log buffer allocations in the log handler to use a buffer of size 8192 instead of 4096. Also adds improved string handling in the form of using `strncpy` rather than `strcpy` in the `too_many_repeated_entries()` check.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
OBS was crashing on startup when logging messages over 4096 characters in length with corruption of the `QPointer` object for the log viewer. It turns out that this was due to a buffer overrun in the log handling code.

https://github.com/obsproject/obs-studio/commit/43a1b309940b7bb7a92fdcd019bd011ef762621f changed the size of the log buffer in obs-app.cpp's `do_log`, but to change the size of the buffer properly we need to also modify the buffer size in the subsequent check for repeated entries, as well as the base log handler in `libobs`. Otherwise the repeated entries check will bulldoze over memory adjacent to `cmp_str` if fed a message exceeding 4096 characters in length, as well as other memory in the base log handler.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Verified that OBS no longer crashes when failing to load VLC on startup, and logging continues to work correctly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
