### PR TITLE
obs-ffmpeg: Honor preferred format in native NVENC

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -1377,7 +1377,12 @@ static bool init_encoder(struct nvenc_data *enc, enum codec_type codec,
 
 	video_t *video = obs_encoder_video(enc->encoder);
 	const struct video_output_info *voi = video_output_get_info(video);
-	enc->in_format = get_preferred_format(voi->format);
+	enum video_format pref_format =
+		obs_encoder_get_preferred_video_format(enc->encoder);
+	if (pref_format == VIDEO_FORMAT_NONE)
+		pref_format = voi->format;
+
+	enc->in_format = get_preferred_format(pref_format);
 
 	if (enc->in_format == VIDEO_FORMAT_I444 && !support_444) {
 		NV_FAIL(obs_module_text("NVENC.444Unsupported"));


### PR DESCRIPTION
### Description

Checks preferred format (if set) when configuring NVENC encoder.

### Motivation and Context

This is used to prevent people from streaming in 444 (which isn't really supported) but wasn't checked in the native implementation as it didnt support 4:4:4 before.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
