### PR TITLE
Use static blake2b library for Windows updater

### DIFF
--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(updater PRIVATE "${CMAKE_SOURCE_DIR}/libobs" "${CMAKE
 
 target_link_libraries(
   updater
-  PRIVATE OBS::blake2
+  PRIVATE OBS::blake2_static
           nlohmann_json::nlohmann_json
           zstd::libzstd_static
           comctl32
@@ -38,10 +38,10 @@ target_link_libraries(
           wintrust)
 
 # zstd is hardcoded with /DEFAULTLIB:LIBCMT
-target_link_options(updater PRIVATE /NODEFAULTLIB:LIBCMT)
+target_link_options(updater PRIVATE $<$<CONFIG:DEBUG>:/NODEFAULTLIB:LIBCMT>)
 
 set_target_properties(
   updater
   PROPERTIES FOLDER frontend
              OUTPUT_NAME updater
-             MSVC_RUNTIME_LIBRARY "MultiThreaded")
+             MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")

--- a/deps/blake2/CMakeLists.txt
+++ b/deps/blake2/CMakeLists.txt
@@ -11,3 +11,16 @@ target_sources(
 target_include_directories(blake2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 set_target_properties(blake2 PROPERTIES FOLDER deps)
+
+if(OS_WINDOWS)
+  add_library(blake2_static OBJECT)
+  add_library(OBS::blake2_static ALIAS blake2_static)
+
+  target_sources(
+    blake2_static
+    PRIVATE src/blake2-impl.h src/blake2b-ref.c
+    PUBLIC src/blake2.h)
+
+  target_include_directories(blake2_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
+  set_target_properties(blake2_static PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()


### PR DESCRIPTION
### Description

Adds a secondary blake2b target that is using the static MSVC runtime and uses that in the updater to allow for fully-static builds that do not have external runtime dependencies.

### Motivation and Context

Want updater to run even if VC runtimes aren't installed/outdated.

### How Has This Been Tested?

Tested on Windows sandbox without installing any redistributables.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
