### PR TITLE
UI: Set invalid parameter handler in non-debug builds

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -2929,6 +2929,15 @@ static bool vc_runtime_outdated()
 
 	return true;
 }
+
+void obs_invalid_parameter_handler(const wchar_t *, const wchar_t *,
+				   const wchar_t *, unsigned int, uintptr_t)
+{
+	/* In Release builds the parameters are all NULL, but not having a
+	 * handler would result in the program being terminated.
+	 * By having one that does not abort execution we let the caller handle
+	 * the error codes returned by the function that invoked this. */
+}
 #endif
 
 int main(int argc, char *argv[])
@@ -2957,6 +2966,9 @@ int main(int argc, char *argv[])
 #endif
 
 #ifdef _WIN32
+#ifndef _DEBUG
+	_set_invalid_parameter_handler(obs_invalid_parameter_handler);
+#endif
 	// Abort as early as possible if MSVC runtime is outdated
 	if (vc_runtime_outdated())
 		return 1;


### PR DESCRIPTION
### Description

Sets the invalid parameter handler for Windows's "secure" functions like `strcat_s()`. By having one that does not abort execution we let the caller handle the error codes, instead of crashing to desktop.

### Motivation and Context

We have error handling, we don't need Windows to abort execution of the program.

### How Has This Been Tested?

Tested with issues found with #10834 

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
