### PR TITLE
UI: Cleanup frontend event handling

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -305,8 +305,8 @@ bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
 		return false;
 	}
 
-	if (api && !rename)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
+	if (!rename)
+		OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
 
 	config_set_string(App()->GlobalConfig(), "Basic", "Profile",
 			  newName.c_str());
@@ -355,9 +355,9 @@ bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
 		wizard.exec();
 	}
 
-	if (api && !rename) {
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
+	if (!rename) {
+		OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
+		OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 	}
 	return true;
 }
@@ -451,8 +451,7 @@ void OBSBasic::DeleteProfile(const QString &profileName)
 	DeleteProfile(name.c_str(), profileDir);
 	RefreshProfiles();
 	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
 }
 
 void OBSBasic::RefreshProfiles()
@@ -539,8 +538,7 @@ void OBSBasic::on_actionRenameProfile_triggered()
 		RefreshProfiles();
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_RENAMED);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_RENAMED);
 }
 
 void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
@@ -589,8 +587,7 @@ void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
 
 	newPath.resize(newPath_len);
 
@@ -626,10 +623,8 @@ void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
 
 	Auth::Load();
 
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 
 	if (needsRestart) {
 		QMessageBox::StandardButton button = OBSMessageBox::question(
@@ -768,8 +763,7 @@ void OBSBasic::ChangeProfile()
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
 
 	path.resize(path_len);
 
@@ -811,8 +805,7 @@ void OBSBasic::ChangeProfile()
 	blog(LOG_INFO, "Switched to profile '%s' (%s)", newName, newDir);
 	blog(LOG_INFO, "------------------------------------------------");
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
 
 	if (needsRestart) {
 		QMessageBox::StandardButton button = OBSMessageBox::question(

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -168,8 +168,7 @@ bool OBSBasic::AddSceneCollection(bool create_new, const QString &qname)
 		RefreshSceneCollections();
 	};
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
 
 	new_collection(file, name);
 
@@ -179,10 +178,8 @@ bool OBSBasic::AddSceneCollection(bool create_new, const QString &qname)
 
 	UpdateTitleBar();
 
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
 
 	return true;
 }
@@ -294,8 +291,7 @@ void OBSBasic::on_actionRenameSceneCollection_triggered()
 	UpdateTitleBar();
 	RefreshSceneCollections();
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED);
 }
 
 void OBSBasic::on_actionRemoveSceneCollection_triggered()
@@ -339,8 +335,7 @@ void OBSBasic::on_actionRemoveSceneCollection_triggered()
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
 
 	oldFile.insert(0, path);
 	/* os_rename() overwrites if necessary, only the .bak file will remain. */
@@ -360,10 +355,8 @@ void OBSBasic::on_actionRemoveSceneCollection_triggered()
 
 	UpdateTitleBar();
 
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
 }
 
 void OBSBasic::on_actionImportSceneCollection_triggered()
@@ -461,8 +454,7 @@ void OBSBasic::ChangeSceneCollection()
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);
 
 	SaveProjectNow();
 
@@ -480,6 +472,5 @@ void OBSBasic::ChangeSceneCollection()
 
 	UpdateTitleBar();
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
 }

--- a/UI/window-basic-main-screenshot.cpp
+++ b/UI/window-basic-main-screenshot.cpp
@@ -57,9 +57,7 @@ ScreenshotObj::~ScreenshotObj()
 
 			main->lastScreenshot = path;
 
-			if (main->api)
-				main->api->on_event(
-					OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);
+			main->OnEvent(OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);
 		}
 	}
 }

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -267,10 +267,8 @@ void OBSBasic::TransitionStopped()
 	EnableTransitionWidgets(true);
 	UpdatePreviewProgramIndicators();
 
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_STOPPED);
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_STOPPED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
 
 	swapScene = nullptr;
 }
@@ -371,8 +369,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force,
 
 	if (force) {
 		obs_transition_set(transition, source);
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_SCENE_CHANGED);
+		OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
 	} else {
 		int duration = ui->transitionDuration->value();
 
@@ -450,8 +447,7 @@ void OBSBasic::SetTransition(OBSSource transition)
 	ui->transitionRemove->setEnabled(configurable);
 	ui->transitionProps->setEnabled(configurable);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_CHANGED);
 }
 
 OBSSource OBSBasic::GetCurrentTransition()
