### PR TITLE
UI: Adjust Yami (Classic) styling

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -477,7 +477,7 @@ OBSDock > QWidget {
 }
 
 #transitionsFrame {
-    padding: 4px 8px;
+    padding: var(--padding_large);
 }
 
 OBSDock QLabel {
@@ -827,7 +827,7 @@ QComboBox::drop-down,
 QDateTimeEdit::drop-down {
     border:none;
     border-left: 1px solid var(--grey6);
-    width: 32px;
+    width: var(--input_height);
 }
 
 QComboBox::down-arrow,
@@ -923,7 +923,7 @@ QDoubleSpinBox::up-button {
     subcontrol-origin: padding;
     subcontrol-position: top right; /* position at the top right corner */
 
-    width: 32px;
+    width: var(--input_height);
     height: var(--spinbox_button_height);
     border-left: 1px solid var(--grey6);
     border-bottom: 1px solid transparent;
@@ -936,7 +936,7 @@ QDoubleSpinBox::down-button {
     subcontrol-origin: padding;
     subcontrol-position: bottom right; /* position at the top right corner */
 
-    width: 32px;
+    width: var(--input_height);
     height: var(--spinbox_button_height);
     border-left: 1px solid var(--grey6);
     border-top: 1px solid var(--grey6);
@@ -1078,6 +1078,8 @@ QPushButton:hover {
 
 QToolButton:hover,
 QToolButton:focus,
+QPushButton[toolButton="true"]:hover,
+QPushButton[toolButton="true"]:focus,
 MuteCheckBox::indicator:hover,
 MuteCheckBox::indicator:focus {
     border-color: var(--button_border);
@@ -1104,7 +1106,9 @@ QPushButton:pressed:hover {
 }
 
 QToolButton:pressed,
-QToolButton:pressed:hover {
+QToolButton:pressed:hover,
+QPushButton[toolButton="true"]:pressed,
+QPushButton[toolButton="true"]:pressed:hover {
     background-color: var(--button_bg_down);
     border-color: var(--button_border);
 }
@@ -1275,7 +1279,6 @@ VolControl #volLabel {
 #vMixerScrollArea VolControl #volLabel {
     padding: var(--padding_base) 0px var(--padding_base);
     min-width: var(--volume_slider_label);
-    max-width: var(--volume_slider_label);
     margin-left: var(--padding_xlarge);
     text-align: center;
 }

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -11,7 +11,7 @@
     --grey2: rgb(134,135,134);
     --grey3: rgb(122,121,122);
     --grey4: rgb(76,76,76);
-    --grey5: rgb(88,87,88);
+    --grey5: rgb(70,69,70);
     --grey6: rgb(31,30,31);
     --grey7: rgb(58,57,58);
     --grey8: rgb(46,45,46);
@@ -31,7 +31,11 @@
     /* OS Fixes */
     --os_mac_font_base_value: 11;
 
+    --font_small: calc(0.8pt * var(--font_base_value));
+
     --icon_base: calc(6px + var(--font_base_value));
+
+    --padding_xlarge: calc(2px + calc(0.5px * var(--padding_base_value)));
 
     --padding_wide: calc(18px + calc(0.25 * var(--padding_base_value)));
     --padding_menu: calc(8px + calc(1 * var(--padding_base_value)));
@@ -45,14 +49,14 @@
     --border_radius_large: 2px;
 
     --input_bg: var(--grey4);
-    --input_bg_hover: var(--grey5);
+    --input_bg_hover: var(--grey1);
     --input_bg_focus: var(--grey6);
 
     --list_item_bg_selected: var(--primary);
     --list_item_bg_hover: var(--primary_light);
 
     --input_border: var(--grey4);
-    --input_border_hover: var(--grey5);
+    --input_border_hover: var(--grey1);
     --input_border_focus: var(--grey6);
 
     --spacing_input: var(--spacing_base);
@@ -91,17 +95,27 @@ QStatusBar {
     background-color: var(--bg_window);
 }
 
+OBSDock > QWidget {
+  border-top: 1px solid var(--border_color);
+  padding-top: var(--spacing_large);
+}
+
 QDockWidget {
     font-weight: normal;
 }
 
 QDockWidget::title {
+    background-color: var(--grey5);
     padding: var(--dock_title_padding);
     text-align: center;
 }
 
 QDockWidget > QWidget {
     background: var(--bg_window);
+}
+
+#transitionsFrame {
+    padding: var(--padding_xlarge);
 }
 
 SceneTree::item,
@@ -193,10 +207,18 @@ OBSBasicSettings QListWidget::item {
     padding: 4px;
 }
 
+QPushButton:checked {
+  border-color: var(--primary);
+}
+
 QToolButton,
 QPushButton[toolButton="true"] {
     background-color: var(--bg_window);
     border-color: var(--bg_window);
+}
+
+#stackedMixerArea QScrollArea {
+  background: var(--bg_base);
 }
 
 #stackedMixerArea QPushButton {
@@ -213,6 +235,33 @@ QPushButton[toolButton="true"] {
 #stackedMixerArea QPushButton:hover {
     background-color: var(--bg_base);
     border: none;
+}
+
+#hMixerScrollArea VolControl {
+    padding: 0px 2px;
+    margin-bottom: 1px;
+}
+
+#hMixerScrollArea QLabel {
+  margin: var(--padding_xlarge) 0px;
+}
+
+#hMixerScrollArea #volMeterFrame {
+  margin-top: var(--spacing_large);
+}
+
+#vMixerScrollArea VolControl {
+    padding: 0px var(--padding_xlarge) var(--spacing_large);
+    border-right: 1px solid var(--bg_window);
+}
+
+#vMixerScrollArea QLabel {
+  font-size: var(--font_small);
+  margin: var(--padding_xlarge) 0px;
+}
+
+#vMixerScrollArea #volLabel {
+  font-size: var(--font_base);
 }
 
 MuteCheckBox::indicator,
