### PR TITLE
UI: Add pragma once to ScreenshotObj header

### DIFF
--- a/UI/screenshot-obj.hpp
+++ b/UI/screenshot-obj.hpp
@@ -15,6 +15,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#pragma once
+
 #include <QObject>
 #include <string>
 #include <thread>


### PR DESCRIPTION
### Description
Makes sure header is only included once preventing code clashes.

### Motivation and Context
Found when looking through code

### How Has This Been Tested?
Made sure OBS still compiled

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
