### PR TITLE
libobs: Fix buffer overrun in os_wcs_to_utf8()

### DIFF
--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -429,8 +429,7 @@ size_t os_wcs_to_utf8(const wchar_t *str, size_t len, char *dst,
 			return 0;
 
 		if (out_len)
-			out_len =
-				wchar_to_utf8(str, in_len, dst, out_len + 1, 0);
+			out_len = wchar_to_utf8(str, in_len, dst, out_len, 0);
 
 		dst[out_len] = 0;
 	}


### PR DESCRIPTION
### Description

Fixes a buffer overrun in `os_wcs_to_utf8()`

### Motivation and Context

If the output buffer size is exactly the same as the length of the converted string, `out_len` would point to the first element past the end of the buffer, thus writing the terminating NULL character out of bounds.

To fix that, only pass in the size of the buffer minus terminating NULL into `wchar_to_utf8()`.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