@@ -254,4 +303,8 @@ VolumeMeter {
     qproperty-majorTickColor: var(--text);
     qproperty-minorTickColor: rgb(122,121,122); /* light */
     qproperty-meterThickness: 3;
+}
+
+OBSBasicStats {
+    background: var(--bg_window);
 }

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -128,6 +128,9 @@
                <property name="themeID" stdset="0">
                 <string>addIconSmall</string>
                </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item>
@@ -156,6 +159,9 @@
                </property>
                <property name="themeID" stdset="0">
                 <string>removeIconSmall</string>
+               </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -186,6 +192,9 @@
                <property name="themeID" stdset="0">
                 <string>upArrowIconSmall</string>
                </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item>
@@ -214,6 +223,9 @@
                </property>
                <property name="themeID" stdset="0">
                 <string>downArrowIconSmall</string>
+               </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -350,6 +362,9 @@
                <property name="themeID" stdset="0">
                 <string>addIconSmall</string>
                </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item>
@@ -378,6 +393,9 @@
                </property>
                <property name="themeID" stdset="0">
                 <string>removeIconSmall</string>
+               </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -408,6 +426,9 @@
                <property name="themeID" stdset="0">
                 <string>upArrowIconSmall</string>
                </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
+               </property>
               </widget>
              </item>
              <item>
@@ -436,6 +457,9 @@
                </property>
                <property name="themeID" stdset="0">
                 <string>downArrowIconSmall</string>
+               </property>
+               <property name="toolButton" stdset="0">
+                <bool>true</bool>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
### Description
Many of the changes to Yami had some unintended side effects to the Classic variant that were not properly accounted for before.

### Motivation and Context
Trying to match the old Dark theme more closely

### How Has This Been Tested?
Before:
![image](https://github.com/obsproject/obs-studio/assets/1554753/f3ce0663-1e9e-44fa-a8cc-a93dc752f422)

After:
![image](https://github.com/obsproject/obs-studio/assets/1554753/ad3e19d0-1ee5-4502-9295-afe6a4d28e7e)


Before:
![image](https://github.com/obsproject/obs-studio/assets/1554753/cb49e6d2-bd5a-4a09-b259-0e91009977cd)

After:
![image](https://github.com/obsproject/obs-studio/assets/1554753/addc00ab-6ea1-47cd-beb4-5934014c6280)


### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
