### PR TITLE
libobs: Fix buffer overrun in os_get_path_internal()

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -494,12 +494,15 @@ static int os_get_path_internal(char *dst, size_t size, const char *name,
 
 	SHGetFolderPathW(NULL, folder, NULL, SHGFP_TYPE_CURRENT, path_utf16);
 
-	if (os_wcs_to_utf8(path_utf16, 0, dst, size) != 0) {
+	size_t out_len = os_wcs_to_utf8(path_utf16, 0, dst, size);
+	if (out_len) {
 		if (!name || !*name) {
 			return (int)strlen(dst);
 		}
 
-		if (strcat_s(dst, size, "\\") == 0) {
+		size -= out_len;
+		if (size && strcat_s(dst, size, "\\") == 0) {
+			size -= sizeof('\\');
 			if (strcat_s(dst, size, name) == 0) {
 				return (int)strlen(dst);
 			}


### PR DESCRIPTION
### Description

Additional fix for problem mitigated by #10834

### Motivation and Context

The function did not subtract the size already written from the size passed into `strcat_s()`, thus resulting in it assuming it can write `size` bytes, when in reality it was `size - os_wcs_to_utf8()` bytes, resulting in a buffer overflow.

### How Has This Been Tested?

Tested without #10834 applied to verify the crash no longer happens, and instead the function (correctly) returns -1 to indicate a failure.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
