### PR TITLE
UI: Don't create default desktop audio source on macOS 13+

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -133,6 +133,15 @@ void SetAlwaysOnTop(QWidget *window, bool enable)
     window->show();
 }
 
+bool shouldCreateDefaultAudioSource(void)
+{
+    if (@available(macOS 13, *)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
 bool SetDisplayAffinitySupported(void)
 {
     // Not implemented yet

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -104,6 +104,7 @@ void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
 void SetMacOSDarkMode(bool dark);
+bool shouldCreateDefaultAudioSource();
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type,
 					      bool prompt_for_permission);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -997,6 +997,10 @@ void OBSBasic::CreateFirstRunSources()
 	bool hasDesktopAudio = HasAudioDevices(App()->OutputAudioSource());
 	bool hasInputAudio = HasAudioDevices(App()->InputAudioSource());
 
+#ifdef __APPLE__
+	hasDesktopAudio = hasDesktopAudio && shouldCreateDefaultAudioSource();
+#endif
+
 	if (hasDesktopAudio)
 		ResetAudioDevice(App()->OutputAudioSource(), "default",
 				 Str("Basic.DesktopDevice1"), 1);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the default device-based "Desktop Audio" source created on first run if the user is on macOS 13+.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Since adding macOS Screen Capture in macOS 13, the recommended way to capture audio on macOS is via that source (or alternately, the macOS Audio Capture source for strictly audio-only sources). The device-based audio source idiom is only relevant for older versions of macOS, or for some specialized workflows that require advanced audio routing via programs like Blackhole, VB-Cable, et. al.

The creation of this device-based source by default on new macOS 13+ systems very often leads to new user confusion. It doesn't provide any audio, and users often think that they need to configure it to get desktop audio, which can actually point them *away* from the newer, easier-to-use audio capture methods.

On top of being nonfunctional, the source also just takes up space in the audio mixer until the user disables it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS 15. On a fresh startup of OBS, the Desktop Audio device in Settings is now set to "Disabled," with only the Mic/Aux source configured in the audio mixer.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
