### PR TITLE
libobs: Add `obs_encoder_get_group()`

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -2046,6 +2046,13 @@ uint32_t obs_encoder_get_roi_increment(const obs_encoder_t *encoder)
 	return encoder->roi_increment;
 }
 
+obs_encoder_group_t *obs_encoder_get_group(obs_encoder_t *encoder)
+{
+	return obs_encoder_valid(encoder, "obs_encoder_get_group")
+		       ? encoder->encoder_group
+		       : NULL;
+}
+
 bool obs_encoder_set_group(obs_encoder_t *encoder, obs_encoder_group_t *group)
 {
 	if (!obs_encoder_valid(encoder, "obs_encoder_set_group"))

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2609,14 +2609,15 @@ EXPORT void obs_encoder_set_last_error(obs_encoder_t *encoder,
 
 EXPORT uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder);
 
+EXPORT obs_encoder_group_t *obs_encoder_get_group(obs_encoder_t *encoder);
+EXPORT bool obs_encoder_set_group(obs_encoder_t *encoder,
+				  obs_encoder_group_t *group);
 /**
  * Creates an "encoder group", allowing synchronized startup of encoders within
  * the group. Encoder groups are single owner, and hold strong references to
  * encoders within the group. Calling destroy on an active group will not actually
  * destroy the group until it becomes completely inactive.
  */
-EXPORT bool obs_encoder_set_group(obs_encoder_t *encoder,
-				  obs_encoder_group_t *group);
 EXPORT obs_encoder_group_t *obs_encoder_group_create();
 EXPORT void obs_encoder_group_destroy(obs_encoder_group_t *group);
 


### PR DESCRIPTION
### Description
Allows getting of the current encoder group of an encoder. Not useful for too much on its own, but allows encoder implementations to know if they are in a group or not.

### Motivation and Context
Needed in my case for enabling some performance optimizations in an encoder plugin. I can rely on encoder groups in my plugin to create a shared scaler object for encoders within the group, rather than always one scaler per encoder always. This gives me a >30% efficiency boost in my scaler utilization.

### How Has This Been Tested?
Compiles on Ubuntu 22.04

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
