### PR TITLE
cmake: Copy shared library soname file to rundir on Linux

### DIFF
--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -74,6 +74,8 @@ function(set_target_properties_obs target)
       COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
       COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_FILE:${target}>"
               "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}/"
+      COMMAND "${CMAKE_COMMAND}" -E copy_if_different "$<TARGET_SONAME_FILE:${target}>"
+              "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}/"
       COMMENT "Copy ${target} to library directory (${OBS_LIBRARY_DESTINATION})"
       VERBATIM)
 


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Soname files are required since 1d8c377240dbeb601c8cc3c22bdd1888f685dcb7

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Relocatable OBS can't be ran from rundir without this change.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I had to remove my system install of OBS to make sure that no `libobs-opengl.so.30` were in library paths.

With the PR, OBS ran from the rundir. Doesn't without.

With the PR and OBS install on the system, OBS ran from the rundir loading the right file.
Without the PR it loads the system install file.

`LD_DEBUG=libs ./obs` partial output with PR:
```
info: OBS 30.2.0-beta1-5-ge69061ad8-modified (linux)
info: ---------------------------------
info: ---------------------------------
info: audio settings reset:
	samples per sec: 48000
	speakers:        2
	max buffering:   960 milliseconds
	buffering type:  dynamically increasing
     56595:	find library=libobs-opengl.so.30 [0]; searching
     56595:	 search path=/home/user/obs-studio/build/rundir/Debug/lib:glibc-hwcaps/x86-64-v4:glibc-hwcaps/x86-64-v3:glibc-hwcaps/x86-64-v2:		(RUNPATH from file ./obs)
     56595:	  trying file=/home/user/obs-studio/build/rundir/Debug/lib/libobs-opengl.so.30
     56595:	
     56595:	
     56595:	calling init: /home/user/obs-studio/build/rundir/Debug/lib/libobs-opengl.so.30
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
