### PR TITLE
UI: Media source always played if close file when inactive is checked

### DIFF
--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -267,9 +267,19 @@ void MediaControls::RefreshControls()
 	uint32_t flags = 0;
 	const char *id = nullptr;
 
+	obs_data_t *settings = obs_source_get_settings(source);
+	bool sourceIsActive = obs_source_active(source);
+	bool closeWhenInactive =
+		obs_data_get_bool(settings, "close_when_inactive");
+
 	if (source) {
 		flags = obs_source_get_output_flags(source);
 		id = obs_source_get_unversioned_id(source);
+	}
+
+	if (!sourceIsActive && closeWhenInactive) {
+		SetPausedState();
+		return;
 	}
 
 	if (!source || !(flags & OBS_SOURCE_CONTROLLABLE_MEDIA)) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Even when the "Close when Inactive" property is checked  and the source is inactive, the media was being played. 
Issue - [ #10676 ]

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This PR aims at resolving the issue by pausing the media play when the source is inactive and the "Close when Inactive" property is checked.
Issue - [ #10676 ]

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested manually in Windows 11.
Added a video drive link - [Video Link](https://drive.google.com/file/d/1vTx85_dKfeiJ30B25Tx9OsGrbcPHDwO6/view?usp=sharing) of the fix working

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
