### PR TITLE
shared/media-playback: Unref sw_frame before reuse if using hardware decoding

### DIFF
--- a/shared/media-playback/media-playback/decode.c
+++ b/shared/media-playback/media-playback/decode.c
@@ -337,16 +337,7 @@ static int decode_packet(struct mp_decode *d, int *got_frame)
 			return ret;
 		}
 
-		/* does not check for color format or other parameter changes which would require frame buffer realloc */
-		if (d->sw_frame->data[0] &&
-		    (d->sw_frame->width != d->hw_frame->width ||
-		     d->sw_frame->height != d->hw_frame->height)) {
-			blog(LOG_DEBUG,
-			     "MP: hardware frame size changed from %dx%d to %dx%d. reallocating frame",
-			     d->sw_frame->width, d->sw_frame->height,
-			     d->hw_frame->width, d->hw_frame->height);
-			av_frame_unref(d->sw_frame);
-		}
+		av_frame_unref(d->sw_frame);
 
 		int err = av_hwframe_transfer_data(d->sw_frame, d->hw_frame, 0);
 		if (err == 0) {


### PR DESCRIPTION
### Description
By not performing an unref on sw_frame before using it again, a memory "leak" was being created if the frame had side data. This removes a previously-added check that optionally unrefs sw_frame, and just does it every tick.

### Motivation and Context
Noticed a memory leak the other day when playing back an HDR media file. It was quite extreme (ticking up by 1MB every few seconds).

### How Has This Been Tested?
Memory usage no longer goes up over time, other behaviors that I could test still work as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
