### PR TITLE
UI: Fix parsing of Multitrack Video stream key query parameters

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -116,13 +116,15 @@ create_service(const GoLiveApi::Config &go_live_config,
 
 	/* The stream key itself may contain query parameters, such as
 	 * "bandwidthtest" that need to be carried over. */
+	QUrl parsed_user_key{in_stream_key};
+	QUrlQuery user_key_query{parsed_user_key};
+
 	QUrl parsed_key{stream_key};
-	QUrlQuery key_query{parsed_key};
 
 	QUrl parsed_url{url};
 	QUrlQuery parsed_query{parsed_url};
 
-	for (const auto &[key, value] : key_query.queryItems())
+	for (const auto &[key, value] : user_key_query.queryItems())
 		parsed_query.addQueryItem(key, value);
 
 	if (!go_live_config.meta.config_id.empty()) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The code was checking stream_key, but stream_key could be the user-supplied value (in_stream_key) or the server-supplied value (endpoint.authentication). The server-supplied value may lack the query parameters set in the user-supplied value. To ensure that user-specified query parameters (such as bandwidthtest) are passed along, parse the user-supplied key instead of the server-supplied key.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
@derrod remarked:
> seems like bandwidth test mode is broken in beta3 with enhanced broadcast

We want Bandwidth Test Mode and other URL parameters to work with Multitrack Video (Enhanced Broadcasting).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 10 with a GTX 1060.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
