### PR TITLE
mac-virtualcam: Improve 'not found' error message

### DIFF
--- a/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
+++ b/plugins/mac-virtualcam/src/obs-plugin/data/locale/en-US.ini
@@ -1,7 +1,7 @@
 Plugin_Name="macOS Virtual Webcam"
 Error.SystemExtension.NotInstalled="The virtual camera is not installed.\n\nPlease allow OBS to install system software in System Settings → Privacy & Security → Security.\n\nYou may need to restart OBS if this message still appears afterward."
 Error.SystemExtension.NotInstalled.MacOS15="The virtual camera is not installed.\n\nPlease allow OBS to install the camera system extension in System Settings → General → Login Items & Extensions → Camera Extensions.\n\nYou may need to restart OBS if this message still appears afterward."
-Error.SystemExtension.CameraUnavailable="Could not find virtual camera.\n\nPlease try again."
+Error.SystemExtension.CameraUnavailable="Could not find the virtual camera system process.\n\nThis may be resolved by logging out of and back into your macOS user account, or by restarting your computer."
 Error.SystemExtension.CameraNotStarted="Unable to start virtual camera.\n\nPlease try again."
 Error.SystemExtension.InstallationError="An error has occured while installing the virtual camera:"
 Error.SystemExtension.WrongLocation="OBS cannot install the virtual camera if it's not in \"/Applications\". Please move OBS to the \"/Applications\" directory."


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the error text associated with the macOS camera extension failing to find its system-level counterpart to provide a more helpful hint for resolving the issue.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This error seems to be the one most frequently encountered by Mac users launching the virtual camera and reasonably results in a lot of [user](https://github.com/obsproject/obs-studio/issues/10381) [confusion](https://github.com/obsproject/obs-studio/issues/9912).

On an update, OBS replaces its system extension even if nothing material has changed within it, in order to conform with signing requirements and keep versioning consistent.

For some users, macOS will fail to launch the process for the newly installed extension, despite installing it successfully and reporting that it is both `[activated  enabled]` in systemextensionsctl. This is reported as FB13331352.

The simplest resolution for this issue is to log out of and back into the user's macOS account, which triggers a relaunch of all system extensions for that user. This will almost always successfully resolve this particular error.

Even if there are other ways that OBS could possibly mitigate this issue, it seems like it would assist users to have a better error message in the interim, as the current error message is cryptic and unhelpful.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Looked at the new dialog.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.