### PR TITLE
UI: Output timer bug

### DIFF
--- a/UI/frontend-plugins/frontend-tools/output-timer.cpp
+++ b/UI/frontend-plugins/frontend-tools/output-timer.cpp
@@ -136,7 +136,7 @@ void OutputTimer::StreamTimerStop()
 {
 	streamingAlreadyActive = false;
 
-	if (!isVisible() && streamingTimer->isActive() == false)
+	if (!isVisible() && streamingTimer->isActive() == true)
 		return;
 
 	if (streamingTimer->isActive())
@@ -155,7 +155,7 @@ void OutputTimer::RecordTimerStop()
 {
 	recordingAlreadyActive = false;
 
-	if (!isVisible() && recordingTimer->isActive() == false)
+	if (!isVisible() && recordingTimer->isActive() == true)
 		return;
 
 	if (recordingTimer->isActive())


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Output Timer for Recording dosen't update from Stop -> Start even after the timer expires when the Output Timer dialog is closed.
Issue - [#10900](https://github.com/obsproject/obs-studio/issues/10900)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This PR aims at proper updating of buttons when the timer is expired and even when the Dialog is closed.
Fixes the Issue - [#10900](https://github.com/obsproject/obs-studio/issues/10900)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested manually in Windows 11.
Added a video drive link - [Video Link](https://drive.google.com/file/d/15BWv-c0PZ91qNfVXS2z19lNGE5hdsxpE/view?usp=sharing) of the fix working

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
