### PR TITLE
libobs: Fix bug with frame count in stat card

### DIFF
--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -63,6 +63,9 @@ static void *gpu_encode_thread(void *data)
 		next_key = tf.lock_key;
 
 		video_output_inc_texture_frames(video->video);
+		if (video->video != obs->video.main_mix->video)
+			video_output_inc_texture_frames(
+				obs->video.main_mix->video);
 
 		for (size_t i = 0; i < video->gpu_encoders.num; i++) {
 			obs_encoder_t *encoder = obs_encoder_get_ref(
@@ -186,6 +189,9 @@ static void *gpu_encode_thread(void *data)
 					 sizeof(tf));
 
 			video_output_inc_texture_skipped_frames(video->video);
+			if (video->video != obs->video.main_mix->video)
+				video_output_inc_texture_skipped_frames(
+					obs->video.main_mix->video);
 		} else {
 			deque_push_back(&video->gpu_encoder_avail_queue, &tf,
 					sizeof(tf));


### PR DESCRIPTION
Now the frame count in statcard will display correctly with rescale output  turned on

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Increase both encoder media and the obs main mix video 's frame count in gpu_encode_thread

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
fixes issue: https://github.com/obsproject/obs-studio/issues/10744

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The encoded & lagged frame count works correctly with a simple scene

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
