### PR TITLE
Remove unused functions

### DIFF
--- a/UI/window-basic-settings-a11y.cpp
+++ b/UI/window-basic-settings-a11y.cpp
@@ -11,11 +11,6 @@ enum ColorPreset {
 	COLOR_PRESET_CUSTOM = 99,
 };
 
-static inline bool WidgetChanged(QWidget *widget)
-{
-	return widget->property("changed").toBool();
-}
-
 static inline QColor color_from_int(long long val)
 {
 	return QColor(val & 0xff, (val >> 8) & 0xff, (val >> 16) & 0xff,

--- a/libobs-opengl/gl-shader.c
+++ b/libobs-opengl/gl-shader.c
@@ -25,11 +25,6 @@
 #include "gl-subsystem.h"
 #include "gl-shaderparser.h"
 
-static inline void shader_param_init(struct gs_shader_param *param)
-{
-	memset(param, 0, sizeof(struct gs_shader_param));
-}
-
 static inline void shader_param_free(struct gs_shader_param *param)
 {
 	bfree(param->name);

--- a/libobs/callback/calldata.c
+++ b/libobs/callback/calldata.c
@@ -41,12 +41,6 @@
  * direct referencing.
  */
 
-static inline void cd_serialize(uint8_t **pos, void *ptr, size_t size)
-{
-	memcpy(ptr, *pos, size);
-	*pos += size;
-}
-
 static inline size_t cd_serialize_size(uint8_t **pos)
 {
 	size_t size = 0;

--- a/libobs/graphics/half.h
+++ b/libobs/graphics/half.h
@@ -51,7 +51,7 @@ struct half {
 };
 
 /* adapted from DirectXMath XMConvertFloatToHalf */
-static struct half half_from_float(float f)
+static inline struct half half_from_float(float f)
 {
 	uint32_t Result;
 
@@ -90,7 +90,7 @@ static struct half half_from_float(float f)
 	return h;
 }
 
-static struct half half_from_bits(uint16_t u)
+static inline struct half half_from_bits(uint16_t u)
 {
 	struct half h;
 	h.u = u;

--- a/libobs/graphics/image-file.h
+++ b/libobs/graphics/image-file.h
@@ -94,33 +94,33 @@ EXPORT bool gs_image_file4_tick(gs_image_file4_t *if4,
 				uint64_t elapsed_time_ns);
 EXPORT void gs_image_file4_update_texture(gs_image_file4_t *if4);
 
-static void gs_image_file2_free(gs_image_file2_t *if2)
+static inline void gs_image_file2_free(gs_image_file2_t *if2)
 {
 	gs_image_file_free(&if2->image);
 	if2->mem_usage = 0;
 }
 
-static void gs_image_file2_init_texture(gs_image_file2_t *if2)
+static inline void gs_image_file2_init_texture(gs_image_file2_t *if2)
 {
 	gs_image_file_init_texture(&if2->image);
 }
 
-static void gs_image_file3_free(gs_image_file3_t *if3)
+static inline void gs_image_file3_free(gs_image_file3_t *if3)
 {
 	gs_image_file2_free(&if3->image2);
 }
 
-static void gs_image_file3_init_texture(gs_image_file3_t *if3)
+static inline void gs_image_file3_init_texture(gs_image_file3_t *if3)
 {
 	gs_image_file2_init_texture(&if3->image2);
 }
 
-static void gs_image_file4_free(gs_image_file4_t *if4)
+static inline void gs_image_file4_free(gs_image_file4_t *if4)
 {
 	gs_image_file3_free(&if4->image3);
 }
 
-static void gs_image_file4_init_texture(gs_image_file4_t *if4)
+static inline void gs_image_file4_init_texture(gs_image_file4_t *if4)
 {
 	gs_image_file3_init_texture(&if4->image3);
 }

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -318,26 +318,6 @@ obs_source_t *obs_transition_get_active_source(obs_source_t *transition)
 	return ret;
 }
 
-static inline bool activate_child(obs_source_t *transition, size_t idx)
-{
-	bool success = true;
-
-	lock_transition(transition);
-
-	if (transition->transition_sources[idx] &&
-	    !transition->transition_source_active[idx]) {
-
-		success = obs_source_add_active_child(
-			transition, transition->transition_sources[idx]);
-		if (success)
-			transition->transition_source_active[idx] = true;
-	}
-
-	unlock_transition(transition);
-
-	return success;
-}
-
 static bool activate_transition(obs_source_t *transition, size_t idx,
 				obs_source_t *child)
 {
@@ -637,19 +617,6 @@ static inline void copy_transition_state(obs_source_t *transition,
 
 	state->transitioning_video = transition->transitioning_video;
 	state->transitioning_audio = transition->transitioning_audio;
-}
-
-static inline void enum_child(obs_source_t *tr, obs_source_t *child,
-			      obs_source_enum_proc_t enum_callback, void *param)
-{
-	if (!child)
-		return;
-
-	if (child->context.data && child->info.enum_active_sources)
-		child->info.enum_active_sources(child->context.data,
-						enum_callback, param);
-
-	enum_callback(tr, child, param);
 }
 
 void obs_transition_enum_sources(obs_source_t *transition,

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -161,12 +161,6 @@ static void allocate_audio_mix_buffer(struct obs_source *source)
 	}
 }
 
-static inline bool is_async_video_source(const struct obs_source *source)
-{
-	return (source->info.output_flags & OBS_SOURCE_ASYNC_VIDEO) ==
-	       OBS_SOURCE_ASYNC_VIDEO;
-}
-
 static inline bool is_audio_source(const struct obs_source *source)
 {
 	return source->info.output_flags & OBS_SOURCE_AUDIO;
@@ -2364,12 +2358,6 @@ static inline void set_eparam(gs_effect_t *effect, const char *name, float val)
 {
 	gs_eparam_t *param = gs_effect_get_param_by_name(effect, name);
 	gs_effect_set_float(param, val);
-}
-
-static inline void set_eparami(gs_effect_t *effect, const char *name, int val)
-{
-	gs_eparam_t *param = gs_effect_get_param_by_name(effect, name);
-	gs_effect_set_int(param, val);
 }
 
 static bool update_async_texrender(struct obs_source *source,

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2043,11 +2043,6 @@ static inline void *obs_service_addref_safe_(void *ref)
 	return obs_service_get_ref(ref);
 }
 
-static inline void *obs_id_(void *data)
-{
-	return data;
-}
-
 obs_source_t *obs_get_source_by_name(const char *name)
 {
 	return get_context_by_name(&obs->data.public_sources, name,

--- a/libobs/util/config-file.c
+++ b/libobs/util/config-file.c
@@ -87,19 +87,6 @@ config_t *config_create(const char *file)
 	return config;
 }
 
-static inline void remove_ref_whitespace(struct strref *ref)
-{
-	if (ref->array) {
-		while (ref->len && is_whitespace(*ref->array)) {
-			ref->array++;
-			ref->len--;
-		}
-
-		while (ref->len && is_whitespace(ref->array[ref->len - 1]))
-			ref->len--;
-	}
-}
-
 static bool config_parse_string(struct lexer *lex, struct strref *ref, char end)
 {
 	bool success = end != 0;

--- a/plugins/linux-alsa/alsa-input.c
+++ b/plugins/linux-alsa/alsa-input.c
@@ -70,8 +70,10 @@ static bool alsa_devices_changed(obs_properties_t *props, obs_property_t *p,
 static obs_properties_t *alsa_get_properties(void *);
 static void *alsa_create(obs_data_t *, obs_source_t *);
 static void alsa_destroy(void *);
+#if SHUTDOWN_ON_DEACTIVATE
 static void alsa_activate(void *);
 static void alsa_deactivate(void *);
+#endif
 static void alsa_get_defaults(obs_data_t *);
 static void alsa_update(void *, obs_data_t *);
 

--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -108,23 +108,6 @@ static GDBusProxy *get_camera_portal_proxy(void)
 	return camera_proxy;
 }
 
-static uint32_t get_camera_version(void)
-{
-	g_autoptr(GVariant) cached_version = NULL;
-	uint32_t version;
-
-	ensure_camera_portal_proxy();
-
-	if (!camera_proxy)
-		return 0;
-
-	cached_version =
-		g_dbus_proxy_get_cached_property(camera_proxy, "version");
-	version = cached_version ? g_variant_get_uint32(cached_version) : 0;
-
-	return version;
-}
-
 /* ------------------------------------------------- */
 
 struct camera_device {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-formats.h
@@ -69,7 +69,7 @@ obs_to_ffmpeg_video_format(enum video_format format)
 	}
 }
 
-static enum AVChromaLocation
+static inline enum AVChromaLocation
 determine_chroma_location(enum AVPixelFormat pix_fmt,
 			  enum AVColorSpace colorspace)
 {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-output.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-output.c
@@ -565,6 +565,7 @@ static inline const char *safe_str(const char *s)
 		return s;
 }
 
+#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 static enum AVCodecID get_codec_id(const char *name, int id)
 {
 	const AVCodec *codec;
@@ -582,7 +583,6 @@ static enum AVCodecID get_codec_id(const char *name, int id)
 	return codec->id;
 }
 
-#if LIBAVFORMAT_VERSION_INT < AV_VERSION_INT(59, 0, 100)
 static void set_encoder_ids(struct ffmpeg_data *data)
 {
 	data->output->oformat->video_codec = get_codec_id(

--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -236,9 +236,9 @@ static void noise_suppress_destroy(void *data)
 	bfree(ng);
 }
 
+#ifdef LIBNVAFX_ENABLED
 static bool nvafx_initialize_internal(void *data)
 {
-#ifdef LIBNVAFX_ENABLED
 	struct noise_suppress_data *ng = data;
 	NvAFX_Status err;
 
@@ -320,16 +320,12 @@ static bool nvafx_initialize_internal(void *data)
 failure:
 	ng->use_nvafx = false;
 	return false;
-
-#else
-	UNUSED_PARAMETER(data);
-	return false;
-#endif
 }
+#endif
 
+#ifdef LIBNVAFX_ENABLED
 static void *nvafx_initialize(void *data)
 {
-#ifdef LIBNVAFX_ENABLED
 	struct noise_suppress_data *ng = data;
 	NvAFX_Status err;
 
@@ -382,12 +378,8 @@ failure:
 	pthread_mutex_unlock(&nvafx_initializer_mutex);
 	pthread_mutex_unlock(&ng->nvafx_mutex);
 	return NULL;
-
-#else
-	UNUSED_PARAMETER(data);
-	return NULL;
-#endif
 }
+#endif
 
 static inline void alloc_channel(struct noise_suppress_data *ng,
 				 uint32_t sample_rate, size_t channel,

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -350,6 +350,7 @@ static void droptest_cap_data_rate(struct rtmp_stream *stream, size_t size)
 }
 #endif
 
+#ifdef _WIN32
 static int socket_queue_data(RTMPSockBuf *sb, const char *data, int len,
 			     void *arg)
 {
@@ -384,6 +385,7 @@ retry_send:
 
 	return len;
 }
+#endif // _WIN32
 
 static int handle_socket_read(struct rtmp_stream *stream)
 {
@@ -639,7 +641,6 @@ static void dbr_set_bitrate(struct rtmp_stream *stream);
 
 #ifdef _WIN32
 #define socklen_t int
-#endif
 
 static void log_sndbuf_size(struct rtmp_stream *stream)
 {
@@ -651,6 +652,7 @@ static void log_sndbuf_size(struct rtmp_stream *stream)
 		info("Socket send buffer is %d bytes", cur_sendbuf_size);
 	}
 }
+#endif
 
 static void *send_thread(void *data)
 {
@@ -658,7 +660,7 @@ static void *send_thread(void *data)
 
 	os_set_thread_name("rtmp-stream: send_thread");
 
-#if defined(_WIN32)
+#ifdef _WIN32
 	log_sndbuf_size(stream);
 #endif
 
@@ -733,7 +735,7 @@ static void *send_thread(void *data)
 		send_footers(stream); // Y2023 spec
 	}
 
-#if defined(_WIN32)
+#ifdef _WIN32
 	log_sndbuf_size(stream);
 #endif
 

--- a/plugins/obs-qsv11/common_utils_linux.cpp
+++ b/plugins/obs-qsv11/common_utils_linux.cpp
@@ -491,29 +491,6 @@ static uint32_t vaapi_check_support(VADisplay display, VAProfile profile,
 	return (rc & VA_RC_CBR || rc & VA_RC_CQP || rc & VA_RC_VBR);
 }
 
-static bool vaapi_supports_h264(VADisplay display)
-{
-	bool ret = false;
-	ret |= vaapi_check_support(display, VAProfileH264ConstrainedBaseline,
-				   VAEntrypointEncSlice);
-	ret |= vaapi_check_support(display, VAProfileH264Main,
-				   VAEntrypointEncSlice);
-	ret |= vaapi_check_support(display, VAProfileH264High,
-				   VAEntrypointEncSlice);
-
-	if (!ret) {
-		ret |= vaapi_check_support(display,
-					   VAProfileH264ConstrainedBaseline,
-					   VAEntrypointEncSliceLP);
-		ret |= vaapi_check_support(display, VAProfileH264Main,
-					   VAEntrypointEncSliceLP);
-		ret |= vaapi_check_support(display, VAProfileH264High,
-					   VAEntrypointEncSliceLP);
-	}
-
-	return ret;
-}
-
 static bool vaapi_supports_av1(VADisplay display)
 {
 	bool ret = false;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -136,8 +136,6 @@ static const char *obs_qsv_getname_hevc(void *type_data)
 	return "QuickSync HEVC";
 }
 
-static void obs_qsv_stop(void *data);
-
 static void clear_data(struct obs_qsv *obsqsv)
 {
 	if (obsqsv->context) {
@@ -239,13 +237,6 @@ static inline void add_translated_strings(obs_property_t *list,
 #define TEXT_ICQ_QUALITY obs_module_text("ICQQuality")
 #define TEXT_KEYINT_SEC obs_module_text("KeyframeIntervalSec")
 #define TEXT_BFRAMES obs_module_text("BFrames")
-
-static inline bool is_skl_or_greater_platform()
-{
-	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
-	return (plat >= QSV_CPU_PLATFORM_SKL ||
-		plat == QSV_CPU_PLATFORM_UNKNOWN);
-}
 
 static bool update_latency(obs_data_t *settings)
 {

--- a/plugins/obs-x264/obs-x264.c
+++ b/plugins/obs-x264/obs-x264.c
@@ -74,8 +74,6 @@ static const char *obs_x264_getname(void *unused)
 	return "x264";
 }
 
-static void obs_x264_stop(void *data);
-
 static void clear_data(struct obs_x264 *obsx264)
 {
 	if (obsx264->context) {

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -35,6 +35,21 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 uint32_t texbuf_w = 2048, texbuf_h = 2048;
 
+static const char *ft2_source_get_name(void *unused);
+static void *ft2_source_create(obs_data_t *settings, obs_source_t *source);
+static void ft2_source_destroy(void *data);
+static void ft2_source_update(void *data, obs_data_t *settings);
+static obs_missing_files_t *ft2_missing_files(void *data);
+
+static void ft2_source_render(void *data, gs_effect_t *effect);
+static void ft2_video_tick(void *data, float seconds);
+static uint32_t ft2_source_get_width(void *data);
+static uint32_t ft2_source_get_height(void *data);
+
+static void ft2_source_defaults_v1(obs_data_t *settings);
+static void ft2_source_defaults_v2(obs_data_t *settings);
+static obs_properties_t *ft2_source_properties(void *unused);
+
 static struct obs_source_info freetype2_source_info_v1 = {
 	.id = "text_ft2_source",
 	.type = OBS_SOURCE_TYPE_INPUT,

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -70,26 +70,8 @@ struct ft2_source {
 
 extern FT_Library ft2_lib;
 
-static void *ft2_source_create(obs_data_t *settings, obs_source_t *source);
-static void ft2_source_destroy(void *data);
-static void ft2_source_update(void *data, obs_data_t *settings);
-static void ft2_source_render(void *data, gs_effect_t *effect);
-static void ft2_video_tick(void *data, float seconds);
-
 void draw_outlines(struct ft2_source *srcdata);
 void draw_drop_shadow(struct ft2_source *srcdata);
-
-static uint32_t ft2_source_get_width(void *data);
-static uint32_t ft2_source_get_height(void *data);
-
-static void ft2_source_defaults_v1(obs_data_t *settings);
-static void ft2_source_defaults_v2(obs_data_t *settings);
-
-static obs_properties_t *ft2_source_properties(void *unused);
-
-static const char *ft2_source_get_name(void *unused);
-
-static obs_missing_files_t *ft2_missing_files(void *data);
 
 uint32_t get_ft2_text_width(wchar_t *text, struct ft2_source *srcdata);
 

--- a/shared/obs-scripting/obs-scripting-lua.h
+++ b/shared/obs-scripting/obs-scripting-lua.h
@@ -184,17 +184,17 @@ static inline void free_lua_obs_callback(struct lua_obs_callback *cb)
 
 /* ------------------------------------------------ */
 
-static int is_ptr(lua_State *script, int idx)
+static inline int is_ptr(lua_State *script, int idx)
 {
 	return lua_isuserdata(script, idx) || lua_isnil(script, idx);
 }
 
-static int is_table(lua_State *script, int idx)
+static inline int is_table(lua_State *script, int idx)
 {
 	return lua_istable(script, idx);
 }
 
-static int is_function(lua_State *script, int idx)
+static inline int is_function(lua_State *script, int idx)
 {
 	return lua_isfunction(script, idx);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR removes unused functions that were not exported, ie. functions declared with `static` qualifier.

This PR also adds `inline` qualifier to `static` functions defined in header files.
This will affect 3rd party plugins but it should not make something wrong.

text-freetype2: Some functions were unnecessarily declared in a header file. They were moved to a proper location.

libobs/graphics/effect-parser.c: Exceptionally,
I didn't remove `ep_getparam`
as it is a variant of `ep_get*` functions so that it might be used in future.

libobs/obs-source.c: The removed function `set_eparami` was introduced at e7f754df97 but later removed by bdd8d6405.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Unused functions should not be left.

I want to enable `-Wunused-function` (but I gave up for now since qt automoc generates an unused function without `static inline` qualifier.)

For public header files, it's better to avoid `static` functions without `inline`
so that 3rd party plugins can enable `-Wunused-function`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

Added `-Wunused-function` to the compile option.
Ran a command below to temporarily remove `inline` qualifier.
```sh
for f in $(git grep -l 'inline' ':*.c*'); do
  ed $f <<EOF
\$
?#include
a
#define inline
.
wq
EOF
done
```
Ran build flow and checked errors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
