### PR TITLE
CI: Update Windows Patches Action

### DIFF
--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -86,7 +86,10 @@ runs:
       run: |
         # Release notes are just the tag body on Windows
         Set-Location repo
-        git tag -l --format='%(contents:body)' ${{ inputs.tagName }} > "${{ github.workspace }}/notes.rst"
+        git tag -l --format='%(contents:subject)' ${{ inputs.tagName }} > "${{ github.workspace }}/notes.rst"
+        Write-Output "###################################################" >> "${{ github.workspace }}/notes.rst"
+        Write-Output "" >> "${{ github.workspace }}/notes.rst"
+        git tag -l --format='%(contents:body)' ${{ inputs.tagName }} >> "${{ github.workspace }}/notes.rst"
 
     - name: Run bouf
       shell: pwsh

--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -40,9 +40,9 @@ runs:
     - name: Setup bouf
       shell: pwsh
       env:
-        BOUF_TAG: 'v0.6.3'
-        BOUF_HASH: '7f1d266467620aa553a705391ee06128e8ee14af66129a0e64a282997fb6fd83'
-        BOUF_NSIS_HASH: 'a234126de89f122b6a552df3416de3eabcb4195217626c7f4eaec71b20fe36eb'
+        BOUF_TAG: 'v0.6.4'
+        BOUF_HASH: 'aca6810e741dc38ff843fab7b25a0ad8570ee84f5595132cf0cc4a5b0131b4c4'
+        BOUF_NSIS_HASH: 'ed453784486556bd959d56743a8478ad3f68fe0305e9b43ac19d8771d0515257'
         GH_TOKEN: ${{ github.token }}
       run: |
         # Download bouf release


### PR DESCRIPTION
### Description

- Updates bouf version to fix pandoc conversion using the wrong input format
- Updates creation of notes file to be in line with the Sparkle variant that does include the "subject" line as a header

### Motivation and Context

Improve patch notes.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
