### PR TITLE
win-capture: Improve fullscreen window detection

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1131,7 +1131,15 @@ static void get_fullscreen_window(struct game_capture *gc)
 		return;
 	}
 
-	if (rect.left == mi.rcMonitor.left && rect.right == mi.rcMonitor.right && rect.bottom == mi.rcMonitor.bottom &&
+	/* some apps extend their windows ~1px beyond the monitor's
+	 * supported resolution to circumvent certain exclusive
+	 * fullscreen-related issues caused either by their graphics
+	 * library, Windows itself, or both; thus, we use a strict
+	 * comparison to check the coordinates of the top-left corner
+	 * of a window against those of a monitor, and a more relaxed
+	 * one to check the bottom-right corner, allowing it to extend
+	 * slightly past the edge of the monitor */
+	if (rect.left == mi.rcMonitor.left && rect.right >= mi.rcMonitor.right && rect.bottom >= mi.rcMonitor.bottom &&
 	    rect.top == mi.rcMonitor.top) {
 		setup_window(gc, window);
 	} else {

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1104,6 +1104,12 @@ static void setup_window(struct game_capture *gc, HWND window)
 	}
 }
 
+static int rects_nearly_equal(RECT first, RECT second, long delta)
+{
+	return abs(first.left - second.left) <= delta && abs(first.right - second.right) <= delta &&
+	       abs(first.top - second.top) <= delta && abs(first.bottom - second.bottom) <= delta;
+}
+
 static void get_fullscreen_window(struct game_capture *gc)
 {
 	HWND window = GetForegroundWindow();
@@ -1137,8 +1143,11 @@ static void get_fullscreen_window(struct game_capture *gc)
 		return;
 	}
 
-	if (rect.left == mi.rcMonitor.left && rect.right == mi.rcMonitor.right && rect.bottom == mi.rcMonitor.bottom &&
-	    rect.top == mi.rcMonitor.top) {
+	/* Some apps extend their windows 1-2 pixels beyond the monitor's supported resolution to circumvent certain
+	 * exclusive fullscreen-related issues caused either by their graphics library, Windows itself, or both. Thus,
+	 * we compare the window's corner coordinates with those of the monitor using an acceptable relative margin of
+	 * 2, allowing it to extend slightly past the edge of the monitor. */
+	if (rects_nearly_equal(rect, mi.rcMonitor, 2)) {
 		setup_window(gc, window);
 	} else {
 		gc->wait_for_target_startup = true;


### PR DESCRIPTION
### Description

This small change allows windows that extend slightly beyond the defined viewport to be properly detected as fullscreen ones.

While, in general, one should not assume that `bottom > top` and `right > left`, `win-capture` is tailored to Windows, where this assumption always holds true. Therefore, simply swapping `==` with `>=` when comparing `rect.right` with `mi.rcMonitor.right` and `rect.bottom` with `mi.rcMonitor.bottom` should suffice.

### Motivation and Context

While it may sound crazy, some apps on Windows use a dirty hack of extending their windows slightly beyond the monitor's declared resolution, usually by 1px, to preserve "true" windowed fullscreen and circumvent some issues related to the exclusive fullscreen mode presented by the graphics library being used, Windows itself, or both. As an example, see: https://github.com/glfw/glfw/issues/527#issuecomment-143183771.

At the moment, these windows are not recognized by OBS Game Capture because they fail the strict comparison rules defined here: https://github.com/obsproject/obs-studio/blob/48b1298fafb941f70edfa3b17bd2441e9124c3c9/plugins/win-capture/game-capture.c#L1221-L1228

And this is quite annoying because, from the user's perspective, these windows are clearly in the fullscreen mode.

Additionally, Windows itself doesn't resort to such strict comparison rules, as evidenced by the fact that the taskbar disappears, as it always does for fullscreen windows, even when a window stretches slightly beyond the defined viewport. So, if anything, this should be considered a parity feature.

### How Has This Been Tested?

There isn't much to test, so I just ran the freshly built OBS on Windows in a VM to check if it works. Thankfully, a two-symbol change didn't break the project :D

The change is very localized, shouldn't affect other areas of the code, and doesn't introduce any breaking changes. It simply fixes a minor issue/tweaks the pre-existing functionality to better match the, ahem, nuances of Windows development.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. *(I.e., none)*
