### PR TITLE
UI: Fix `qt-helpers.{c,h}pp` not being removed from legacy.cmake

### DIFF
--- a/UI/cmake/legacy.cmake
+++ b/UI/cmake/legacy.cmake
@@ -295,8 +295,6 @@ target_sources(
           multitrack-video-error.hpp
           multitrack-video-output.cpp
           multitrack-video-output.hpp
-          qt-helpers.cpp
-          qt-helpers.hpp
           system-info.hpp)
 
 target_sources(obs PRIVATE importers/importers.cpp importers/importers.hpp importers/classic.cpp importers/sl.cpp


### PR DESCRIPTION
### Description
https://github.com/obsproject/obs-studio/pull/10957 removed a few files from `CMakeLists.txt`, but did not remove them from `legacy.cmake` (see https://github.com/obsproject/obs-studio/pull/10957#issuecomment-2222635224)

### Motivation and Context
Legacy CMake should still work

### How Has This Been Tested?
Untested

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
