### PR TITLE
CI: Fix input variable name when getting Windows release notes

### DIFF
--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -86,7 +86,7 @@ runs:
       run: |
         # Release notes are just the tag body on Windows
         Set-Location repo
-        git tag -l --format='%(contents:body)' ${{ inputs.version }} > "${{ github.workspace }}/notes.rst"
+        git tag -l --format='%(contents:body)' ${{ inputs.tagName }} > "${{ github.workspace }}/notes.rst"
 
     - name: Run bouf
       shell: pwsh


### PR DESCRIPTION
### Description

Fixes the input variable name.

### Motivation and Context

Release notes should only be the latest tag, not all of them, silly.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
