### PR TITLE
obs-outputs: Add multitrack flag to null output

### DIFF
--- a/plugins/obs-outputs/null-output.c
+++ b/plugins/obs-outputs/null-output.c
@@ -89,7 +89,7 @@ static void null_output_data(void *data, struct encoder_packet *packet)
 
 struct obs_output_info null_output_info = {
 	.id = "null_output",
-	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED,
+	.flags = OBS_OUTPUT_AV | OBS_OUTPUT_ENCODED | OBS_OUTPUT_MULTI_TRACK_AV,
 	.get_name = null_output_getname,
 	.create = null_output_create,
 	.destroy = null_output_destroy,


### PR DESCRIPTION
### Description
Adds the multitrack flag to the null output to allow multiple audio or video tracks to be assigned to it

### Motivation and Context
For various reasons, I need to artificially start up encoders (due to current limitations of grouped video encoders) even without a real output running, so this happens to be a useful tool to make that happen.

### How Has This Been Tested?
Code compiled

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
