### PR TITLE
UI: Set default container for beta builds to hybrid MP4

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1549,7 +1549,7 @@ extern void CheckExistingCookieId();
 #elif OBS_RELEASE_CANDIDATE == 0 && OBS_BETA == 0
 #define DEFAULT_CONTAINER "mkv"
 #else
-#define DEFAULT_CONTAINER "fragmented_mp4"
+#define DEFAULT_CONTAINER "hybrid_mp4"
 #endif
 
 bool OBSBasic::InitBasicConfigDefaults()


### PR DESCRIPTION
### Description

Changes default format to from fragmented to hybrid MP4 for Windows beta builds.

### Motivation and Context

Should've been done earlier to get more people testing it, but alas.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
