### PR TITLE
obs-ffmpeg: Close VAAPI device on vaInitialize fail (memory leak fix)

### DIFF
--- a/plugins/obs-ffmpeg/vaapi-utils.c
+++ b/plugins/obs-ffmpeg/vaapi-utils.c
@@ -99,6 +99,7 @@ VADisplay vaapi_open_device(int *fd, const char *device_path,
 	if (va_status != VA_STATUS_SUCCESS) {
 		blog(LOG_ERROR, "VAAPI: Failed to initialize display in %s",
 		     func_name);
+		vaapi_close_device(fd, va_dpy);
 		return NULL;
 	}
 


### PR DESCRIPTION
### Description
On some systems (eg. mine), VAAPI fails on vaInitialize. Valgrind was able to spot that the device was not being closed, and it appears to have been correct. This fixes a memory leak.

### Motivation and Context
Using NVIDIA GPUs on Ubuntu 22.04 shouldn't cause memory leaks, even if small.

### How Has This Been Tested?
Tested on Ubuntu 22.04 that valgrind does not complain about this function when patched.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
