### PR TITLE
UI: Prevent recursion in theme dependencies

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -485,6 +485,16 @@ void OBSApp::FindThemes()
 				break;
 			}
 
+			if (parent->id == theme.id ||
+			    theme.dependencies.contains(parent->id)) {
+				blog(LOG_ERROR,
+				     R"(Dependency chain of "%s" ("%s") contains recursion!)",
+				     QT_TO_UTF8(theme.id),
+				     QT_TO_UTF8(parent->id));
+				invalid.insert(theme.id);
+				break;
+			}
+
 			/* Mark this theme as a variant of first parent that is a base theme. */
 			if (!theme.isBaseTheme && parent->isBaseTheme &&
 			    theme.parent.isEmpty())


### PR DESCRIPTION
### Description

Prevents a theme's dependency graph from containing itself or duplicates.

### Motivation and Context

User reported out of memory crash on discord.

### How Has This Been Tested?

Verified regular OBS themes still load, unfortunately the user has not provided their broken one.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
