### PR TITLE
Encoder Group Resynchronisation

### DIFF
--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -37,6 +37,7 @@ typedef struct obs_encoder obs_encoder_t;
 #define OBS_ENCODER_CAP_DYN_BITRATE (1 << 2)
 #define OBS_ENCODER_CAP_INTERNAL (1 << 3)
 #define OBS_ENCODER_CAP_ROI (1 << 4)
+#define OBS_ENCODER_CAP_FORCE_IDR (1 << 5)
 
 /** Specifies the encoder type */
 enum obs_encoder_type {
@@ -91,6 +92,12 @@ struct encoder_packet {
 	obs_encoder_t *encoder;
 };
 
+/** Specifies flags to be applied to next frame */
+typedef enum obs_frame_flags {
+	OBS_FRAME_NONE = 0,
+	OBS_FRAME_FORCE_IDR = 1 << 0,
+} obs_frame_flags;
+
 /** Encoder input frame */
 struct encoder_frame {
 	/** Data for the frame/audio */
@@ -104,6 +111,9 @@ struct encoder_frame {
 
 	/** Presentation timestamp */
 	int64_t pts;
+
+	/** Frame flags */
+	obs_frame_flags flags;
 };
 
 /** Encoder region of interest */
@@ -131,6 +141,8 @@ struct encoder_texture {
 	uint32_t handle;
 	/** Textures, length determined by format */
 	struct gs_texture *tex[4];
+	/** Frame flags */
+	obs_frame_flags flags;
 };
 
 /**

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -256,6 +256,7 @@ struct obs_tex_frame {
 	uint64_t lock_key;
 	int count;
 	bool released;
+	bool skip;
 };
 
 struct obs_task_info {

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1248,6 +1248,9 @@ struct encoder_group {
 	uint32_t encoders_added;
 	uint32_t encoders_started;
 	uint64_t start_timestamp;
+	int64_t last_missing_pts;
+	bool resync_supported;
+	int64_t force_idr_pts;
 };
 
 struct obs_encoder {

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -137,6 +137,18 @@ static void *gpu_encode_thread(void *data)
 			if (skip)
 				continue;
 
+			if (tf.skip) {
+				/* Skip frame but increment PTS to maintain
+				 * sync if encoder already started. */
+				if (encoder->start_ts) {
+					encoder->cur_pts +=
+						encoder->timebase_num *
+						encoder->frame_rate_divisor;
+				}
+
+				continue;
+			}
+
 			if (!encoder->start_ts)
 				encoder->start_ts = timestamp;
 
@@ -182,9 +194,13 @@ static void *gpu_encode_thread(void *data)
 
 		if (--tf.count) {
 			tf.timestamp += interval;
-			deque_push_front(&video->gpu_encoder_queue, &tf,
-					 sizeof(tf));
-
+			deque_push_back(&video->gpu_encoder_queue, &tf,
+					sizeof(tf));
+			if (tf.skip) {
+				video_output_inc_texture_skipped_frames(
+					video->video);
+			}
+		} else if (tf.skip) {
 			video_output_inc_texture_skipped_frames(video->video);
 		} else {
 			deque_push_back(&video->gpu_encoder_avail_queue, &tf,
@@ -243,7 +259,8 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 
 		struct obs_tex_frame frame = {.tex = tex,
 					      .tex_uv = tex_uv,
-					      .handle = handle};
+					      .handle = handle,
+					      .skip = false};
 
 		deque_push_back(&video->gpu_encoder_avail_queue, &frame,
 				sizeof(frame));

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -161,6 +161,18 @@ static void *gpu_encode_thread(void *data)
 			if (encoder->info.encode_texture2) {
 				struct encoder_texture tex = {0};
 
+				/* Force IDR frame to reset GOP and resync grouped encoders */
+				if (encoder->encoder_group &&
+				    encoder->encoder_group->force_idr_pts ==
+					    encoder->cur_pts &&
+				    encoder->info.caps &
+					    OBS_ENCODER_CAP_FORCE_IDR) {
+					blog(LOG_DEBUG,
+					     "Forcing IDR on encoder \"%s\"",
+					     obs_encoder_get_name(encoder));
+					tex.flags |= OBS_FRAME_FORCE_IDR;
+				}
+
 				tex.handle = tf.handle;
 				tex.tex[0] = tf.tex;
 				tex.tex[1] = tf.tex_uv;

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -858,6 +858,9 @@ static bool obs_x264_encode(void *data, struct encoder_frame *frame,
 	if (obs_encoder_has_roi(obsx264->encoder))
 		add_roi(obsx264, &pic);
 
+	if (frame->flags & OBS_FRAME_FORCE_IDR)
+		pic.i_type = X264_TYPE_IDR;
+
 	ret = x264_encoder_encode(obsx264->context, &nals, &nal_count,
 				  (frame ? &pic : NULL), &pic_out);
 	if (ret < 0) {
@@ -930,5 +933,6 @@ struct obs_encoder_info obs_x264_encoder = {
 	.get_extra_data = obs_x264_extra_data,
 	.get_sei_data = obs_x264_sei,
 	.get_video_info = obs_x264_video_info,
-	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI,
+	.caps = OBS_ENCODER_CAP_DYN_BITRATE | OBS_ENCODER_CAP_ROI |
+		OBS_ENCODER_CAP_FORCE_IDR,
 };


### PR DESCRIPTION
### Description

Adds a mechanism to resynchronise grouped encoders if keyframes are no longer aligned to the same PTS interval.

Resynchronisation works by determining a future PTS all encoders are expected to hit, and adding a flag to that frame instructing the encoder to force an IDR frame, thus starting a new GOP and bringing encoders back in-sync.

This PR adds a mechanism to adds the following on top of #10096:
- `OBS_ENCODER_CAP_FORCE_IDR` to indicate that an encoder supports forcing IDR frames
- Adds `obs_frame_flags` to `encoder_frame`/`encoder_texture`
    + Only `OBS_FRAME_FORCE_IDR` exists for now
- Repurposes the existing check for frame misalignments to determine a future resync point
- Implements forcing IDR frames for x264 and NVENC

### Motivation and Context

With the goal of #10096 (included here) being to allow encoders to skip frames to avoid the death spiral after GPU stalls while being close to the maximum throughput, we need a means of resyncing encoders if frames are skipped.

While this PR only implements this feature for x264 and NVENC, all the other relevant encoders (QSV, AMF, VideoToolbox) also support forcing/requesting IDR frames.

### How Has This Been Tested?

Has been tested in one form or another during my personal test streams going back to January.

### Types of changes

- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
