### PR TITLE
obs-webrtc: Default H264 profile to main if unset

### DIFF
--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -34,6 +34,14 @@ void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 	if (video_settings) {
 		obs_data_set_int(video_settings, "bf", 0);
 		obs_data_set_bool(video_settings, "repeat_headers", true);
+
+		const char *profile =
+			obs_data_get_string(video_settings, "profile");
+		if (profile == nullptr || profile[0] == '\0') {
+			obs_data_set_string(video_settings, "profile", "main");
+			blog(LOG_INFO,
+			     "[obs-webrtc] no H264 profile set, default to main");
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
If user requests a specific H264 profile respect it, otherwise default to main.

### Motivation and Context
OBS defaults to H264 settings that aren't supported by browsers. This requires all WebRTC users to set advanced settings by default. 

This is a frequent debugging topic by users on discord. I had 3 different users who were inconvenienced because of this behavior. 

The new beta release of OBS was also tested by QA at Twitch. The 'WebRTC tests' were marked as failed because of the current behavior. We had to re-run the tests and ask to explicitly set the H264 profile.

### How Has This Been Tested?
I have tested locally with X264, QSV, nvenc and AOM AV1 on Windows.

On discord 3 users have been testing. Will link ticket so they can provide feedback.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Resolves #10821 