### PR TITLE
obs-outputs: Skip trak box if track has no data

### DIFF
--- a/plugins/obs-outputs/mp4-mux.c
+++ b/plugins/obs-outputs/mp4-mux.c
@@ -1718,6 +1718,10 @@ static size_t mp4_write_trak(struct mp4_mux *mux, struct mp4_track *track,
 	struct serializer *s = mux->serializer;
 	int64_t start = serializer_get_pos(s);
 
+	/* If track has no data, omit it from full moov. */
+	if (!fragmented && !track->chunks.num)
+		return 0;
+
 	write_box(s, 0, "trak");
 
 	// tkhd


### PR DESCRIPTION
### Description

Skips writing a `trak` box for tracks that do not have any data (chunks) when writing the full moov.

### Motivation and Context

This would crash if the encoder failed after starting, but before producing any packets, due to an assumption that there would be at least one chunk. Since there's no point in writing the box at all if there are no chunks (i.e. data) we can just skip the entire box.

Reported on the forums: https://obsproject.com/forum/threads/an-issue-where-an-error-occurs-with-certain-color-formats.176240/

### How Has This Been Tested?

Verified with setup outlined in the forum thread.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
