### PR TITLE
UI: Link Qt::DBus on FreeBSD

### DIFF
--- a/UI/cmake/os-freebsd.cmake
+++ b/UI/cmake/os-freebsd.cmake
@@ -1,6 +1,6 @@
 target_sources(obs-studio PRIVATE platform-x11.cpp)
 target_compile_definitions(obs-studio PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
-target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate procstat)
+target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus procstat)
 
 target_sources(obs-studio PRIVATE system-info-posix.cpp)
 


### PR DESCRIPTION
As with Linux we need to link Qt::DBus on FreeBSD now that there's a HighContrastEnabled implementation that makes use of it.

Fixes: 41ba8bdfdd02 ("UI: Add HighContrastEnabled implementation fo...")

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Link Qt::DBus on FreeBSD
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
41ba8bdfdd02 added a HighContrastEnabled implementation which makes use of DBus, and updated UI/cmake/os-linux.cmake to link Qt:DBus. os-freebsd.cmake needs the same change.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Built-tested on my laptop.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
