### PR TITLE
CI: Do not mark legacy MF/AMF plugins as deleted

### DIFF
--- a/.github/actions/windows-patches/config.toml
+++ b/.github/actions/windows-patches/config.toml
@@ -15,6 +15,12 @@ skip_sign = true
 patch_type = "zstd"
 compress_files = true
 
+# Prevent some legacy plugins from being marked as deleted
+exclude_from_removal = [
+    "enc-amf",
+    "win-mf",
+]
+
 [package]
 
 [package.installer]


### PR DESCRIPTION
### Description

Exclude legacy AMF and MF plugins from removal.

### Motivation and Context

Had some complaints from users about them being deleted, while they are deprecated we do not intend to hard-remove them yet without having a migration path.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
