### PR TITLE
UI: Disable multitrack video settings on non-win32 platforms

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -6325,6 +6325,10 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 			ui->enableMultitrackVideo->setChecked(false);
 	}
 
+#ifndef _WIN32
+	available = available && MultitrackVideoDeveloperModeEnabled();
+#endif
+
 	if (IsCustomService())
 		available = available && MultitrackVideoDeveloperModeEnabled();
 


### PR DESCRIPTION
### Description
Disables multitrack video output settings for platforms other than windows

### Motivation and Context
System info is not implemented for platforms other than windows, so the overall sentiment is/was to disable the multitrack video output for other platforms until system info is implemented (and ideally encoders for those other platforms are validated and/or encoder ladders/configs are available)

### How Has This Been Tested?
Verified that these settings are available on windows builds, but aren't available on MacOS builds

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
