### PR TITLE
UI: Hide multitrack video options for custom output

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -6325,6 +6325,9 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 			ui->enableMultitrackVideo->setChecked(false);
 	}
 
+	if (IsCustomService())
+		available = available && MultitrackVideoDeveloperModeEnabled();
+
 	ui->multitrackVideoGroupBox->setVisible(available);
 
 	ui->enableMultitrackVideo->setEnabled(toggle_available);


### PR DESCRIPTION
### Description
Custom output doesn't currently allow specifying a config URL, so disable relevant settings for now

### Motivation and Context
Enabling multitrack video when service is set to "Custom..." results in an error message, with nowhere to enter a custom URL

### How Has This Been Tested?
- Multitrack video groupbox is hidden when setting service to "Custom..."
- Enabled multitrack video with service set to Twitch, saved settings, switched to "Custom..." service and observed no "missing configuration url" error message when clicking "start stream"

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