@@ -509,9 +505,7 @@ void OBSBasic::AddTransition(const char *id)
 		CreatePropertiesWindow(source);
 		obs_source_release(source);
 
-		if (api)
-			api->on_event(
-				OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
+		OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
 
 		ClearQuickTransitionWidgets();
 		RefreshQuickTransitions();
@@ -566,8 +560,7 @@ void OBSBasic::on_transitionRemove_clicked()
 
 	ui->transitions->removeItem(idx);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
 
 	ClearQuickTransitionWidgets();
 	RefreshQuickTransitions();
@@ -607,9 +600,7 @@ void OBSBasic::RenameTransition(OBSSource transition)
 	if (idx != -1) {
 		ui->transitions->setItemText(idx, QT_UTF8(name.c_str()));
 
-		if (api)
-			api->on_event(
-				OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
+		OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
 
 		ClearQuickTransitionWidgets();
 		RefreshQuickTransitions();
@@ -643,9 +634,7 @@ void OBSBasic::on_transitionProps_clicked()
 
 void OBSBasic::on_transitionDuration_valueChanged()
 {
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
 }
 
 QuickTransition *OBSBasic::GetQuickTransition(int id)
@@ -714,9 +703,7 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 					outputHandler
 						->UpdateVirtualCamOutputSource();
 
-				if (api)
-					api->on_event(
-						OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
+				OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 				break;
 			}
 		}
@@ -968,8 +955,7 @@ void OBSBasic::TBarChanged(int value)
 	obs_transition_set_manual_time(transition,
 				       (float)value / T_BAR_PRECISION_F);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_TBAR_VALUE_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_TBAR_VALUE_CHANGED);
 }
 
 int OBSBasic::GetTbarPosition()
@@ -1668,8 +1654,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->setAlignment(programOptions,
 						Qt::AlignCenter);
 
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
+		OnEvent(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
 
 		blog(LOG_INFO, "Switched to Preview/Program mode");
 		blog(LOG_INFO, "-----------------------------"
@@ -1707,8 +1692,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->transitions->setEnabled(true);
 		tBarActive = false;
 
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED);
+		OnEvent(OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED);
 
 		blog(LOG_INFO, "Switched to regular Preview mode");
 		blog(LOG_INFO, "-----------------------------"

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -619,10 +619,8 @@ OBSBasic::OBSBasic(QWidget *parent)
 	connect(ui->scenes, &SceneTree::scenesReordered,
 		[]() { OBSProjector::UpdateMultiviewProjectors(); });
 
-	connect(App(), &OBSApp::StyleChanged, this, [this]() {
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_THEME_CHANGED);
-	});
+	connect(App(), &OBSApp::StyleChanged, this,
+		[this]() { OnEvent(OBS_FRONTEND_EVENT_THEME_CHANGED); });
 
 	QActionGroup *actionGroup = new QActionGroup(this);
 	actionGroup->addAction(ui->actionSceneListMode);
@@ -1470,10 +1468,8 @@ retryScene:
 	if (vcamEnabled)
 		outputHandler->UpdateVirtualCamOutputSource();
 
-	if (api) {
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_CHANGED);
-		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
-	}
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 }
 
 #define SERVICE_PATH "service.json"
@@ -2549,8 +2545,7 @@ void OBSBasic::OBSInit()
 
 void OBSBasic::OnFirstLoad()
 {
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_FINISHED_LOADING);
+	OnEvent(OBS_FRONTEND_EVENT_FINISHED_LOADING);
 
 #ifdef WHATSNEW_ENABLED
 	/* Attempt to load init screen if available */
@@ -3376,8 +3371,7 @@ void OBSBasic::AddScene(OBSSource source)
 		OBSProjector::UpdateMultiviewProjectors();
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
 }
 
 void OBSBasic::RemoveScene(OBSSource source)
@@ -3412,8 +3406,7 @@ void OBSBasic::RemoveScene(OBSSource source)
 		OBSProjector::UpdateMultiviewProjectors();
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
 }
 
 static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item,
