### PR TITLE
obs-ffmpeg: Set encoder error message for CUDA errors

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -270,14 +270,22 @@ static inline bool cuda_error_check(struct nvenc_data *enc, CUresult res,
 	if (res == CUDA_SUCCESS)
 		return true;
 
+	struct dstr message = {0};
+
 	const char *name, *desc;
 	if (cuda_get_error_desc(res, &name, &desc)) {
-		error("%s: CUDA call \"%s\" failed with %s (%d): %s", func,
-		      call, name, res, desc);
+		dstr_printf(&message,
+			    "%s: CUDA call \"%s\" failed with %s (%d): %s",
+			    func, call, name, res, desc);
 	} else {
-		error("%s: CUDA call \"%s\" failed with %d", func, call, res);
+		dstr_printf(&message, "%s: CUDA call \"%s\" failed with %d",
+			    func, call, res);
 	}
 
+	error("%s", message.array);
+	obs_encoder_set_last_error(enc->encoder, message.array);
+
+	dstr_free(&message);
 	return false;
 }
 


### PR DESCRIPTION
### Description

Set last encoder error when a CUDA error occurs.

### Motivation and Context

CUDA failures, e.g. due to the user setting an invalid device, are not currently set, so users just get generic error messages.

### How Has This Been Tested?

Set GPU index > 0 on a system with a single GPU:
![cuda_error](https://github.com/obsproject/obs-studio/assets/3123295/03f749df-8dcb-4d21-b2f3-20cbd0633122)

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
