### PR TITLE
CI: Update bouf release

### DIFF
--- a/.github/actions/windows-signing/action.yaml
+++ b/.github/actions/windows-signing/action.yaml
@@ -27,9 +27,9 @@ runs:
     - name: Setup bouf
       shell: pwsh
       env:
-        BOUF_TAG: 'v0.6.3'
-        BOUF_HASH: '7f1d266467620aa553a705391ee06128e8ee14af66129a0e64a282997fb6fd83'
-        BOUF_NSIS_HASH: 'a234126de89f122b6a552df3416de3eabcb4195217626c7f4eaec71b20fe36eb'
+        BOUF_TAG: 'v0.6.3-nsis-update'
+        BOUF_HASH: 'c5b58f613e7d7ad8090900cbd6b5f4b057528ee9f0b7e4ba52038ddfdd50b924'
+        BOUF_NSIS_HASH: 'd77cda42d33af77774beddb3fd6edb89e75050f03c174260df7d66bc8247334f'
         GH_TOKEN: ${{ github.token }}
       run: |
         # Download bouf release

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,7 +207,7 @@ jobs:
 
   sign-windows-build:
     name: Windows Signing ✍️
-    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@b5b457d7b059397b70f6e3dd09b65e172ad734c3
+    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@d2b05a6e0c6a0f51c42f247efd581bed8f4a1877
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
     needs: build-project
     permissions:


### PR DESCRIPTION
### Description

Updates bouf release to https://github.com/obsproject/bouf/releases/tag/v0.6.3-nsis-update

Note that this does not include any changes to bouf itself, just to the NSIS script and VC runtime checker/installer.

### Motivation and Context

Don't want people to install OBS and not have it work.

### How Has This Been Tested?

Installer has been tested in the Windows Sandbox, CI has not been tested.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