@@ -4505,8 +4498,7 @@ void OBSBasic::RemoveSelectedScene()
 
 	RemoveSceneAndReleaseNested(source);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
 }
 
 void OBSBasic::ReorderSources(OBSScene scene)
@@ -5131,8 +5123,7 @@ void OBSBasic::ClearSceneData()
 	obs_enum_scenes(cb, nullptr);
 	obs_enum_sources(cb, nullptr);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP);
 
 	undo_s.clear();
 
@@ -5304,8 +5295,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	ClearExtraBrowserDocks();
 #endif
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN);
+	OnEvent(OBS_FRONTEND_EVENT_SCRIPTING_SHUTDOWN);
 
 	disableSaving++;
 
@@ -5313,8 +5303,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 	 * sources, etc) so that all references are released before shutdown */
 	ClearSceneData();
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_EXIT);
+	OnEvent(OBS_FRONTEND_EVENT_EXIT);
 
 	// Destroys the frontend API so plugins can't continue calling it
 	obs_frontend_set_callbacks_internal(nullptr);
@@ -5554,8 +5543,7 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current,
 	if (vcamEnabled && vcamConfig.type == VCamOutputType::PreviewOutput)
 		outputHandler->UpdateVirtualCamOutputSource();
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
 
 	UpdateContextBar();
 }
@@ -6898,8 +6886,7 @@ void OBSBasic::SceneNameEdited(QWidget *editor)
 
 	ui->scenesDock->addAction(renameScene);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
 }
 
 void OBSBasic::OpenFilters(OBSSource source)
@@ -7132,8 +7119,7 @@ void OBSBasic::StartStreaming()
 			return;
 		}
 
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_STREAMING_STARTING);
+		OnEvent(OBS_FRONTEND_EVENT_STREAMING_STARTING);
 
 		SaveProject();
 
@@ -7490,8 +7476,7 @@ void OBSBasic::StreamDelayStopping(int sec)
 
 	ui->statusbar->StreamDelayStopping(sec);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_STREAMING_STOPPING);
+	OnEvent(OBS_FRONTEND_EVENT_STREAMING_STOPPING);
 }
 
 void OBSBasic::StreamingStart()
@@ -7522,8 +7507,7 @@ void OBSBasic::StreamingStart()
 	}
 #endif
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_STREAMING_STARTED);
+	OnEvent(OBS_FRONTEND_EVENT_STREAMING_STARTED);
 
 	OnActivate();
 
@@ -7543,8 +7527,7 @@ void OBSBasic::StreamStopping()
 		sysTrayStream->setText(QTStr("Basic.Main.StoppingStreaming"));
 
 	streamingStopping = true;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_STREAMING_STOPPING);
+	OnEvent(OBS_FRONTEND_EVENT_STREAMING_STOPPING);
 }
 
 void OBSBasic::StreamingStop(int code, QString last_error)
@@ -7605,8 +7588,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 	}
 
 	streamingStopping = false;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_STREAMING_STOPPED);
+	OnEvent(OBS_FRONTEND_EVENT_STREAMING_STOPPED);
 
 	OnDeactivate();
 
@@ -7738,8 +7720,7 @@ void OBSBasic::StartRecording()
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STARTING);
+	OnEvent(OBS_FRONTEND_EVENT_RECORDING_STARTING);
 
 	SaveProject();
 
@@ -7754,8 +7735,7 @@ void OBSBasic::RecordStopping()
 		sysTrayRecord->setText(QTStr("Basic.Main.StoppingRecording"));
 
 	recordingStopping = true;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STOPPING);
+	OnEvent(OBS_FRONTEND_EVENT_RECORDING_STOPPING);
 }
 
 void OBSBasic::StopRecording()
@@ -7777,8 +7757,7 @@ void OBSBasic::RecordingStart()
 		sysTrayRecord->setText(QTStr("Basic.Main.StopRecording"));
 
 	recordingStopping = false;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STARTED);
+	OnEvent(OBS_FRONTEND_EVENT_RECORDING_STARTED);
 
 	if (!diskFullTimer->isActive())
 		diskFullTimer->start(1000);
