### PR TITLE
UI: Fix icon-size values in theme files

### DIFF
--- a/UI/data/themes/System.obt
+++ b/UI/data/themes/System.obt
@@ -396,13 +396,13 @@ QCalendarWidget QToolButton {
 QCalendarWidget #qt_calendar_prevmonth {
     padding: 2px;
     qproperty-icon: url(theme:Dark/left.svg);
-    icon-size: 16px, 16px;
+    icon-size: 16px;
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: 2px;
     qproperty-icon: url(theme:Dark/right.svg);
-    icon-size: 16px, 16px;
+    icon-size: 16px;
 }
 
 /* Status Bar */

--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -649,12 +649,12 @@ QScrollBar::handle:horizontal {
 
 QPushButton#sourcePropertiesButton {
     qproperty-icon: url(theme:Dark/settings/general.svg);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 QPushButton#sourceFiltersButton {
     qproperty-icon: url(theme:Dark/filter.svg);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 /* Scenes and Sources toolbar */
@@ -1041,7 +1041,7 @@ QPushButton {
     height: var(--input_height);
     max-height: var(--input_height);
     padding: var(--input_padding) var(--padding_wide);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 QPushButton {
@@ -1059,7 +1059,7 @@ QPushButton[toolButton="true"] {
     margin: 0px var(--spacing_base);
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 QToolButton:last-child,
@@ -1212,7 +1212,7 @@ QSlider::handle:disabled {
     margin: 0px;
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 /* This is an incredibly cursed but necessary fix */
@@ -1603,7 +1603,7 @@ MuteCheckBox::indicator:unchecked {
     margin: 0px;
     border: 1px solid var(--button_border);
     border-radius: var(--border_radius);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 MuteCheckBox::indicator:hover,
@@ -1612,7 +1612,7 @@ MuteCheckBox::indicator:unchecked:hover {
     padding: var(--padding_base_border) var(--padding_base_border);
     margin: 0px;
     border: 1px solid var(--button_border_hover);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 MuteCheckBox::indicator:pressed,
@@ -1883,13 +1883,13 @@ QCalendarWidget QToolButton {
 QCalendarWidget #qt_calendar_prevmonth {
     padding: var(--padding_small);
     qproperty-icon: url(theme:Dark/left.svg);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 QCalendarWidget #qt_calendar_nextmonth {
     padding: var(--padding_small);
     qproperty-icon: url(theme:Dark/right.svg);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 QCalendarWidget QToolButton:hover {

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -198,7 +198,7 @@ QPushButton[toolButton="true"] {
 #stackedMixerArea QPushButton {
     min-width: var(--icon_base);
     padding: var(--padding_large) var(--padding_large);
-    icon-size: var(--icon_base), var(--icon_base);
+    icon-size: var(--icon_base);
 }
 
 #stackedMixerArea QPushButton:!hover {
@@ -217,7 +217,7 @@ MuteCheckBox::indicator:unchecked {
     border: none;
     width: var(--icon_base_mixer);
     height: var(--icon_base_mixer);
-    icon-size: var(--icon_base_mixer), var(--icon_base_mixer);
+    icon-size: var(--icon_base_mixer);
 }
 
 MuteCheckBox::indicator:checked {
@@ -231,7 +231,7 @@ MuteCheckBox::indicator:unchecked:hover {
 
 MuteCheckBox::indicator:hover,
 MuteCheckBox::indicator:unchecked:hover {
-    icon-size: var(--icon_base_mixer), var(--icon_base_mixer);
+    icon-size: var(--icon_base_mixer);
     border: none;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Qt docs on icon-size say its Type is Length, which is further defined as, "A number followed by a measurement unit."

https://doc.qt.io/qt-6/stylesheet-reference.html#icon-size
https://doc.qt.io/qt-6/stylesheet-reference.html#length

This fixes the following logged Qt warning:
> QCssParser::sizeValue: Too many values provided


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want to use correct Qt syntax. Want less warnings in logs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
