### PR TITLE
deps/media-playback: Fix initialization of swscale with hw decode

### DIFF
--- a/deps/media-playback/media-playback/media.c
+++ b/deps/media-playback/media-playback/media.c
@@ -246,15 +246,14 @@ static inline int get_sws_range(enum AVColorRange r)
 
 static bool mp_media_init_scaling(mp_media_t *m)
 {
-	int space = get_sws_colorspace(m->v.decoder->colorspace);
-	int range = get_sws_range(m->v.decoder->color_range);
+	int space = get_sws_colorspace(m->v.frame->colorspace);
+	int range = get_sws_range(m->v.frame->color_range);
 	const int *coeff = sws_getCoefficients(space);
 
-	m->swscale = sws_getCachedContext(NULL, m->v.decoder->width,
-					  m->v.decoder->height,
-					  m->v.decoder->pix_fmt,
-					  m->v.decoder->width,
-					  m->v.decoder->height, m->scale_format,
+	m->swscale = sws_getCachedContext(NULL, m->v.frame->width,
+					  m->v.frame->height,
+					  m->v.frame->format, m->v.frame->width,
+					  m->v.frame->height, m->scale_format,
 					  SWS_POINT, NULL, NULL, NULL);
 	if (!m->swscale) {
 		blog(LOG_WARNING, "MP: Failed to initialize scaler");
@@ -265,7 +264,7 @@ static bool mp_media_init_scaling(mp_media_t *m)
 				 FIXED_1_0, FIXED_1_0);
 
 	int ret = av_image_alloc(m->scale_pic, m->scale_linesizes,
-				 m->v.decoder->width, m->v.decoder->height,
+				 m->v.frame->width, m->v.frame->height,
 				 m->scale_format, 32);
 	if (ret < 0) {
 		blog(LOG_WARNING, "MP: Failed to create scale pic data");


### PR DESCRIPTION
### Description
Checking the format of the AVCodecContext will result in using the format of the hardware-side frames, not the software-side frames. This uses the software frame parameters itself to initialize the swscale context.

### Motivation and Context
When playing back a 4:4:4 file with NVDEC, the swscaler was being initialized with the AVCodecContext's hardware format instead of the host frame's format. This changes everything to use the host frame's parameters instead of the device frame's parameters.

### How Has This Been Tested?
Test file does not work without this, but works with this.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
