### PR TITLE
obs-x264: Ignore stats/qp file and multipass options

### DIFF
--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -309,7 +309,9 @@ static inline void set_param(struct obs_x264 *obsx264, struct obs_option option)
 	if (strcmp(name, "preset") != 0 && strcmp(name, "profile") != 0 &&
 	    strcmp(name, "tune") != 0 && strcmp(name, "fps") != 0 &&
 	    strcmp(name, "force-cfr") != 0 && strcmp(name, "width") != 0 &&
-	    strcmp(name, "height") != 0 && strcmp(name, "opencl") != 0) {
+	    strcmp(name, "height") != 0 && strcmp(name, "opencl") != 0 &&
+	    strcmp(name, "stats") != 0 && strcmp(name, "qpfile") != 0 &&
+	    strcmp(name, "pass") != 0) {
 		if (strcmp(option.name, OPENCL_ALIAS) == 0)
 			name = "opencl";
 		if (x264_param_parse(&obsx264->params, name, val) != 0)


### PR DESCRIPTION
### Description

Adds some more options to the x264 options blacklist.

### Motivation and Context

Multipass encoding doesn't work in OBS so there's no point. Also a precaution to avoid potentially malicious configuration data delivered via the new multi-track auto-configuration API leading to arbitrary files being written on the users PC.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [X] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
