### PR TITLE
Add support for compiling for Windows on ARM

### DIFF
--- a/deps/w32-pthreads/context.h
+++ b/deps/w32-pthreads/context.h
@@ -63,7 +63,7 @@
 #define PTW32_PROGCTR(Context)  ((Context).Rip)
 #endif
 
-#if defined(_ARM_) || defined(ARM)
+#if defined(_ARM_) || defined(ARM) || defined(_M_ARM) || defined(_M_ARM64)
 #define PTW32_PROGCTR(Context)  ((Context).Pc)
 #endif
 

--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -30,7 +30,9 @@
 #include <QLineEdit>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
+#endif
 #include <Windows.h>
 #endif
 

--- a/frontend/dialogs/OBSBasicInteraction.cpp
+++ b/frontend/dialogs/OBSBasicInteraction.cpp
@@ -27,7 +27,9 @@
 #include <QInputEvent>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
+#endif
 #include <Windows.h>
 #endif
 

--- a/frontend/dialogs/OBSBasicProperties.cpp
+++ b/frontend/dialogs/OBSBasicProperties.cpp
@@ -27,7 +27,9 @@
 #include <QPushButton>
 
 #ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
+#endif
 #include <Windows.h>
 #endif
 

--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -138,7 +138,13 @@ static inline bool get_dbghelp_imports(struct exception_handler_data *data)
 
 static inline void init_instruction_data(struct stack_trace *trace)
 {
-#ifdef _WIN64
+#if defined(_M_ARM64)
+	trace->instruction_ptr = trace->context.Pc;
+	trace->frame.AddrPC.Offset = trace->instruction_ptr;
+	trace->frame.AddrFrame.Offset = trace->context.Fp;
+	trace->frame.AddrStack.Offset = trace->context.Sp;
+	trace->image_type = IMAGE_FILE_MACHINE_ARM64;
+#elif defined(_WIN64)
 	trace->instruction_ptr = trace->context.Rip;
 	trace->frame.AddrPC.Offset = trace->instruction_ptr;
 	trace->frame.AddrFrame.Offset = trace->context.Rbp;

--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -27,7 +27,7 @@
 /* clang-format off */
 
 #define S_RATIO                         "ratio"
-#define S_THRESHOLD                     "threshold"
+#define S_FILTER_THRESHOLD              "threshold"
 #define S_ATTACK_TIME                   "attack_time"
 #define S_RELEASE_TIME                  "release_time"
 #define S_OUTPUT_GAIN                   "output_gain"
@@ -190,7 +190,7 @@ static void compressor_update(void *data, obs_data_t *s)
 	const char *sidechain_name = obs_data_get_string(s, S_SIDECHAIN_SOURCE);
 
 	cd->ratio = (float)obs_data_get_double(s, S_RATIO);
-	cd->threshold = (float)obs_data_get_double(s, S_THRESHOLD);
+	cd->threshold = (float)obs_data_get_double(s, S_FILTER_THRESHOLD);
 	cd->attack_gain = gain_coefficient(sample_rate, attack_time_ms / MS_IN_S_F);
 	cd->release_gain = gain_coefficient(sample_rate, release_time_ms / MS_IN_S_F);
 	cd->output_gain = db_to_mul(output_gain_db);
@@ -438,7 +438,7 @@ static struct obs_audio_data *compressor_filter_audio(void *data, struct obs_aud
 static void compressor_defaults(obs_data_t *s)
 {
 	obs_data_set_default_double(s, S_RATIO, 10.0f);
-	obs_data_set_default_double(s, S_THRESHOLD, -18.0f);
+	obs_data_set_default_double(s, S_FILTER_THRESHOLD, -18.0f);
 	obs_data_set_default_int(s, S_ATTACK_TIME, 6);
 	obs_data_set_default_int(s, S_RELEASE_TIME, 60);
 	obs_data_set_default_double(s, S_OUTPUT_GAIN, 0.0f);
@@ -477,8 +477,8 @@ static obs_properties_t *compressor_properties(void *data)
 
 	p = obs_properties_add_float_slider(props, S_RATIO, TEXT_RATIO, MIN_RATIO, MAX_RATIO, 0.5);
 	obs_property_float_set_suffix(p, ":1");
-	p = obs_properties_add_float_slider(props, S_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB,
-					    0.1);
+	p = obs_properties_add_float_slider(props, S_FILTER_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB,
+					    MAX_THRESHOLD_DB, 0.1);
 	obs_property_float_set_suffix(p, " dB");
 	p = obs_properties_add_int_slider(props, S_ATTACK_TIME, TEXT_ATTACK_TIME, MIN_ATK_RLS_MS, MAX_ATK_MS, 1);
 	obs_property_int_set_suffix(p, " ms");

--- a/plugins/obs-filters/expander-filter.c
+++ b/plugins/obs-filters/expander-filter.c
@@ -27,7 +27,7 @@
 /* clang-format off */
 
 #define S_RATIO                         "ratio"
-#define S_THRESHOLD                     "threshold"
+#define S_FILTER_THRESHOLD              "threshold"
 #define S_ATTACK_TIME                   "attack_time"
 #define S_RELEASE_TIME                  "release_time"
 #define S_OUTPUT_GAIN                   "output_gain"
@@ -158,7 +158,7 @@ static void expander_defaults(obs_data_t *s)
 		is_expander_preset = false;
 	obs_data_set_default_string(s, S_PRESETS, is_expander_preset ? "expander" : "gate");
 	obs_data_set_default_double(s, S_RATIO, is_expander_preset ? 2.0 : 10.0);
-	obs_data_set_default_double(s, S_THRESHOLD, -40.0f);
+	obs_data_set_default_double(s, S_FILTER_THRESHOLD, -40.0f);
 	obs_data_set_default_int(s, S_ATTACK_TIME, 10);
 	obs_data_set_default_int(s, S_RELEASE_TIME, is_expander_preset ? 50 : 125);
 	obs_data_set_default_double(s, S_OUTPUT_GAIN, 0.0);
@@ -168,7 +168,7 @@ static void expander_defaults(obs_data_t *s)
 static void upward_compressor_defaults(obs_data_t *s)
 {
 	obs_data_set_default_double(s, S_RATIO, 0.5);
-	obs_data_set_default_double(s, S_THRESHOLD, -20.0f);
+	obs_data_set_default_double(s, S_FILTER_THRESHOLD, -20.0f);
 	obs_data_set_default_int(s, S_ATTACK_TIME, 10);
 	obs_data_set_default_int(s, S_RELEASE_TIME, 50);
 	obs_data_set_default_double(s, S_OUTPUT_GAIN, 0.0);
@@ -204,7 +204,7 @@ static void expander_update(void *data, obs_data_t *s)
 
 	cd->ratio = (float)obs_data_get_double(s, S_RATIO);
 
-	cd->threshold = (float)obs_data_get_double(s, S_THRESHOLD);
+	cd->threshold = (float)obs_data_get_double(s, S_FILTER_THRESHOLD);
 	cd->attack_gain = gain_coefficient(sample_rate, attack_time_ms / MS_IN_S_F);
 	cd->release_gain = gain_coefficient(sample_rate, release_time_ms / MS_IN_S_F);
 	cd->output_gain = db_to_mul(output_gain_db);
@@ -445,8 +445,8 @@ static obs_properties_t *expander_properties(void *data)
 	p = obs_properties_add_float_slider(props, S_RATIO, TEXT_RATIO, !cd->is_upwcomp ? MIN_RATIO : MIN_RATIO_UPW,
 					    !cd->is_upwcomp ? MAX_RATIO : MAX_RATIO_UPW, 0.1);
 	obs_property_float_set_suffix(p, ":1");
-	p = obs_properties_add_float_slider(props, S_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB,
-					    0.1);
+	p = obs_properties_add_float_slider(props, S_FILTER_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB,
+					    MAX_THRESHOLD_DB, 0.1);
 	obs_property_float_set_suffix(p, " dB");
 	p = obs_properties_add_int_slider(props, S_ATTACK_TIME, TEXT_ATTACK_TIME, MIN_ATK_RLS_MS, MAX_ATK_MS, 1);
 	obs_property_int_set_suffix(p, " ms");

--- a/plugins/obs-filters/limiter-filter.c
+++ b/plugins/obs-filters/limiter-filter.c
@@ -24,7 +24,7 @@
 
 /* clang-format off */
 
-#define S_THRESHOLD                     "threshold"
+#define S_FILTER_THRESHOLD              "threshold"
 #define S_RELEASE_TIME                  "release_time"
 
 #define MT_ obs_module_text
@@ -90,7 +90,7 @@ static void limiter_update(void *data, obs_data_t *s)
 	const float release_time_ms = (float)obs_data_get_int(s, S_RELEASE_TIME);
 	const float output_gain_db = 0;
 
-	cd->threshold = (float)obs_data_get_double(s, S_THRESHOLD);
+	cd->threshold = (float)obs_data_get_double(s, S_FILTER_THRESHOLD);
 
 	cd->attack_gain = gain_coefficient(sample_rate, attack_time_ms / MS_IN_S_F);
 	cd->release_gain = gain_coefficient(sample_rate, release_time_ms / MS_IN_S_F);
@@ -181,7 +181,7 @@ static struct obs_audio_data *limiter_filter_audio(void *data, struct obs_audio_
 
 static void limiter_defaults(obs_data_t *s)
 {
-	obs_data_set_default_double(s, S_THRESHOLD, -6.0f);
+	obs_data_set_default_double(s, S_FILTER_THRESHOLD, -6.0f);
 	obs_data_set_default_int(s, S_RELEASE_TIME, 60);
 }
 
@@ -190,8 +190,8 @@ static obs_properties_t *limiter_properties(void *data)
 	obs_properties_t *props = obs_properties_create();
 	obs_property_t *p;
 
-	p = obs_properties_add_float_slider(props, S_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB, MAX_THRESHOLD_DB,
-					    0.1);
+	p = obs_properties_add_float_slider(props, S_FILTER_THRESHOLD, TEXT_THRESHOLD, MIN_THRESHOLD_DB,
+					    MAX_THRESHOLD_DB, 0.1);
 	obs_property_float_set_suffix(p, " dB");
 	p = obs_properties_add_int_slider(props, S_RELEASE_TIME, TEXT_RELEASE_TIME, MIN_ATK_RLS_MS, MAX_RLS_MS, 1);
 	obs_property_int_set_suffix(p, " ms");

--- a/plugins/obs-outputs/utils.h
+++ b/plugins/obs-outputs/utils.h
@@ -22,7 +22,11 @@ static inline uint32_t clz32(unsigned long val)
 
 static inline uint32_t ctz32(unsigned long val)
 {
+#if defined(_M_ARM64)
+	return _CountTrailingZeros(val);
+#else
 	return _tzcnt_u32(val);
+#endif
 }
 #else
 static uint32_t popcnt(uint32_t x)


### PR DESCRIPTION
Introduces Windows on ARM support to the OBS-studio application. This includes modifications that are guarded with ARM-specific macros to ensure compatibility without affecting the existing codebase.

### Description
This pull request introduces several code refactoring changes to enhance WOA support and resolve conflicts in the OBS-Studio application. The key changes include:

- **w32-pthreads:** Added additional definitions of ARM macros `_M_ARM` and `_M_ARM64`.
- **libobs:** updated `obs-win-crash-handler.c` to handle instruction pointers and stack traces, improving crash reporting on ARM64 systems .
- **obs-filters:** Renaming `S_THRESHOLD` to `S_FILTER_THRESHOLD` to avoid a conflict with existing macro with a numeric value.
- **obs-outputs:** Replaced `__tzcnt_u32()` with `_CountTrailingZeros()` for ARM.
- **Frontend:** ensured `WIN32_LEAN_AND_MEAN` is defined conditionally if not defined.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The primary motivation for these changes is to expand compatibility with ARM architecture (windows) by addressing conflicts with existing macros and functions. By introducing ARM-specific macros and guarding ARM-specific code, we ensure that the application runs smoothly without affecting the existing codebase.

- **Additional ARM definitions in deps/w32-pthreads/context.h:**
    - Update w32-pthreads/context.h to include definitions for _M_ARM and _M_ARM64 in addition to existing ARM definitions.

- **Libobs changes:**
  - Adjust obs-win-crash-handler.c to handle instruction pointers & stack traces for crash reporting.

- **Obs-filters changes:**
   - Renaming `S_THRESHOLD` macro to `S_FILTER_THRESHOLD` to avoid conflicts with existing definition

- **Obs-outputs: Use _CountTrailingZeros() in ctz32**
    - Replaced `tzcnt_u32` with `_CountTrailingZeros` to ensure compatibility with WOA machines.

- **Frontend Changes:**
  - Ensured WIN32_LEAN_AND_MEAN is included conditionally in OBSBasicFilters.cpp, OBSBasicInteraction.cpp, and OBSBasicProperties.cpp.

### How Has This Been Tested?
The changes have been tested by building OBS Studio on an ARM machine (X Elite machine, Win11). All builds were successful, Basic functionality tests confirmed that the OBS Studio application with the modifications is functional.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
