### PR TITLE
UI: Use unique_ptr for theme objects

### DIFF
--- a/UI/obs-app-theming.cpp
+++ b/UI/obs-app-theming.cpp
@@ -417,6 +417,7 @@ static vector<OBSThemeVariable> ParseThemeVariables(const char *themeData)
 void OBSApp::FindThemes()
 {
 	string themeDir;
+	unique_ptr<OBSTheme> theme;
 
 	QStringList filters;
 	filters << "*.obt" // OBS Base Theme
@@ -427,11 +428,9 @@ void OBSApp::FindThemes()
 	GetDataFilePath("themes/", themeDir);
 	QDirIterator it(QString::fromStdString(themeDir), filters, QDir::Files);
 	while (it.hasNext()) {
-		OBSTheme *theme = ParseThemeMeta(it.next());
+		theme.reset(ParseThemeMeta(it.next()));
 		if (theme && !themes.contains(theme->id))
 			themes[theme->id] = std::move(*theme);
-		else
-			delete theme;
 	}
 
 	themeDir.resize(1024);
@@ -441,11 +440,9 @@ void OBSApp::FindThemes()
 				QDir::Files);
 
 		while (it.hasNext()) {
-			OBSTheme *theme = ParseThemeMeta(it.next());
+			theme.reset(ParseThemeMeta(it.next()));
 			if (theme && !themes.contains(theme->id))
 				themes[theme->id] = std::move(*theme);
-			else
-				delete theme;
 		}
 	}
 


### PR DESCRIPTION
### Description

Always delete the `theme` pointer to avoid memory leaks.

### Motivation and Context

While the `std::move` will (probably) result in the object's contained members being moved the copy constructed within the hash map, the original object should be deleted as it's no longer needed.

### How Has This Been Tested?

Verified with a debugger that everything works correctly and values get moved.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
