### PR TITLE
UI: Fix cast of pointer type at invalid current scene setting on load

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1293,10 +1293,8 @@ retryScene:
 
 	if (!curScene) {
 		auto find_scene_cb = [](void *source_ptr, obs_source_t *scene) {
-			OBSSourceAutoRelease &source =
-				reinterpret_cast<OBSSourceAutoRelease &>(
-					source_ptr);
-			source = obs_source_get_ref(scene);
+			*static_cast<OBSSourceAutoRelease *>(source_ptr) =
+				obs_source_get_ref(scene);
 			return false;
 		};
 		obs_enum_scenes(find_scene_cb, &curScene);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

A variable `curScene` has a type `OBSSourceAutoRelease`.
It's pointer `&curScene` is passed to `obs_enum_scenes`.
Hence, the right type is `OBSSourceAutoRelease *`.

Though the first commit 496e599 fixed the bug, there was a complaint that the code is not easy to read. This PR additionally change them for a little better readability of the code.
- Use `static_cast` instead of `reintepret_cast` so that some type-checks will be performed at compile time.
- Instead of having a reference type of `OBSSourceAutoRelease`, put the parameter `source_ptr` with the cast to the left hand side of the assignment.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The code was introduced by #9944.

A crash was reported on the forum. https://obsproject.com/forum/attachments/crash-2024-07-18-09-59-21-txt.105470/

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

1. Created a new scene collection having one scene named `Scene`.
2. Manually edit the scene collection file as below and start OBS Studio.
```diff
@@ -61,8 +61,8 @@
     "monitoring_type": 0,
     "private_settings": {}
   },
-  "current_scene": "Scene",
-  "current_program_scene": "Scene",
+  "current_scene": "Scene 1",
+  "current_program_scene": "Scene 1",
   "scene_order": [
     {
       "name": "Scene"
```

Without this fix, I confirmed the crash was reproduced.
With this fix, I confirmed no crash was observed and `Scene` was selected at the startup.

Also checked with Studio Mode.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
