### PR TITLE
UI: Remove dead code from multitrack output

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -144,34 +144,6 @@ create_service(const GoLiveApi::Config &go_live_config,
 	return service;
 }
 
-static void ensure_directory_exists(std::string &path)
-{
-	replace(path.begin(), path.end(), '\\', '/');
-
-	size_t last = path.rfind('/');
-	if (last == std::string::npos)
-		return;
-
-	std::string directory = path.substr(0, last);
-	os_mkdirs(directory.c_str());
-}
-
-std::string GetOutputFilename(const std::string &path, const char *format)
-{
-	std::string strPath;
-	strPath += path;
-
-	char lastChar = strPath.back();
-	if (lastChar != '/' && lastChar != '\\')
-		strPath += "/";
-
-	strPath += BPtr<char>{
-		os_generate_formatted_filename("flv", false, format)};
-	ensure_directory_exists(strPath);
-
-	return strPath;
-}
-
 static OBSOutputAutoRelease create_output()
 {
 	OBSOutputAutoRelease output = obs_output_create(


### PR DESCRIPTION
### Description

Removes some dead code.

### Motivation and Context

Not needed anymore, just adds noise.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
