### PR TITLE
CI: Restrict PVS-Studio analysis to obsproject repo

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -5,6 +5,7 @@ jobs:
   windows:
     name: Windows 🪟 (PVS-Studio)
     runs-on: windows-2022
+    if: github.repository_owner == 'obsproject'
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
### Description

Disables PVS Studio analysis job on forks as they (probably) won't have the licence key for PVS set up.

### Motivation and Context

Don't want run failures on people's forks.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
