### PR TITLE
libobs: Fix plane heights for odd values

### DIFF
--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -133,14 +133,14 @@ void video_frame_get_plane_heights(uint32_t heights[MAX_AV_PLANES],
 	case VIDEO_FORMAT_I420: /* three planes: full height, half height, half height */
 	case VIDEO_FORMAT_I010:
 		heights[0] = height;
-		heights[1] = height / 2;
-		heights[2] = height / 2;
+		heights[1] = HALF(height);
+		heights[2] = HALF(height);
 		break;
 
 	case VIDEO_FORMAT_NV12: /* two planes: full height, half height */
 	case VIDEO_FORMAT_P010:
 		heights[0] = height;
-		heights[1] = height / 2;
+		heights[1] = HALF(height);
 		break;
 
 	case VIDEO_FORMAT_Y800: /* one plane: full height */
@@ -168,8 +168,8 @@ void video_frame_get_plane_heights(uint32_t heights[MAX_AV_PLANES],
 
 	case VIDEO_FORMAT_I40A: /* four planes: full height, half height, half height, full height */
 		heights[0] = height;
-		heights[1] = height / 2;
-		heights[2] = height / 2;
+		heights[1] = HALF(height);
+		heights[2] = HALF(height);
 		heights[3] = height;
 		break;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This was short by one line compared to copies executed in obs-source.c:copy_frame_data which resulted in copying garbage immediately after the frame and causing crashes typically.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes crashes when media source loads files with odd resolutions.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Replication file no longer crashes obs or triggers asan.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
