### PR TITLE
UI: Add config option to use MP4 for debug recording

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -189,11 +189,21 @@ static OBSOutputAutoRelease create_output()
 
 static OBSOutputAutoRelease create_recording_output(obs_data_t *settings)
 {
-	OBSOutputAutoRelease output = obs_output_create(
-		"flv_output", "flv multitrack video", settings, nullptr);
+	OBSOutputAutoRelease output;
+	bool useMP4 = obs_data_get_bool(settings, "use_mp4");
 
-	if (!output)
-		blog(LOG_ERROR, "Failed to create multitrack video flv output");
+	if (useMP4) {
+		output = obs_output_create("mp4_output", "mp4 multitrack video",
+					   settings, nullptr);
+	} else {
+		output = obs_output_create("flv_output", "flv multitrack video",
+					   settings, nullptr);
+	}
+
+	if (!output) {
+		blog(LOG_ERROR, "Failed to create multitrack video %s output",
+		     useMP4 ? "mp4" : "flv");
+	}
 
 	return output;
 }

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2854,16 +2854,26 @@ OBSDataAutoRelease BasicOutputHandler::GenerateMultitrackVideoStreamDumpConfig()
 						       "FilenameFormatting");
 	bool overwriteIfExists =
 		config_get_bool(main->Config(), "Output", "OverwriteIfExists");
+	bool useMP4 = config_get_bool(main->Config(), "Stream1",
+				      "MultitrackVideoStreamDumpAsMP4");
 
 	string f;
 
 	OBSDataAutoRelease settings = obs_data_create();
 	f = GetFormatString(filenameFormat, nullptr, nullptr);
-	string strPath = GetRecordingFilename(path, "flv", noSpace,
-					      overwriteIfExists, f.c_str(),
+	string strPath = GetRecordingFilename(path, useMP4 ? "mp4" : "flv",
+					      noSpace, overwriteIfExists,
+					      f.c_str(),
 					      // never remux stream dump
 					      false);
 	obs_data_set_string(settings, "path", strPath.c_str());
+
+	if (useMP4) {
+		obs_data_set_bool(settings, "use_mp4", true);
+		obs_data_set_string(settings, "muxer_settings",
+				    "write_encoder_info=1");
+	}
+
 	return settings;
 }
 


### PR DESCRIPTION
### Description

Adds config option `MultitrackVideoStreamDumpAsMP4` to use the native MP4 muxer instead of FLV for dumping multi-track video to disk.

### Motivation and Context

The "multitrack recording dump" output is hidden by default and exists for debugging/testing purposes, but it uses multi-track FLV which is not yet supported by FFmpeg and other tools. So when it's not being used to debug the FLV muxer itself this will make it easier to get a file containing all synchronised streams in one that is actually usable with existing software.

### How Has This Been Tested?

Tested locally. Opened file in MPC-HC:
![2024-06-07_18-16-57_lylbPi](https://github.com/obsproject/obs-studio/assets/3123295/d2fa379a-e77f-4302-9667-53daa20d30d6)


### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
