### PR TITLE
UI: Fix multitrack-video audio track index

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2287,7 +2287,7 @@ FutureHolder<bool> AdvancedOutput::SetupStreaming(obs_service_t *service)
 	const char *audio_encoder_id =
 		config_get_string(main->Config(), "AdvOut", "AudioEncoder");
 	int streamTrackIndex =
-		config_get_int(main->Config(), "AdvOut", "TrackIndex");
+		config_get_int(main->Config(), "AdvOut", "TrackIndex") - 1;
 
 	auto holder =
 		SetupMultitrackVideo(service, audio_encoder_id,


### PR DESCRIPTION
### Description
Fix a minor oversight from a recent commit. Audio track indexing in the UI is 1-based while underlying code uses 0-based indexing.

### How Has This Been Tested?
Tested with a local build against Twitch Enhanced Broadcasting.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
