### PR TITLE
UI: Adjust sizing of Classic audio meter elements

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -129,7 +129,7 @@
 
     --spinbox_button_height: calc(var(--input_height_half) - 1px);
 
-    --volume_slider: calc(calc(10px + var(--font_base_value)) / 4);
+    --volume_slider: calc(calc(4px + var(--font_base_value)) / 4);
     --volume_slider_box: calc(var(--volume_slider) * 4);
     --volume_slider_label: calc(var(--volume_slider_box) * 2);
 

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -31,7 +31,7 @@
     /* OS Fixes */
     --os_mac_font_base_value: 11;
 
-    --font_small: calc(0.8pt * var(--font_base_value));
+    --font_small: calc(0.75pt * var(--font_base_value));
 
     --icon_base: calc(6px + var(--font_base_value));
 
@@ -290,6 +290,13 @@ MuteCheckBox::indicator:unchecked:hover {
 
 #contextContainer {
   background-color: var(--bg_window);
+}
+
+#stackedMixerArea QPushButton,
+#stackedMixerArea QPushButton:!hover {
+    width: var(--icon_base_mixer);
+    height: var(--icon_base_mixer);
+    padding: var(--spacing_base);
 }
 
 VolumeMeter {


### PR DESCRIPTION
### Description
Fixes some sizing of volume meters on Classic theme and the alignment of the kebab menu in horizontal layout.

### Motivation and Context
Goal with the new audio meters was to make better use of space while doing our best to not use more space than before. 

Classic was using a bit more extra space than intended due to the larger slider width that Yami uses.

**Before**
![image](https://github.com/user-attachments/assets/d6a0296a-ad9a-43f1-9294-2282a9a4f8c9)
![image](https://github.com/user-attachments/assets/dff0208c-fdde-4907-ab25-cb384e3fd2ef)

**After**
![image](https://github.com/user-attachments/assets/f9692a98-3948-4b97-93f2-60bbf1a1bb28)

![image](https://github.com/user-attachments/assets/1615a1d2-5ae1-486c-bea2-2d80a0e0844e)


### How Has This Been Tested?
Windows

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
