### PR TITLE
obs-ffmpeg: Add QVBR rate control for VA-API

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -234,6 +234,7 @@ static const rc_mode_t *get_rc_mode(const char *name)
 		{.name = "CBR", .qp = false, .bitrate = true, .maxrate = false},
 		{.name = "CQP", .qp = true, .bitrate = false, .maxrate = false},
 		{.name = "VBR", .qp = false, .bitrate = true, .maxrate = true},
+		{.name = "QVBR", .qp = true, .bitrate = true, .maxrate = true},
 		{0}};
 
 	const rc_mode_t *rc_mode = RC_MODES;
@@ -1020,6 +1021,9 @@ static bool vaapi_device_modified(obs_properties_t *ppts, obs_property_t *p,
 
 	if (vaapi_device_rc_supported(profile, va_dpy, VA_RC_VBR, device))
 		obs_property_list_add_string(rc_p, "VBR", "VBR");
+
+	if (vaapi_device_rc_supported(profile, va_dpy, VA_RC_QVBR, device))
+		obs_property_list_add_string(rc_p, "QVBR", "QVBR");
 
 	if (vaapi_device_rc_supported(profile, va_dpy, VA_RC_CQP, device))
 		obs_property_list_add_string(rc_p, "CQP", "CQP");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add QVBR rate control for VA-API

![2024-07-22_09:10:01](https://github.com/user-attachments/assets/6dcec6f6-548c-4139-b663-e9c0680f0cac)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This rate control is supported by both Intel and AMD, so make it available in OBS.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested with Mesa (https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30221).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
