### PR TITLE
UI: Fix crash when exiting with a multitrack video stream active

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -507,9 +507,9 @@ void MultitrackVideoOutput::PrepareStreaming(
 			const std::lock_guard current_stream_dump_lock{
 				current_stream_dump_mutex};
 			current_stream_dump.emplace(OBSOutputObjects{
-				std::move(recording_output),
 				video_encoder_group,
 				std::move(recording_audio_encoders),
+				std::move(recording_output),
 				nullptr,
 				std::move(start_recording),
 				std::move(stop_recording),
@@ -520,9 +520,9 @@ void MultitrackVideoOutput::PrepareStreaming(
 
 	const std::lock_guard current_lock{current_mutex};
 	current.emplace(OBSOutputObjects{
-		std::move(output),
 		video_encoder_group,
 		std::move(audio_encoders),
+		std::move(output),
 		std::move(multitrack_video_service),
 		std::move(start_streaming),
 		std::move(stop_streaming),

--- a/UI/multitrack-video-output.hpp
+++ b/UI/multitrack-video-output.hpp
@@ -52,9 +52,13 @@ public:
 
 private:
 	struct OBSOutputObjects {
-		OBSOutputAutoRelease output_;
 		std::shared_ptr<obs_encoder_group_t> video_encoder_group_;
 		std::vector<OBSEncoderAutoRelease> audio_encoders_;
+		/* Outputs do not hold on to their encoders,
+		 * so the output needs to be stopped/released
+		 * before the encoders are released
+		 */
+		OBSOutputAutoRelease output_;
 		OBSServiceAutoRelease multitrack_video_service_;
 		OBSSignal start_signal, stop_signal, deactivate_signal;
 	};


### PR DESCRIPTION
Not entirely sure if this is a good fix/the right fix, commit title etc is somewhat not final cc @tt2468, @RytoEX 

### Description
changes order that multitrack video output encoders and outputs are released in, to work around a crash on shutdown while the multitrack video output is active

### Motivation and Context
exiting obs while the multitrack video output is active will currently cause obs to crash:
code around the crash https://github.com/obsproject/obs-studio/blob/608d3bfc26b5ff88ea6467d0183826c344bb1bd5/libobs/obs-encoder.c#L358-L360
-> `remove_connection` calls `obs_encoder_group_actually_destroy` which in turn releases the last strong ref to the current encoder so encoder is an invalid pointer in `remove_connection` after that point, and it currently crashes in `pthread_mutex_unlock(&encoder->encoder_group->mutex)` for me

### How Has This Been Tested?
exited obs with multitrack video output active and it no longer crashes

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
