### PR TITLE
UI: Avoid allowing to override provided themes

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -425,6 +425,16 @@ void OBSApp::FindThemes()
 		<< "*.oha" // OBS High-contrast Adjustment layer
 		;
 
+	GetDataFilePath("themes/", themeDir);
+	QDirIterator it(QString::fromStdString(themeDir), filters, QDir::Files);
+	while (it.hasNext()) {
+		OBSTheme *theme = ParseThemeMeta(it.next());
+		if (theme && !themes.contains(theme->id))
+			themes[theme->id] = std::move(*theme);
+		else
+			delete theme;
+	}
+
 	if (GetConfigPath(themeDir.data(), themeDir.capacity(),
 			  "obs-studio/themes/") > 0) {
 		QDirIterator it(QT_UTF8(themeDir.c_str()), filters,
@@ -437,16 +447,6 @@ void OBSApp::FindThemes()
 			else
 				delete theme;
 		}
-	}
-
-	GetDataFilePath("themes/", themeDir);
-	QDirIterator it(QString::fromStdString(themeDir), filters, QDir::Files);
-	while (it.hasNext()) {
-		OBSTheme *theme = ParseThemeMeta(it.next());
-		if (theme && !themes.contains(theme->id))
-			themes[theme->id] = std::move(*theme);
-		else
-			delete theme;
 	}
 
 	/* Build dependency tree for all themes, removing ones that have items missing. */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Avoid allowing to override provided themes when a user adds a themes with the same id.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

User themes with same id as provided themes should be ignored/skipped.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
