### PR TITLE
UI: Remove unnecessary string copy from log filter

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -350,7 +350,6 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg,
 	static mutex log_mutex;
 	static const char *last_msg_ptr = nullptr;
 	static int last_char_sum = 0;
-	static char cmp_str[8192];
 	static int rep_count = 0;
 
 	int new_sum = sum_chars(output_str);
@@ -376,8 +375,6 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg,
 	}
 
 	last_msg_ptr = msg;
-	strncpy(cmp_str, output_str, sizeof(cmp_str));
-	cmp_str[sizeof(cmp_str) - 1] = 0;
 	last_char_sum = new_sum;
 	rep_count = 0;
 


### PR DESCRIPTION
### Description

Removes an unused string copy of the last log output.

### Motivation and Context

Found while looking at #10799, though unrelated to the crash.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
