### PR TITLE
obs-webrtc: Add Simulcast Support

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1014,6 +1014,9 @@ Basic.Settings.Stream.MultitrackVideoConfigOverride="Config Override (JSON)"
 Basic.Settings.Stream.MultitrackVideoConfigOverrideEnable="Enable Config Override"
 Basic.Settings.Stream.MultitrackVideoLabel="Multitrack Video"
 Basic.Settings.Stream.MultitrackVideoExtraCanvas="Additional Canvas"
+Basic.Settings.Stream.WHIPSimulcastLabel="Simulcast"
+Basic.Settings.Stream.WHIPSimulcastInfo="Simulcast allows you to encode and send multiple video qualities. <a href='https://obsproject.com/kb/whip-streaming-guide'>Learn More</a>"
+Basic.Settings.Stream.WHIPSimulcastTotalLayers="Total Layers"
 Basic.Settings.Stream.AdvancedOptions="Advanced Options"
 
 # basic mode 'output' settings

--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -2083,6 +2083,100 @@
                </widget>
               </item>
               <item>
+               <widget class="QGroupBox" name="whipSimulcastGroupBox">
+                <property name="title">
+                 <string>Basic.Settings.Stream.WHIPSimulcastLabel</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_35">
+                 <property name="leftMargin">
+                  <number>9</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>2</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>9</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>9</number>
+                 </property>
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout_33">
+                   <item>
+                    <spacer name="horizontalSpacer_33">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Fixed</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>170</width>
+                       <height>10</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="whipSimulcastInfo">
+                     <property name="text">
+                      <string>Basic.Settings.Stream.WHIPSimulcastInfo</string>
+                     </property>
+                     <property name="textFormat">
+                      <enum>Qt::RichText</enum>
+                     </property>
+                     <property name="wordWrap">
+                      <bool>true</bool>
+                     </property>
+                     <property name="openExternalLinks">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <layout class="QFormLayout" name="formLayout_39">
+                   <property name="fieldGrowthPolicy">
+                    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+                   </property>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="whipSimulcastTotalLayersLabel">
+                     <property name="text">
+                      <string>Basic.Settings.Stream.WHIPSimulcastTotalLayers</string>
+                     </property>
+                     <property name="minimumSize">
+                      <size>
+                       <width>170</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_34" stretch="0,0">
+                     <item>
+                      <widget class="QSpinBox" name="whipSimulcastTotalLayers">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="maximum">
+                        <number>4</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </widget>
+               </item>
+              <item>
                <widget class="QGroupBox" name="serviceAdvancedOptionsGroupBox">
                 <property name="title">
                  <string>Basic.Settings.Stream.AdvancedOptions</string>

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -385,6 +385,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->authUsername,         EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->authPw,               EDIT_CHANGED,   STREAM1_CHANGED);
 	HookWidget(ui->ignoreRecommended,    CHECK_CHANGED,  STREAM1_CHANGED);
