### PR TITLE
UI: Fix leak with paint event of volume slider.

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1606,6 +1606,7 @@ void VolumeSlider::paintEvent(QPaintEvent *event)
 	}
 
 	QSlider::paintEvent(event);
+	delete tickColor;
 }
 
 VolumeAccessibleInterface::VolumeAccessibleInterface(QWidget *w)


### PR DESCRIPTION
### Description
This fixes a memory leak introduced in [1] where a new QColor is not balanced by a delete.

[1] UI: Update volume meter appearance
https://github.com/obsproject/obs-studio/commit/52ae5fc4bd518c67edd8ab94121ace05d9076892

### Motivation and Context
The leak was found with VLD.

### How Has This Been Tested?
Leak is gone.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
