### PR TITLE
UI: Fix read-only QTextEdit background color

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -890,7 +890,9 @@ QPlainTextEdit:focus {
     border-color: var(--input_border_focus);
 }
 
-QTextEdit:!editable {
+QTextEdit:!editable,
+QTextEdit:!editable:hover,
+QTextEdit:!editable:focus {
     background-color: var(--input_bg);
 }
 

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -171,6 +171,12 @@ QPlainTextEdit:hover {
     background-color: var(--input_bg_focus);
 }
 
+QTextEdit:!editable,
+QTextEdit:!editable:hover,
+QTextEdit:!editable:focus {
+    background-color: var(--input_bg_focus);
+}
+
 QSpinBox,
 QDoubleSpinBox {
     background-color: var(--input_bg_focus);


### PR DESCRIPTION
### Description
Fixes background color of read-only line edit boxes.

**Before**
![image](https://github.com/user-attachments/assets/6c463fcd-6d02-4c76-967a-a5efbe8d08a3)

**After**
![image](https://github.com/user-attachments/assets/71f944dc-79f5-4bb5-a5c5-ede0075aa47b)


### Motivation and Context
Fixes some poor contrast on Classic especially

### How Has This Been Tested?
Windows About dialog

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
