### PR TITLE
UI: Make audio_configurations.vod optional

### DIFF
--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -279,7 +279,7 @@ struct AudioEncoderConfiguration {
 
 struct AudioConfigurations {
 	std::vector<AudioEncoderConfiguration> live;
-	std::vector<AudioEncoderConfiguration> vod;
+	optional<std::vector<AudioEncoderConfiguration>> vod;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE_WITH_DEFAULT(AudioConfigurations, live,
 						    vod)

--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -777,8 +777,10 @@ create_audio_encoders(const GoLiveApi::Config &go_live_config,
 	if (!vod_track_mixer.has_value())
 		return;
 
+	// we already check for empty inside of `create_encoders`
+	encoder_configs_type empty = {};
 	create_encoders("multitrack video vod audio",
-			go_live_config.audio_configurations.vod,
+			go_live_config.audio_configurations.vod.value_or(empty),
 			*vod_track_mixer);
 
 	return;


### PR DESCRIPTION
This currently depends on https://github.com/obsproject/obs-studio/pull/10845

### Description
Mark multitrack video config audio vod key as optional

### Motivation and Context
VOD track is currently a Twitch specific feature (Amazon IVS doesn't support it, and probably no other services?), so marking the key as optional to simplify canonical config examples

### How Has This Been Tested?
Config overrides and Twitch internal API tests

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
