### PR TITLE
UI: Fix submenu arrow indicator position in menus

### DIFF
--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -113,6 +113,10 @@ QMenu::item {
     padding: var(--padding_menu_y) var(--padding_menu);
 }
 
+QMenu::item {
+    padding-right: 20px;
+}
+
 QGroupBox {
     background: var(--bg_window);
     border: 1px solid var(--border_color);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Commit b11d61c89f822502f8c543304a7c32081a44a2c7 (#8082) added padding-right to provide some minimal padding for this element. In the Composable Themes changes, this was seemingly accounted for in the Yami Base Theme (Yami.obt), but was missed in the Yami Classic Variant Theme (Yami_Classic.ovt).

Re-add the padding-right to restore the padding.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want submenu indicators to have some padding.

Before:
![image](https://github.com/obsproject/obs-studio/assets/624931/bbe79846-151c-476a-b4d9-1979f51f9548)

After:
![image](https://github.com/obsproject/obs-studio/assets/624931/8e1c37fc-cf76-4baa-a722-46cb02c7bbc3)

I'm not sure if there is a reason Yami.obt has two `QMenu::item` rules for padding, but I'll leave that mystery to others to solve.

https://github.com/obsproject/obs-studio/blob/77d31fa33fa25fc3b66f823776ddbd3c1b9b3c96/UI/data/themes/Yami.obt#L365-L371

https://github.com/obsproject/obs-studio/blob/77d31fa33fa25fc3b66f823776ddbd3c1b9b3c96/UI/data/themes/Yami_Classic.ovt#L112-L114

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11. See above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
