### PR TITLE
UI: Connect replay buffer stopping to signal instead of slot

### DIFF
--- a/UI/basic-controls.cpp
+++ b/UI/basic-controls.cpp
@@ -117,7 +117,7 @@ OBSBasicControls::OBSBasicControls(OBSBasic *main)
 
 	connect(main, &OBSBasic::ReplayBufStarted, this,
 		&OBSBasicControls::ReplayBufferStarted);
-	connect(main, &OBSBasic::ReplayBufferStopping, this,
+	connect(main, &OBSBasic::ReplayBufStopping, this,
 		&OBSBasicControls::ReplayBufferStopping);
 	connect(main, &OBSBasic::ReplayBufStopped, this,
 		&OBSBasicControls::ReplayBufferStopped);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a typo that resulted in a wrong connection, where the controls dock slot would attempt to connect to the main window slot instead of signal, which of course doesn't work.
To the user, this would mean that the replay buffer button text wouldn't change to "Stopping" when pressing "Stop", instead staying on "Stop" while stopping and then going to "Start" directly.

30.2 regression.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw obsproject/loganalyzer#163 that excluded an `OBSBasic`, which looked suspicious. No log should contain `OBSBasic`.
Turns out that Qt logged a warning that a signal couldn't be found. Looking into that further , this makes sense since the signal that the slot was connected to wasn't a signal.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.5
Firstly, made sure the bug indeed exists (see observation in Description).
Tested that with this patch, the button does show "Stopping".

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
