### PR TITLE
obs-outputs: Preserve signedness of FLV timestamp

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -130,7 +130,7 @@ static void s_wstring(struct serializer *s, const char *str)
 static inline void s_wtimestamp(struct serializer *s, int32_t i32)
 {
 	s_wb24(s, (uint32_t)(i32 & 0xFFFFFF));
-	s_w8(s, (uint32_t)(i32 >> 24) & 0x7F);
+	s_w8(s, (uint32_t)(i32 >> 24) & 0xFF);
 }
 
 static inline double encoder_bitrate(obs_encoder_t *encoder)
@@ -340,7 +340,7 @@ static void flv_video(struct serializer *s, int32_t dts_offset,
 
 	s_wb24(s, (uint32_t)packet->size + 5);
 	s_wb24(s, (uint32_t)time_ms);
-	s_w8(s, (time_ms >> 24) & 0x7F);
+	s_w8(s, (time_ms >> 24) & 0xFF);
 	s_wb24(s, 0);
 
 	/* these are the 5 extra bytes mentioned above */
@@ -373,7 +373,7 @@ static void flv_audio(struct serializer *s, int32_t dts_offset,
 
 	s_wb24(s, (uint32_t)packet->size + 2);
 	s_wb24(s, (uint32_t)time_ms);
-	s_w8(s, (time_ms >> 24) & 0x7F);
+	s_w8(s, (time_ms >> 24) & 0xFF);
 	s_wb24(s, 0);
 
 	/* these are the two extra bytes mentioned above */
@@ -436,7 +436,7 @@ void flv_packet_audio_ex(struct encoder_packet *packet,
 
 	s_wb24(&s, (uint32_t)packet->size + header_metadata_size);
 	s_wb24(&s, (uint32_t)time_ms);
-	s_w8(&s, (time_ms >> 24) & 0x7F);
+	s_w8(&s, (time_ms >> 24) & 0xFF);
 	s_wb24(&s, 0);
 
 	s_w8(&s, AUDIO_HEADER_EX |


### PR DESCRIPTION
### Description
obs-outputs: Preserve signedness of FLV timestamp

### Motivation and Context
[Video File Format Specification Version 10](https://rtmp.veriskope.com/pdf/video_file_format_spec_v10.pdf) states that a timestamp in FLV format is a signed 32-bit integer, which are composed of two integers.

> |Field|Type|Comment|
> |-|-|-|
> |...|...|...|
> |Timestamp|UI24|Time in milliseconds at which the data in this tag applies. This value is relative to the first tag in the FLV file, which always has a timestamp of 0.|
> |TimestampExtended|UI8|Extension of the Timestamp fields to form a **SI32** value. This field represents the upper 8 bits, while the previous Timestamp field represents the lower 24 bits of the time in milliseconds.|
> |...|...|...|

### How Has This Been Tested?
Inspected RTMP packets with Wireshark.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
