### PR TITLE
deps/media-playback: Fix scaler initialisation with some hardware decoders

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -250,12 +250,10 @@ static bool mp_media_init_scaling(mp_media_t *m)
 	int range = get_sws_range(m->v.decoder->color_range);
 	const int *coeff = sws_getCoefficients(space);
 
-	m->swscale = sws_getCachedContext(NULL, m->v.decoder->width,
-					  m->v.decoder->height,
-					  m->v.decoder->pix_fmt,
-					  m->v.decoder->width,
-					  m->v.decoder->height, m->scale_format,
-					  SWS_POINT, NULL, NULL, NULL);
+	m->swscale = sws_getCachedContext(
+		NULL, m->v.decoder->width, m->v.decoder->height,
+		m->v.frame->format, m->v.decoder->width, m->v.decoder->height,
+		m->scale_format, SWS_POINT, NULL, NULL, NULL);
 	if (!m->swscale) {
 		blog(LOG_WARNING, "MP: Failed to initialize scaler");
 		return false;


### PR DESCRIPTION
### Description

Fixes scaler when CUDA hardware decoding is used and scaling is needed.

### Motivation and Context

The decoder's format will be `AV_PIX_FMT_CUDA` instead of the underlying format, so use the frame's actual format to initialise the scaler instead.

Reported by @EposVox on Discord: https://discord.com/channels/348973006581923840/1248822154980757564/1251225266412326983

### How Has This Been Tested?

Tested with 444 10-bit HEVC file.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
