### PR TITLE
UI: Improve macOS properties tooltip spacing workaround

### DIFF
--- a/UI/properties-view.cpp
+++ b/UI/properties-view.cpp
@@ -1640,18 +1640,15 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 			QHBoxLayout *boxLayout = new QHBoxLayout(newWidget);
 			boxLayout->setContentsMargins(0, 0, 0, 0);
 			boxLayout->setAlignment(Qt::AlignLeft);
-#ifdef __APPLE__
-			/* TODO: This fixes the issue of tooltip not aligning
-			 * correcty on macOS, the root cause needs further
-			 * investigation. */
-			boxLayout->setSpacing(10);
-#else
 			boxLayout->setSpacing(0);
-#endif
+
 			QCheckBox *check = qobject_cast<QCheckBox *>(widget);
 			check->setText(desc);
 			check->setToolTip(
 				obs_property_long_description(property));
+#ifdef __APPLE__
+			check->setAttribute(Qt::WA_LayoutUsesWidgetRect);
+#endif
 
 			QLabel *help = new QLabel(check);
 			help->setText(bStr.arg(file));


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
QMacStyle appears to have an issue where it messes up the positions of some widgets. The previous workaround added extra spacing to force the icon further to the right. Forcing the widget rectangle to be used instead of the one made by the style also fixes this, arguably in a nicer way.
See also b760b24ff00e844c34be0d26222976ee99281472 which does this for checkboxes in the source tree.

I'm planning to take a deeper look into what QMacStyle is doing that messes this up at a later point.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stumbled across this when trying to look into why the checkbox has some sort of spacing to the left.
<img width="239" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/23922cce-e67c-4043-84de-d21bb16c2e59">

I did not yet succeed with that investigation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.5.1

See that even without extra spacing, the icon is at the correct position (that matches other operating systems):
<img width="782" alt="image" src="https://github.com/obsproject/obs-studio/assets/59806498/2486eab7-b348-4b95-aa9f-c331f1b8c2cc">

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
