### PR TITLE
UI: Initialize members in constructor

### DIFF
--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -350,7 +350,7 @@ std::shared_ptr<Auth> YoutubeAuth::Login(QWidget *owner,
 }
 
 #ifdef BROWSER_AVAILABLE
-void YoutubeChatDock::SetWidget(QCefWidget *widget_)
+YoutubeChatDock::YoutubeChatDock(const QString &title) : BrowserDock(title)
 {
 	lineEdit = new LineEditAutoResize();
 	lineEdit->setVisible(false);
@@ -364,6 +364,14 @@ void YoutubeChatDock::SetWidget(QCefWidget *widget_)
 	chatLayout->addWidget(lineEdit, 1);
 	chatLayout->addWidget(sendButton);
 
+	QWidget::connect(lineEdit, &LineEditAutoResize::returnPressed, this,
+			 &YoutubeChatDock::SendChatMessage);
+	QWidget::connect(sendButton, &QPushButton::pressed, this,
+			 &YoutubeChatDock::SendChatMessage);
+}
+
+void YoutubeChatDock::SetWidget(QCefWidget *widget_)
+{
 	QVBoxLayout *layout = new QVBoxLayout();
 	layout->setContentsMargins(0, 0, 0, 0);
 	layout->addWidget(widget_, 1);
@@ -372,11 +380,6 @@ void YoutubeChatDock::SetWidget(QCefWidget *widget_)
 	QWidget *widget = new QWidget();
 	widget->setLayout(layout);
 	setWidget(widget);
-
-	QWidget::connect(lineEdit, &LineEditAutoResize::returnPressed, this,
-			 &YoutubeChatDock::SendChatMessage);
-	QWidget::connect(sendButton, &QPushButton::pressed, this,
-			 &YoutubeChatDock::SendChatMessage);
 
 	cefWidget.reset(widget_);
 }

--- a/UI/auth-youtube.hpp
+++ b/UI/auth-youtube.hpp
@@ -21,7 +21,7 @@ private:
 	QHBoxLayout *chatLayout;
 
 public:
-	inline YoutubeChatDock(const QString &title) : BrowserDock(title) {}
+	YoutubeChatDock(const QString &title);
 	void SetWidget(QCefWidget *widget_);
 	void SetApiChatId(const std::string &id);
 

--- a/UI/lineedit-autoresize.cpp
+++ b/UI/lineedit-autoresize.cpp
@@ -1,6 +1,6 @@
 #include "lineedit-autoresize.hpp"
 
-LineEditAutoResize::LineEditAutoResize()
+LineEditAutoResize::LineEditAutoResize() : m_maxLength(32767)
 {
 	connect(this, &LineEditAutoResize::textChanged, this,
 		&LineEditAutoResize::checkTextLength);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes mistakes I made in the past that the PVS-Studio analysis uncovered:

LineEditAutoResize didn't have its maxLength initialized in the constructor, leaving it to be a random value until set via setMaxLength. The one place where LineEditAutoResize was used immediately set this after calling the constructor, but if we use this anywhere else in the future it makes sense to have this initialized.
As it is meant to mostly behave like a QLineEdit, lets use the same default value of 32767.

Currently, the chat input elements (lineEdit, sendButton, and chatLayout) are initialized when the QCefWidget gets set. This is problematic behavior that only happened to work because we're a bit lucky: The chat is only enabled after a widget is set, and it's only set once. Without those conditions, the chat dock would crash when enabling the chat before a widget is set, and the elements would get recreated if the widget is set a second time, resulting in the original elements not
getting freed and leaking.
Moving the element creation to the constructor fixes both of these problems, as now they're created immediately and only once.
The inline-diff for this commit is a bit misleading, a lot of code gets moved up so it shows something getting inserted in the middle.

Detected by PVS-Studio

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want things I did to have an entry in the `Security` tab :p
As mentioned above these don't currently have real-world implications, but if someone were to assume that the functions worked correctly, they could get problems.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 14.5
Confirmed that the line edit of the YouTube chat is still limited to 200 characters.
Did testing with the YouTube chat, switching back and forth between broadcasts, to confirm that the chat input still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
