### PR TITLE
Fix loading Lua scripts on Linux through a refactor of how C path are added

### DIFF
--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -31,7 +31,7 @@ set(OBS_CMAKE_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake")
 
 # Set additional paths used by OBS for self-discovery
 set(OBS_PLUGIN_PATH "${CMAKE_INSTALL_LIBDIR}/obs-plugins")
-set(OBS_SCRIPT_PLUGIN_PATH "../${CMAKE_INSTALL_LIBDIR}/obs-scripting")
+set(OBS_SCRIPT_PLUGIN_PATH "${CMAKE_INSTALL_LIBDIR}/obs-scripting")
 set(OBS_DATA_PATH "${OBS_DATA_DESTINATION}")
 set(OBS_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Try to fix the same issue as #10800 but more correctly, as the latter does not work on Linux system install.

This PR reverts #10800 and refactor how C paths are added to enable adding more than two paths.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix loading Lua script on Linux.
 If you have a better approach (taking CMake 2 and 3 in mind), please feel free to supersede this PR.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Lua script loads with OBS install system-wide and relocatable.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
