### PR TITLE
UI: Various audio mixer adjustments and clean up

### DIFF
--- a/UI/absolute-slider.cpp
+++ b/UI/absolute-slider.cpp
@@ -65,9 +65,6 @@ bool AbsoluteSlider::eventFilter(QObject *obj, QEvent *event)
 		}
 	}
 
-	if (event->type() == QEvent::Wheel)
-		return true;
-
 	return QSlider::eventFilter(obj, event);
 }
 

--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -129,9 +129,9 @@
 
     --spinbox_button_height: calc(var(--input_height) - 2px);
 
-    --volume_slider: calc(calc(6px + var(--font_base_value)) / 2);
+    --volume_slider: calc(calc(10px + var(--font_base_value)) / 4);
     --volume_slider_box: calc(var(--volume_slider) * 4);
-    --volume_slider_label: calc(var(--volume_slider) * 6);
+    --volume_slider_label: calc(var(--volume_slider_box) * 2);
 
     --scrollbar_size: 12px;
 
@@ -1197,7 +1197,7 @@ QSlider::handle:disabled {
     height: var(--icon_base);
     background-color: var(--button_bg);
     padding: var(--padding_base_border) var(--padding_base_border);
-    margin: 0px var(--spacing_base);
+    margin: 0px;
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);
     icon-size: var(--icon_base), var(--icon_base);
@@ -1232,21 +1232,17 @@ VolControl #volLabel {
 
 /* Horizontal Mixer */
 #hMixerScrollArea VolControl {
-    padding: 0px var(--padding_large);
+    padding: 0px var(--padding_xlarge) var(--padding_base);
     border-bottom: 1px solid var(--border_color);
 }
 
 #hMixerScrollArea VolControl QSlider {
-    margin: 0px 0px;
+    margin: 0px 0px var(--padding_base);
 }
 
 #hMixerScrollArea VolControl QSlider::groove:horizontal {
     background: var(--bg_window);
     height: var(--volume_slider);
-}
-
-#hMixerScrollArea VolControl QPushButton {
-    margin-right: var(--padding_xlarge);
 }
 
 /* Vertical Mixer */
@@ -1261,13 +1257,14 @@ VolControl #volLabel {
 
 #vMixerScrollArea VolControl QSlider {
     width: var(--volume_slider_box);
+    margin: 0px var(--padding_xlarge);
 }
 
 #vMixerScrollArea VolControl #volLabel {
     padding: var(--padding_base) 0px var(--padding_base);
     min-width: var(--volume_slider_label);
     max-width: var(--volume_slider_label);
-    margin-right: 0;
+    margin-left: var(--padding_xlarge);
     text-align: center;
 }
 
@@ -1277,7 +1274,7 @@ VolControl #volLabel {
 }
 
 #vMixerScrollArea VolControl #volMeterFrame {
-    padding: var(--padding_large) var(--padding_xlarge);
+    padding: var(--padding_large) var(--padding_xlarge) var(--padding_large) 0px;
 }
 
 #vMixerScrollArea VolControl QLabel {
@@ -1586,7 +1583,7 @@ MuteCheckBox::indicator:unchecked {
     height: var(--icon_base);
     background-color: var(--button_bg);
     padding: var(--padding_base_border) var(--padding_base_border);
-    margin: 0px var(--spacing_base);
+    margin: 0px;
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);
     icon-size: var(--icon_base), var(--icon_base);
@@ -1596,7 +1593,7 @@ MuteCheckBox::indicator:hover,
 MuteCheckBox::indicator:unchecked:hover {
     background-color: var(--button_bg_hover);
     padding: var(--padding_base_border) var(--padding_base_border);
-    margin: 0px var(--spacing_base);
+    margin: 0px;
     border: 1px solid var(--button_border_hover);
     icon-size: var(--icon_base), var(--icon_base);
 }

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -257,6 +257,8 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		config->setProperty("themeID", "menuIconSmall");
 		config->setAutoDefault(false);
 
+		config->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
 		config->setAccessibleName(
 			QTStr("VolControl.Properties").arg(sourceName));
 
