### PR TITLE
obs-ffmpeg: Disable NVENC/AMF DTS adjustment for AV1

### DIFF
--- a/plugins/obs-ffmpeg/obs-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-nvenc.c
@@ -1980,8 +1980,9 @@ static bool nvenc_encode_shared(struct nvenc_data *enc, struct nv_bitstream *bs,
 		int64_t dts;
 		deque_pop_front(&enc->dts_list, &dts, sizeof(dts));
 
-		/* subtract bframe delay from dts */
-		dts -= (int64_t)enc->bframes * packet->timebase_num;
+		/* subtract bframe delay from dts for H.264 and HEVC */
+		if (enc->codec != CODEC_AV1)
+			dts -= (int64_t)enc->bframes * packet->timebase_num;
 
 		*received_packet = true;
 		packet->data = enc->packet_data.array;

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -575,7 +575,7 @@ static void convert_to_encoder_packet(amf_base *enc, AMFDataPtr &data,
 	packet->dts = convert_to_obs_ts(enc, data->GetPts());
 	packet->keyframe = type == AMF_VIDEO_ENCODER_OUTPUT_DATA_TYPE_IDR;
 
-	if (enc->dts_offset)
+	if (enc->dts_offset && enc->codec != amf_codec_type::AV1)
 		packet->dts -= enc->dts_offset;
 }
 


### PR DESCRIPTION
### Description
Aligns AV1 DTS and PTS, since AV1 doesn't use b-frame delay (similar to VP9/VP8). AV1 instead handles reordering of frames transparently by outputting frames that aren't displayed in the same encode call; e.g. with b-frames enabled the first time data is returned by these encoders there will generally be a keyframe in the output that can be displayed immediately, and the next time data is returned (with the next dts) will contain various frames that aren't displayed and one frame that is displayed

in the image below, frames with green underline are output in the same encode call:
![image](https://github.com/user-attachments/assets/a6ffb545-6a22-404d-9897-0ec229c8137b)

consider also the ertmp (v1 and later) spec https://github.com/veovera/enhanced-rtmp/blob/6445c80106c418ebe6bb18602e1c86645b2c1778/docs/enhanced/enhanced-rtmp-v1.md where `PacketTypeCodedFrames` for AV1 does not include `SI24 = [CompositionTime Offset]`


### Motivation and Context
AV1 timestamps are currently misaligned for NVENC/AMF in multi codec ladders for Enhanced Broadcasting/Multitrack Video on Twitch

### How Has This Been Tested?
Twitch Enhanced Broadcasting Beta, inspected timestamps via broadcast performance metrics logs

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
