### PR TITLE
Fix issues with file splitting in Hybrid MP4

### DIFF
--- a/plugins/obs-outputs/mp4-mux.c
+++ b/plugins/obs-outputs/mp4-mux.c
@@ -2409,7 +2409,7 @@ static void write_packets(struct mp4_mux *mux, struct mp4_track *track)
 	struct serializer *s = mux->serializer;
 
 	size_t count = track->packets.size / sizeof(struct encoder_packet);
-	if (!count)
+	if (!count || !track->fragment_samples.num)
 		return;
 
 	struct chunk *chk = da_push_back_new(track->chunks);

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -112,20 +112,23 @@ static inline void ts_offset_update(struct mp4_output *out,
 				    struct encoder_packet *packet)
 {
 	int64_t *offset;
+	int64_t ts;
 	bool *found;
 
 	if (packet->type == OBS_ENCODER_VIDEO) {
 		offset = &out->video_pts_offsets[packet->track_idx];
 		found = &out->found_video[packet->track_idx];
+		ts = packet->pts;
 	} else {
 		offset = &out->audio_dts_offsets[packet->track_idx];
 		found = &out->found_audio[packet->track_idx];
+		ts = packet->dts;
 	}
 
 	if (*found)
 		return;
 
-	*offset = packet->dts;
+	*offset = ts;
 	*found = true;
 }
 


### PR DESCRIPTION
### Description

- Fixes an oversight where zero-size chunks were being added to the `moov`, this is invalid, but no data loss occured
- Fixes DTS being used instead of PTS for file splitting, resulting in the first video packets not having a PTS of 0

### Motivation and Context

Fixes #10903 

### How Has This Been Tested?

Made some recordings, verified things are now fine.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
