### PR TITLE
UI: Fixup configID name and add `composition_gpu_index`

### DIFF
--- a/UI/goliveapi-postdata.cpp
+++ b/UI/goliveapi-postdata.cpp
@@ -36,6 +36,8 @@ constructGoLivePost(QString streamKey,
 
 		preferences.canvas_width = ovi.base_width;
 		preferences.canvas_height = ovi.base_height;
+
+		preferences.composition_gpu_index = ovi.adapter;
 	}
 
 	if (maximum_aggregate_bitrate.has_value())

--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -191,11 +191,12 @@ struct Preferences {
 	media_frames_per_second framerate;
 	uint32_t canvas_width;
 	uint32_t canvas_height;
+	optional<uint32_t> composition_gpu_index;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Preferences, maximum_aggregate_bitrate,
 				       maximum_video_tracks, vod_track_audio,
 				       width, height, framerate, canvas_width,
-				       canvas_height)
+				       canvas_height, composition_gpu_index)
 };
 
 struct PostData {

--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -127,7 +127,7 @@ create_service(const GoLiveApi::Config &go_live_config,
 
 	if (!go_live_config.meta.config_id.empty()) {
 		parsed_query.addQueryItem(
-			"obsConfigId",
+			"clientConfigId",
 			QString::fromStdString(go_live_config.meta.config_id));
 	}
 


### PR DESCRIPTION
### Description
Two simple improvements:

1. Recent multitrack schema changes have modified the `obsConfigId` name to `clientConfigId`
2. To help inform GetClientCapabilities() API for eRTMP, add the `composition_gpu_index` to the postdata

### Motivation and Context
Both of these are recent improvements resulting from the ongoing eRTMP/multitrack video implementation. They first is needed to align with the new schema. The second is needed to help in situation where multiple GPU's are present, for example an AMD-based system with an iGPU and dGPU.

### How Has This Been Tested?
Both have been and are currently being tested in the Enhanced Broadcasting closed beta.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
