### PR TITLE
UI: Translate Multitrack Video error dialog buttons

### DIFF
--- a/UI/multitrack-video-error.cpp
+++ b/UI/multitrack-video-error.cpp
@@ -1,6 +1,7 @@
 #include "multitrack-video-error.hpp"
 
 #include <QMessageBox>
+#include <QPushButton>
 #include "obs-app.hpp"
 
 MultitrackVideoError MultitrackVideoError::critical(QString error)
@@ -31,9 +32,12 @@ bool MultitrackVideoError::ShowDialog(
 			QTStr("FailedToStartStream.WarningRetryNonMultitrackVideo")
 				.arg(multitrack_video_name));
 		mb.setIcon(QMessageBox::Warning);
-		mb.setStandardButtons(QMessageBox::StandardButton::Yes |
-				      QMessageBox::StandardButton::No);
-		return mb.exec() == QMessageBox::StandardButton::Yes;
+		QAbstractButton *yesButton =
+			mb.addButton(QTStr("Yes"), QMessageBox::YesRole);
+		mb.addButton(QTStr("No"), QMessageBox::NoRole);
+		mb.exec();
+
+		return mb.clickedButton() == yesButton;
 	} else if (type == Type::Critical) {
 		mb.setText(error);
 		mb.setIcon(QMessageBox::Critical);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
UI: Translate Multitrack Video error dialog buttons

The Yes and No standard buttons are not translated unless we manually set the translated text ourselves.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
A user reported to us in OBS Studio 30.2.0-beta1 that these buttons were not translated. We already use this pattern elsewhere in the codebase.
https://github.com/obsproject/obs-studio/blob/0680b642e9cb85101971e8e03bbcd9b574cff6f7/UI/ui-validation.cpp#L47-L49


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've built this locally on Windows 11, but I could not seem to get this specific dialog to pop up.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
