### PR TITLE
obs-outputs: Set FLV DTS offset based on first audio or video packet

### DIFF
--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1314,7 +1314,7 @@ static bool init_connect(struct rtmp_stream *stream)
 	stream->total_bytes_sent = 0;
 	stream->dropped_frames = 0;
 	stream->min_priority = 0;
-	stream->got_first_video = false;
+	stream->got_first_packet = false;
 
 	settings = obs_output_get_settings(stream->output);
 	dstr_copy(&stream->path,
@@ -1761,10 +1761,10 @@ static void rtmp_stream_data(void *data, struct encoder_packet *packet)
 	}
 
 	if (packet->type == OBS_ENCODER_VIDEO) {
-		if (!stream->got_first_video) {
+		if (!stream->got_first_packet) {
 			stream->start_dts_offset =
 				get_ms_time(packet, packet->dts);
-			stream->got_first_video = true;
+			stream->got_first_packet = true;
 		}
 
 		switch (stream->video_codec[packet->track_idx]) {
@@ -1788,6 +1788,12 @@ static void rtmp_stream_data(void *data, struct encoder_packet *packet)
 			break;
 		}
 	} else {
+		if (!stream->got_first_packet) {
+			stream->start_dts_offset =
+				get_ms_time(packet, packet->dts);
+			stream->got_first_packet = true;
+		}
+
 		obs_encoder_packet_ref(&new_packet, packet);
 	}
 

--- a/plugins/obs-outputs/rtmp-stream.h
+++ b/plugins/obs-outputs/rtmp-stream.h
@@ -60,7 +60,7 @@ struct rtmp_stream {
 	struct deque packets;
 	bool sent_headers;
 
-	bool got_first_video;
+	bool got_first_packet;
 	int64_t start_dts_offset;
 
 	volatile bool connecting;


### PR DESCRIPTION
### Description

Ensures that PTS/DTS for audio start at 0 if there by ensuring the DTS offset is based on the first packet that comes in, regardless of whether or not it's video (b-frame delay), or audio (priming sample delay).

### Motivation and Context

Fixes #10998

This became necessary due to #10689 and #10690 which fix handling of audio priming samples with negative timestamps. Note that if users have a sufficiently large number of b-frames configured (1 is enough) this currently doesn't actually cause any issues.

### How Has This Been Tested?

Logged output packets and ensured the resulting FLV files are playable.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
