### PR TITLE
UI: Fix source tree icon spacing

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -1532,13 +1532,16 @@ QGroupBox::indicator:unchecked:disabled {
 QCheckBox[lockCheckBox=true] {
     outline: none;
     background: transparent;
+    max-width: var(--icon_base);
+    max-height: var(--icon_base);
+    padding: var(--padding_base);
+    border: 1px solid transparent;
+    margin-left: var(--spacing_large);
 }
 
 QCheckBox[lockCheckBox=true]::indicator {
     width: var(--icon_base);
     height: var(--icon_base);
-    padding: 1px;
-    border: 1px solid transparent;
     border-radius: 4px;
 }
 
@@ -1552,8 +1555,8 @@ QCheckBox[lockCheckBox=true]::indicator:unchecked:hover {
     image: url(:res/images/unlocked.svg);
 }
 
-QCheckBox[lockCheckBox=true]::indicator:hover,
-QCheckBox[lockCheckBox=true]::indicator:focus {
+QCheckBox[lockCheckBox=true]:hover,
+QCheckBox[lockCheckBox=true]:focus {
     border: 1px solid var(--border_highlight);
 }
 
@@ -1562,13 +1565,16 @@ QCheckBox[lockCheckBox=true]::indicator:focus {
 QCheckBox[visibilityCheckBox=true] {
     outline: none;
     background: transparent;
+    max-width: var(--icon_base);
+    max-height: var(--icon_base);
+    padding: var(--padding_base);
+    border: 1px solid transparent;
+    margin-left: var(--spacing_large);
 }
 
 QCheckBox[visibilityCheckBox=true]::indicator {
     width: var(--icon_base);
     height: var(--icon_base);
-    padding: 1px;
-    border: 1px solid transparent;
     border-radius: 4px;
 }
 
@@ -1582,8 +1588,8 @@ QCheckBox[visibilityCheckBox=true]::indicator:unchecked:hover {
     image: url(:res/images/invisible.svg);
 }
 
-QCheckBox[visibilityCheckBox=true]::indicator:hover,
-QCheckBox[visibilityCheckBox=true]::indicator:focus {
+QCheckBox[visibilityCheckBox=true]:hover,
+QCheckBox[visibilityCheckBox=true]:focus {
     border: 1px solid var(--border_highlight);
 }
 

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -77,6 +77,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 		iconLabel->setPixmap(pixmap);
 		iconLabel->setEnabled(sourceVisible);
 		iconLabel->setStyleSheet("background: none");
+		iconLabel->setProperty("TH_Source_Icon", true);
 	}
 
 	vis = new QCheckBox();
@@ -111,6 +112,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 	boxLayout = new QHBoxLayout();
 
 	boxLayout->setContentsMargins(0, 0, 0, 0);
+	boxLayout->setSpacing(0);
 	if (iconLabel) {
 		boxLayout->addWidget(iconLabel);
 		boxLayout->addSpacing(2);


### PR DESCRIPTION
### Description
Fixes the spacing on source tree icons to be consistent and properly sized.

### Motivation and Context
More consistent and proper spacing of all icons in source list entries. This had more averse effects on the Classic theme due to it inheriting from Yami now.

**Before**
![image](https://github.com/user-attachments/assets/83f1756e-59fb-46ff-a783-a22c232764a0)

**After**
![image](https://github.com/user-attachments/assets/4f2d5e93-5d5b-4be9-8908-7c166a00bc8e)


**Before**
![image](https://github.com/user-attachments/assets/1d5b47ec-cdc9-46f8-8b3b-87cabcba4fc2)

**After**
![image](https://github.com/user-attachments/assets/9c44bea6-c090-4618-a3da-e29c3867b762)


### How Has This Been Tested?
Tested on Windows

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
