### PR TITLE
libobs: Fix destroy_on_stop functionality of encoder groups

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -786,13 +786,18 @@ void obs_encoder_start(obs_encoder_t *encoder,
 	pthread_mutex_unlock(&encoder->init_mutex);
 }
 
-static inline void obs_encoder_stop_internal(
-	obs_encoder_t *encoder,
-	void (*new_packet)(void *param, struct encoder_packet *packet),
-	void *param)
+void obs_encoder_stop(obs_encoder_t *encoder,
+		      void (*new_packet)(void *param,
+					 struct encoder_packet *packet),
+		      void *param)
 {
 	bool last = false;
 	size_t idx;
+
+	if (!obs_encoder_valid(encoder, "obs_encoder_stop"))
+		return;
+	if (!obs_ptr_valid(new_packet, "obs_encoder_stop"))
+		return;
 
 	pthread_mutex_lock(&encoder->init_mutex);
 	pthread_mutex_lock(&encoder->callbacks_mutex);
@@ -833,21 +838,6 @@ static inline void obs_encoder_stop_internal(
 	}
 
 	pthread_mutex_unlock(&encoder->init_mutex);
-}
-
-void obs_encoder_stop(obs_encoder_t *encoder,
-		      void (*new_packet)(void *param,
-					 struct encoder_packet *packet),
-		      void *param)
-{
-	bool destroyed;
-
-	if (!obs_encoder_valid(encoder, "obs_encoder_stop"))
-		return;
-	if (!obs_ptr_valid(new_packet, "obs_encoder_stop"))
-		return;
-
-	obs_encoder_stop_internal(encoder, new_packet, param);
 }
 
 const char *obs_encoder_get_codec(const obs_encoder_t *encoder)

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -371,6 +371,8 @@ static void remove_connection(struct obs_encoder *encoder, bool shutdown)
 	 * up again */
 	if (shutdown)
 		obs_encoder_shutdown(encoder);
+	encoder->initialized = false;
+
 	set_encoder_active(encoder, false);
 }
 
@@ -810,7 +812,6 @@ static inline bool obs_encoder_stop_internal(
 
 	if (last) {
 		remove_connection(encoder, true);
-		encoder->initialized = false;
 
 		if (encoder->destroy_on_stop) {
 			pthread_mutex_unlock(&encoder->init_mutex);
@@ -1334,7 +1335,6 @@ void full_stop(struct obs_encoder *encoder)
 		pthread_mutex_unlock(&encoder->callbacks_mutex);
 
 		remove_connection(encoder, false);
-		encoder->initialized = false;
 	}
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes a crash when the following steps occur:
- Encoder group created and then started with encoders, only the group owning encoder refs
- Encoder group destroy called: group has `destroy_on_stop` set without actual destroy
- Outputs holding encoders from stopping are stopped
- `remove_connection()` function destroys encoder group, releasing encoders and causing the currently processed encoder to be destroyed early
- parent scopes try to access destroyed encoder pointer and crash

This change moves some logic around to improve the release/destruct order of `obs_encoder_stop()` to fix the race above.

Note: Cases of encoder errors will not destruct the group if it has `destroy_on_stop` set, as the encoder is also not destroyed if it also is set to destroy on stop. This part of the code should be revisited at a later date and fixed up to prevent memory leaks.

Closes #10890 

### Motivation and Context
Shutting down OBS with an EB stream running was resulting in a crash when the output object was destroyed after "destroy" was called on the group.

### How Has This Been Tested?
Todo testing

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