@@ -7852,8 +7831,7 @@ void OBSBasic::RecordingStop(int code, QString last_error)
 		}
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_RECORDING_STOPPED);
+	OnEvent(OBS_FRONTEND_EVENT_RECORDING_STOPPED);
 
 	if (diskFullTimer->isActive())
 		diskFullTimer->stop();
@@ -7924,8 +7902,7 @@ void OBSBasic::StartReplayBuffer()
 		return;
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING);
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTING);
 
 	SaveProject();
 
@@ -7947,8 +7924,7 @@ void OBSBasic::ReplayBufferStopping()
 			QTStr("Basic.Main.StoppingReplayBuffer"));
 
 	replayBufferStopping = true;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING);
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPING);
 }
 
 void OBSBasic::StopReplayBuffer()
@@ -7976,8 +7952,7 @@ void OBSBasic::ReplayBufferStart()
 			QTStr("Basic.Main.StopReplayBuffer"));
 
 	replayBufferStopping = false;
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED);
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STARTED);
 
 	OnActivate();
 
@@ -8016,8 +7991,7 @@ void OBSBasic::ReplayBufferSaved()
 	lastReplay = path;
 	calldata_free(&cd);
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);
 
 	AutoRemux(QT_UTF8(path.c_str()));
 }
@@ -8061,8 +8035,7 @@ void OBSBasic::ReplayBufferStop(int code)
 			      QSystemTrayIcon::Warning);
 	}
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED);
+	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_STOPPED);
 
 	OnDeactivate();
 }
@@ -8104,8 +8077,7 @@ void OBSBasic::OnVirtualCamStart()
 	if (sysTrayVirtualCam)
 		sysTrayVirtualCam->setText(QTStr("Basic.Main.StopVirtualCam"));
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED);
+	OnEvent(OBS_FRONTEND_EVENT_VIRTUALCAM_STARTED);
 
 	OnActivate();
 
@@ -8122,8 +8094,7 @@ void OBSBasic::OnVirtualCamStop(int)
 	if (sysTrayVirtualCam)
 		sysTrayVirtualCam->setText(QTStr("Basic.Main.StartVirtualCam"));
 
-	if (api)
-		api->on_event(OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED);
+	OnEvent(OBS_FRONTEND_EVENT_VIRTUALCAM_STOPPED);
 
 	blog(LOG_INFO, VIRTUAL_CAM_STOP);
 
@@ -10751,8 +10722,7 @@ void OBSBasic::PauseRecording()
 							   trayIconFile));
 		}
 
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_RECORDING_PAUSED);
+		OnEvent(OBS_FRONTEND_EVENT_RECORDING_PAUSED);
 
 		if (os_atomic_load_bool(&replaybuf_active))
 			ShowReplayBufferPauseWarning();
@@ -10789,8 +10759,7 @@ void OBSBasic::UnpauseRecording()
 							   trayIconFile));
 		}
 
-		if (api)
-			api->on_event(OBS_FRONTEND_EVENT_RECORDING_UNPAUSED);
+		OnEvent(OBS_FRONTEND_EVENT_RECORDING_UNPAUSED);
 	}
 }
 
@@ -11113,4 +11082,10 @@ void OBSBasic::UpdatePreviewSpacingHelpers()
 float OBSBasic::GetDevicePixelRatio()
 {
 	return dpi;
+}
+
+void OBSBasic::OnEvent(enum obs_frontend_event event)
+{
+	if (api)
+		api->on_event(event);
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -359,6 +359,8 @@ private:
 	std::atomic<obs_scene_t *> currentScene = nullptr;
 	std::optional<std::pair<uint32_t, uint32_t>> lastOutputResolution;
 
+	void OnEvent(enum obs_frontend_event event);
+
 	void UpdateMultiviewProjectorMenu();
 
 	void DrawBackdrop(float cx, float cy);


### PR DESCRIPTION
### Description
This adds a function to OBSBasic to call on_event, so every time a event is called, the api variable doesn't have to be checked every time.

### Motivation and Context
Code cleanup

### How Has This Been Tested?
Tested events with one of my plugins

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
