### PR TITLE
UI: Fix crash after canceling stream attempt with incompatible settings

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -688,6 +688,9 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(
 		return true;
 	}
 
+	MultitrackVideoOutput::ReleaseOnMainThread(take_current());
+	MultitrackVideoOutput::ReleaseOnMainThread(take_current_stream_dump());
+
 	return false;
 }
 


### PR DESCRIPTION
### Description
OBS crashes after canceling a stream attempt with the multitrack video output with incompatible settings

found by @notr1ch 

### Motivation and Context
Repro steps:
1. Enable an incompatible setting in settings
2. Start stream, hit cancel on incompatible settings dialog
3. Disable incompatible setting in settings
4. Start stream -> crash

### How Has This Been Tested?
Followed repro steps and the crash no longer happens

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
