### PR TITLE
CI: Fix FreeBSD package installation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
 
 task:
   install_script:
-  - pkg-install -y
+  - pkg install -y
     cmake ninja binutils pkgconf curl
     ffmpeg qt6-base qt6-svg jansson libsysinfo e2fsprogs-libuuid pulseaudio
     alsa-lib pipewire v4l_compat libpci librist srt nlohmann-json uthash


### PR DESCRIPTION
FreeBSD's package tool is pkg(8), and install is the command verb passed to it.

Fixes: fb4d65875e27 ("CI: Update Linux build scripts to use CMake presets")

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Correct `pkg install` invocation in FreeBSD Cirrus-CI invocation.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
FreeBSD CI failed, e.g. https://cirrus-ci.com/build/5788727706910720

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Push to my fork and observe CI progress. 

The build currently fails but this change allows us to get further.

```
/tmp/cirrus-ci-build/plugins/linux-alsa/alsa-input.c:132:15: warning: implicit conversion loses integer precision: 'long long' to 'unsigned int' [-Wshorten-64-to-32]
        data->rate = obs_data_get_int(settings, "rate");
                   ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/cirrus-ci-build/plugins/linux-alsa/alsa-input.c:201:9: warning: implicit conversion loses integer precision: 'long long' to 'unsigned int' [-Wshorten-64-to-32]
        rate = obs_data_get_int(settings, "rate");
             ~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/cirrus-ci-build/plugins/linux-alsa/alsa-input.c:587:43: warning: implicit conversion loses integer precision: 'snd_pcm_sframes_t' (aka 'long') to 'int' [-Wshorten-64-to-32]
                        frames = snd_pcm_recover(data->handle, frames, 0);
                                 ~~~~~~~~~~~~~~~               ^~~~~~
/tmp/cirrus-ci-build/plugins/linux-alsa/alsa-input.c:594:16: warning: implicit conversion loses integer precision: 'snd_pcm_sframes_t' (aka 'long') to 'uint32_t' (aka 'unsigned int') [-Wshorten-64-to-32]
                out.frames = frames;
                           ~ ^~~~~~
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
