### PR TITLE
CI: Fix Windows Patches action release notes generation

### DIFF
--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -25,6 +25,7 @@ runs:
       with:
         path: "repo"
         fetch-depth: 0
+        ref: ${{ inputs.tagName }}
 
     - name: Download Release Artifact
       shell: pwsh


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
By not specifying a checkout ref, actions/checkout does a second checkout when this action is invoked by the Publish workflow (release event). When this happens, it checks out the commit object from the tag, and git can no longer locate the annotated tag that contains the release notes. This then causes the release notes to be just the commit message and not the annotated tag message.

The sparkle-appcast action in general and this actioo when invoked via the Dispatch workflow do not have this issue, and they both specify the tag as the ref.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want the CI automation to work on release/publish.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my fork.
https://github.com/RytoEX/obs-studio/actions/runs/9575363185

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