+	HookWidget(ui->whipSimulcastTotalLayers, SCROLL_CHANGED, STREAM1_CHANGED);
 	HookWidget(ui->enableMultitrackVideo,      CHECK_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->multitrackVideoMaximumAggregateBitrateAuto, CHECK_CHANGED,  STREAM1_CHANGED);
 	HookWidget(ui->multitrackVideoMaximumAggregateBitrate,     SCROLL_CHANGED, STREAM1_CHANGED);

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -95,6 +95,7 @@ void OBSBasicSettings::InitStreamPage()
 void OBSBasicSettings::LoadStream1Settings()
 {
 	bool ignoreRecommended = config_get_bool(main->Config(), "Stream1", "IgnoreRecommended");
+	int whipSimulcastTotalLayers = config_get_int(main->Config(), "Stream1", "WHIPSimulcastTotalLayers");
 
 	obs_service_t *service_obj = main->GetService();
 	const char *type = obs_service_get_type(service_obj);
@@ -209,10 +210,13 @@ void OBSBasicSettings::LoadStream1Settings()
 	if (use_custom_server)
 		ui->serviceCustomServer->setText(server);
 
-	if (is_whip)
+	if (is_whip) {
 		ui->key->setText(bearer_token);
-	else
+		ui->whipSimulcastGroupBox->show();
+	} else {
 		ui->key->setText(key);
+		ui->whipSimulcastGroupBox->hide();
+	}
 
 	ServiceChanged(true);
 
@@ -226,6 +230,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	ui->streamPage->setEnabled(!streamActive);
 
 	ui->ignoreRecommended->setChecked(ignoreRecommended);
+	ui->whipSimulcastTotalLayers->setValue(whipSimulcastTotalLayers);
 
 	loading = false;
 
@@ -327,6 +332,9 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	SaveCheckBox(ui->ignoreRecommended, "Stream1", "IgnoreRecommended");
 
+	auto oldWHIPSimulcastTotalLayers = config_get_int(main->Config(), "Stream1", "WHIPSimulcastTotalLayers");
+	SaveSpinBox(ui->whipSimulcastTotalLayers, "Stream1", "WHIPSimulcastTotalLayers");
+
 	auto oldMultitrackVideoSetting = config_get_bool(main->Config(), "Stream1", "EnableMultitrackVideo");
 
 	if (!IsCustomService()) {
@@ -355,7 +363,8 @@ void OBSBasicSettings::SaveStream1Settings()
 	SaveText(ui->multitrackVideoConfigOverride, "Stream1", "MultitrackVideoConfigOverride");
 	SaveComboData(ui->multitrackVideoAdditionalCanvas, "Stream1", "MultitrackExtraCanvas");
 
-	if (oldMultitrackVideoSetting != ui->enableMultitrackVideo->isChecked())
+	if (oldMultitrackVideoSetting != ui->enableMultitrackVideo->isChecked() ||
+	    oldWHIPSimulcastTotalLayers != ui->whipSimulcastTotalLayers->value())
 		main->ResetOutputs();
 
 	SwapMultiTrack(QT_TO_UTF8(protocol));
@@ -587,6 +596,12 @@ void OBSBasicSettings::on_service_currentIndexChanged(int idx)
 		ui->advStreamTrackWidget->setCurrentWidget(ui->streamSingleTracks);
 	} else {
 		SwapMultiTrack(QT_TO_UTF8(protocol));
+	}
+
+	if (IsWHIP()) {
+		ui->whipSimulcastGroupBox->show();
+	} else {
+		ui->whipSimulcastGroupBox->hide();
 	}
 }
 

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -236,6 +236,9 @@ BasicOutputHandler::BasicOutputHandler(OBSBasic *main_) : main(main_)
 
 	if (multitrack_enabled)
 		multitrackVideo = make_unique<MultitrackVideoOutput>();
+
+	if (config_get_int(main->Config(), "Stream1", "WHIPSimulcastTotalLayers") > 1)
+		whipSimulcastEncoders = make_unique<WHIPSimulcastEncoders>();
 }
 
 extern void log_vcam_changed(const VCamConfig &config, bool starting);

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <utility/MultitrackVideoOutput.hpp>
+#include <utility/WHIPSimulcastEncoders.hpp>
 
 #include <obs.hpp>
 #include <util/dstr.hpp>
@@ -41,6 +42,8 @@ struct BasicOutputHandler {
 	video_t *virtualCamVideo = nullptr;
 	obs_scene_t *vCamSourceScene = nullptr;
 	obs_sceneitem_t *vCamSourceSceneItem = nullptr;
+
+	std::unique_ptr<WHIPSimulcastEncoders> whipSimulcastEncoders;
 
 	std::string outputType;
 	std::string lastError;

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -75,6 +75,13 @@ void SimpleOutput::LoadStreamingPreset_Lossy(const char *encoderId)
 	if (!videoStreaming)
 		throw "Failed to create video streaming encoder (simple output)";
 	obs_encoder_release(videoStreaming);
+
+	if (whipSimulcastEncoders != nullptr) {
+		whipSimulcastEncoders->Create(encoderId, config_get_int(main->Config(), "AdvOut", "RescaleFilter"),
+					      config_get_int(main->Config(), "Stream1", "WHIPSimulcastTotalLayers"),
+					      video_output_get_width(obs_get_video()),
+					      video_output_get_height(obs_get_video()));
+	}
 }
 
 /* mistakes have been made to lead us to this. */
@@ -351,11 +358,18 @@ void SimpleOutput::Update()
 		break;
 	default:
 		obs_encoder_set_preferred_video_format(videoStreaming, VIDEO_FORMAT_NV12);
+		if (whipSimulcastEncoders != nullptr) {
+			whipSimulcastEncoders->SetVideoFormat(VIDEO_FORMAT_NV12);
+		}
 	}
 
 	obs_encoder_update(videoStreaming, videoSettings);
 	obs_encoder_update(audioStreaming, audioSettings);
 	obs_encoder_update(audioArchive, audioSettings);
+
+	if (whipSimulcastEncoders != nullptr) {
+		whipSimulcastEncoders->Update(videoSettings, videoBitrate);
+	}
 }
 
 void SimpleOutput::UpdateRecordingAudioSettings()
@@ -630,6 +644,9 @@ std::shared_future<void> SimpleOutput::SetupStreaming(obs_service_t *service, Se
 		}
 
 		obs_output_set_video_encoder(streamOutput, videoStreaming);
