### PR TITLE
UI: Use advanced mode audio track in multitrack video output

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -333,7 +333,7 @@ SetupOBSOutput(obs_data_t *dump_stream_to_file_config,
 	       const GoLiveApi::Config &go_live_config,
 	       std::vector<OBSEncoderAutoRelease> &audio_encoders,
 	       std::shared_ptr<obs_encoder_group_t> &video_encoder_group,
-	       const char *audio_encoder_id,
+	       const char *audio_encoder_id, size_t main_audio_mixer,
 	       std::optional<size_t> vod_track_mixer);
 static void SetupSignalHandlers(bool recording, MultitrackVideoOutput *self,
 				obs_output_t *output, OBSSignal &start,
@@ -346,7 +346,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 	std::optional<uint32_t> maximum_aggregate_bitrate,
 	std::optional<uint32_t> maximum_video_tracks,
 	std::optional<std::string> custom_config,
-	obs_data_t *dump_stream_to_file_config,
+	obs_data_t *dump_stream_to_file_config, size_t main_audio_mixer,
 	std::optional<size_t> vod_track_mixer)
 {
 	{
@@ -465,7 +465,8 @@ void MultitrackVideoOutput::PrepareStreaming(
 	std::shared_ptr<obs_encoder_group_t> video_encoder_group;
 	auto outputs = SetupOBSOutput(dump_stream_to_file_config, output_config,
 				      audio_encoders, video_encoder_group,
-				      audio_encoder_id, vod_track_mixer);
+				      audio_encoder_id, main_audio_mixer,
+				      vod_track_mixer);
 	auto output = std::move(outputs.output);
 	auto recording_output = std::move(outputs.recording_output);
 	if (!output)
@@ -726,7 +727,7 @@ static void
 create_audio_encoders(const GoLiveApi::Config &go_live_config,
 		      std::vector<OBSEncoderAutoRelease> &audio_encoders,
 		      obs_output_t *output, obs_output_t *recording_output,
-		      const char *audio_encoder_id,
+		      const char *audio_encoder_id, size_t main_audio_mixer,
 		      std::optional<size_t> vod_track_mixer)
 {
 	using encoder_configs_type =
@@ -766,7 +767,8 @@ create_audio_encoders(const GoLiveApi::Config &go_live_config,
 	};
 
 	create_encoders("multitrack video live audio",
-			go_live_config.audio_configurations.live, 0);
+			go_live_config.audio_configurations.live,
+			main_audio_mixer);
 
 	if (!vod_track_mixer.has_value())
 		return;
@@ -785,7 +787,7 @@ SetupOBSOutput(obs_data_t *dump_stream_to_file_config,
 	       const GoLiveApi::Config &go_live_config,
 	       std::vector<OBSEncoderAutoRelease> &audio_encoders,
 	       std::shared_ptr<obs_encoder_group_t> &video_encoder_group,
-	       const char *audio_encoder_id,
+	       const char *audio_encoder_id, size_t main_audio_mixer,
 	       std::optional<size_t> vod_track_mixer)
 {
 
@@ -801,7 +803,7 @@ SetupOBSOutput(obs_data_t *dump_stream_to_file_config,
 
 	create_audio_encoders(go_live_config, audio_encoders, output,
 			      recording_output, audio_encoder_id,
-			      vod_track_mixer);
+			      main_audio_mixer, vod_track_mixer);
 
 	return {std::move(output), std::move(recording_output)};
 }

--- a/UI/multitrack-video-output.hpp
+++ b/UI/multitrack-video-output.hpp
@@ -35,6 +35,7 @@ public:
 			      std::optional<uint32_t> maximum_video_tracks,
 			      std::optional<std::string> custom_config,
 			      obs_data_t *dump_stream_to_file_config,
+			      size_t main_audio_mixer,
 			      std::optional<size_t> vod_track_mixer);
 	signal_handler_t *StreamingSignalHandler();
 	void StartedStreaming();

--- a/UI/window-basic-main-outputs.hpp
+++ b/UI/window-basic-main-outputs.hpp
@@ -98,10 +98,9 @@ protected:
 					 bool overwrite, const char *format,
 					 bool ffmpeg);
 
-	FutureHolder<std::optional<bool>>
-	SetupMultitrackVideo(obs_service_t *service,
-			     std::string audio_encoder_id,
-			     std::optional<size_t> vod_track_mixer);
+	FutureHolder<std::optional<bool>> SetupMultitrackVideo(
+		obs_service_t *service, std::string audio_encoder_id,
+		size_t main_audio_mixer, std::optional<size_t> vod_track_mixer);
 	OBSDataAutoRelease GenerateMultitrackVideoStreamDumpConfig();
 };
 


### PR DESCRIPTION
### Description
Fixes using the configured audio track (for advanced mode) with the multitrack video output

### Motivation and Context
The multitrack video output defaulted its (main) streaming audio track to track 0 (i.e. simple output settings), as opposed to taking advanced mode main audio track selection into account

### How Has This Been Tested?
Set up a scene with two audio sources, one set to output to all tracks, the other only to one track, and verified that switching advanced stream track setting was being honored

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