@@ -338,9 +340,10 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		setMaximumWidth(110);
 	} else {
 		QHBoxLayout *textLayout = new QHBoxLayout;
+		QHBoxLayout *controlLayout = new QHBoxLayout;
 		QFrame *meterFrame = new QFrame;
-		QHBoxLayout *meterLayout = new QHBoxLayout;
-		QHBoxLayout *botLayout = new QHBoxLayout;
+		QVBoxLayout *meterLayout = new QVBoxLayout;
+		QVBoxLayout *buttonLayout = new QVBoxLayout;
 
 		volMeter = new VolumeMeter(nullptr, obs_volmeter, false);
 		volMeter->setSizePolicy(QSizePolicy::MinimumExpanding,
@@ -362,23 +365,25 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		meterLayout->setContentsMargins(0, 0, 0, 0);
 		meterLayout->setSpacing(0);
 
-		if (showConfig) {
-			meterLayout->addWidget(config);
-			meterLayout->setAlignment(config, Qt::AlignVCenter);
-		}
 		meterLayout->addWidget(volMeter);
+		meterLayout->addWidget(slider);
 
-		botLayout->setContentsMargins(0, 0, 0, 0);
-		botLayout->setSpacing(0);
-		botLayout->addWidget(mute);
-		botLayout->addWidget(slider);
+		buttonLayout->setContentsMargins(0, 0, 0, 0);
+		buttonLayout->setSpacing(0);
 
-		botLayout->setAlignment(slider, Qt::AlignVCenter);
-		botLayout->setAlignment(mute, Qt::AlignVCenter);
+		if (showConfig) {
+			buttonLayout->addWidget(config);
+		}
+		buttonLayout->addItem(
+			new QSpacerItem(0, 0, QSizePolicy::Minimum,
+					QSizePolicy::MinimumExpanding));
+		buttonLayout->addWidget(mute);
+
+		controlLayout->addItem(buttonLayout);
+		controlLayout->addWidget(meterFrame);
 
 		mainLayout->addItem(textLayout);
-		mainLayout->addWidget(meterFrame);
-		mainLayout->addItem(botLayout);
+		mainLayout->addItem(controlLayout);
 
 		volMeter->setFocusProxy(slider);
 	}

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -249,6 +249,10 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 	volLabel->setObjectName("volLabel");
 	volLabel->setAlignment(Qt::AlignCenter);
 
+#ifdef __APPLE__
+	mute->setAttribute(Qt::WA_LayoutUsesWidgetRect);
+#endif
+
 	QString sourceName = obs_source_get_name(source);
 	setObjectName(sourceName);
 

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -300,24 +300,16 @@ VolControl::VolControl(OBSSource source_, bool showConfig, bool vertical)
 		controlLayout->setContentsMargins(0, 0, 0, 0);
 		controlLayout->setSpacing(0);
 
-		controlLayout->setAlignment(mute, Qt::AlignVCenter);
 		// Add Headphone (audio monitoring) widget here
 		controlLayout->addWidget(mute);
-		controlLayout->addItem(
-			new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding,
-					QSizePolicy::Minimum));
 
 		if (showConfig) {
 			controlLayout->addWidget(config);
-			controlLayout->setAlignment(config, Qt::AlignVCenter);
 		}
 
 		meterLayout->setContentsMargins(0, 0, 0, 0);
 		meterLayout->setSpacing(0);
 		meterLayout->addWidget(slider);
-		meterLayout->addItem(
-			new QSpacerItem(0, 0, QSizePolicy::MinimumExpanding,
-					QSizePolicy::Minimum));
 		meterLayout->addWidget(volMeter);
 
 		meterFrame->setLayout(meterLayout);


### PR DESCRIPTION
### Description
These commits make a few adjustments or fixes to the audio mixer.

1. Group the buttons together in horizontal layout for better alignment
2. Cleans up some spacing and sizing of audio mixer widgets
3. Remove wheel events from the absolute-slider event filter. This is still appropriately handled by the slider-ignorewheel widget
4. macOS-specific fix. May be able to squash
5. Center widgets in vertical layout

Before:
![image](https://github.com/obsproject/obs-studio/assets/1554753/1522cd70-6a0e-4a56-af1e-012b1e1feb05)

After:
![image](https://github.com/obsproject/obs-studio/assets/1554753/3db6cf49-4ffb-4161-b45b-996f3f43e7ad)


Before:
![image](https://github.com/obsproject/obs-studio/assets/1554753/2a5a15af-d689-48a8-b3f3-9d7c347d65a7)

After:
![image](https://github.com/obsproject/obs-studio/assets/1554753/595fa2a0-502d-4dc3-8629-0603dceb75b7)


### Motivation and Context
Fix and clean up audio mixer changes.

### How Has This Been Tested?
Tried scrolling the audio mixer while hovering a volume meter or slider

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