+		if (whipSimulcastEncoders != nullptr) {
+			whipSimulcastEncoders->SetStreamOutput(streamOutput);
+		}
 		obs_output_set_audio_encoder(streamOutput, audioStreaming, 0);
 		obs_output_set_service(streamOutput, service);
 		return true;

--- a/frontend/utility/WHIPSimulcastEncoders.hpp
+++ b/frontend/utility/WHIPSimulcastEncoders.hpp
@@ -1,0 +1,84 @@
+/******************************************************************************
+    Copyright (C) 2025 by Sean DuBois <sean@pion.ly>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+#pragma once
+
+struct WHIPSimulcastEncoders {
+public:
+	void Create(const char *encoderId, int rescaleFilter, int whipSimulcastTotalLayers, uint32_t outputWidth,
+		    uint32_t outputHeight)
+	{
+		if (rescaleFilter == OBS_SCALE_DISABLE) {
+			rescaleFilter = OBS_SCALE_BICUBIC;
+		}
+
+		if (whipSimulcastTotalLayers <= 1) {
+			return;
+		}
+
+		auto widthStep = outputWidth / whipSimulcastTotalLayers;
+		auto heightStep = outputHeight / whipSimulcastTotalLayers;
+		std::string encoder_name = "whip_simulcast_0";
+
+		for (auto i = whipSimulcastTotalLayers - 1; i > 0; i--) {
+			uint32_t width = widthStep * i;
+			width -= width % 2;
+
+			uint32_t height = heightStep * i;
+			height -= height % 2;
+
+			encoder_name[encoder_name.size() - 1] = std::to_string(i).at(0);
+			auto whip_simulcast_encoder =
+				obs_video_encoder_create(encoderId, encoder_name.c_str(), nullptr, nullptr);
+
+			if (whip_simulcast_encoder) {
+				obs_encoder_set_video(whip_simulcast_encoder, obs_get_video());
+				obs_encoder_set_scaled_size(whip_simulcast_encoder, width, height);
+				obs_encoder_set_gpu_scale_type(whip_simulcast_encoder, (obs_scale_type)rescaleFilter);
+				whipSimulcastEncoders.push_back(whip_simulcast_encoder);
+				obs_encoder_release(whip_simulcast_encoder);
+			} else {
+				blog(LOG_WARNING,
+				     "Failed to create video streaming WHIP Simulcast encoders (BasicOutputHandler)");
+			}
+		}
+	}
+
+	void Update(obs_data_t *videoSettings, int videoBitrate)
+	{
+		auto bitrateStep = videoBitrate / static_cast<int>(whipSimulcastEncoders.size() + 1);
+		for (auto &whipSimulcastEncoder : whipSimulcastEncoders) {
+			videoBitrate -= bitrateStep;
+			obs_data_set_int(videoSettings, "bitrate", videoBitrate);
+			obs_encoder_update(whipSimulcastEncoder, videoSettings);
+		}
+	}
+
+	void SetVideoFormat(enum video_format format)
+	{
+		for (auto enc : whipSimulcastEncoders)
+			obs_encoder_set_preferred_video_format(enc, format);
+	}
+
+	void SetStreamOutput(obs_output_t *streamOutput)
+	{
+		for (size_t i = 0; i < whipSimulcastEncoders.size(); i++)
+			obs_output_set_video_encoder2(streamOutput, whipSimulcastEncoders[i], i + 1);
+	}
+
+private:
+	std::vector<OBSEncoder> whipSimulcastEncoders;
+};

--- a/plugins/obs-webrtc/data/locale/en-US.ini
+++ b/plugins/obs-webrtc/data/locale/en-US.ini
@@ -4,3 +4,4 @@ Service.BearerToken="Bearer Token"
 
 Error.InvalidSDP="WHIP server responded with invalid SDP: %1"
 Error.NoRemoteDescription="Failed to set remote description: %1"
+Error.SimulcastLayersRejected="WHIP server only accepted %1 simulcast layers"

--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -10,8 +10,17 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
+#include <algorithm>
 
 #include <rtc/rtc.hpp>
+
+struct videoLayerState {
+	uint16_t sequenceNumber;
+	uint32_t rtpTimestamp;
+	int64_t lastVideoTimestamp;
+	uint32_t ssrc;
+	std::string rid;
+};
 
 class WHIPOutput {
 public:
@@ -36,7 +45,6 @@ private:
 	void SendDelete();
 	void StopThread(bool signal);
 	void ParseLinkHeader(std::string linkHeader, std::vector<rtc::IceServer> &iceServers);
-
 	void Send(void *data, uintptr_t size, uint64_t duration, std::shared_ptr<rtc::Track> track,
 		  std::shared_ptr<rtc::RtcpSrReporter> rtcp_sr_reporter);
 
@@ -58,11 +66,12 @@ private:
 	std::shared_ptr<rtc::RtcpSrReporter> audio_sr_reporter;
 	std::shared_ptr<rtc::RtcpSrReporter> video_sr_reporter;
 
+	std::map<obs_encoder_t *, std::shared_ptr<videoLayerState>> videoLayerStates;
+
 	std::atomic<size_t> total_bytes_sent;
 	std::atomic<int> connect_time_ms;
 	int64_t start_time_ns;
 	int64_t last_audio_timestamp;
-	int64_t last_video_timestamp;
 };
 
 void register_whip_output();

--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -83,3 +83,25 @@ static inline std::string generate_user_agent()
 
 	return ua.str();
 }
+
+static size_t simulcast_layers_in_answer(std::string answer)
+{
+	auto layersStart = answer.find("a=simulcast");
+	if (layersStart == std::string::npos) {
+		return 0;
+	}
+
+	auto layersEnd = answer.find("\r\n", layersStart);
+	if (layersEnd == std::string::npos) {
+		return 0;
+	}
+
+	size_t layersAccepted = 1;
+	for (auto i = layersStart; i < layersEnd; i++) {
+		if (answer[i] == ';') {
+			layersAccepted++;
+		}
+	}
+
+	return layersAccepted;
+}


### PR DESCRIPTION
## Description
This PR adds supports for Simulcast to the obs-webrtc output. Simulcast allows for multiple quality levels to be sent over one track in WebRTC.

[RFC 8853](https://datatracker.ietf.org/doc/rfc8853/) is a technical description. For a less technical explanation [Wowza](https://www.wowza.com/blog/webrtc-simulcast-what-it-is-and-how-it-works), [Dolby](https://docs.dolby.io/streaming-apis/docs/using-webrtc-simulcast) and [LiveKit](https://blog.livekit.io/an-introduction-to-webrtc-simulcast-6c5f1f6402eb/) have all written articles on it.

This PR starts with adding a Spinbox when `WHIP` is selected. This allows the user to choose how many layers to send in total. The acceptable range (for now) is 1-4.
![defaultPage](https://github.com/user-attachments/assets/ed5e3693-9442-4882-bb44-c7553eed3585)

The Height/Width/Bitrate is scaled from the users global choice. So depending on the users choice.
* 1 Layers (
  * 100% Height/Width/Bitrate
* 2 Layers 
  * 100% Height/Width/Bitrate,
  * 50% Height/Width/Bitrate
* 3 Layers 
  * 100% Height/Width/Bitrate
  * 66% Height/Width/Bitrate
  * 33% Height/Width/Bitrate
* 4 Layers 
  * 100% Height/Width/Bitrate
  * 75% Height/Width/Bitrate 
  * 50% Height/Width/Bitrate 
  * 25% Height/Width/Bitrate

A server may wish to only accept a subset of the layers offered. Today if the user rejects any layers we throw an error and say how many layers were accepted. The user can lower the amount of layers they are sending and try again. Services in their documentation will be expected to tell users how they want video encoded and how many layers they are willing to accept.

![failedToAcceptLayer](https://github.com/user-attachments/assets/73106175-4880-4f62-8a0a-cf0fc434d985)

### Motivation and Context

* Low Latency - Decoding/Re-encoding adds too much latency for interactive content
* Make self hosting easier - Running ffmpeg is costly and difficult to scale
* Streamers more control - If streamers can generate transcodes they control the quality 
* E2E Encryption/Prevent Modification- Streamers can distribute keys to viewers and servers can't modify video anymore.

Some questions that have been asked by reviewers already.

**What about Enhanced Broadcasting?** -  Simulcast is part of an existing standard that already sees [a billion minutes per day](https://bloggeek.me/kranky-geek-webrtc-summary-2022/) so it is here to stay and is already deployed massively. I would like to see Enhanced Broadcasting in the JSON blob be able to specify the protocol. When a user starts a enhanced broadcasting session it should be able to switch between RTMP/WebRTC/$x. I think both flows can/should exist because they serve different purposes. 

**UI/UX Considerations** - A single opt-in is non-intrusive and respects the user. It would be good to get feedback from all OBS WebRTC users (Dolby, LiveKit, Cloudflare etc...) that this is a sound decision though. 

### How Has This Been Tested?
This has been tested with the nvenc, qsv, and x264.

I have tested this against Twitch, Broadcast Box, LiveKit and Dolby. 

### Types of changes
- New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
