### PR TITLE
UI: Add supported codecs to GetClientConfiguration request

### DIFF
--- a/UI/goliveapi-postdata.cpp
+++ b/UI/goliveapi-postdata.cpp
@@ -24,6 +24,32 @@ constructGoLivePost(QString streamKey,
 	client.name = "obs-studio";
 	client.version = obs_get_version_string();
 
+	auto add_codec = [&](const char *codec) {
+		auto it = std::find(std::begin(client.supported_codecs),
+				    std::end(client.supported_codecs), codec);
+		if (it != std::end(client.supported_codecs))
+			return;
+
+		client.supported_codecs.push_back(codec);
+	};
+
+	const char *encoder_id = nullptr;
+	for (size_t i = 0; obs_enum_encoder_types(i, &encoder_id); i++) {
+		auto codec = obs_get_encoder_codec(encoder_id);
+		if (!codec)
+			continue;
+
+		if (qstricmp(codec, "h264") == 0) {
+			add_codec("h264");
+#ifdef ENABLE_HEVC
+		} else if (qstricmp(codec, "hevc")) {
+			add_codec("h265");
+#endif
+		} else if (qstricmp(codec, "av1")) {
+			add_codec("av1");
+		}
+	}
+
 	auto &preferences = post_data.preferences;
 	preferences.vod_track_audio = vod_track_enabled;
 

--- a/UI/models/multitrack-video.hpp
+++ b/UI/models/multitrack-video.hpp
@@ -109,8 +109,9 @@ using json = nlohmann::json;
 struct Client {
 	string name = "obs-studio";
 	string version;
+	std::vector<string> supported_codecs;
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Client, name, version)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Client, name, version, supported_codecs)
 };
 
 struct Cpu {


### PR DESCRIPTION
### Description
Communicate available codecs to configuration API for multitrack video output streams

The default value for this according to the current (still WIP) version of the Twitch/IVS integration guide is `['h264']`, so enabling HEVC or AV1 will require this at some point in the future

### Motivation and Context
OBS built without HEVC support does not(?) support HEVC, even though e.g. hardware encoders may be capable of producing HEVC bitstreams; also, codecs may not be supported in case hardware encoders are disabled on startup or similar

### How Has This Been Tested?
Twitch Enhanced Broadcasting beta internal testing

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
