### PR TITLE
UI: Fix themeDir buffer being resized incorrectly

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -417,7 +417,6 @@ static vector<OBSThemeVariable> ParseThemeVariables(const char *themeData)
 void OBSApp::FindThemes()
 {
 	string themeDir;
-	themeDir.resize(512);
 
 	QStringList filters;
 	filters << "*.obt" // OBS Base Theme
@@ -435,6 +434,7 @@ void OBSApp::FindThemes()
 			delete theme;
 	}
 
+	themeDir.resize(1024);
 	if (GetConfigPath(themeDir.data(), themeDir.capacity(),
 			  "obs-studio/themes/") > 0) {
 		QDirIterator it(QT_UTF8(themeDir.c_str()), filters,


### PR DESCRIPTION
### Description

Fixes `themeDir` string being too small for holding the config directory path.

### Motivation and Context

c677bac875e6b3b6e4d3358aa8b38679ff4fcb1f changed the order here, but this also resulted in the string having whatever size was necessary for the install data path, rather than being large enough to fit a userdata path. To fix this, move the resize operaetion *after* the buit-in themes are searched, and also bump it to 1024 just to be sure.

This resulted in a crash due to a bug in os_get_path_internal() which will need to be fixed separately.

### How Has This Been Tested?

Booted up OBS without a crash.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
