### PR TITLE
UI: Simplify multitrack encoder availability check

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -259,30 +259,16 @@ static void adjust_encoder_frame_rate_divisor(
 	obs_encoder_set_frame_rate_divisor(video_encoder, divisor);
 }
 
-static const std::vector<const char *> &get_available_encoders()
-{
-	// encoders are currently only registered during startup, so keeping
-	// a static vector around shouldn't be a problem
-	static std::vector<const char *> available_encoders = [] {
-		std::vector<const char *> available_encoders;
-		for (size_t i = 0;; i++) {
-			const char *id = nullptr;
-			if (!obs_enum_encoder_types(i, &id))
-				break;
-			available_encoders.push_back(id);
-		}
-		return available_encoders;
-	}();
-	return available_encoders;
-}
-
 static bool encoder_available(const char *type)
 {
-	auto &encoders = get_available_encoders();
-	return std::find_if(std::begin(encoders), std::end(encoders),
-			    [=](const char *encoder) {
-				    return strcmp(type, encoder) == 0;
-			    }) != std::end(encoders);
+	const char *id = nullptr;
+
+	for (size_t idx = 0; obs_enum_encoder_types(idx, &id); idx++) {
+		if (strcmp(id, type) == 0)
+			return true;
+	}
+
+	return false;
 }
 
 static OBSEncoderAutoRelease create_video_encoder(


### PR DESCRIPTION
### Description

Simplifies the check for whether or not an encoder is available.

### Motivation and Context

Much more readable and avoids the creation of a pointless `std::vector`.

### How Has This Been Tested?

Locally.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
