### PR TITLE
UI: Try to opt out of reaction effects by default on macOS

### DIFF
--- a/UI/cmake/macos/Info.plist.in
+++ b/UI/cmake/macos/Info.plist.in
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>
+	<key>NSCameraReactionEffectsEnabled</key>
+	<false/>
 	<key>LSAppNapIsDisabled</key>
 	<true/>
 	<key>SUFeedURL</key>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

> [!IMPORTANT]
> This PR most needs testing by a user on macOS 14+ who has not yet modified system camera effects with OBS open, to see if "reaction" effects trigger for camera inputs.

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the `NSCameraReactionEffectsEnabled = false` key-value pair to the default Info.plist file on macOS, in an attempt to make reaction effects not appear by default for all camera inputs in OBS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Much has been written complaining about macOS system "reaction" effects inappropriately triggering in different scenarios on macOS, due to Apple's decision to opt all applications into these effects by default for all camera inputs. This PR is an attempt to make OBS opt out of these effects by default.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on my machine (on the macOS Sequoia beta) to verify that if the user intentionally enables reaction effects with OBS open, the setting will still persist between restarts of OBS. Thus, if users want reaction effects, this PR will not prevent them from enabling them and keeping them enabled.

Was *unable* to test if this PR successfully prevents reaction effects from appearing by default. This is because there is no mechanism in macOS (that I know of) to reset the status of effects preferences for programs across the system. Attempted to test in a VM, but no existing VM software (that I know of) supports camera input for macOS VMs.

This could also use testing from users still on macOS Sonoma to verify that effects settings continue to persist there as they do on macOS Sequoia.

Even if this PR is ineffective at preventing reaction effects from appearing by default, it is unlikely to hurt either.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.