### PR TITLE
UI: Ensure collection name is set before creating default scene

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1163,12 +1163,34 @@ void OBSBasic::Load(const char *file)
 	obs_data_t *data = obs_data_create_from_json_file_safe(file, "bak");
 	if (!data) {
 		disableSaving--;
-		blog(LOG_INFO, "No scene file found, creating default scene");
-		const string name = filesystem::u8path(file).stem().u8string();
+		const auto path = filesystem::u8path(file);
+		const string name = path.stem().u8string();
+		/* Check if file exists but failed to load. */
+		if (filesystem::exists(path)) {
+			/* Assume the file is corrupt and rename it to allow
+			 * for manual recovery if possible. */
+			auto newPath = path;
+			newPath.concat(".invalid");
+
+			blog(LOG_WARNING,
+			     "File exists but appears to be corrupt, renaming "
+			     "to \"%s\" before continuing.",
+			     newPath.filename().u8string().c_str());
+
+			error_code ec;
+			filesystem::rename(path, newPath, ec);
+			if (ec) {
+				blog(LOG_ERROR,
+				     "Failed renaming corrupt file with %d",
+				     ec.value());
+			}
+		}
+
 		config_set_string(App()->GlobalConfig(), "Basic",
 				  "SceneCollection", name.c_str());
 		config_set_string(App()->GlobalConfig(), "Basic",
 				  "SceneCollectionFile", name.c_str());
+		blog(LOG_INFO, "No scene file found, creating default scene");
 		CreateDefaultScene(true);
 		SaveProject();
 		return;

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1164,6 +1164,11 @@ void OBSBasic::Load(const char *file)
 	if (!data) {
 		disableSaving--;
 		blog(LOG_INFO, "No scene file found, creating default scene");
+		const string name = filesystem::u8path(file).stem().u8string();
+		config_set_string(App()->GlobalConfig(), "Basic",
+				  "SceneCollection", name.c_str());
+		config_set_string(App()->GlobalConfig(), "Basic",
+				  "SceneCollectionFile", name.c_str());
 		CreateDefaultScene(true);
 		SaveProject();
 		return;


### PR DESCRIPTION
### Description

Ensure scene collection name and filename are set correctly before creating default scene.

### Motivation and Context

Fixes #11037 

### How Has This Been Tested?

Locally based on reproduction steps outlines in #11037 

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
