### PR TITLE
Update multitrack video schema to version 2024-06-04

### DIFF
--- a/UI/goliveapi-postdata.cpp
+++ b/UI/goliveapi-postdata.cpp
@@ -14,29 +14,30 @@ constructGoLivePost(QString streamKey,
 {
 	GoLiveApi::PostData post_data{};
 	post_data.service = "IVS";
-	post_data.schema_version = "2023-05-10";
+	post_data.schema_version = "2024-06-04";
 	post_data.authentication = streamKey.toStdString();
 
 	system_info(post_data.capabilities);
 
-	auto &client = post_data.capabilities.client;
+	auto &client = post_data.client;
 
 	client.name = "obs-studio";
 	client.version = obs_get_version_string();
-	client.vod_track_audio = vod_track_enabled;
+
+	auto &preferences = post_data.preferences;
+	preferences.vod_track_audio = vod_track_enabled;
 
 	obs_video_info ovi;
 	if (obs_get_video_info(&ovi)) {
-		client.width = ovi.output_width;
-		client.height = ovi.output_height;
-		client.fps_numerator = ovi.fps_num;
-		client.fps_denominator = ovi.fps_den;
+		preferences.width = ovi.output_width;
+		preferences.height = ovi.output_height;
+		preferences.framerate.numerator = ovi.fps_num;
+		preferences.framerate.denominator = ovi.fps_den;
 
-		client.canvas_width = ovi.base_width;
-		client.canvas_height = ovi.base_height;
+		preferences.canvas_width = ovi.base_width;
+		preferences.canvas_height = ovi.base_height;
 	}
 
-	auto &preferences = post_data.preferences;
 	if (maximum_aggregate_bitrate.has_value())
 		preferences.maximum_aggregate_bitrate =
 			maximum_aggregate_bitrate.value();

--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -202,8 +202,8 @@ struct Preferences {
 };
 
 struct PostData {
-	string service = "IVS";
-	string schema_version = "2023-05-10";
+	string service;
+	string schema_version;
 	string authentication;
 
 	Capabilities capabilities;

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -456,8 +456,17 @@ bool AutoConfigStreamPage::validatePage()
 			int multitrackVideoBitrate = 0;
 			for (auto &encoder_config :
 			     config.encoder_configurations) {
-				multitrackVideoBitrate +=
-					encoder_config.config.bitrate;
+				auto it =
+					encoder_config.settings.find("bitrate");
+				if (it == encoder_config.settings.end())
+					continue;
+
+				if (!it->is_number_integer())
+					continue;
+
+				int bitrate = 0;
+				it->get_to(bitrate);
+				multitrackVideoBitrate += bitrate;
 			}
 
 			// grab a streamkey from the go live config if we can


### PR DESCRIPTION
### Description
Updated GetClientConfiguration request to conform to new 2024-06-04 schema, with clearer separation of encoder `settings` and libobs encoder selection/configuration, some other movement of fields

### Motivation and Context
The previous version of this schema mixed encoder settings and libobs encoder selection/configuration such as `"type": "jim_nvenc"` and `"bitrate": 6000` in the same json object, which is fine for encoders currently used in the Twitch Enhanced Broadcasting beta, but it's a potential compatibility hazard and also this separation makes it clearer which values should go to the encoder implementation vs libobs configuration

### How Has This Been Tested?
Twitch Enhanced Broadcasting beta, support for the new schema should be available for Twitch/Amazon IVS globally

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
