### PR TITLE
libobs/util,text-freetype2: Permit internal nulls

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -14,6 +14,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 #include <wchar.h>
+#include <string.h>
 
 #include "utf8.h"
 
@@ -142,13 +143,10 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 
 	total = 0;
 	p = (unsigned char *)in;
-	lim = (insize != 0) ? (p + insize) : (unsigned char *)-1;
+	lim = p + (insize != 0 ? insize : strlen(in));
 	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
-		if (!*p && insize == 0)
-			break;
-
 		if (utf8_forbidden(*p) != 0 && (flags & UTF8_IGNORE_ERROR) == 0)
 			return 0;
 
@@ -270,15 +268,12 @@ size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 		return 0;
 
 	w = (wchar_t *)in;
-	wlim = (insize != 0) ? (w + insize) : (wchar_t *)-1;
+	wlim = w + (insize != 0 ? insize : wcslen(w));
 	p = (unsigned char *)out;
 	lim = out == NULL ? NULL : p + outsize;
 	total = 0;
 
 	for (; w < wlim; w++) {
-		if (!*w && insize == 0)
-			break;
-
 		if (wchar_forbidden(*w) != 0) {
 			if ((flags & UTF8_IGNORE_ERROR) == 0)
 				return 0;

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -238,6 +238,7 @@ static void ft2_source_destroy(void *data)
 		bfree(srcdata->font_style);
 	if (srcdata->text != NULL)
 		bfree(srcdata->text);
+	srcdata->text_len = 0;
 	if (srcdata->texbuf != NULL)
 		bfree(srcdata->texbuf);
 	if (srcdata->text_file != NULL)
@@ -271,7 +272,8 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 
 	if (srcdata->tex == NULL || srcdata->vbuf == NULL)
 		return;
-	if (srcdata->text == NULL || *srcdata->text == 0)
+	if (srcdata->text == NULL || *srcdata->text == 0 ||
+	    srcdata->text_len == 0)
 		return;
 
 	gs_reset_blend_state();
@@ -281,7 +283,7 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 		draw_drop_shadow(srcdata);
 
 	draw_uv_vbuffer(srcdata->vbuf, srcdata->tex, srcdata->draw_effect,
-			(uint32_t)wcslen(srcdata->text) * 6, true);
+			(uint32_t)srcdata->text_len * 6, true);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -304,7 +306,7 @@ static void ft2_video_tick(void *data, float seconds)
 			else
 				load_text_from_file(srcdata,
 						    srcdata->text_file);
-			cache_glyphs(srcdata, srcdata->text);
+			cache_glyphs(srcdata, srcdata->text, srcdata->text_len);
 			set_up_vertex_buffer(srcdata);
 			srcdata->update_file = false;
 		}
@@ -490,8 +492,8 @@ skip_font_load:
 			bfree(srcdata->text);
 			srcdata->text = NULL;
 
-			os_utf8_to_wcs_ptr(emptystr, strlen(emptystr),
-					   &srcdata->text);
+			srcdata->text_len = os_utf8_to_wcs_ptr(
+				emptystr, strlen(emptystr), &srcdata->text);
 			blog(LOG_WARNING,
 			     "FT2-text: Failed to open %s for "
 			     "reading",
@@ -519,13 +521,15 @@ skip_font_load:
 		if (srcdata->text != NULL) {
 			bfree(srcdata->text);
 			srcdata->text = NULL;
+			srcdata->text_len = 0;
 		}
 
-		os_utf8_to_wcs_ptr(tmp, strlen(tmp), &srcdata->text);
+		srcdata->text_len =
+			os_utf8_to_wcs_ptr(tmp, strlen(tmp), &srcdata->text);
 	}
 
 	if (srcdata->font_face) {
-		cache_glyphs(srcdata, srcdata->text);
+		cache_glyphs(srcdata, srcdata->text, srcdata->text_len);
 		set_up_vertex_buffer(srcdata);
 	}
 

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -40,6 +40,7 @@ struct ft2_source {
 	bool antialiasing;
 	char *text_file;
 	wchar_t *text;
+	size_t text_len;
 	time_t m_timestamp;
 	bool update_file;
 	uint64_t last_checked;
@@ -98,7 +99,8 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename);
 void read_from_end(struct ft2_source *srcdata, const char *filename);
 
 void cache_standard_glyphs(struct ft2_source *srcdata);
-void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs);
+void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs,
+		  size_t cache_glyphs_len);
 
 void set_up_vertex_buffer(struct ft2_source *srcdata);
 void fill_vertex_buffer(struct ft2_source *srcdata);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes handling of text to attempt to parse past the first null character when buffer sizes are known and correct some length handling throughout the plugin.

This probably makes unmeasured conversion twice as slow. Since it introduces a `wcslen()`/`strlen()` into the conversion routine that was previously just done during conversion. Maybe reintegrating that is a good first issue for someone :)

Largely just #7622 but with some fixes that were found during review.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #7595

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
utf-8 example file from the issue is fixed.
utf16 is blank instead of being a bunch of broken characters and possibly overrunning buffers, presumably windows will continue working.

It probably needs a second or third set of eyes.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
