### PR TITLE
win-wasapi: Remove noisy and useless debug logging

### DIFF
--- a/plugins/win-wasapi/win-wasapi.cpp
+++ b/plugins/win-wasapi/win-wasapi.cpp
@@ -1109,16 +1109,7 @@ bool WASAPISource::ProcessCaptureData()
 			sawBadTimestamp = true;
 		}
 
-		if (flags & AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY) {
-			/* libobs should handle discontinuities fine. */
-			blog(LOG_DEBUG, "[WASAPISource::ProcessCaptureData]"
-					" Discontinuity flag is set.");
-		}
-
 		if (flags & AUDCLNT_BUFFERFLAGS_SILENT) {
-			blog(LOG_DEBUG, "[WASAPISource::ProcessCaptureData]"
-					" Silent flag is set.");
-
 			/* buffer size = frame size * number of frames
 			 * frame size = channels * sample size
 			 * sample size = 4 bytes (always float per InitFormat) */


### PR DESCRIPTION
### Description

Removes some leftover debug logging messages that have outlived their usefulness.

### Motivation and Context

These were originally added to help troubleshoot the application audio capture issues. Since it has been established that those are a Windows bug we can't detect or work around, we don't need these any longer.

They also keep annoying me because I run OBS with verbose logging for testing and especially the silent flag gets quite spammy.

### How Has This Been Tested?

N/A

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
