### PR TITLE
UI: Implement backend work for configurable storage locations for settings, profiles, and scene collections

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -125,7 +125,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	stackedWidget->addWidget(percent);
 
 	VolumeType volType = (VolumeType)config_get_int(
-		GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType");
+		App()->GetUserConfig(), "BasicWindow", "AdvAudioVolumeType");
 
 	SetVolumeWidget(volType);
 

--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -511,310 +511,352 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	config_t *obs_frontend_get_profile_config(void) override
 	{
 		return main->basicConfig;
-	}
-
-	config_t *obs_frontend_get_global_config(void) override
-	{
-		return App()->GlobalConfig();
-	}
-
-	void obs_frontend_open_projector(const char *type, int monitor,
-					 const char *geometry,
-					 const char *name) override
-	{
-		SavedProjectorInfo proj = {
-			ProjectorType::Preview,
-			monitor,
-			geometry ? geometry : "",
-			name ? name : "",
-		};
-		if (type) {
-			if (astrcmpi(type, "Source") == 0)
-				proj.type = ProjectorType::Source;
-			else if (astrcmpi(type, "Scene") == 0)
-				proj.type = ProjectorType::Scene;
-			else if (astrcmpi(type, "StudioProgram") == 0)
-				proj.type = ProjectorType::StudioProgram;
-			else if (astrcmpi(type, "Multiview") == 0)
-				proj.type = ProjectorType::Multiview;
-		}
-		QMetaObject::invokeMethod(main, "OpenSavedProjector",
-					  WaitConnection(),
-					  Q_ARG(SavedProjectorInfo *, &proj));
-	}
-
-	void obs_frontend_save(void) override { main->SaveProject(); }
-
-	void obs_frontend_defer_save_begin(void) override
-	{
-		QMetaObject::invokeMethod(main, "DeferSaveBegin");
-	}
-
-	void obs_frontend_defer_save_end(void) override
-	{
-		QMetaObject::invokeMethod(main, "DeferSaveEnd");
-	}
-
-	void obs_frontend_add_save_callback(obs_frontend_save_cb callback,
-					    void *private_data) override
-	{
-		size_t idx =
-			GetCallbackIdx(saveCallbacks, callback, private_data);
-		if (idx == (size_t)-1)
-			saveCallbacks.emplace_back(callback, private_data);
-	}
-
-	void obs_frontend_remove_save_callback(obs_frontend_save_cb callback,
-					       void *private_data) override
-	{
-		size_t idx =
-			GetCallbackIdx(saveCallbacks, callback, private_data);
-		if (idx == (size_t)-1)
-			return;
-
-		saveCallbacks.erase(saveCallbacks.begin() + idx);
-	}
-
-	void obs_frontend_add_preload_callback(obs_frontend_save_cb callback,
-					       void *private_data) override
-	{
-		size_t idx = GetCallbackIdx(preloadCallbacks, callback,
-					    private_data);
-		if (idx == (size_t)-1)
-			preloadCallbacks.emplace_back(callback, private_data);
-	}
-
-	void obs_frontend_remove_preload_callback(obs_frontend_save_cb callback,
-						  void *private_data) override
-	{
-		size_t idx = GetCallbackIdx(preloadCallbacks, callback,
-					    private_data);
-		if (idx == (size_t)-1)
-			return;
-
-		preloadCallbacks.erase(preloadCallbacks.begin() + idx);
-	}
-
-	void obs_frontend_push_ui_translation(
-		obs_frontend_translate_ui_cb translate) override
-	{
-		App()->PushUITranslation(translate);
-	}
-
-	void obs_frontend_pop_ui_translation(void) override
-	{
-		App()->PopUITranslation();
-	}
-
-	void obs_frontend_set_streaming_service(obs_service_t *service) override
-	{
-		main->SetService(service);
-	}
-
-	obs_service_t *obs_frontend_get_streaming_service(void) override
-	{
-		return main->GetService();
-	}
-
-	void obs_frontend_save_streaming_service(void) override
-	{
-		main->SaveService();
-	}
-
-	bool obs_frontend_preview_program_mode_active(void) override
-	{
-		return main->IsPreviewProgramMode();
-	}
-
-	void obs_frontend_set_preview_program_mode(bool enable) override
-	{
-		main->SetPreviewProgramMode(enable);
-	}
-
-	void obs_frontend_preview_program_trigger_transition(void) override
-	{
-		QMetaObject::invokeMethod(main, "TransitionClicked");
-	}
-
-	bool obs_frontend_preview_enabled(void) override
-	{
-		return main->previewEnabled;
-	}
-
-	void obs_frontend_set_preview_enabled(bool enable) override
-	{
-		if (main->previewEnabled != enable)
-			main->EnablePreviewDisplay(enable);
-	}
-
-	obs_source_t *obs_frontend_get_current_preview_scene(void) override
-	{
-		if (main->IsPreviewProgramMode()) {
-			OBSSource source = main->GetCurrentSceneSource();
-			return obs_source_get_ref(source);
+		config_t *obs_frontend_get_global_config(void) override
+		{
+			blog(LOG_WARNING,
+			     "DEPRECATION: obs_frontend_get_global_config is deprecated. Read from global or user configuration explicitly instead.");
+			return App()->GetAppConfig();
 		}
 
-		return nullptr;
-	}
+		config_t *obs_frontend_get_app_config(void) override
+		{
+			return App()->GetAppConfig();
+		}
 
-	void
-	obs_frontend_set_current_preview_scene(obs_source_t *scene) override
-	{
-		if (main->IsPreviewProgramMode()) {
-			QMetaObject::invokeMethod(main, "SetCurrentScene",
+		config_t *obs_frontend_get_user_config(void) override
+		{
+			return App()->GetUserConfig();
+		}
+
+		void obs_frontend_open_projector(const char *type, int monitor,
+						 const char *geometry,
+						 const char *name) override
+		{
+			SavedProjectorInfo proj = {
+				ProjectorType::Preview,
+				monitor,
+				geometry ? geometry : "",
+				name ? name : "",
+			};
+			if (type) {
+				if (astrcmpi(type, "Source") == 0)
+					proj.type = ProjectorType::Source;
+				else if (astrcmpi(type, "Scene") == 0)
+					proj.type = ProjectorType::Scene;
+				else if (astrcmpi(type, "StudioProgram") == 0)
+					proj.type =
+						ProjectorType::StudioProgram;
+				else if (astrcmpi(type, "Multiview") == 0)
+					proj.type = ProjectorType::Multiview;
+			}
+			QMetaObject::invokeMethod(
+				main, "OpenSavedProjector", WaitConnection(),
+				Q_ARG(SavedProjectorInfo *, &proj));
+		}
+
+		void obs_frontend_save(void) override
+		{
+			main->SaveProject();
+		}
+
+		void obs_frontend_defer_save_begin(void) override
+		{
+			QMetaObject::invokeMethod(main, "DeferSaveBegin");
+		}
+
+		void obs_frontend_defer_save_end(void) override
+		{
+			QMetaObject::invokeMethod(main, "DeferSaveEnd");
+		}
+
+		void obs_frontend_add_save_callback(
+			obs_frontend_save_cb callback, void *private_data)
+			override
+		{
+			size_t idx = GetCallbackIdx(saveCallbacks, callback,
+						    private_data);
+			if (idx == (size_t)-1)
+				saveCallbacks.emplace_back(callback,
+							   private_data);
+		}
+
+		void obs_frontend_remove_save_callback(
+			obs_frontend_save_cb callback, void *private_data)
+			override
+		{
+			size_t idx = GetCallbackIdx(saveCallbacks, callback,
+						    private_data);
+			if (idx == (size_t)-1)
+				return;
+
+			saveCallbacks.erase(saveCallbacks.begin() + idx);
+		}
+
+		void obs_frontend_add_preload_callback(
+			obs_frontend_save_cb callback, void *private_data)
+			override
+		{
+			size_t idx = GetCallbackIdx(preloadCallbacks, callback,
+						    private_data);
+			if (idx == (size_t)-1)
+				preloadCallbacks.emplace_back(callback,
+							      private_data);
+		}
+
+		void obs_frontend_remove_preload_callback(
+			obs_frontend_save_cb callback, void *private_data)
+			override
+		{
+			size_t idx = GetCallbackIdx(preloadCallbacks, callback,
+						    private_data);
+			if (idx == (size_t)-1)
+				return;
+
+			preloadCallbacks.erase(preloadCallbacks.begin() + idx);
+		}
+
+		void obs_frontend_push_ui_translation(
+			obs_frontend_translate_ui_cb translate) override
+		{
+			App()->PushUITranslation(translate);
+		}
+
+		void obs_frontend_pop_ui_translation(void) override
+		{
+			App()->PopUITranslation();
+		}
+
+		void obs_frontend_set_streaming_service(obs_service_t * service)
+			override
+		{
+			main->SetService(service);
+		}
+
+		obs_service_t *obs_frontend_get_streaming_service(void) override
+		{
+			return main->GetService();
+		}
+
+		void obs_frontend_save_streaming_service(void) override
+		{
+			main->SaveService();
+		}
+
+		bool obs_frontend_preview_program_mode_active(void) override
+		{
+			return main->IsPreviewProgramMode();
+		}
+
+		void obs_frontend_set_preview_program_mode(bool enable) override
+		{
+			main->SetPreviewProgramMode(enable);
+		}
+
+		void obs_frontend_preview_program_trigger_transition(void)
+			override
+		{
+			QMetaObject::invokeMethod(main, "TransitionClicked");
+		}
+
+		bool obs_frontend_preview_enabled(void) override
+		{
+			return main->previewEnabled;
+		}
+
+		void obs_frontend_set_preview_enabled(bool enable) override
+		{
+			if (main->previewEnabled != enable)
+				main->EnablePreviewDisplay(enable);
+		}
+
+		obs_source_t *obs_frontend_get_current_preview_scene(void)
+			override
+		{
+			if (main->IsPreviewProgramMode()) {
+				OBSSource source =
+					main->GetCurrentSceneSource();
+				return obs_source_get_ref(source);
+			}
+
+			return nullptr;
+		}
+
+		void obs_frontend_set_current_preview_scene(obs_source_t *
+							    scene) override
+		{
+			if (main->IsPreviewProgramMode()) {
+				QMetaObject::invokeMethod(
+					main, "SetCurrentScene",
+					Q_ARG(OBSSource, OBSSource(scene)),
+					Q_ARG(bool, false));
+			}
+		}
+
+		void obs_frontend_take_screenshot(void) override
+		{
+			QMetaObject::invokeMethod(main, "Screenshot");
+		}
+
+		void obs_frontend_take_source_screenshot(obs_source_t * source)
+			override
+		{
+			QMetaObject::invokeMethod(main, "Screenshot",
 						  Q_ARG(OBSSource,
-							OBSSource(scene)),
-						  Q_ARG(bool, false));
+							OBSSource(source)));
 		}
-	}
 
-	void obs_frontend_take_screenshot(void) override
-	{
-		QMetaObject::invokeMethod(main, "Screenshot");
-	}
-
-	void obs_frontend_take_source_screenshot(obs_source_t *source) override
-	{
-		QMetaObject::invokeMethod(main, "Screenshot",
-					  Q_ARG(OBSSource, OBSSource(source)));
-	}
-
-	obs_output_t *obs_frontend_get_virtualcam_output(void) override
-	{
-		OBSOutput output = main->outputHandler->virtualCam.Get();
-		return obs_output_get_ref(output);
-	}
-
-	void obs_frontend_start_virtualcam(void) override
-	{
-		QMetaObject::invokeMethod(main, "StartVirtualCam");
-	}
-
-	void obs_frontend_stop_virtualcam(void) override
-	{
-		QMetaObject::invokeMethod(main, "StopVirtualCam");
-	}
-
-	bool obs_frontend_virtualcam_active(void) override
-	{
-		return os_atomic_load_bool(&virtualcam_active);
-	}
-
-	void obs_frontend_reset_video(void) override { main->ResetVideo(); }
-
-	void obs_frontend_open_source_properties(obs_source_t *source) override
-	{
-		QMetaObject::invokeMethod(main, "OpenProperties",
-					  Q_ARG(OBSSource, OBSSource(source)));
-	}
-
-	void obs_frontend_open_source_filters(obs_source_t *source) override
-	{
-		QMetaObject::invokeMethod(main, "OpenFilters",
-					  Q_ARG(OBSSource, OBSSource(source)));
-	}
-
-	void obs_frontend_open_source_interaction(obs_source_t *source) override
-	{
-		QMetaObject::invokeMethod(main, "OpenInteraction",
-					  Q_ARG(OBSSource, OBSSource(source)));
-	}
-
-	void obs_frontend_open_sceneitem_edit_transform(
-		obs_sceneitem_t *item) override
-	{
-		QMetaObject::invokeMethod(main, "OpenEditTransform",
-					  Q_ARG(OBSSceneItem,
-						OBSSceneItem(item)));
-	}
-
-	char *obs_frontend_get_current_record_output_path(void) override
-	{
-		const char *recordOutputPath = main->GetCurrentOutputPath();
-
-		return bstrdup(recordOutputPath);
-	}
-
-	const char *obs_frontend_get_locale_string(const char *string) override
-	{
-		return Str(string);
-	}
-
-	bool obs_frontend_is_theme_dark(void) override
-	{
-		return App()->IsThemeDark();
-	}
-
-	char *obs_frontend_get_last_recording(void) override
-	{
-		return bstrdup(main->outputHandler->lastRecordingPath.c_str());
-	}
-
-	char *obs_frontend_get_last_screenshot(void) override
-	{
-		return bstrdup(main->lastScreenshot.c_str());
-	}
-
-	char *obs_frontend_get_last_replay(void) override
-	{
-		return bstrdup(main->lastReplay.c_str());
-	}
-
-	void obs_frontend_add_undo_redo_action(const char *name,
-					       const undo_redo_cb undo,
-					       const undo_redo_cb redo,
-					       const char *undo_data,
-					       const char *redo_data,
-					       bool repeatable) override
-	{
-		main->undo_s.add_action(
-			name,
-			[undo](const std::string &data) { undo(data.c_str()); },
-			[redo](const std::string &data) { redo(data.c_str()); },
-			undo_data, redo_data, repeatable);
-	}
-
-	void on_load(obs_data_t *settings) override
-	{
-		for (size_t i = saveCallbacks.size(); i > 0; i--) {
-			auto cb = saveCallbacks[i - 1];
-			cb.callback(settings, false, cb.private_data);
+		obs_output_t *obs_frontend_get_virtualcam_output(void) override
+		{
+			OBSOutput output =
+				main->outputHandler->virtualCam.Get();
+			return obs_output_get_ref(output);
 		}
-	}
 
-	void on_preload(obs_data_t *settings) override
-	{
-		for (size_t i = preloadCallbacks.size(); i > 0; i--) {
-			auto cb = preloadCallbacks[i - 1];
-			cb.callback(settings, false, cb.private_data);
+		void obs_frontend_start_virtualcam(void) override
+		{
+			QMetaObject::invokeMethod(main, "StartVirtualCam");
 		}
-	}
 
-	void on_save(obs_data_t *settings) override
-	{
-		for (size_t i = saveCallbacks.size(); i > 0; i--) {
-			auto cb = saveCallbacks[i - 1];
-			cb.callback(settings, true, cb.private_data);
+		void obs_frontend_stop_virtualcam(void) override
+		{
+			QMetaObject::invokeMethod(main, "StopVirtualCam");
 		}
-	}
 
-	void on_event(enum obs_frontend_event event) override
-	{
-		if (main->disableSaving &&
-		    event != OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP &&
-		    event != OBS_FRONTEND_EVENT_EXIT)
-			return;
-
-		for (size_t i = callbacks.size(); i > 0; i--) {
-			auto cb = callbacks[i - 1];
-			cb.callback(event, cb.private_data);
+		bool obs_frontend_virtualcam_active(void) override
+		{
+			return os_atomic_load_bool(&virtualcam_active);
 		}
-	}
-};
 
-obs_frontend_callbacks *InitializeAPIInterface(OBSBasic *main)
-{
-	obs_frontend_callbacks *api = new OBSStudioAPI(main);
-	obs_frontend_set_callbacks_internal(api);
-	return api;
-}
+		void obs_frontend_reset_video(void) override
+		{
+			main->ResetVideo();
+		}
+
+		void obs_frontend_open_source_properties(obs_source_t * source)
+			override
+		{
+			QMetaObject::invokeMethod(main, "OpenProperties",
+						  Q_ARG(OBSSource,
+							OBSSource(source)));
+		}
+
+		void obs_frontend_open_source_filters(obs_source_t * source)
+			override
+		{
+			QMetaObject::invokeMethod(main, "OpenFilters",
+						  Q_ARG(OBSSource,
+							OBSSource(source)));
+		}
+
+		void obs_frontend_open_source_interaction(obs_source_t * source)
+			override
+		{
+			QMetaObject::invokeMethod(main, "OpenInteraction",
+						  Q_ARG(OBSSource,
+							OBSSource(source)));
+		}
+
+		void obs_frontend_open_sceneitem_edit_transform(
+			obs_sceneitem_t * item) override
+		{
+			QMetaObject::invokeMethod(main, "OpenEditTransform",
+						  Q_ARG(OBSSceneItem,
+							OBSSceneItem(item)));
+		}
+
+		char *obs_frontend_get_current_record_output_path(void) override
+		{
+			const char *recordOutputPath =
+				main->GetCurrentOutputPath();
+
+			return bstrdup(recordOutputPath);
+		}
+
+		const char *obs_frontend_get_locale_string(const char *string)
+			override
+		{
+			return Str(string);
+		}
+
+		bool obs_frontend_is_theme_dark(void) override
+		{
+			return App()->IsThemeDark();
+		}
+
+		char *obs_frontend_get_last_recording(void) override
+		{
+			return bstrdup(
+				main->outputHandler->lastRecordingPath.c_str());
+		}
+
+		char *obs_frontend_get_last_screenshot(void) override
+		{
+			return bstrdup(main->lastScreenshot.c_str());
+		}
+
+		char *obs_frontend_get_last_replay(void) override
+		{
+			return bstrdup(main->lastReplay.c_str());
+		}
+
+		void obs_frontend_add_undo_redo_action(
+			const char *name, const undo_redo_cb undo,
+			const undo_redo_cb redo, const char *undo_data,
+			const char *redo_data, bool repeatable) override
+		{
+			main->undo_s.add_action(
+				name,
+				[undo](const std::string &data) {
+					undo(data.c_str());
+				},
+				[redo](const std::string &data) {
+					redo(data.c_str());
+				},
+				undo_data, redo_data, repeatable);
+		}
+
+		void on_load(obs_data_t * settings) override
+		{
+			for (size_t i = saveCallbacks.size(); i > 0; i--) {
+				auto cb = saveCallbacks[i - 1];
+				cb.callback(settings, false, cb.private_data);
+			}
+		}
+
+		void on_preload(obs_data_t * settings) override
+		{
+			for (size_t i = preloadCallbacks.size(); i > 0; i--) {
+				auto cb = preloadCallbacks[i - 1];
+				cb.callback(settings, false, cb.private_data);
+			}
+		}
+
+		void on_save(obs_data_t * settings) override
+		{
+			for (size_t i = saveCallbacks.size(); i > 0; i--) {
+				auto cb = saveCallbacks[i - 1];
+				cb.callback(settings, true, cb.private_data);
+			}
+		}
+
+		void on_event(enum obs_frontend_event event) override
+		{
+			if (main->disableSaving &&
+			    event !=
+				    OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP &&
+			    event != OBS_FRONTEND_EVENT_EXIT)
+				return;
+
+			for (size_t i = callbacks.size(); i > 0; i--) {
+				auto cb = callbacks[i - 1];
+				cb.callback(event, cb.private_data);
+			}
+		}
+	};
+
+	obs_frontend_callbacks *InitializeAPIInterface(OBSBasic *main)
+	{
+		obs_frontend_callbacks *api = new OBSStudioAPI(main);
+		obs_frontend_set_callbacks_internal(api);
+		return api;
+	}

--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -410,7 +410,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 		stats->setVisible(false);
 		feed->setVisible(false);
 	} else {
-		uint32_t lastVersion = config_get_int(App()->GlobalConfig(),
+		uint32_t lastVersion = config_get_int(App()->GetAppConfig(),
 						      "General", "LastVersion");
 
 		if (lastVersion <= MAKE_SEMANTIC_VERSION(23, 0, 2)) {

--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -113,7 +113,7 @@ ScriptLogWindow::ScriptLogWindow() : QDialog(nullptr)
 
 	resize(600, 400);
 
-	config_t *global_config = obs_frontend_get_global_config();
+	config_t *global_config = obs_frontend_get_user_config();
 	const char *geom =
 		config_get_string(global_config, "ScriptLogWindow", "geometry");
 	if (geom != nullptr) {
@@ -129,7 +129,7 @@ ScriptLogWindow::ScriptLogWindow() : QDialog(nullptr)
 
 ScriptLogWindow::~ScriptLogWindow()
 {
-	config_t *global_config = obs_frontend_get_global_config();
+	config_t *global_config = obs_frontend_get_user_config();
 	config_set_string(global_config, "ScriptLogWindow", "geometry",
 			  saveGeometry().toBase64().constData());
 }
@@ -189,7 +189,7 @@ ScriptsTool::ScriptsTool() : QDialog(nullptr), ui(new Ui_ScriptsTool)
 	RefreshLists();
 
 #if PYTHON_UI
-	config_t *config = obs_frontend_get_global_config();
+	config_t *config = obs_frontend_get_user_config();
 	const char *path =
 		config_get_string(config, "Python", "Path" ARCH_NAME);
 	ui->pythonPath->setText(path);
@@ -207,16 +207,15 @@ ScriptsTool::ScriptsTool() : QDialog(nullptr), ui(new Ui_ScriptsTool)
 				      QSizePolicy::Expanding);
 	ui->propertiesLayout->addWidget(propertiesView);
 
-	config_t *global_config = obs_frontend_get_global_config();
-	int row =
-		config_get_int(global_config, "scripts-tool", "prevScriptRow");
+	config_t *user_config = obs_frontend_get_user_config();
+	int row = config_get_int(user_config, "scripts-tool", "prevScriptRow");
 	ui->scripts->setCurrentRow(row);
 }
 
 ScriptsTool::~ScriptsTool()
 {
-	config_t *global_config = obs_frontend_get_global_config();
-	config_set_int(global_config, "scripts-tool", "prevScriptRow",
+	config_t *user_config = obs_frontend_get_user_config();
+	config_set_int(user_config, "scripts-tool", "prevScriptRow",
 		       ui->scripts->currentRow());
 }
 
@@ -465,7 +464,7 @@ void ScriptsTool::on_pythonPathBrowse_clicked()
 	QByteArray array = newPath.toUtf8();
 	const char *path = array.constData();
 
-	config_t *config = obs_frontend_get_global_config();
+	config_t *config = obs_frontend_get_user_config();
 	config_set_string(config, "Python", "Path" ARCH_NAME, path);
 
 	ui->pythonPath->setText(newPath);
@@ -685,7 +684,7 @@ extern "C" void InitScripts()
 		obs_module_text("Scripts"));
 
 #if PYTHON_UI
-	config_t *config = obs_frontend_get_global_config();
+	config_t *config = obs_frontend_get_user_config();
 	const char *python_path =
 		config_get_string(config, "Python", "Path" ARCH_NAME);
 

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -23,12 +23,12 @@ OBSLogViewer::OBSLogViewer(QWidget *parent)
 	ui->setupUi(this);
 
 	bool showLogViewerOnStartup = config_get_bool(
-		App()->GlobalConfig(), "LogViewer", "ShowLogStartup");
+		App()->GetUserConfig(), "LogViewer", "ShowLogStartup");
 
 	ui->showStartup->setChecked(showLogViewerOnStartup);
 
-	const char *geom = config_get_string(App()->GlobalConfig(), "LogViewer",
-					     "geometry");
+	const char *geom = config_get_string(App()->GetUserConfig(),
+					     "LogViewer", "geometry");
 
 	if (geom != nullptr) {
 		QByteArray ba = QByteArray::fromBase64(QByteArray(geom));
@@ -40,13 +40,13 @@ OBSLogViewer::OBSLogViewer(QWidget *parent)
 
 OBSLogViewer::~OBSLogViewer()
 {
-	config_set_string(App()->GlobalConfig(), "LogViewer", "geometry",
+	config_set_string(App()->GetUserConfig(), "LogViewer", "geometry",
 			  saveGeometry().toBase64().constData());
 }
 
 void OBSLogViewer::on_showStartup_clicked(bool checked)
 {
-	config_set_bool(App()->GlobalConfig(), "LogViewer", "ShowLogStartup",
+	config_set_bool(App()->GetUserConfig(), "LogViewer", "ShowLogStartup",
 			checked);
 }
 
@@ -57,7 +57,7 @@ void OBSLogViewer::InitLog()
 	char logDir[512];
 	std::string path;
 
-	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/logs")) {
+	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs")) {
 		path += logDir;
 		path += "/";
 		path += App()->GetCurrentLog();
@@ -124,7 +124,7 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 void OBSLogViewer::on_openButton_clicked()
 {
 	char logDir[512];
-	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
+	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
 		return;
 
 	const char *log = App()->GetCurrentLog();

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -67,7 +67,7 @@ MediaControls::MediaControls(QWidget *parent)
 	connect(ui->slider, &AbsoluteSlider::sliderMoved, this,
 		&MediaControls::AbsoluteSliderMoved);
 
-	countDownTimer = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	countDownTimer = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "MediaControlsCountdownTimer");
 
 	QAction *restartAction = new QAction(this);
@@ -465,7 +465,7 @@ void MediaControls::on_durationLabel_clicked()
 {
 	countDownTimer = !countDownTimer;
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"MediaControlsCountdownTimer", countDownTimer);
 
 	if (MediaPaused())

--- a/UI/obs-frontend-api/obs-frontend-api.cpp
+++ b/UI/obs-frontend-api/obs-frontend-api.cpp
@@ -394,10 +394,22 @@ config_t *obs_frontend_get_profile_config(void)
 				   : nullptr;
 }
 
+config_t *obs_frontend_get_app_config(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_app_config() : nullptr;
+}
+
+config_t *obs_frontend_get_user_config(void)
+{
+	return !!callbacks_valid() ? c->obs_frontend_get_user_config()
+				   : nullptr;
+}
+
 config_t *obs_frontend_get_global_config(void)
 {
-	return !!callbacks_valid() ? c->obs_frontend_get_global_config()
-				   : nullptr;
+	blog(LOG_WARNING,
+	     "DEPRECATION: obs_frontend_get_global_config is deprecated. Read from global or user configuration explicitly instead.");
+	return !!callbacks_valid() ? c->obs_frontend_get_app_config() : nullptr;
 }
 
 void obs_frontend_open_projector(const char *type, int monitor,

--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -208,7 +208,9 @@ EXPORT obs_output_t *obs_frontend_get_recording_output(void);
 EXPORT obs_output_t *obs_frontend_get_replay_buffer_output(void);
 
 EXPORT config_t *obs_frontend_get_profile_config(void);
-EXPORT config_t *obs_frontend_get_global_config(void);
+OBS_DEPRECATED EXPORT config_t *obs_frontend_get_global_config(void);
+EXPORT config_t *obs_frontend_get_app_config(void);
+EXPORT config_t *obs_frontend_get_user_config(void);
 
 EXPORT void obs_frontend_set_streaming_service(obs_service_t *service);
 EXPORT obs_service_t *obs_frontend_get_streaming_service(void);

--- a/UI/obs-frontend-api/obs-frontend-internal.hpp
+++ b/UI/obs-frontend-api/obs-frontend-internal.hpp
@@ -86,7 +86,11 @@ struct obs_frontend_callbacks {
 	virtual obs_output_t *obs_frontend_get_replay_buffer_output(void) = 0;
 
 	virtual config_t *obs_frontend_get_profile_config(void) = 0;
-	virtual config_t *obs_frontend_get_global_config(void) = 0;
+	OBS_DEPRECATED virtual config_t *
+	obs_frontend_get_global_config(void) = 0;
+
+	virtual config_t *obs_frontend_get_app_config(void) = 0;
+	virtual config_t *obs_frontend_get_user_config(void) = 0;
 
 	virtual void obs_frontend_open_projector(const char *type, int monitor,
 						 const char *geometry,

--- a/UI/platform-windows.cpp
+++ b/UI/platform-windows.cpp
@@ -307,7 +307,7 @@ RunOnceMutex CheckIfAlreadyRunning(bool &already_running)
 		char absPath[512];
 		*path = 0;
 		*absPath = 0;
-		GetConfigPath(path, sizeof(path), "");
+		GetAppConfigPath(path, sizeof(path), "");
 		os_get_abs_path(path, absPath, sizeof(absPath));
 		name = "OBSStudioPortable";
 		name += absPath;

--- a/UI/update/mac-update.cpp
+++ b/UI/update/mac-update.cpp
@@ -18,8 +18,8 @@ static const char *MAC_DEFAULT_BRANCH = "stable";
 
 bool GetBranch(std::string &selectedBranch)
 {
-	const char *config_branch =
-		config_get_string(GetGlobalConfig(), "General", "UpdateBranch");
+	const char *config_branch = config_get_string(
+		App()->GetAppConfig(), "General", "UpdateBranch");
 	if (!config_branch)
 		return true;
 
@@ -70,8 +70,8 @@ try {
 	 * Validate branch selection           */
 
 	if (!GetBranch(branch)) {
-		config_set_string(GetGlobalConfig(), "General", "UpdateBranch",
-				  MAC_DEFAULT_BRANCH);
+		config_set_string(App()->GetAppConfig(), "General",
+				  "UpdateBranch", MAC_DEFAULT_BRANCH);
 		info(QTStr("Updater.BranchNotFound.Title"),
 		     QTStr("Updater.BranchNotFound.Text"));
 	}

--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -147,8 +147,8 @@ std::string GetProgramGUID()
 	/* NOTE: this is an arbitrary random number that we use to count the
 	 * number of unique OBS installations and is not associated with any
 	 * kind of identifiable information */
-	const char *pguid =
-		config_get_string(GetGlobalConfig(), "General", "InstallGUID");
+	const char *pguid = config_get_string(App()->GetAppConfig(), "General",
+					      "InstallGUID");
 	std::string guid;
 	if (pguid)
 		guid = pguid;
@@ -157,7 +157,7 @@ std::string GetProgramGUID()
 		GenerateGUID(guid);
 
 		if (!guid.empty())
-			config_set_string(GetGlobalConfig(), "General",
+			config_set_string(App()->GetAppConfig(), "General",
 					  "InstallGUID", guid.c_str());
 	}
 
@@ -220,7 +220,7 @@ bool FetchAndVerifyFile(const char *name, const char *file, const char *url,
 	uint8_t fileHash[BLAKE2_HASH_LENGTH];
 	bool success;
 
-	BPtr<char> filePath = GetConfigPathPtr(file);
+	BPtr<char> filePath = GetAppConfigPathPtr(file);
 
 	if (!extraHeaders.empty()) {
 		headers.insert(headers.end(), extraHeaders.begin(),

--- a/UI/update/win-update.cpp
+++ b/UI/update/win-update.cpp
@@ -112,8 +112,8 @@ try {
 
 bool GetBranchAndUrl(string &selectedBranch, string &manifestUrl)
 {
-	const char *config_branch =
-		config_get_string(GetGlobalConfig(), "General", "UpdateBranch");
+	const char *config_branch = config_get_string(
+		App()->GetAppConfig(), "General", "UpdateBranch");
 	if (!config_branch)
 		return true;
 
@@ -219,8 +219,8 @@ try {
 	 * check branch and get manifest url   */
 
 	if (!GetBranchAndUrl(branch, manifestUrl)) {
-		config_set_string(GetGlobalConfig(), "General", "UpdateBranch",
-				  WIN_DEFAULT_BRANCH);
+		config_set_string(App()->GetAppConfig(), "General",
+				  "UpdateBranch", WIN_DEFAULT_BRANCH);
 		info(QTStr("Updater.BranchNotFound.Title"),
 		     QTStr("Updater.BranchNotFound.Text"));
 	}
@@ -264,7 +264,7 @@ try {
 	 * skip this version if set to skip    */
 
 	const char *skipUpdateVer = config_get_string(
-		GetGlobalConfig(), "General", "SkipUpdateVersion");
+		App()->GetAppConfig(), "General", "SkipUpdateVersion");
 	if (!manualUpdate && !repairMode && skipUpdateVer &&
 	    updateVer == skipUpdateVer)
 		return;
@@ -288,13 +288,13 @@ try {
 		if (queryResult == OBSUpdate::No) {
 			if (!manualUpdate) {
 				long long t = (long long)time(nullptr);
-				config_set_int(GetGlobalConfig(), "General",
+				config_set_int(App()->GetAppConfig(), "General",
 					       "LastUpdateCheck", t);
 			}
 			return;
 
 		} else if (queryResult == OBSUpdate::Skip) {
-			config_set_string(GetGlobalConfig(), "General",
+			config_set_string(App()->GetAppConfig(), "General",
 					  "SkipUpdateVersion",
 					  updateVer.c_str());
 			return;
@@ -314,7 +314,7 @@ try {
 	 * execute updater                     */
 
 	BPtr<char> updateFilePath =
-		GetConfigPathPtr("obs-studio\\updates\\updater.exe");
+		GetAppConfigPathPtr("obs-studio\\updates\\updater.exe");
 	BPtr<wchar_t> wUpdateFilePath;
 
 	size_t size = os_utf8_to_wcs_ptr(updateFilePath, 0, &wUpdateFilePath);
@@ -366,8 +366,8 @@ try {
 
 	/* force OBS to perform another update check immediately after updating
 	 * in case of issues with the new version */
-	config_set_int(GetGlobalConfig(), "General", "LastUpdateCheck", 0);
-	config_set_string(GetGlobalConfig(), "General", "SkipUpdateVersion",
+	config_set_int(App()->GetAppConfig(), "General", "LastUpdateCheck", 0);
+	config_set_string(App()->GetAppConfig(), "General", "SkipUpdateVersion",
 			  "0");
 
 	QMetaObject::invokeMethod(App()->GetMainWindow(), "close");

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -61,9 +61,10 @@ static void ShowUnassignedWarning(const char *name)
 		msgbox.exec();
 
 		if (cb->isChecked()) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"WarnedAboutUnassignedSources", true);
-			config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+			config_save_safe(App()->GetUserConfig(), "tmp",
+					 nullptr);
 		}
 	};
 
@@ -150,7 +151,7 @@ void VolControl::SetMuted(bool)
 		mute->setCheckState(Qt::PartiallyChecked);
 		/* Show notice about the source no being assigned to any tracks */
 		bool has_shown_warning =
-			config_get_bool(App()->GlobalConfig(), "General",
+			config_get_bool(App()->GetUserConfig(), "General",
 					"WarnedAboutUnassignedSources");
 		if (!has_shown_warning)
 			ShowUnassignedWarning(obs_source_get_name(source));
@@ -459,10 +460,10 @@ void VolumeMeter::setBackgroundNominalColor(QColor c)
 {
 	p_backgroundNominalColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		backgroundNominalColor = color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "MixerGreen"));
+			App()->GetUserConfig(), "Accessibility", "MixerGreen"));
 	} else {
 		backgroundNominalColor = p_backgroundNominalColor;
 	}
@@ -487,10 +488,11 @@ void VolumeMeter::setBackgroundWarningColor(QColor c)
 {
 	p_backgroundWarningColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
-		backgroundWarningColor = color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "MixerYellow"));
+		backgroundWarningColor = color_from_int(
+			config_get_int(App()->GetUserConfig(), "Accessibility",
+				       "MixerYellow"));
 	} else {
 		backgroundWarningColor = p_backgroundWarningColor;
 	}
@@ -515,10 +517,10 @@ void VolumeMeter::setBackgroundErrorColor(QColor c)
 {
 	p_backgroundErrorColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		backgroundErrorColor = color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "MixerRed"));
+			App()->GetUserConfig(), "Accessibility", "MixerRed"));
 	} else {
 		backgroundErrorColor = p_backgroundErrorColor;
 	}
@@ -543,10 +545,10 @@ void VolumeMeter::setForegroundNominalColor(QColor c)
 {
 	p_foregroundNominalColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		foregroundNominalColor = color_from_int(
-			config_get_int(GetGlobalConfig(), "Accessibility",
+			config_get_int(App()->GetUserConfig(), "Accessibility",
 				       "MixerGreenActive"));
 	} else {
 		foregroundNominalColor = p_foregroundNominalColor;
@@ -572,10 +574,10 @@ void VolumeMeter::setForegroundWarningColor(QColor c)
 {
 	p_foregroundWarningColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		foregroundWarningColor = color_from_int(
-			config_get_int(GetGlobalConfig(), "Accessibility",
+			config_get_int(App()->GetUserConfig(), "Accessibility",
 				       "MixerYellowActive"));
 	} else {
 		foregroundWarningColor = p_foregroundWarningColor;
@@ -601,10 +603,11 @@ void VolumeMeter::setForegroundErrorColor(QColor c)
 {
 	p_foregroundErrorColor = std::move(c);
 
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
-		foregroundErrorColor = color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "MixerRedActive"));
+		foregroundErrorColor = color_from_int(
+			config_get_int(App()->GetUserConfig(), "Accessibility",
+				       "MixerRedActive"));
 	} else {
 		foregroundErrorColor = p_foregroundErrorColor;
 	}

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -24,7 +24,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 	sigs.emplace_back(sh, "source_deactivate", OBSSourceRemoved, this);
 
 	VolumeType volType = (VolumeType)config_get_int(
-		GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType");
+		App()->GetUserConfig(), "BasicWindow", "AdvAudioVolumeType");
 
 	if (volType == VolumeType::Percent)
 		ui->usePercent->setChecked(true);
@@ -140,8 +140,8 @@ void OBSBasicAdvAudio::on_usePercent_toggled(bool checked)
 	for (size_t i = 0; i < controls.size(); i++)
 		controls[i]->SetVolumeWidget(type);
 
-	config_set_int(GetGlobalConfig(), "BasicWindow", "AdvAudioVolumeType",
-		       (int)type);
+	config_set_int(App()->GetUserConfig(), "BasicWindow",
+		       "AdvAudioVolumeType", (int)type);
 }
 
 void OBSBasicAdvAudio::on_activeOnly_toggled(bool checked)

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -39,18 +39,24 @@ extern QCefCookieManager *panel_cookies;
 
 /* ------------------------------------------------------------------------- */
 
-#define SERVICE_PATH "service.json"
+constexpr std::string_view OBSServiceFileName = "service.json";
 
 static OBSData OpenServiceSettings(std::string &type)
 {
-	char serviceJsonPath[512];
-	int ret = GetProfilePath(serviceJsonPath, sizeof(serviceJsonPath),
-				 SERVICE_PATH);
-	if (ret <= 0)
-		return OBSData();
+	const OBSBasic *basic =
+		reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	const OBSProfile &currentProfile = basic->GetCurrentProfile();
 
-	OBSDataAutoRelease data =
-		obs_data_create_from_json_file_safe(serviceJsonPath, "bak");
+	const std::filesystem::path jsonFilePath =
+		currentProfile.path /
+		std::filesystem::u8path(OBSServiceFileName);
+
+	if (!std::filesystem::exists(jsonFilePath)) {
+		return OBSData();
+	}
+
+	OBSDataAutoRelease data = obs_data_create_from_json_file_safe(
+		jsonFilePath.u8string().c_str(), "bak");
 
 	obs_data_set_default_string(data, "type", "rtmp_common");
 	type = obs_data_get_string(data, "type");

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -44,10 +44,10 @@ OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 			OBSBasicInteraction::SourceRenamed, this),
 	  eventFilter(BuildEventFilter())
 {
-	int cx = (int)config_get_int(App()->GlobalConfig(), "InteractionWindow",
-				     "cx");
-	int cy = (int)config_get_int(App()->GlobalConfig(), "InteractionWindow",
-				     "cy");
+	int cx = (int)config_get_int(App()->GetUserConfig(),
+				     "InteractionWindow", "cx");
+	int cy = (int)config_get_int(App()->GetUserConfig(),
+				     "InteractionWindow", "cy");
 
 	Qt::WindowFlags flags = windowFlags();
 	Qt::WindowFlags helpFlag = Qt::WindowContextHelpButtonHint;
@@ -166,9 +166,9 @@ void OBSBasicInteraction::closeEvent(QCloseEvent *event)
 	if (!event->isAccepted())
 		return;
 
-	config_set_int(App()->GlobalConfig(), "InteractionWindow", "cx",
+	config_set_int(App()->GetAppConfig(), "InteractionWindow", "cx",
 		       width());
-	config_set_int(App()->GlobalConfig(), "InteractionWindow", "cy",
+	config_set_int(App()->GetAppConfig(), "InteractionWindow", "cy",
 		       height());
 
 	obs_display_remove_draw_callback(ui->preview->GetDisplay(),

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1246,8 +1246,9 @@ bool SimpleOutput::IsVodTrackEnabled(obs_service_t *service)
 		config_get_bool(main->Config(), "SimpleOutput", "UseAdvanced");
 	bool enable = config_get_bool(main->Config(), "SimpleOutput",
 				      "VodTrackEnabled");
-	bool enableForCustomServer = config_get_bool(
-		GetGlobalConfig(), "General", "EnableCustomServerVodTrack");
+	bool enableForCustomServer =
+		config_get_bool(App()->GetUserConfig(), "General",
+				"EnableCustomServerVodTrack");
 
 	OBSDataAutoRelease settings = obs_service_get_settings(service);
 	const char *name = obs_data_get_string(settings, "service");
@@ -2252,8 +2253,9 @@ AdvancedOutput::VodTrackMixerIdx(obs_service_t *service)
 		config_get_bool(main->Config(), "AdvOut", "VodTrackEnabled");
 	int vodTrackIndex =
 		config_get_int(main->Config(), "AdvOut", "VodTrackIndex");
-	bool enableForCustomServer = config_get_bool(
-		GetGlobalConfig(), "General", "EnableCustomServerVodTrack");
+	bool enableForCustomServer =
+		config_get_bool(App()->GetUserConfig(), "General",
+				"EnableCustomServerVodTrack");
 
 	const char *id = obs_service_get_id(service);
 	if (strcmp(id, "rtmp_custom") == 0) {

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -1616,19 +1616,28 @@ struct AdvancedOutput : BasicOutputHandler {
 
 static OBSData GetDataFromJsonFile(const char *jsonFile)
 {
-	char fullPath[512];
+	const OBSBasic *basic =
+		reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	const OBSProfile &currentProfile = basic->GetCurrentProfile();
+
+	const std::filesystem::path jsonFilePath =
+		currentProfile.path / std::filesystem::u8path(jsonFile);
+
 	OBSDataAutoRelease data = nullptr;
 
-	int ret = GetProfilePath(fullPath, sizeof(fullPath), jsonFile);
-	if (ret > 0) {
-		BPtr<char> jsonData = os_quick_read_utf8_file(fullPath);
+	if (!jsonFilePath.empty()) {
+		BPtr<char> jsonData = os_quick_read_utf8_file(
+			jsonFilePath.u8string().c_str());
+
 		if (!!jsonData) {
 			data = obs_data_create_from_json(jsonData);
 		}
 	}
 
-	if (!data)
+	if (!data) {
 		data = obs_data_create();
+	}
 
 	return data.Get();
 }

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -15,6 +15,11 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <map>
+#include <tuple>
 #include <obs.hpp>
 #include <util/platform.h>
 #include <util/util.hpp>
@@ -26,467 +31,773 @@
 #include "window-basic-auto-config.hpp"
 #include "window-namedialog.hpp"
 
+// MARK: Constant Expressions
+
+constexpr std::string_view OBSProfilePath = "/obs-studio/basic/profiles/";
+constexpr std::string_view OBSProfileSettingsFile = "basic.ini";
+
+// MARK: Forward Declarations
+
 extern void DestroyPanelCookieManager();
 extern void DuplicateCurrentCookieProfile(ConfigFile &config);
 extern void CheckExistingCookieId();
 extern void DeleteCookies();
 
-void EnumProfiles(std::function<bool(const char *, const char *)> &&cb)
+// MARK: - Main Profile Management Functions
+
+void OBSBasic::SetupNewProfile(const std::string &profileName, bool useWizard)
 {
-	char path[512];
-	os_glob_t *glob;
+	const OBSProfile &newProfile = CreateProfile(profileName);
 
-	int ret = GetConfigPath(path, sizeof(path),
-				"obs-studio/basic/profiles/*");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profiles config path");
-		return;
-	}
+	config_set_bool(App()->GetUserConfig(), "Basic", "ConfigOnNewProfile",
+			useWizard);
 
-	if (os_glob(path, 0, &glob) != 0) {
-		blog(LOG_WARNING, "Failed to glob profiles");
-		return;
-	}
+	ActivateProfile(newProfile, true);
 
-	for (size_t i = 0; i < glob->gl_pathc; i++) {
-		const char *filePath = glob->gl_pathv[i].path;
-		const char *dirName = strrchr(filePath, '/') + 1;
-
-		if (!glob->gl_pathv[i].directory)
-			continue;
-
-		if (strcmp(dirName, ".") == 0 || strcmp(dirName, "..") == 0)
-			continue;
-
-		std::string file = filePath;
-		file += "/basic.ini";
-
-		ConfigFile config;
-		int ret = config.Open(file.c_str(), CONFIG_OPEN_EXISTING);
-		if (ret != CONFIG_SUCCESS)
-			continue;
-
-		const char *name = config_get_string(config, "General", "Name");
-		if (!name)
-			name = strrchr(filePath, '/') + 1;
-
-		if (!cb(name, filePath))
-			break;
-	}
-
-	os_globfree(glob);
-}
-
-static bool GetProfileDir(const char *findName, const char *&profileDir)
-{
-	bool found = false;
-	auto func = [&](const char *name, const char *path) {
-		if (strcmp(name, findName) == 0) {
-			found = true;
-			profileDir = strrchr(path, '/') + 1;
-			return false;
-		}
-		return true;
-	};
-
-	EnumProfiles(func);
-	return found;
-}
-
-static bool ProfileExists(const char *findName)
-{
-	const char *profileDir = nullptr;
-	return GetProfileDir(findName, profileDir);
-}
-
-static bool AskForProfileName(QWidget *parent, std::string &name,
-			      const char *title, const char *text,
-			      const bool showWizard, bool &wizardChecked,
-			      const char *oldName = nullptr)
-{
-	for (;;) {
-		bool success = false;
-
-		if (showWizard) {
-			success = NameDialog::AskForNameWithOption(
-				parent, title, text, name,
-				QTStr("AddProfile.WizardCheckbox"),
-				wizardChecked, QT_UTF8(oldName));
-		} else {
-			success = NameDialog::AskForName(
-				parent, title, text, name, QT_UTF8(oldName));
-		}
-
-		if (!success) {
-			return false;
-		}
-		if (name.empty()) {
-			OBSMessageBox::warning(parent,
-					       QTStr("NoNameEntered.Title"),
-					       QTStr("NoNameEntered.Text"));
-			continue;
-		}
-		if (ProfileExists(name.c_str())) {
-			OBSMessageBox::warning(parent,
-					       QTStr("NameExists.Title"),
-					       QTStr("NameExists.Text"));
-			continue;
-		}
-		break;
-	}
-	return true;
-}
-
-static bool FindSafeProfileDirName(const std::string &profileName,
-				   std::string &dirName)
-{
-	char path[512];
-	int ret;
-
-	if (ProfileExists(profileName.c_str())) {
-		blog(LOG_WARNING, "Profile '%s' exists", profileName.c_str());
-		return false;
-	}
-
-	if (!GetFileSafeName(profileName.c_str(), dirName)) {
-		blog(LOG_WARNING, "Failed to create safe file name for '%s'",
-		     profileName.c_str());
-		return false;
-	}
-
-	ret = GetConfigPath(path, sizeof(path), "obs-studio/basic/profiles/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profiles config path");
-		return false;
-	}
-
-	dirName.insert(0, path);
-
-	if (!GetClosestUnusedFileName(dirName, nullptr)) {
-		blog(LOG_WARNING, "Failed to get closest file name for %s",
-		     dirName.c_str());
-		return false;
-	}
-
-	dirName.erase(0, ret);
-	return true;
-}
-
-static bool CopyProfile(const char *fromPartial, const char *to)
-{
-	os_glob_t *glob;
-	char path[514];
-	char dir[512];
-	int ret;
-
-	ret = GetConfigPath(dir, sizeof(dir), "obs-studio/basic/profiles/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profiles config path");
-		return false;
-	}
-
-	snprintf(path, sizeof(path), "%s%s/*", dir, fromPartial);
-
-	if (os_glob(path, 0, &glob) != 0) {
-		blog(LOG_WARNING, "Failed to glob profile '%s'", fromPartial);
-		return false;
-	}
-
-	for (size_t i = 0; i < glob->gl_pathc; i++) {
-		const char *filePath = glob->gl_pathv[i].path;
-		if (glob->gl_pathv[i].directory)
-			continue;
-
-		ret = snprintf(path, sizeof(path), "%s/%s", to,
-			       strrchr(filePath, '/') + 1);
-		if (ret > 0) {
-			if (os_copyfile(filePath, path) != 0) {
-				blog(LOG_WARNING,
-				     "CopyProfile: Failed to "
-				     "copy file %s to %s",
-				     filePath, path);
-			}
-		}
-	}
-
-	os_globfree(glob);
-
-	return true;
-}
-
-static bool ProfileNeedsRestart(config_t *newConfig, QString &settings)
-{
-	OBSBasic *main = OBSBasic::Get();
-
-	const char *oldSpeakers =
-		config_get_string(main->Config(), "Audio", "ChannelSetup");
-	uint oldSampleRate =
-		config_get_uint(main->Config(), "Audio", "SampleRate");
-
-	const char *newSpeakers =
-		config_get_string(newConfig, "Audio", "ChannelSetup");
-	uint newSampleRate = config_get_uint(newConfig, "Audio", "SampleRate");
-
-	auto appendSetting = [&settings](const char *name) {
-		settings += QStringLiteral("\n") + QTStr(name);
-	};
-
-	bool result = false;
-	if (oldSpeakers != NULL && newSpeakers != NULL) {
-		result = strcmp(oldSpeakers, newSpeakers) != 0;
-		appendSetting("Basic.Settings.Audio.Channels");
-	}
-	if (oldSampleRate != 0 && newSampleRate != 0) {
-		result |= oldSampleRate != newSampleRate;
-		appendSetting("Basic.Settings.Audio.SampleRate");
-	}
-
-	return result;
-}
-
-bool OBSBasic::AddProfile(bool create_new, const char *title, const char *text,
-			  const char *init_text, bool rename)
-{
-	std::string name;
-
-	bool showWizardChecked = config_get_bool(App()->GlobalConfig(), "Basic",
-						 "ConfigOnNewProfile");
-
-	if (!AskForProfileName(this, name, title, text, create_new,
-			       showWizardChecked, init_text))
-		return false;
-
-	return CreateProfile(name, create_new, showWizardChecked, rename);
-}
-
-bool OBSBasic::CreateProfile(const std::string &newName, bool create_new,
-			     bool showWizardChecked, bool rename)
-{
-	std::string newDir;
-	std::string newPath;
-	ConfigFile config;
-
-	if (!FindSafeProfileDirName(newName, newDir))
-		return false;
-
-	if (create_new) {
-		config_set_bool(App()->GlobalConfig(), "Basic",
-				"ConfigOnNewProfile", showWizardChecked);
-	}
-
-	std::string curDir =
-		config_get_string(App()->GlobalConfig(), "Basic", "ProfileDir");
-
-	char baseDir[512];
-	int ret = GetConfigPath(baseDir, sizeof(baseDir),
-				"obs-studio/basic/profiles/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profiles config path");
-		return false;
-	}
-
-	newPath = baseDir;
-	newPath += newDir;
-
-	if (os_mkdir(newPath.c_str()) < 0) {
-		blog(LOG_WARNING, "Failed to create profile directory '%s'",
-		     newDir.c_str());
-		return false;
-	}
-
-	if (!create_new)
-		CopyProfile(curDir.c_str(), newPath.c_str());
-
-	newPath += "/basic.ini";
-
-	if (config.Open(newPath.c_str(), CONFIG_OPEN_ALWAYS) != 0) {
-		blog(LOG_ERROR, "Failed to open new config file '%s'",
-		     newDir.c_str());
-		return false;
-	}
-
-	if (!rename)
-		OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
-
-	config_set_string(App()->GlobalConfig(), "Basic", "Profile",
-			  newName.c_str());
-	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir",
-			  newDir.c_str());
-
-	Auth::Save();
-	if (create_new) {
-		auth.reset();
-		DestroyPanelCookieManager();
-#ifdef YOUTUBE_ENABLED
-		if (youtubeAppDock)
-			DeleteYouTubeAppDock();
-#endif
-	} else if (!rename) {
-		DuplicateCurrentCookieProfile(config);
-	}
-
-	config_set_string(config, "General", "Name", newName.c_str());
-	basicConfig.SaveSafe("tmp");
-	config.SaveSafe("tmp");
-	config.Swap(basicConfig);
-	InitBasicConfigDefaults();
-	InitBasicConfigDefaults2();
-	RefreshProfiles();
-
-	if (create_new)
-		ResetProfileData();
-
-	blog(LOG_INFO, "Created profile '%s' (%s, %s)", newName.c_str(),
-	     create_new ? "clean" : "duplicate", newDir.c_str());
+	blog(LOG_INFO, "Created profile '%s' (clean, %s)",
+	     newProfile.name.c_str(), newProfile.directoryName.c_str());
 	blog(LOG_INFO, "------------------------------------------------");
 
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
-	UpdateTitleBar();
-	UpdateVolumeControlsDecayRate();
-
-	Auth::Load();
-
-	// Run auto configuration setup wizard when a new profile is made to assist
-	// setting up blank settings
-	if (create_new && showWizardChecked) {
+	if (useWizard) {
 		AutoConfig wizard(this);
 		wizard.setModal(true);
 		wizard.show();
 		wizard.exec();
 	}
+}
 
-	if (!rename) {
-		OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
-		OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
+void OBSBasic::SetupDuplicateProfile(const std::string &profileName)
+{
+	const OBSProfile &newProfile = CreateProfile(profileName);
+	const OBSProfile &currentProfile = GetCurrentProfile();
+
+	const auto copyOptions =
+		std::filesystem::copy_options::recursive |
+		std::filesystem::copy_options::overwrite_existing;
+
+	try {
+		std::filesystem::copy(currentProfile.path, newProfile.path,
+				      copyOptions);
+	} catch (const std::filesystem::filesystem_error &error) {
+		blog(LOG_DEBUG, "%s", error.what());
+		throw std::logic_error(
+			"Failed to copy files for cloned profile: " +
+			newProfile.name);
 	}
-	return true;
+
+	ActivateProfile(newProfile);
+
+	blog(LOG_INFO, "Created profile '%s' (duplicate, %s)",
+	     newProfile.name.c_str(), newProfile.directoryName.c_str());
+	blog(LOG_INFO, "------------------------------------------------");
 }
 
-bool OBSBasic::NewProfile(const QString &name)
+void OBSBasic::SetupRenameProfile(const std::string &profileName)
 {
-	return CreateProfile(name.toStdString(), true, false, false);
+	const OBSProfile &newProfile = CreateProfile(profileName);
+	const OBSProfile currentProfile = GetCurrentProfile();
+
+	const auto copyOptions =
+		std::filesystem::copy_options::recursive |
+		std::filesystem::copy_options::overwrite_existing;
+
+	try {
+		std::filesystem::copy(currentProfile.path, newProfile.path,
+				      copyOptions);
+	} catch (const std::filesystem::filesystem_error &error) {
+		blog(LOG_DEBUG, "%s", error.what());
+		throw std::logic_error("Failed to copy files for profile: " +
+				       currentProfile.name);
+	}
+
+	profiles.erase(currentProfile.name);
+
+	ActivateProfile(newProfile);
+	RemoveProfile(currentProfile);
+
+	blog(LOG_INFO, "Renamed profile '%s' to '%s' (%s)",
+	     currentProfile.name.c_str(), newProfile.name.c_str(),
+	     newProfile.directoryName.c_str());
+	blog(LOG_INFO, "------------------------------------------------");
+
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_RENAMED);
 }
 
-bool OBSBasic::DuplicateProfile(const QString &name)
+// MARK: - Profile File Management Functions
+
+const OBSProfile &OBSBasic::CreateProfile(const std::string &profileName)
 {
-	return CreateProfile(name.toStdString(), false, false, false);
+	if (const auto &foundProfile = GetProfileByName(profileName)) {
+		throw std::invalid_argument("Profile already exists: " +
+					    profileName);
+	}
+
+	std::string directoryName;
+	if (!GetFileSafeName(profileName.c_str(), directoryName)) {
+		throw std::invalid_argument(
+			"Failed to create safe directory for new profile: " +
+			profileName);
+	}
+
+	std::string profileDirectory;
+	profileDirectory.reserve(App()->userProfilesLocation.u8string().size() +
+				 OBSProfilePath.size() + directoryName.size());
+	profileDirectory.append(App()->userProfilesLocation.u8string())
+		.append(OBSProfilePath)
+		.append(directoryName);
+
+	if (!GetClosestUnusedFileName(profileDirectory, nullptr)) {
+		throw std::invalid_argument(
+			"Failed to get closest directory name for new profile: " +
+			profileName);
+	}
+
+	const std::filesystem::path profileDirectoryPath =
+		std::filesystem::u8path(profileDirectory);
+
+	try {
+		std::filesystem::create_directory(profileDirectoryPath);
+	} catch (const std::filesystem::filesystem_error error) {
+		throw std::logic_error(
+			"Failed to create directory for new profile: " +
+			profileDirectory);
+	}
+
+	const std::filesystem::path profileFile =
+		profileDirectoryPath /
+		std::filesystem::u8path(OBSProfileSettingsFile);
+
+	auto [iterator, success] = profiles.try_emplace(
+		profileName,
+		OBSProfile{profileName,
+			   profileDirectoryPath.filename().u8string(),
+			   profileDirectoryPath, profileFile});
+
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
+
+	return iterator->second;
 }
 
-void OBSBasic::DeleteProfile(const char *profileName, const char *profileDir)
+void OBSBasic::RemoveProfile(OBSProfile profile)
 {
-	char profilePath[512];
-	char basePath[512];
+	try {
+		std::filesystem::remove_all(profile.path);
+	} catch (const std::filesystem::filesystem_error &error) {
+		blog(LOG_DEBUG, "%s", error.what());
+		throw std::logic_error("Failed to remove profile directory: " +
+				       profile.directoryName);
+	}
 
-	int ret = GetConfigPath(basePath, sizeof(basePath),
-				"obs-studio/basic/profiles");
-	if (ret <= 0) {
+	blog(LOG_INFO, "------------------------------------------------");
+	blog(LOG_INFO, "Removed profile '%s' (%s)", profile.name.c_str(),
+	     profile.directoryName.c_str());
+	blog(LOG_INFO, "------------------------------------------------");
+}
+
+// MARK: - Profile UI Handling Functions
+
+bool OBSBasic::CreateNewProfile(const QString &name)
+{
+	try {
+		SetupNewProfile(name.toStdString());
+		return true;
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+		return false;
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+		return false;
+	}
+}
+
+bool OBSBasic::CreateDuplicateProfile(const QString &name)
+{
+	try {
+		SetupDuplicateProfile(name.toStdString());
+		return true;
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+		return false;
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+		return false;
+	}
+}
+
+void OBSBasic::DeleteProfile(const QString &name)
+{
+	const std::string_view currentProfileName{
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile")};
+
+	if (currentProfileName == name.toStdString()) {
+		on_actionRemoveProfile_triggered();
+		return;
+	}
+
+	auto foundProfile = GetProfileByName(name.toStdString());
+
+	if (!foundProfile) {
+		blog(LOG_ERROR, "Invalid profile name: %s", QT_TO_UTF8(name));
+		return;
+	}
+
+	RemoveProfile(foundProfile.value());
+	profiles.erase(name.toStdString());
+
+	RefreshProfiles();
+
+	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
+
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
+}
+
+void OBSBasic::ChangeProfile()
+{
+	QAction *action = reinterpret_cast<QAction *>(sender());
+
+	if (!action) {
+		return;
+	}
+
+	const std::string_view currentProfileName{
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile")};
+	const std::string selectedProfileName{action->text().toStdString()};
+
+	if (currentProfileName == selectedProfileName) {
+		action->setChecked(true);
+		return;
+	}
+
+	const std::optional<OBSProfile> foundProfile =
+		GetProfileByName(selectedProfileName);
+
+	if (!foundProfile) {
+		const std::string errorMessage{"Selected profile not found: "};
+
+		throw std::invalid_argument(errorMessage +
+					    currentProfileName.data());
+	}
+
+	const OBSProfile &selectedProfile = foundProfile.value();
+
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
+
+	ActivateProfile(selectedProfile, true);
+
+	blog(LOG_INFO, "Switched to profile '%s' (%s)",
+	     selectedProfile.name.c_str(),
+	     selectedProfile.directoryName.c_str());
+	blog(LOG_INFO, "------------------------------------------------");
+}
+
+void OBSBasic::RefreshProfiles(bool refreshCache)
+{
+	std::string_view currentProfileName{
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile")};
+
+	QList<QAction *> menuActions = ui->profileMenu->actions();
+
+	for (auto &action : menuActions) {
+		QVariant variant = action->property("file_name");
+
+		if (variant.typeName() != nullptr) {
+			delete action;
+		}
+	}
+
+	if (refreshCache) {
+		RefreshProfileCache();
+	}
+
+	size_t numAddedProfiles = 0;
+	for (auto &[profileName, profile] : profiles) {
+		QAction *action =
+			new QAction(QString().fromStdString(profileName), this);
+		action->setProperty(
+			"file_name",
+			QString().fromStdString(profile.directoryName));
+		connect(action, &QAction::triggered, this,
+			&OBSBasic::ChangeProfile);
+		action->setCheckable(true);
+		action->setChecked(profileName == currentProfileName);
+
+		ui->profileMenu->addAction(action);
+
+		numAddedProfiles += 1;
+	}
+
+	ui->actionRemoveProfile->setEnabled(numAddedProfiles > 1);
+}
+
+// MARK: - Profile Cache Functions
+
+/// Refreshes profile cache data with profile state found on local file system.
+void OBSBasic::RefreshProfileCache()
+{
+	std::map<std::string, OBSProfile> foundProfiles{};
+
+	const std::filesystem::path profilesPath =
+		App()->userProfilesLocation /
+		std::filesystem::u8path(OBSProfilePath.substr(1));
+
+	if (!std::filesystem::exists(profilesPath)) {
 		blog(LOG_WARNING, "Failed to get profiles config path");
 		return;
 	}
 
-	ret = snprintf(profilePath, sizeof(profilePath), "%s/%s/*", basePath,
-		       profileDir);
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get path for profile dir '%s'",
-		     profileDir);
-		return;
-	}
-
-	os_glob_t *glob;
-	if (os_glob(profilePath, 0, &glob) != 0) {
-		blog(LOG_WARNING, "Failed to glob profile dir '%s'",
-		     profileDir);
-		return;
-	}
-
-	for (size_t i = 0; i < glob->gl_pathc; i++) {
-		const char *filePath = glob->gl_pathv[i].path;
-
-		if (glob->gl_pathv[i].directory)
+	for (const auto &entry :
+	     std::filesystem::directory_iterator(profilesPath)) {
+		if (!entry.is_directory()) {
 			continue;
+		}
 
-		os_unlink(filePath);
+		std::string profileCandidate;
+		profileCandidate.reserve(entry.path().u8string().size() +
+					 OBSProfileSettingsFile.size() + 1);
+		profileCandidate.append(entry.path().u8string())
+			.append("/")
+			.append(OBSProfileSettingsFile);
+
+		ConfigFile config;
+
+		if (config.Open(profileCandidate.c_str(),
+				CONFIG_OPEN_EXISTING) != CONFIG_SUCCESS) {
+			continue;
+		}
+
+		std::string candidateName;
+		const char *configName =
+			config_get_string(config, "General", "Name");
+
+		if (configName) {
+			candidateName = configName;
+		} else {
+			candidateName = entry.path().filename().u8string();
+		}
+
+		foundProfiles.try_emplace(
+			candidateName,
+			OBSProfile{candidateName,
+				   entry.path().filename().u8string(),
+				   entry.path(), profileCandidate});
 	}
 
-	os_globfree(glob);
+	profiles.swap(foundProfiles);
+}
 
-	ret = snprintf(profilePath, sizeof(profilePath), "%s/%s", basePath,
-		       profileDir);
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get path for profile dir '%s'",
-		     profileDir);
+const OBSProfile &OBSBasic::GetCurrentProfile() const
+{
+	std::string currentProfileName{
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile")};
+
+	if (currentProfileName.empty()) {
+		throw std::invalid_argument(
+			"No valid profile name in configuration Basic->Profile");
+	}
+
+	const auto &foundProfile = profiles.find(currentProfileName);
+
+	if (foundProfile != profiles.end()) {
+		return foundProfile->second;
+	} else {
+		throw std::invalid_argument(
+			"Profile not found in profile list: " +
+			currentProfileName);
+	}
+}
+
+std::optional<OBSProfile>
+OBSBasic::GetProfileByName(const std::string &profileName) const
+{
+	auto foundProfile = profiles.find(profileName);
+
+	if (foundProfile == profiles.end()) {
+		return {};
+	} else {
+		return foundProfile->second;
+	}
+}
+
+std::optional<OBSProfile>
+OBSBasic::GetProfileByDirectoryName(const std::string &directoryName) const
+{
+	for (auto &[iterator, profile] : profiles) {
+		if (profile.directoryName == directoryName) {
+			return profile;
+		}
+	}
+
+	return {};
+}
+
+// MARK: - Qt Slot Functions
+
+void OBSBasic::on_actionNewProfile_triggered()
+{
+	bool useProfileWizard = config_get_bool(App()->GetUserConfig(), "Basic",
+						"ConfigOnNewProfile");
+
+	const OBSPromptCallback profilePromptCallback =
+		[this](const OBSPromptResult &result) {
+			if (GetProfileByName(result.promptValue)) {
+				return false;
+			}
+
+			return true;
+		};
+
+	const OBSPromptRequest request{Str("AddProfile.Title"),
+				       Str("AddProfile.Text"),
+				       "",
+				       true,
+				       Str("AddProfile.WizardCheckbox"),
+				       useProfileWizard};
+
+	OBSPromptResult result = PromptForName(request, profilePromptCallback);
+
+	if (!result.success) {
 		return;
 	}
 
-	os_rmdir(profilePath);
+	try {
+		SetupNewProfile(result.promptValue, result.optionValue);
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
+}
 
-	blog(LOG_INFO, "------------------------------------------------");
-	blog(LOG_INFO, "Removed profile '%s' (%s)", profileName, profileDir);
+void OBSBasic::on_actionDupProfile_triggered()
+{
+	const OBSPromptCallback profilePromptCallback =
+		[this](const OBSPromptResult &result) {
+			if (GetProfileByName(result.promptValue)) {
+				return false;
+			}
+
+			return true;
+		};
+
+	const OBSPromptRequest request{Str("AddProfile.Title"),
+				       Str("AddProfile.Text")};
+
+	OBSPromptResult result = PromptForName(request, profilePromptCallback);
+
+	if (!result.success) {
+		return;
+	}
+
+	try {
+		SetupDuplicateProfile(result.promptValue);
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
+}
+
+void OBSBasic::on_actionRenameProfile_triggered()
+{
+	const std::string currentProfileName =
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile");
+
+	const OBSPromptCallback profilePromptCallback =
+		[this](const OBSPromptResult &result) {
+			if (GetProfileByName(result.promptValue)) {
+				return false;
+			}
+
+			return true;
+		};
+
+	const OBSPromptRequest request{Str("RenameProfile.Title"),
+				       Str("RenameProfile.Text"),
+				       currentProfileName};
+
+	OBSPromptResult result = PromptForName(request, profilePromptCallback);
+
+	if (!result.success) {
+		return;
+	}
+
+	try {
+		SetupRenameProfile(result.promptValue);
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
+}
+
+void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
+{
+	if (profiles.size() < 2) {
+		return;
+	}
+
+	OBSProfile currentProfile;
+
+	try {
+		currentProfile = GetCurrentProfile();
+
+		if (!skipConfirmation) {
+			const QString confirmationText =
+				QTStr("ConfirmRemove.Text")
+					.arg(QString::fromStdString(
+						currentProfile.name));
+
+			const QMessageBox::StandardButton button =
+				OBSMessageBox::question(
+					this, QTStr("ConfirmRemove.Title"),
+					confirmationText);
+
+			if (button == QMessageBox::No) {
+				return;
+			}
+		}
+
+		OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
+
+		profiles.erase(currentProfile.name);
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	} catch (const std::logic_error &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
+
+	const OBSProfile &newProfile = profiles.rbegin()->second;
+
+	ActivateProfile(newProfile, true);
+	RemoveProfile(currentProfile);
+
+#ifdef YOUTUBE_ENABLED
+	if (YouTubeAppDock::IsYTServiceSelected() && !youtubeAppDock)
+		NewYouTubeAppDock();
+#endif
+
+	blog(LOG_INFO, "Switched to profile '%s' (%s)", newProfile.name.c_str(),
+	     newProfile.directoryName.c_str());
 	blog(LOG_INFO, "------------------------------------------------");
 }
 
-void OBSBasic::DeleteProfile(const QString &profileName)
+void OBSBasic::on_actionImportProfile_triggered()
 {
-	std::string name = profileName.toStdString();
-	const char *curName =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
+	const QString home = QDir::homePath();
 
-	if (strcmp(curName, name.c_str()) == 0) {
-		on_actionRemoveProfile_triggered(true);
-		return;
+	const QString sourceDirectory = SelectDirectory(
+		this, QTStr("Basic.MainMenu.Profile.Import"), home);
+
+	if (!sourceDirectory.isEmpty() && !sourceDirectory.isNull()) {
+		const std::filesystem::path sourcePath =
+			std::filesystem::u8path(sourceDirectory.toStdString());
+		const std::string directoryName =
+			sourcePath.filename().string();
+
+		if (auto profile = GetProfileByDirectoryName(directoryName)) {
+			OBSMessageBox::warning(
+				this, QTStr("Basic.MainMenu.Profile.Import"),
+				QTStr("Basic.MainMenu.Profile.Exists"));
+			return;
+		}
+
+		std::string destinationPathString;
+		destinationPathString.reserve(
+			App()->userProfilesLocation.u8string().size() +
+			OBSProfilePath.size() + directoryName.size());
+		destinationPathString
+			.append(App()->userProfilesLocation.u8string())
+			.append(OBSProfilePath)
+			.append(directoryName);
+
+		const std::filesystem::path destinationPath =
+			std::filesystem::u8path(destinationPathString);
+
+		try {
+			std::filesystem::create_directory(destinationPath);
+		} catch (const std::filesystem::filesystem_error &error) {
+			blog(LOG_WARNING,
+			     "Failed to create profile directory '%s':\n%s",
+			     directoryName.c_str(), error.what());
+			return;
+		}
+
+		const std::array<std::pair<std::string, bool>, 4> profileFiles{{
+			{"basic.ini", true},
+			{"service.json", false},
+			{"streamEncoder.json", false},
+			{"recordEncoder.json", false},
+		}};
+
+		for (auto &[file, isMandatory] : profileFiles) {
+			const std::filesystem::path sourceFile =
+				sourcePath / std::filesystem::u8path(file);
+
+			if (!std::filesystem::exists(sourceFile)) {
+				if (isMandatory) {
+					blog(LOG_ERROR,
+					     "Failed to import profile from directory '%s' - necessary file '%s' not found",
+					     directoryName.c_str(),
+					     file.c_str());
+					return;
+				}
+				continue;
+			}
+
+			const std::filesystem::path destinationFile =
+				destinationPath / std::filesystem::u8path(file);
+
+			try {
+				std::filesystem::copy(sourceFile,
+						      destinationFile);
+			} catch (
+				const std::filesystem::filesystem_error &error) {
+				blog(LOG_WARNING,
+				     "Failed to copy import file '%s' for profile '%s':\n%s",
+				     file.c_str(), directoryName.c_str(),
+				     error.what());
+				return;
+			}
+		}
+
+		RefreshProfiles(true);
+	}
+}
+
+void OBSBasic::on_actionExportProfile_triggered()
+{
+	const OBSProfile &currentProfile = GetCurrentProfile();
+
+	const QString home = QDir::homePath();
+
+	const QString destinationDirectory = SelectDirectory(
+		this, QTStr("Basic.MainMenu.Profile.Export"), home);
+
+	const std::array<std::string, 4> profileFiles{"basic.ini",
+						      "service.json",
+						      "streamEncoder.json",
+						      "recordEncoder.json"};
+
+	if (!destinationDirectory.isEmpty() && !destinationDirectory.isNull()) {
+		const std::filesystem::path sourcePath = currentProfile.path;
+		const std::filesystem::path destinationPath =
+			std::filesystem::u8path(
+				destinationDirectory.toStdString()) /
+			std::filesystem::u8path(currentProfile.directoryName);
+
+		if (!std::filesystem::exists(destinationPath)) {
+			std::filesystem::create_directory(destinationPath);
+		}
+
+		std::filesystem::copy_options copyOptions =
+			std::filesystem::copy_options::overwrite_existing;
+
+		for (auto &file : profileFiles) {
+			const std::filesystem::path sourceFile =
+				sourcePath / std::filesystem::u8path(file);
+
+			if (!std::filesystem::exists(sourceFile)) {
+				continue;
+			}
+
+			const std::filesystem::path destinationFile =
+				destinationPath / std::filesystem::u8path(file);
+
+			try {
+				std::filesystem::copy(sourceFile,
+						      destinationFile,
+						      copyOptions);
+			} catch (
+				const std::filesystem::filesystem_error &error) {
+				blog(LOG_WARNING,
+				     "Failed to copy export file '%s' for profile '%s'\n%s",
+				     file.c_str(), currentProfile.name.c_str(),
+				     error.what());
+				return;
+			}
+		}
+	}
+}
+
+// MARK: - Profile Management Helper Functions
+
+void OBSBasic::ActivateProfile(const OBSProfile &profile, bool reset)
+{
+	ConfigFile config;
+	if (config.Open(profile.profileFile.u8string().c_str(),
+			CONFIG_OPEN_ALWAYS) != CONFIG_SUCCESS) {
+		throw std::logic_error(
+			"failed to open configuration file of new profile: " +
+			profile.profileFile.string());
 	}
 
-	const char *profileDir = nullptr;
-	if (!GetProfileDir(name.c_str(), profileDir)) {
-		blog(LOG_WARNING, "Profile '%s' not found", name.c_str());
-		return;
+	config_set_string(config, "General", "Name", profile.name.c_str());
+	config.SaveSafe("tmp");
+
+	std::vector<std::string> restartRequirements;
+
+	if (activeConfiguration) {
+		Auth::Save();
+
+		if (reset) {
+			auth.reset();
+			DestroyPanelCookieManager();
+#ifdef YOUTUBE_ENABLED
+			if (youtubeAppDock) {
+				DeleteYouTubeAppDock();
+			}
+#endif
+		}
+		restartRequirements = GetRestartRequirements(config);
+
+		activeConfiguration.SaveSafe("tmp");
 	}
 
-	if (!profileDir) {
-		blog(LOG_WARNING, "Failed to get profile dir for profile '%s'",
-		     name.c_str());
-		return;
+	activeConfiguration.Swap(config);
+
+	config_set_string(App()->GetUserConfig(), "Basic", "Profile",
+			  profile.name.c_str());
+	config_set_string(App()->GetUserConfig(), "Basic", "ProfileDir",
+			  profile.directoryName.c_str());
+
+	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
+
+	InitBasicConfigDefaults();
+	InitBasicConfigDefaults2();
+
+	if (reset) {
+		ResetProfileData();
 	}
 
-	DeleteProfile(name.c_str(), profileDir);
+	CheckForSimpleModeX264Fallback();
+
 	RefreshProfiles();
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
-}
 
-void OBSBasic::RefreshProfiles()
-{
-	QList<QAction *> menuActions = ui->profileMenu->actions();
-	int count = 0;
+	UpdateTitleBar();
+	UpdateVolumeControlsDecayRate();
 
-	for (int i = 0; i < menuActions.count(); i++) {
-		QVariant v = menuActions[i]->property("file_name");
-		if (v.typeName() != nullptr)
-			delete menuActions[i];
+	Auth::Load();
+
+	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
+
+	if (!restartRequirements.empty()) {
+		std::string requirements = std::accumulate(
+			std::next(restartRequirements.begin()),
+			restartRequirements.end(), restartRequirements[0],
+			[](std::string a, std::string b) {
+				return std::move(a) + "\n" + b;
+			});
+
+		QMessageBox::StandardButton button = OBSMessageBox::question(
+			this, QTStr("Restart"),
+			QTStr("LoadProfileNeedsRestart")
+				.arg(requirements.c_str()));
+
+		if (button == QMessageBox::Yes) {
+			restart = true;
+			close();
+		}
 	}
-
-	const char *curName =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
-
-	auto addProfile = [&](const char *name, const char *path) {
-		std::string file = strrchr(path, '/') + 1;
-
-		QAction *action = new QAction(QT_UTF8(name), this);
-		action->setProperty("file_name", QT_UTF8(path));
-		connect(action, &QAction::triggered, this,
-			&OBSBasic::ChangeProfile);
-		action->setCheckable(true);
-
-		action->setChecked(strcmp(name, curName) == 0);
-
-		ui->profileMenu->addAction(action);
-		count++;
-		return true;
-	};
-
-	EnumProfiles(addProfile);
-
-	ui->actionRemoveProfile->setEnabled(count > 1);
 }
 
 void OBSBasic::ResetProfileData()
@@ -501,9 +812,9 @@ void OBSBasic::ResetProfileData()
 	/* load audio monitoring */
 	if (obs_audio_monitoring_available()) {
 		const char *device_name = config_get_string(
-			basicConfig, "Audio", "MonitoringDeviceName");
-		const char *device_id = config_get_string(basicConfig, "Audio",
-							  "MonitoringDeviceId");
+			activeConfiguration, "Audio", "MonitoringDeviceName");
+		const char *device_id = config_get_string(
+			activeConfiguration, "Audio", "MonitoringDeviceId");
 
 		obs_set_audio_monitoring_device(device_name, device_id);
 
@@ -512,320 +823,44 @@ void OBSBasic::ResetProfileData()
 	}
 }
 
-void OBSBasic::on_actionNewProfile_triggered()
+std::vector<std::string>
+OBSBasic::GetRestartRequirements(const ConfigFile &config) const
 {
-	AddProfile(true, Str("AddProfile.Title"), Str("AddProfile.Text"));
-}
+	std::vector<std::string> result;
 
-void OBSBasic::on_actionDupProfile_triggered()
-{
-	AddProfile(false, Str("AddProfile.Title"), Str("AddProfile.Text"));
-}
+	const char *oldSpeakers =
+		config_get_string(activeConfiguration, "Audio", "ChannelSetup");
+	const char *newSpeakers =
+		config_get_string(config, "Audio", "ChannelSetup");
 
-void OBSBasic::on_actionRenameProfile_triggered()
-{
-	std::string curDir =
-		config_get_string(App()->GlobalConfig(), "Basic", "ProfileDir");
-	std::string curName =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
+	uint64_t oldSampleRate =
+		config_get_uint(activeConfiguration, "Audio", "SampleRate");
+	uint64_t newSampleRate = config_get_uint(config, "Audio", "SampleRate");
 
-	/* Duplicate and delete in case there are any issues in the process */
-	bool success = AddProfile(false, Str("RenameProfile.Title"),
-				  Str("AddProfile.Text"), curName.c_str(),
-				  true);
-	if (success) {
-		DeleteProfile(curName.c_str(), curDir.c_str());
-		RefreshProfiles();
-	}
-
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_RENAMED);
-}
-
-void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
-{
-	std::string newName;
-	std::string newPath;
-	ConfigFile config;
-
-	std::string oldDir =
-		config_get_string(App()->GlobalConfig(), "Basic", "ProfileDir");
-	std::string oldName =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
-
-	auto cb = [&](const char *name, const char *filePath) {
-		if (strcmp(oldName.c_str(), name) != 0) {
-			newName = name;
-			newPath = filePath;
-			return false;
-		}
-
-		return true;
-	};
-
-	EnumProfiles(cb);
-
-	/* this should never be true due to menu item being grayed out */
-	if (newPath.empty())
-		return;
-
-	if (!skipConfirmation) {
-		QString text = QTStr("ConfirmRemove.Text")
-				       .arg(QT_UTF8(oldName.c_str()));
-
-		QMessageBox::StandardButton button = OBSMessageBox::question(
-			this, QTStr("ConfirmRemove.Title"), text);
-		if (button == QMessageBox::No)
-			return;
-	}
-
-	size_t newPath_len = newPath.size();
-	newPath += "/basic.ini";
-
-	if (config.Open(newPath.c_str(), CONFIG_OPEN_ALWAYS) != 0) {
-		blog(LOG_ERROR, "ChangeProfile: Failed to load file '%s'",
-		     newPath.c_str());
-		return;
-	}
-
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
-
-	newPath.resize(newPath_len);
-
-	const char *newDir = strrchr(newPath.c_str(), '/') + 1;
-
-	config_set_string(App()->GlobalConfig(), "Basic", "Profile",
-			  newName.c_str());
-	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
-
-	QString settingsRequiringRestart;
-	bool needsRestart =
-		ProfileNeedsRestart(config, settingsRequiringRestart);
-
-	Auth::Save();
-	auth.reset();
-	DeleteCookies();
-	DestroyPanelCookieManager();
-
-	config.Swap(basicConfig);
-	InitBasicConfigDefaults();
-	InitBasicConfigDefaults2();
-	ResetProfileData();
-	DeleteProfile(oldName.c_str(), oldDir.c_str());
-	RefreshProfiles();
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
-
-	blog(LOG_INFO, "Switched to profile '%s' (%s)", newName.c_str(),
-	     newDir);
-	blog(LOG_INFO, "------------------------------------------------");
-
-	UpdateTitleBar();
-	UpdateVolumeControlsDecayRate();
-
-	Auth::Load();
-
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_LIST_CHANGED);
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
-
-	if (needsRestart) {
-		QMessageBox::StandardButton button = OBSMessageBox::question(
-			this, QTStr("Restart"),
-			QTStr("LoadProfileNeedsRestart")
-				.arg(settingsRequiringRestart));
-
-		if (button == QMessageBox::Yes) {
-			restart = true;
-			close();
+	if (oldSpeakers != NULL && newSpeakers != NULL) {
+		if (std::string_view{oldSpeakers} !=
+		    std::string_view{newSpeakers}) {
+			result.emplace_back(
+				Str("Basic.Settings.Audio.Channels"));
 		}
 	}
-}
 
-void OBSBasic::on_actionImportProfile_triggered()
-{
-	char path[512];
-
-	QString home = QDir::homePath();
-
-	int ret = GetConfigPath(path, 512, "obs-studio/basic/profiles/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profile config path");
-		return;
-	}
-
-	QString dir = SelectDirectory(
-		this, QTStr("Basic.MainMenu.Profile.Import"), home);
-
-	if (!dir.isEmpty() && !dir.isNull()) {
-		QString inputPath = QString::fromUtf8(path);
-		QFileInfo finfo(dir);
-		QString directory = finfo.fileName();
-		QString profileDir = inputPath + directory;
-
-		if (ProfileExists(directory.toStdString().c_str())) {
-			OBSMessageBox::warning(
-				this, QTStr("Basic.MainMenu.Profile.Import"),
-				QTStr("Basic.MainMenu.Profile.Exists"));
-		} else if (os_mkdir(profileDir.toStdString().c_str()) < 0) {
-			blog(LOG_WARNING,
-			     "Failed to create profile directory '%s'",
-			     directory.toStdString().c_str());
-		} else {
-			QFile::copy(dir + "/basic.ini",
-				    profileDir + "/basic.ini");
-			QFile::copy(dir + "/service.json",
-				    profileDir + "/service.json");
-			QFile::copy(dir + "/streamEncoder.json",
-				    profileDir + "/streamEncoder.json");
-			QFile::copy(dir + "/recordEncoder.json",
-				    profileDir + "/recordEncoder.json");
-			RefreshProfiles();
+	if (oldSampleRate != 0 && newSampleRate != 0) {
+		if (oldSampleRate != newSampleRate) {
+			result.emplace_back(
+				Str("Basic.Settings.Audio.SampleRate"));
 		}
 	}
-}
 
-void OBSBasic::on_actionExportProfile_triggered()
-{
-	char path[512];
-
-	QString home = QDir::homePath();
-
-	QString currentProfile = QString::fromUtf8(config_get_string(
-		App()->GlobalConfig(), "Basic", "ProfileDir"));
-
-	int ret = GetConfigPath(path, 512, "obs-studio/basic/profiles/");
-	if (ret <= 0) {
-		blog(LOG_WARNING, "Failed to get profile config path");
-		return;
-	}
-
-	QString dir = SelectDirectory(
-		this, QTStr("Basic.MainMenu.Profile.Export"), home);
-
-	if (!dir.isEmpty() && !dir.isNull()) {
-		QString outputDir = dir + "/" + currentProfile;
-		QString inputPath = QString::fromUtf8(path);
-		QDir folder(outputDir);
-
-		if (!folder.exists()) {
-			folder.mkpath(outputDir);
-		} else {
-			if (QFile::exists(outputDir + "/basic.ini"))
-				QFile::remove(outputDir + "/basic.ini");
-
-			if (QFile::exists(outputDir + "/service.json"))
-				QFile::remove(outputDir + "/service.json");
-
-			if (QFile::exists(outputDir + "/streamEncoder.json"))
-				QFile::remove(outputDir +
-					      "/streamEncoder.json");
-
-			if (QFile::exists(outputDir + "/recordEncoder.json"))
-				QFile::remove(outputDir +
-					      "/recordEncoder.json");
-		}
-
-		QFile::copy(inputPath + currentProfile + "/basic.ini",
-			    outputDir + "/basic.ini");
-		QFile::copy(inputPath + currentProfile + "/service.json",
-			    outputDir + "/service.json");
-		QFile::copy(inputPath + currentProfile + "/streamEncoder.json",
-			    outputDir + "/streamEncoder.json");
-		QFile::copy(inputPath + currentProfile + "/recordEncoder.json",
-			    outputDir + "/recordEncoder.json");
-	}
-}
-
-void OBSBasic::ChangeProfile()
-{
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	ConfigFile config;
-	std::string path;
-
-	if (!action)
-		return;
-
-	path = QT_TO_UTF8(action->property("file_name").value<QString>());
-	if (path.empty())
-		return;
-
-	const char *oldName =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
-	if (action->text().compare(QT_UTF8(oldName)) == 0) {
-		action->setChecked(true);
-		return;
-	}
-
-	size_t path_len = path.size();
-	path += "/basic.ini";
-
-	if (config.Open(path.c_str(), CONFIG_OPEN_ALWAYS) != 0) {
-		blog(LOG_ERROR, "ChangeProfile: Failed to load file '%s'",
-		     path.c_str());
-		return;
-	}
-
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGING);
-
-	path.resize(path_len);
-
-	const char *newName = config_get_string(config, "General", "Name");
-	const char *newDir = strrchr(path.c_str(), '/') + 1;
-
-	QString settingsRequiringRestart;
-	bool needsRestart =
-		ProfileNeedsRestart(config, settingsRequiringRestart);
-
-	config_set_string(App()->GlobalConfig(), "Basic", "Profile", newName);
-	config_set_string(App()->GlobalConfig(), "Basic", "ProfileDir", newDir);
-
-	Auth::Save();
-	auth.reset();
-	DestroyPanelCookieManager();
-#ifdef YOUTUBE_ENABLED
-	if (youtubeAppDock)
-		DeleteYouTubeAppDock();
-#endif
-
-	config.Swap(basicConfig);
-	InitBasicConfigDefaults();
-	InitBasicConfigDefaults2();
-	ResetProfileData();
-	RefreshProfiles();
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
-	UpdateTitleBar();
-	UpdateVolumeControlsDecayRate();
-
-	Auth::Load();
-#ifdef YOUTUBE_ENABLED
-	if (YouTubeAppDock::IsYTServiceSelected() && !youtubeAppDock)
-		NewYouTubeAppDock();
-#endif
-
-	CheckForSimpleModeX264Fallback();
-
-	blog(LOG_INFO, "Switched to profile '%s' (%s)", newName, newDir);
-	blog(LOG_INFO, "------------------------------------------------");
-
-	OnEvent(OBS_FRONTEND_EVENT_PROFILE_CHANGED);
-
-	if (needsRestart) {
-		QMessageBox::StandardButton button = OBSMessageBox::question(
-			this, QTStr("Restart"),
-			QTStr("LoadProfileNeedsRestart")
-				.arg(settingsRequiringRestart));
-
-		if (button == QMessageBox::Yes) {
-			restart = true;
-			close();
-		}
-	}
+	return result;
 }
 
 void OBSBasic::CheckForSimpleModeX264Fallback()
 {
-	const char *curStreamEncoder =
-		config_get_string(basicConfig, "SimpleOutput", "StreamEncoder");
-	const char *curRecEncoder =
-		config_get_string(basicConfig, "SimpleOutput", "RecEncoder");
+	const char *curStreamEncoder = config_get_string(
+		activeConfiguration, "SimpleOutput", "StreamEncoder");
+	const char *curRecEncoder = config_get_string(
+		activeConfiguration, "SimpleOutput", "RecEncoder");
 	bool qsv_supported = false;
 	bool qsv_av1_supported = false;
 	bool amd_supported = false;
@@ -941,11 +976,12 @@ void OBSBasic::CheckForSimpleModeX264Fallback()
 	};
 
 	if (!CheckEncoder(curStreamEncoder))
-		config_set_string(basicConfig, "SimpleOutput", "StreamEncoder",
-				  curStreamEncoder);
+		config_set_string(activeConfiguration, "SimpleOutput",
+				  "StreamEncoder", curStreamEncoder);
 	if (!CheckEncoder(curRecEncoder))
-		config_set_string(basicConfig, "SimpleOutput", "RecEncoder",
-				  curRecEncoder);
-	if (changed)
-		config_save_safe(basicConfig, "tmp", nullptr);
+		config_set_string(activeConfiguration, "SimpleOutput",
+				  "RecEncoder", curRecEncoder);
+	if (changed) {
+		activeConfiguration.SaveSafe("tmp");
+	}
 }

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -1839,10 +1839,11 @@ int OBSBasic::GetOverrideTransitionDuration(OBSSource source)
 
 void OBSBasic::UpdatePreviewProgramIndicators()
 {
-	bool labels = previewProgramMode ? config_get_bool(GetGlobalConfig(),
-							   "BasicWindow",
-							   "StudioModeLabels")
-					 : false;
+	bool labels = previewProgramMode
+			      ? config_get_bool(App()->GetUserConfig(),
+						"BasicWindow",
+						"StudioModeLabels")
+			      : false;
 
 	ui->previewLabel->setVisible(labels);
 

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2332,28 +2332,12 @@ void OBSBasic::OBSInit()
 {
 	ProfileScope("OBSBasic::OBSInit");
 
-	const char *sceneCollection = config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollectionFile");
-	char savePath[1024];
-	char fileName[1024];
-	int ret;
-
-	if (!sceneCollection)
-		throw "Failed to get scene collection name";
-
-	ret = snprintf(fileName, sizeof(fileName),
-		       "obs-studio/basic/scenes/%s.json", sceneCollection);
-	if (ret <= 0)
-		throw "Failed to create scene collection file name";
-
-	ret = GetConfigPath(savePath, sizeof(savePath), fileName);
-	if (ret <= 0)
-		throw "Failed to get scene collection json file path";
-
 	if (!InitBasicConfig())
 		throw "Failed to load basic.ini";
 	if (!ResetAudio())
 		throw "Failed to initialize audio";
+
+	int ret = 0;
 
 	ret = ResetVideo();
 
@@ -2400,6 +2384,12 @@ void OBSBasic::OBSInit()
 	} else {
 		AddExtraModulePaths();
 	}
+
+	/* Modules can access frontend information (i.e. profile and scene collection data) during their initialization, and some modules (e.g. obs-websockets) are known to use the filesystem location of the current profile in their own code.
+     
+     Thus the profile and scene collection discovery needs to happen before any access to that information (but after intializing global settings) to ensure legacy code gets valid path information.
+     */
+	RefreshSceneCollections(true);
 
 	blog(LOG_INFO, "---------------------------------");
 	obs_load_all_modules2(&mfi);
@@ -2482,7 +2472,19 @@ void OBSBasic::OBSInit()
 	{
 		ProfileScope("OBSBasic::Load");
 		disableSaving--;
-		Load(savePath);
+
+		try {
+			const OBSSceneCollection &currentCollection =
+				GetCurrentSceneCollection();
+			ActivateSceneCollection(currentCollection);
+		} catch (const std::invalid_argument &) {
+			const std::string collectionName =
+				config_get_string(App()->GetUserConfig(),
+						  "Basic", "SceneCollection");
+
+			SetupNewSceneCollection(collectionName);
+		}
+
 		disableSaving++;
 	}
 
@@ -2500,7 +2502,6 @@ void OBSBasic::OBSInit()
 					  Qt::QueuedConnection,
 					  Q_ARG(bool, true));
 
-	RefreshSceneCollections();
 	disableSaving--;
 
 	auto addDisplay = [this](OBSQTDisplay *window) {
@@ -3411,26 +3412,14 @@ void OBSBasic::SaveProjectDeferred()
 
 	projectChanged = false;
 
-	const char *sceneCollection = config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollectionFile");
+	try {
+		const OBSSceneCollection &currentCollection =
+			GetCurrentSceneCollection();
 
-	char savePath[1024];
-	char fileName[1024];
-	int ret;
-
-	if (!sceneCollection)
-		return;
-
-	ret = snprintf(fileName, sizeof(fileName),
-		       "obs-studio/basic/scenes/%s.json", sceneCollection);
-	if (ret <= 0)
-		return;
-
-	ret = GetConfigPath(savePath, sizeof(savePath), fileName);
-	if (ret <= 0)
-		return;
-
-	Save(savePath);
+		Save(currentCollection.collectionFile.u8string().c_str());
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
 }
 
 OBSSource OBSBasic::GetProgramSource()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -191,11 +191,11 @@ static void AddExtraModulePaths()
 	int ret = GetProgramDataPath(base_module_dir, sizeof(base_module_dir),
 				     "obs-studio/plugins/%module%");
 #elif defined(__APPLE__)
-	int ret = GetConfigPath(base_module_dir, sizeof(base_module_dir),
-				"obs-studio/plugins/%module%.plugin");
+	int ret = GetAppConfigPath(base_module_dir, sizeof(base_module_dir),
+				   "obs-studio/plugins/%module%.plugin");
 #else
-	int ret = GetConfigPath(base_module_dir, sizeof(base_module_dir),
-				"obs-studio/plugins/%module%");
+	int ret = GetAppConfigPath(base_module_dir, sizeof(base_module_dir),
+				   "obs-studio/plugins/%module%");
 #endif
 
 	if (ret <= 0)
@@ -219,8 +219,8 @@ static void AddExtraModulePaths()
 
 	/* Legacy User Application Support Search Path */
 	char user_legacy_module_dir[PATH_MAX];
-	GetConfigPath(user_legacy_module_dir, sizeof(user_legacy_module_dir),
-		      "obs-studio/plugins/%module%");
+	GetAppConfigPath(user_legacy_module_dir, sizeof(user_legacy_module_dir),
+			 "obs-studio/plugins/%module%");
 	std::string path_user_legacy = user_legacy_module_dir;
 	obs_add_module_path((path_user_legacy + "/bin").c_str(),
 			    (path_user_legacy + "/data").c_str());
@@ -446,7 +446,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	ui->scenes->setAttribute(Qt::WA_MacShowFocusRect, false);
 	ui->sources->setAttribute(Qt::WA_MacShowFocusRect, false);
 
-	bool sceneGrid = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	bool sceneGrid = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "gridMode");
 	ui->scenes->SetGridMode(sceneGrid);
 
@@ -602,7 +602,7 @@ OBSBasic::OBSBasic(QWidget *parent)
 	QPoint curPos;
 
 	//restore parent window geometry
-	const char *geometry = config_get_string(App()->GlobalConfig(),
+	const char *geometry = config_get_string(App()->GetUserConfig(),
 						 "BasicWindow", "geometry");
 	if (geometry != NULL) {
 		QByteArray byteArray =
@@ -726,7 +726,7 @@ static obs_data_t *GenerateSaveData(obs_data_array_t *sceneOrder,
 	const char *programName = obs_source_get_name(curProgramScene);
 
 	const char *sceneCollection = config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollection");
+		App()->GetUserConfig(), "Basic", "SceneCollection");
 
 	obs_data_set_string(saveData, "current_scene", sceneName);
 	obs_data_set_string(saveData, "current_program_scene", programName);
@@ -1244,12 +1244,16 @@ void OBSBasic::Load(const char *file, bool remigrate)
 			}
 		}
 
-		config_set_string(App()->GlobalConfig(), "Basic",
+		config_set_string(App()->GetUserConfig(), "Basic",
 				  "SceneCollection", name.c_str());
-		config_set_string(App()->GlobalConfig(), "Basic",
+		config_set_string(App()->GetUserConfig(), "Basic",
 				  "SceneCollectionFile", name.c_str());
 		blog(LOG_INFO, "No scene file found, creating default scene");
-		CreateDefaultScene(true);
+
+		bool hasFirstRun = config_get_bool(App()->GetUserConfig(),
+						   "General", "FirstRun");
+
+		CreateDefaultScene(!hasFirstRun);
 		SaveProject();
 		return;
 	}
@@ -1342,7 +1346,7 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file, bool remigrate)
 		transitionName = obs_source_get_name(fadeTransition);
 
 	const char *curSceneCollection = config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollection");
+		App()->GetUserConfig(), "Basic", "SceneCollection");
 
 	obs_data_set_default_string(data, "name", curSceneCollection);
 
@@ -1475,8 +1479,8 @@ retryScene:
 
 	/* ------------------- */
 
-	bool projectorSave = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					     "SaveProjectors");
+	bool projectorSave = config_get_bool(App()->GetUserConfig(),
+					     "BasicWindow", "SaveProjectors");
 
 	if (projectorSave) {
 		OBSDataArrayAutoRelease savedProjectors =
@@ -1494,10 +1498,10 @@ retryScene:
 	std::string file_base = strrchr(file, '/') + 1;
 	file_base.erase(file_base.size() - 5, 5);
 
-	config_set_string(App()->GlobalConfig(), "Basic", "SceneCollection",
+	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollection",
 			  name);
-	config_set_string(App()->GlobalConfig(), "Basic", "SceneCollectionFile",
-			  file_base.c_str());
+	config_set_string(App()->GetUserConfig(), "Basic",
+			  "SceneCollectionFile", file_base.c_str());
 
 	OBSDataArrayAutoRelease quickTransitionData =
 		obs_data_get_array(data, "quick_transitions");
@@ -1733,7 +1737,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	cy *= devicePixelRatioF();
 
 	bool oldResolutionDefaults = config_get_bool(
-		App()->GlobalConfig(), "General", "Pre19Defaults");
+		App()->GetUserConfig(), "General", "Pre19Defaults");
 
 	/* use 1920x1080 for new default base res if main monitor is above
 	 * 1920x1080, but don't apply for people from older builds -- only to
@@ -1774,7 +1778,7 @@ bool OBSBasic::InitBasicConfigDefaults()
 	/* ----------------------------------------------------- */
 	/* set twitch chat extensions to "both" if prev version  */
 	/* is under 24.1                                         */
-	if (config_get_bool(GetGlobalConfig(), "General", "Pre24.1Defaults") &&
+	if (config_get_bool(App()->GetUserConfig(), "General",
 	    !config_has_user_value(basicConfig, "Twitch", "AddonChoice")) {
 		config_set_int(basicConfig, "Twitch", "AddonChoice", 3);
 		changed = true;
@@ -2036,7 +2040,7 @@ extern bool EncoderAvailable(const char *encoder);
 
 void OBSBasic::InitBasicConfigDefaults2()
 {
-	bool oldEncDefaults = config_get_bool(App()->GlobalConfig(), "General",
+	bool oldEncDefaults = config_get_bool(App()->GetUserConfig(), "General",
 					      "Pre23Defaults");
 	bool useNV = EncoderAvailable("ffmpeg_nvenc") && !oldEncDefaults;
 
@@ -2370,14 +2374,14 @@ void OBSBasic::OBSInit()
 	InitPrimitives();
 
 	sceneDuplicationMode = config_get_bool(
-		App()->GlobalConfig(), "BasicWindow", "SceneDuplicationMode");
-	swapScenesMode = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+		App()->GetUserConfig(), "BasicWindow", "SceneDuplicationMode");
+	swapScenesMode = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "SwapScenesMode");
 	editPropertiesMode = config_get_bool(
-		App()->GlobalConfig(), "BasicWindow", "EditPropertiesMode");
+		App()->GetUserConfig(), "BasicWindow", "EditPropertiesMode");
 
 	if (!opt_studio_mode) {
-		SetPreviewProgramMode(config_get_bool(App()->GlobalConfig(),
+		SetPreviewProgramMode(config_get_bool(App()->GetUserConfig(),
 						      "BasicWindow",
 						      "PreviewProgramMode"));
 	} else {
@@ -2385,14 +2389,14 @@ void OBSBasic::OBSInit()
 		opt_studio_mode = false;
 	}
 
-#define SET_VISIBILITY(name, control)                                         \
-	do {                                                                  \
-		if (config_has_user_value(App()->GlobalConfig(),              \
-					  "BasicWindow", name)) {             \
-			bool visible = config_get_bool(App()->GlobalConfig(), \
-						       "BasicWindow", name);  \
-			ui->control->setChecked(visible);                     \
-		}                                                             \
+#define SET_VISIBILITY(name, control)                                          \
+	do {                                                                   \
+		if (config_has_user_value(App()->GetUserConfig(),              \
+					  "BasicWindow", name)) {              \
+			bool visible = config_get_bool(App()->GetUserConfig(), \
+						       "BasicWindow", name);   \
+			ui->control->setChecked(visible);                      \
+		}                                                              \
 	} while (false)
 
 	SET_VISIBILITY("ShowListboxToolbars", toggleListboxToolbars);
@@ -2400,11 +2404,11 @@ void OBSBasic::OBSInit()
 #undef SET_VISIBILITY
 
 	bool sourceIconsVisible = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ShowSourceIcons");
+		App()->GetUserConfig(), "BasicWindow", "ShowSourceIcons");
 	ui->toggleSourceIcons->setChecked(sourceIconsVisible);
 
 	bool contextVisible = config_get_bool(
-		App()->GlobalConfig(), "BasicWindow", "ShowContextToolbars");
+		App()->GetUserConfig(), "BasicWindow", "ShowContextToolbars");
 	ui->toggleContextBar->setChecked(contextVisible);
 	ui->contextContainer->setVisible(contextVisible);
 	if (contextVisible)
@@ -2420,7 +2424,7 @@ void OBSBasic::OBSInit()
 
 	loaded = true;
 
-	previewEnabled = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	previewEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "PreviewEnabled");
 
 	if (!previewEnabled && !IsPreviewProgramMode())
@@ -2449,10 +2453,10 @@ void OBSBasic::OBSInit()
 
 	/* Show the main window, unless the tray icon isn't available
 	 * or neither the setting nor flag for starting minimized is set. */
-	bool sysTrayEnabled = config_get_bool(App()->GlobalConfig(),
+	bool sysTrayEnabled = config_get_bool(App()->GetUserConfig(),
 					      "BasicWindow", "SysTrayEnabled");
 	bool sysTrayWhenStarted = config_get_bool(
-		App()->GlobalConfig(), "BasicWindow", "SysTrayWhenStarted");
+		App()->GetUserConfig(), "BasicWindow", "SysTrayWhenStarted");
 	bool hideWindowOnStart = QSystemTrayIcon::isSystemTrayAvailable() &&
 				 sysTrayEnabled &&
 				 (opt_minimize_tray || sysTrayWhenStarted);
@@ -2464,8 +2468,8 @@ void OBSBasic::OBSInit()
 		show();
 #endif
 
-	bool alwaysOnTop = config_get_bool(App()->GlobalConfig(), "BasicWindow",
-					   "AlwaysOnTop");
+	bool alwaysOnTop = config_get_bool(App()->GetUserConfig(),
+					   "BasicWindow", "AlwaysOnTop");
 
 #ifdef ENABLE_WAYLAND
 	bool isWayland = obs_get_nix_platform() == OBS_NIX_PLATFORM_WAYLAND;
@@ -2522,7 +2526,7 @@ void OBSBasic::OBSInit()
 #endif
 
 	const char *dockStateStr = config_get_string(
-		App()->GlobalConfig(), "BasicWindow", "DockState");
+		App()->GetUserConfig(), "BasicWindow", "DockState");
 
 	if (!dockStateStr) {
 		on_resetDocks_triggered(true);
@@ -2533,28 +2537,29 @@ void OBSBasic::OBSInit()
 			on_resetDocks_triggered(true);
 	}
 
-	bool pre23Defaults = config_get_bool(App()->GlobalConfig(), "General",
+	bool pre23Defaults = config_get_bool(App()->GetUserConfig(), "General",
 					     "Pre23Defaults");
 	if (pre23Defaults) {
 		bool resetDockLock23 = config_get_bool(
-			App()->GlobalConfig(), "General", "ResetDockLock23");
+			App()->GetUserConfig(), "General", "ResetDockLock23");
 		if (!resetDockLock23) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"ResetDockLock23", true);
-			config_remove_value(App()->GlobalConfig(),
+			config_remove_value(App()->GetUserConfig(),
 					    "BasicWindow", "DocksLocked");
-			config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+			config_save_safe(App()->GetUserConfig(), "tmp",
+					 nullptr);
 		}
 	}
 
-	bool docksLocked = config_get_bool(App()->GlobalConfig(), "BasicWindow",
-					   "DocksLocked");
+	bool docksLocked = config_get_bool(App()->GetUserConfig(),
+					   "BasicWindow", "DocksLocked");
 	on_lockDocks_toggled(docksLocked);
 	ui->lockDocks->blockSignals(true);
 	ui->lockDocks->setChecked(docksLocked);
 	ui->lockDocks->blockSignals(false);
 
-	bool sideDocks = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	bool sideDocks = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "SideDocks");
 	on_sideDocks_toggled(sideDocks);
 	ui->sideDocks->blockSignals(true);
@@ -2569,15 +2574,15 @@ void OBSBasic::OBSInit()
 	disableColorSpaceConversion(this);
 #endif
 
-	bool has_last_version = config_has_user_value(App()->GlobalConfig(),
+	bool has_last_version = config_has_user_value(App()->GetUserConfig(),
 						      "General", "LastVersion");
 	bool first_run =
-		config_get_bool(App()->GlobalConfig(), "General", "FirstRun");
+		config_get_bool(App()->GetUserConfig(), "General", "FirstRun");
 
 	if (!first_run) {
-		config_set_bool(App()->GlobalConfig(), "General", "FirstRun",
+		config_set_bool(App()->GetUserConfig(), "General", "FirstRun",
 				true);
-		config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+		config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 	}
 
 	if (!first_run && !has_last_version && !Active())
@@ -2587,18 +2592,18 @@ void OBSBasic::OBSInit()
 #if (defined(_WIN32) || defined(__APPLE__)) && \
 	(OBS_RELEASE_CANDIDATE > 0 || OBS_BETA > 0)
 	/* Automatically set branch to "beta" the first time a pre-release build is run. */
-	if (!config_get_bool(App()->GlobalConfig(), "General",
+	if (!config_get_bool(App()->GetUserConfig(), "General",
 			     "AutoBetaOptIn")) {
-		config_set_string(App()->GlobalConfig(), "General",
+		config_set_string(App()->GetUserConfig(), "General",
 				  "UpdateBranch", "beta");
-		config_set_bool(App()->GlobalConfig(), "General",
+		config_set_bool(App()->GetUserConfig(), "General",
 				"AutoBetaOptIn", true);
-		config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+		config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 	}
 #endif
 	TimedCheckForUpdates();
 
-	ToggleMixerLayout(config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	ToggleMixerLayout(config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					  "VerticalVolControl"));
 
 	if (config_get_bool(basicConfig, "General", "OpenStatsOnStartup"))
@@ -2707,7 +2712,7 @@ void OBSBasic::OnFirstLoad()
 	Auth::Load();
 
 	bool showLogViewerOnStartup = config_get_bool(
-		App()->GlobalConfig(), "LogViewer", "ShowLogStartup");
+		App()->GetUserConfig(), "LogViewer", "ShowLogStartup");
 
 	if (showLogViewerOnStartup)
 		on_actionViewCurrentLog_triggered();
@@ -2775,28 +2780,28 @@ void OBSBasic::ReceivedIntroJson(const QString &text)
 	constexpr uint64_t currentVersion = (uint64_t)LIBOBS_API_VER << 16ULL |
 					    OBS_RELEASE_CANDIDATE << 8ULL |
 					    OBS_BETA;
-	uint64_t lastVersion = config_get_uint(App()->GlobalConfig(), "General",
+	uint64_t lastVersion = config_get_uint(App()->GetAppConfig(), "General",
 					       lastInfoVersion);
 	int current_version_increment = -1;
 
 	if ((lastVersion & ~0xFFFF0000ULL) <
 	    (currentVersion & ~0xFFFF0000ULL)) {
-		config_set_int(App()->GlobalConfig(), "General",
+		config_set_int(App()->GetAppConfig(), "General",
 			       "InfoIncrement", -1);
-		config_set_uint(App()->GlobalConfig(), "General",
+		config_set_uint(App()->GetAppConfig(), "General",
 				lastInfoVersion, currentVersion);
 	} else {
 		current_version_increment = config_get_int(
-			App()->GlobalConfig(), "General", "InfoIncrement");
+			App()->GetAppConfig(), "General", "InfoIncrement");
 	}
 
 	if (info_increment <= current_version_increment) {
 		return;
 	}
 
-	config_set_int(App()->GlobalConfig(), "General", "InfoIncrement",
+	config_set_int(App()->GetAppConfig(), "General", "InfoIncrement",
 		       info_increment);
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+	config_save_safe(App()->GetAppConfig(), "tmp", nullptr);
 
 	cef->init_browser();
 
@@ -3284,26 +3289,27 @@ OBSBasic::~OBSBasic()
 	 * expect or want it to. */
 	QApplication::sendPostedEvents(nullptr);
 
-	config_set_int(App()->GlobalConfig(), "General", "LastVersion",
+	config_set_int(App()->GetAppConfig(), "General", "LastVersion",
 		       LIBOBS_API_VER);
+	config_save_safe(App()->GetAppConfig(), "tmp", nullptr);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "PreviewEnabled",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "PreviewEnabled",
 			previewEnabled);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "AlwaysOnTop",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "AlwaysOnTop",
 			ui->actionAlwaysOnTop->isChecked());
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"SceneDuplicationMode", sceneDuplicationMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "SwapScenesMode",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "SwapScenesMode",
 			swapScenesMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"EditPropertiesMode", editPropertiesMode);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"PreviewProgramMode", IsPreviewProgramMode());
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "DocksLocked",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "DocksLocked",
 			ui->lockDocks->isChecked());
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "SideDocks",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks",
 			ui->sideDocks->isChecked());
-	config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 
 #ifdef BROWSER_AVAILABLE
 	DestroyPanelCookieManager();
@@ -4027,7 +4033,7 @@ void OBSBasic::VolControlContextMenu()
 	QAction toggleControlLayoutAction(QTStr("VerticalLayout"), this);
 	toggleControlLayoutAction.setCheckable(true);
 	toggleControlLayoutAction.setChecked(config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "VerticalVolControl"));
+		App()->GetUserConfig(), "BasicWindow", "VerticalVolControl"));
 
 	/* ------------------- */
 
@@ -4126,7 +4132,7 @@ void OBSBasic::StackedMixerAreaContextMenuRequested()
 	QAction toggleControlLayoutAction(QTStr("VerticalLayout"), this);
 	toggleControlLayoutAction.setCheckable(true);
 	toggleControlLayoutAction.setChecked(config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "VerticalVolControl"));
+		App()->GetUserConfig(), "BasicWindow", "VerticalVolControl"));
 
 	/* ------------------- */
 
@@ -4166,10 +4172,10 @@ void OBSBasic::ToggleMixerLayout(bool vertical)
 
 void OBSBasic::ToggleVolControlLayout()
 {
-	bool vertical = !config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool vertical = !config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "VerticalVolControl");
-	config_set_bool(GetGlobalConfig(), "BasicWindow", "VerticalVolControl",
-			vertical);
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
+			"VerticalVolControl", vertical);
 	ToggleMixerLayout(vertical);
 
 	// We need to store it so we can delete current and then add
@@ -4193,7 +4199,7 @@ void OBSBasic::ActivateAudioSource(OBSSource source)
 	if (!obs_source_audio_active(source))
 		return;
 
-	bool vertical = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool vertical = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"VerticalVolControl");
 	VolControl *vol = new VolControl(source, true, vertical);
 
@@ -4286,21 +4292,21 @@ void OBSBasic::TimedCheckForUpdates()
 {
 	if (App()->IsUpdaterDisabled())
 		return;
-	if (!config_get_bool(App()->GlobalConfig(), "General",
+	if (!config_get_bool(App()->GetUserConfig(), "General",
 			     "EnableAutoUpdates"))
 		return;
 
 #if defined(ENABLE_SPARKLE_UPDATER)
 	CheckForUpdates(false);
 #elif _WIN32
-	long long lastUpdate = config_get_int(App()->GlobalConfig(), "General",
+	long long lastUpdate = config_get_int(App()->GetAppConfig(), "General",
 					      "LastUpdateCheck");
 	uint32_t lastVersion =
-		config_get_int(App()->GlobalConfig(), "General", "LastVersion");
+		config_get_int(App()->GetAppConfig(), "General", "LastVersion");
 
 	if (lastVersion < LIBOBS_API_VER) {
 		lastUpdate = 0;
-		config_set_int(App()->GlobalConfig(), "General",
+		config_set_int(App()->GetAppConfig(), "General",
 			       "LastUpdateCheck", 0);
 	}
 
@@ -4977,7 +4983,7 @@ static inline enum video_colorspace GetVideoColorSpaceFromName(const char *name)
 void OBSBasic::ResetUI()
 {
 	bool studioPortraitLayout = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "StudioPortraitLayout");
+		App()->GetUserConfig(), "BasicWindow", "StudioPortraitLayout");
 
 	if (studioPortraitLayout)
 		ui->previewLayout->setDirection(QBoxLayout::BottomToTop);
@@ -5100,7 +5106,7 @@ bool OBSBasic::ResetAudio()
 		ai.speakers = SPEAKERS_STEREO;
 
 	bool lowLatencyAudioBuffering = config_get_bool(
-		GetGlobalConfig(), "Audio", "LowLatencyAudioBuffering");
+		App()->GetUserConfig(), "Audio", "LowLatencyAudioBuffering");
 	if (lowLatencyAudioBuffering) {
 		ai.max_buffering_ms = 20;
 		ai.fixed_buffering = true;
@@ -5365,12 +5371,12 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 #endif
 
 	if (isVisible())
-		config_set_string(App()->GlobalConfig(), "BasicWindow",
+		config_set_string(App()->GetUserConfig(), "BasicWindow",
 				  "geometry",
 				  saveGeometry().toBase64().constData());
 
-	bool confirmOnExit =
-		config_get_bool(GetGlobalConfig(), "General", "ConfirmOnExit");
+	bool confirmOnExit = config_get_bool(App()->GetUserConfig(), "General",
+					     "ConfirmOnExit");
 
 	if (confirmOnExit && outputHandler && outputHandler->Active() &&
 	    !clearingFailed) {
@@ -5437,7 +5443,7 @@ void OBSBasic::closeEvent(QCloseEvent *event)
 
 	delete extraBrowsers;
 
-	config_set_string(App()->GlobalConfig(), "BasicWindow", "DockState",
+	config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState",
 			  saveState().toBase64().constData());
 
 #ifdef BROWSER_AVAILABLE
@@ -5642,7 +5648,7 @@ void OBSBasic::on_actionAdvAudioProperties_triggered()
 		return;
 	}
 
-	bool iconsVisible = config_get_bool(App()->GlobalConfig(),
+	bool iconsVisible = config_get_bool(App()->GetUserConfig(),
 					    "BasicWindow", "ShowSourceIcons");
 
 	advAudioWindow = new OBSBasicAdvAudio(this);
@@ -5665,7 +5671,7 @@ void OBSBasic::on_actionMixerToolbarMenu_triggered()
 	QAction toggleControlLayoutAction(QTStr("VerticalLayout"), this);
 	toggleControlLayoutAction.setCheckable(true);
 	toggleControlLayoutAction.setChecked(config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "VerticalVolControl"));
+		App()->GetUserConfig(), "BasicWindow", "VerticalVolControl"));
 	connect(&toggleControlLayoutAction, &QAction::changed, this,
 		&OBSBasic::ToggleVolControlLayout, Qt::DirectConnection);
 
@@ -5861,14 +5867,15 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 void OBSBasic::on_actionSceneListMode_triggered()
 {
 	ui->scenes->SetGridMode(false);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode",
 			false);
 }
 
 void OBSBasic::on_actionSceneGridMode_triggered()
 {
 	ui->scenes->SetGridMode(true);
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode", true);
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode",
+			true);
 }
 
 void OBSBasic::GridActionClicked()
@@ -5881,7 +5888,7 @@ void OBSBasic::GridActionClicked()
 	else
 		ui->actionSceneListMode->setChecked(true);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode",
 			gridMode);
 }
 
@@ -6405,7 +6412,7 @@ void OBSBasic::on_scenes_itemDoubleClicked(QListWidgetItem *witem)
 
 	if (IsPreviewProgramMode()) {
 		bool doubleClickSwitch =
-			config_get_bool(App()->GlobalConfig(), "BasicWindow",
+			config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"TransitionOnDoubleClick");
 
 		if (doubleClickSwitch)
@@ -6795,7 +6802,7 @@ void OBSBasic::on_actionMoveToBottom_triggered()
 static BPtr<char> ReadLogFile(const char *subdir, const char *log)
 {
 	char logDir[512];
-	if (GetConfigPath(logDir, sizeof(logDir), subdir) <= 0)
+	if (GetAppConfigPath(logDir, sizeof(logDir), subdir) <= 0)
 		return nullptr;
 
 	string path = logDir;
@@ -6850,7 +6857,7 @@ void OBSBasic::UploadLog(const char *subdir, const char *file, const bool crash)
 void OBSBasic::on_actionShowLogs_triggered()
 {
 	char logDir[512];
-	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
+	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0)
 		return;
 
 	QUrl url = QUrl::fromLocalFile(QT_UTF8(logDir));
@@ -6883,7 +6890,7 @@ void OBSBasic::on_actionViewCurrentLog_triggered()
 void OBSBasic::on_actionShowCrashLogs_triggered()
 {
 	char logDir[512];
-	if (GetConfigPath(logDir, sizeof(logDir), "obs-studio/crashes") <= 0)
+	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/crashes") <= 0)
 		return;
 
 	QUrl url = QUrl::fromLocalFile(QT_UTF8(logDir));
@@ -7208,13 +7215,14 @@ void OBSBasic::ShowYouTubeAutoStartWarning()
 		msgbox.exec();
 
 		if (cb->isChecked()) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"WarnedAboutYouTubeAutoStart", true);
-			config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+			config_save_safe(App()->GetUserConfig(), "tmp",
+					 nullptr);
 		}
 	};
 
-	bool warned = config_get_bool(App()->GlobalConfig(), "General",
+	bool warned = config_get_bool(App()->GetUserConfig(), "General",
 				      "WarnedAboutYouTubeAutoStart");
 	if (!warned) {
 		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection,
@@ -7285,13 +7293,13 @@ void OBSBasic::StartStreaming()
 		}
 
 		bool recordWhenStreaming =
-			config_get_bool(GetGlobalConfig(), "BasicWindow",
+			config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"RecordWhenStreaming");
 		if (recordWhenStreaming)
 			StartRecording();
 
 		bool replayBufferWhileStreaming =
-			config_get_bool(GetGlobalConfig(), "BasicWindow",
+			config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"ReplayBufferWhileStreaming");
 		if (replayBufferWhileStreaming)
 			StartReplayBuffer();
@@ -7344,7 +7352,8 @@ void OBSBasic::BroadcastButtonClicked()
 		emit BroadcastStreamStarted(autoStopBroadcast);
 	} else if (!autoStopBroadcast) {
 #ifdef YOUTUBE_ENABLED
-		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		bool confirm = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "WarnBeforeStoppingStream");
 		if (confirm && isVisible()) {
 			QMessageBox::StandardButton button = OBSMessageBox::question(
@@ -7409,7 +7418,7 @@ void OBSBasic::SetupBroadcast()
 #ifdef _WIN32
 static inline void UpdateProcessPriority()
 {
-	const char *priority = config_get_string(App()->GlobalConfig(),
+	const char *priority = config_get_string(App()->GetAppConfig(),
 						 "General", "ProcessPriority");
 	if (priority && strcmp(priority, "Normal") != 0)
 		SetProcessPriority(priority);
@@ -7417,7 +7426,7 @@ static inline void UpdateProcessPriority()
 
 static inline void ClearProcessPriority()
 {
-	const char *priority = config_get_string(App()->GlobalConfig(),
+	const char *priority = config_get_string(App()->GetAppConfig(),
 						 "General", "ProcessPriority");
 	if (priority && strcmp(priority, "Normal") != 0)
 		SetProcessPriority("Normal");
@@ -7539,17 +7548,18 @@ void OBSBasic::StopStreaming()
 	OnDeactivate();
 
 	bool recordWhenStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "RecordWhenStreaming");
+		App()->GetUserConfig(), "BasicWindow", "RecordWhenStreaming");
 	bool keepRecordingWhenStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepRecordingWhenStreamStops");
 	if (recordWhenStreaming && !keepRecordingWhenStreamStops)
 		StopRecording();
 
-	bool replayBufferWhileStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ReplayBufferWhileStreaming");
+	bool replayBufferWhileStreaming =
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
+				"ReplayBufferWhileStreaming");
 	bool keepReplayBufferStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepReplayBufferStreamStops");
 	if (replayBufferWhileStreaming && !keepReplayBufferStreamStops)
 		StopReplayBuffer();
@@ -7581,17 +7591,18 @@ void OBSBasic::ForceStopStreaming()
 	OnDeactivate();
 
 	bool recordWhenStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "RecordWhenStreaming");
+		App()->GetUserConfig(), "BasicWindow", "RecordWhenStreaming");
 	bool keepRecordingWhenStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepRecordingWhenStreamStops");
 	if (recordWhenStreaming && !keepRecordingWhenStreamStops)
 		StopRecording();
 
-	bool replayBufferWhileStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ReplayBufferWhileStreaming");
+	bool replayBufferWhileStreaming =
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
+				"ReplayBufferWhileStreaming");
 	bool keepReplayBufferStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepReplayBufferStreamStops");
 	if (replayBufferWhileStreaming && !keepReplayBufferStreamStops)
 		StopReplayBuffer();
@@ -7997,13 +8008,14 @@ void OBSBasic::ShowReplayBufferPauseWarning()
 		msgbox.exec();
 
 		if (cb->isChecked()) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"WarnedAboutReplayBufferPausing", true);
-			config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+			config_save_safe(App()->GetUserConfig(), "tmp",
+					 nullptr);
 		}
 	};
 
-	bool warned = config_get_bool(App()->GlobalConfig(), "General",
+	bool warned = config_get_bool(App()->GetUserConfig(), "General",
 				      "WarnedAboutReplayBufferPausing");
 	if (!warned) {
 		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection,
@@ -8242,7 +8254,8 @@ void OBSBasic::OnVirtualCamStop(int)
 void OBSBasic::StreamActionTriggered()
 {
 	if (outputHandler->StreamingActive()) {
-		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		bool confirm = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "WarnBeforeStoppingStream");
 
 #ifdef YOUTUBE_ENABLED
@@ -8294,7 +8307,8 @@ void OBSBasic::StreamActionTriggered()
 			return;
 		}
 
-		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		bool confirm = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "WarnBeforeStartingStream");
 
 		bool bwtest = false;
@@ -8336,7 +8350,8 @@ void OBSBasic::StreamActionTriggered()
 void OBSBasic::RecordActionTriggered()
 {
 	if (outputHandler->RecordingActive()) {
-		bool confirm = config_get_bool(GetGlobalConfig(), "BasicWindow",
+		bool confirm = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "WarnBeforeStoppingRecord");
 
 		if (confirm && isVisible()) {
@@ -8461,7 +8476,7 @@ void OBSBasic::on_actionShowWhatsNew_triggered()
 	if (!cef)
 		return;
 
-	config_set_int(App()->GlobalConfig(), "General", "InfoIncrement", -1);
+	config_set_int(App()->GetUserConfig(), "General", "InfoIncrement", -1);
 
 	WhatsNewInfoThread *wnit = new WhatsNewInfoThread();
 	connect(wnit, &WhatsNewInfoThread::Result, this,
@@ -8482,12 +8497,12 @@ void OBSBasic::on_actionReleaseNotes_triggered()
 
 void OBSBasic::on_actionShowSettingsFolder_triggered()
 {
-	char path[512];
-	int ret = GetConfigPath(path, 512, "obs-studio");
-	if (ret <= 0)
-		return;
+	const std::string userConfigPath =
+		App()->userConfigLocation.u8string() + "/obs-studio";
+	const QString userConfigLocation =
+		QString::fromStdString(userConfigPath);
 
-	QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+	QDesktopServices::openUrl(QUrl::fromLocalFile(userConfigLocation));
 }
 
 void OBSBasic::on_actionShowProfileFolder_triggered()
@@ -9449,7 +9464,8 @@ OBSProjector *OBSBasic::OpenProjector(obs_source_t *source, int monitor,
 	if (monitor > 9 || monitor > QGuiApplication::screens().size() - 1)
 		return nullptr;
 
-	bool closeProjectors = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool closeProjectors = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "CloseExistingProjectors");
 
 	if (closeProjectors && monitor > -1) {
@@ -9604,9 +9620,9 @@ void OBSBasic::UpdateTitleBar()
 	stringstream name;
 
 	const char *profile =
-		config_get_string(App()->GlobalConfig(), "Basic", "Profile");
+		config_get_string(App()->GetUserConfig(), "Basic", "Profile");
 	const char *sceneCollection = config_get_string(
-		App()->GlobalConfig(), "Basic", "SceneCollection");
+		App()->GetUserConfig(), "Basic", "SceneCollection");
 
 	name << "OBS ";
 	if (previewProgramMode)
@@ -9627,8 +9643,8 @@ void OBSBasic::UpdateTitleBar()
 int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const
 {
 	char profiles_path[512];
-	const char *profile =
-		config_get_string(App()->GlobalConfig(), "Basic", "ProfileDir");
+	const char *profile = config_get_string(App()->GetUserConfig(), "Basic",
+						"ProfileDir");
 	int ret;
 
 	if (!profile)
@@ -9638,7 +9654,7 @@ int OBSBasic::GetProfilePath(char *path, size_t size, const char *file) const
 	if (!file)
 		file = "";
 
-	ret = GetConfigPath(profiles_path, 512, "obs-studio/basic/profiles");
+	ret = GetAppConfigPath(profiles_path, 512, "obs-studio/basic/profiles");
 	if (ret <= 0)
 		return ret;
 
@@ -9803,7 +9819,7 @@ void OBSBasic::on_resetUI_triggered()
 	ui->scenes->SetGridMode(false);
 	ui->actionSceneListMode->setChecked(true);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "gridMode",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode",
 			false);
 }
 
@@ -9818,7 +9834,7 @@ void OBSBasic::on_toggleListboxToolbars_toggled(bool visible)
 	ui->scenesToolbar->setVisible(visible);
 	ui->mixerToolbar->setVisible(visible);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"ShowListboxToolbars", visible);
 }
 
@@ -9836,7 +9852,7 @@ void OBSBasic::HideContextBar()
 
 void OBSBasic::on_toggleContextBar_toggled(bool visible)
 {
-	config_set_bool(App()->GlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"ShowContextToolbars", visible);
 	this->ui->contextContainer->setVisible(visible);
 	UpdateContextBar(true);
@@ -9846,7 +9862,7 @@ void OBSBasic::on_toggleStatusBar_toggled(bool visible)
 {
 	ui->statusbar->setVisible(visible);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "ShowStatusBar",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "ShowStatusBar",
 			visible);
 }
 
@@ -9856,8 +9872,8 @@ void OBSBasic::on_toggleSourceIcons_toggled(bool visible)
 	if (advAudioWindow != nullptr)
 		advAudioWindow->SetIconsVisible(visible);
 
-	config_set_bool(App()->GlobalConfig(), "BasicWindow", "ShowSourceIcons",
-			visible);
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
+			"ShowSourceIcons", visible);
 }
 
 void OBSBasic::on_actionLockPreview_triggered()
@@ -9922,7 +9938,7 @@ void OBSBasic::on_actionScaleOutput_triggered()
 void OBSBasic::SetShowing(bool showing)
 {
 	if (!showing && isVisible()) {
-		config_set_string(App()->GlobalConfig(), "BasicWindow",
+		config_set_string(App()->GetUserConfig(), "BasicWindow",
 				  "geometry",
 				  saveGeometry().toBase64().constData());
 
@@ -10107,9 +10123,9 @@ void OBSBasic::SystemTray(bool firstStarted)
 		return;
 
 	bool sysTrayWhenStarted = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SysTrayWhenStarted");
-	bool sysTrayEnabled = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "SysTrayEnabled");
+		App()->GetUserConfig(), "BasicWindow", "SysTrayWhenStarted");
+	bool sysTrayEnabled = config_get_bool(App()->GetUserConfig(),
+					      "BasicWindow", "SysTrayEnabled");
 
 	if (firstStarted)
 		SystemTrayInit();
@@ -10135,7 +10151,7 @@ void OBSBasic::SystemTray(bool firstStarted)
 
 bool OBSBasic::sysTrayMinimizeToTray()
 {
-	return config_get_bool(GetGlobalConfig(), "BasicWindow",
+	return config_get_bool(App()->GetUserConfig(), "BasicWindow",
 			       "SysTrayMinimizeToTray");
 }
 
@@ -11118,17 +11134,17 @@ void OBSBasic::ShowStatusBarMessage(const QString &message)
 
 void OBSBasic::UpdatePreviewSafeAreas()
 {
-	drawSafeAreas = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	drawSafeAreas = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"ShowSafeAreas");
 }
 
 void OBSBasic::UpdatePreviewOverflowSettings()
 {
-	bool hidden = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	bool hidden = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				      "OverflowHidden");
-	bool select = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	bool select = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				      "OverflowSelectionHidden");
-	bool always = config_get_bool(App()->GlobalConfig(), "BasicWindow",
+	bool always = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				      "OverflowAlwaysVisible");
 
 	ui->preview->SetOverflowHidden(hidden);
@@ -11141,7 +11157,7 @@ void OBSBasic::SetDisplayAffinity(QWindow *window)
 	if (!SetDisplayAffinitySupported())
 		return;
 
-	bool hideFromCapture = config_get_bool(App()->GlobalConfig(),
+	bool hideFromCapture = config_get_bool(App()->GetUserConfig(),
 					       "BasicWindow",
 					       "HideOBSWindowsFromCapture");
 
@@ -11175,10 +11191,10 @@ static inline QColor color_from_int(long long val)
 
 QColor OBSBasic::GetSelectionColor() const
 {
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		return color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "SelectRed"));
+			App()->GetUserConfig(), "Accessibility", "SelectRed"));
 	} else {
 		return QColor::fromRgb(255, 0, 0);
 	}
@@ -11186,10 +11202,11 @@ QColor OBSBasic::GetSelectionColor() const
 
 QColor OBSBasic::GetCropColor() const
 {
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
-		return color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "SelectGreen"));
+		return color_from_int(config_get_int(App()->GetUserConfig(),
+						     "Accessibility",
+						     "SelectGreen"));
 	} else {
 		return QColor::fromRgb(0, 255, 0);
 	}
@@ -11197,10 +11214,10 @@ QColor OBSBasic::GetCropColor() const
 
 QColor OBSBasic::GetHoverColor() const
 {
-	if (config_get_bool(GetGlobalConfig(), "Accessibility",
+	if (config_get_bool(App()->GetUserConfig(), "Accessibility",
 			    "OverrideColors")) {
 		return color_from_int(config_get_int(
-			GetGlobalConfig(), "Accessibility", "SelectBlue"));
+			App()->GetUserConfig(), "Accessibility", "SelectBlue"));
 	} else {
 		return QColor::fromRgb(0, 127, 255);
 	}
@@ -11209,7 +11226,7 @@ QColor OBSBasic::GetHoverColor() const
 void OBSBasic::UpdatePreviewSpacingHelpers()
 {
 	drawSpacingHelpers = config_get_bool(
-		App()->GlobalConfig(), "BasicWindow", "SpacingHelpersEnabled");
+		App()->GetUserConfig(), "BasicWindow", "SpacingHelpersEnabled");
 }
 
 float OBSBasic::GetDevicePixelRatio()

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -308,7 +308,7 @@ private:
 	int previewCX = 0, previewCY = 0;
 	float previewScale = 0.0f;
 
-	ConfigFile basicConfig;
+	ConfigFile activeConfiguration;
 
 	std::vector<SavedProjectorInfo *> savedProjectorsArray;
 	std::vector<OBSProjector *> projectors;

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -165,6 +165,8 @@ struct OBSPromptRequest {
 using OBSPromptCallback = std::function<bool(const OBSPromptResult &result)>;
 
 using OBSProfileCache = std::map<std::string, OBSProfile>;
+using OBSSceneCollectionCache = std::map<std::string, OBSSceneCollection>;
+
 class ColorSelect : public QWidget {
 
 public:
@@ -471,8 +473,6 @@ private:
 	void ToggleVolControlLayout();
 	void ToggleMixerLayout(bool vertical);
 
-	void RefreshSceneCollections();
-	void ChangeSceneCollection();
 	void LogScenes();
 	void SaveProjectNow();
 
@@ -760,8 +760,6 @@ public slots:
 			       bool manual = false);
 	void SetCurrentScene(OBSSource scene, bool force = false);
 
-	bool AddSceneCollection(bool create_new,
-				const QString &name = QString());
 	void UpdatePatronJson(const QString &text, const QString &error);
 
 	void ShowContextBar();
@@ -1163,14 +1161,6 @@ private slots:
 	void ProgramViewContextMenuRequested();
 	void on_previewDisabledWidget_customContextMenuRequested();
 
-	void on_actionNewSceneCollection_triggered();
-	void on_actionDupSceneCollection_triggered();
-	void on_actionRenameSceneCollection_triggered();
-	void on_actionRemoveSceneCollection_triggered();
-	void on_actionImportSceneCollection_triggered();
-	void on_actionExportSceneCollection_triggered();
-	void on_actionRemigrateSceneCollection_triggered();
-
 	void on_actionShowSettingsFolder_triggered();
 	void on_actionShowProfileFolder_triggered();
 
@@ -1398,6 +1388,54 @@ public slots:
 	bool CreateNewProfile(const QString &name);
 	bool CreateDuplicateProfile(const QString &name);
 	void DeleteProfile(const QString &profileName);
+
+	// MARK: - OBS Scene Collection Management
+private:
+	OBSSceneCollectionCache collections{};
+
+	void SetupNewSceneCollection(const std::string &collectionName);
+	void SetupDuplicateSceneCollection(const std::string &collectionName);
+	void SetupRenameSceneCollection(const std::string &collectionName);
+
+	const OBSSceneCollection &
+	CreateSceneCollection(const std::string &collectionName);
+	void RemoveSceneCollection(OBSSceneCollection collection);
+
+	bool CreateDuplicateSceneCollection(const QString &name);
+	void DeleteSceneCollection(const QString &name);
+	void ChangeSceneCollection();
+
+	void RefreshSceneCollectionCache();
+
+	void RefreshSceneCollections(bool refreshCache = false);
+	void ActivateSceneCollection(const OBSSceneCollection &collection);
+
+public:
+	inline const OBSSceneCollectionCache &
+	GetSceneCollectionCache() const noexcept
+	{
+		return collections;
+	};
+
+	const OBSSceneCollection &GetCurrentSceneCollection() const;
+
+	std::optional<OBSSceneCollection>
+	GetSceneCollectionByName(const std::string &collectionName) const;
+	std::optional<OBSSceneCollection>
+	GetSceneCollectionByFileName(const std::string &fileName) const;
+
+private slots:
+	void on_actionNewSceneCollection_triggered();
+	void on_actionDupSceneCollection_triggered();
+	void on_actionRenameSceneCollection_triggered();
+	void
+	on_actionRemoveSceneCollection_triggered(bool skipConfirmation = false);
+	void on_actionImportSceneCollection_triggered();
+	void on_actionExportSceneCollection_triggered();
+	void on_actionRemigrateSceneCollection_triggered();
+
+public slots:
+	bool CreateNewSceneCollection(const QString &name);
 };
 
 extern bool cef_js_avail;

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -192,17 +192,17 @@ vec3 OBSBasicPreview::GetSnapOffset(const vec3 &tl, const vec3 &br)
 
 	vec3_zero(&clampOffset);
 
-	const bool snap = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	const bool snap = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					  "SnappingEnabled");
 	if (snap == false)
 		return clampOffset;
 
 	const bool screenSnap = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ScreenSnapping");
+		App()->GetUserConfig(), "BasicWindow", "ScreenSnapping");
 	const bool centerSnap = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "CenterSnapping");
+		App()->GetUserConfig(), "BasicWindow", "CenterSnapping");
 
-	const float clampDist = config_get_double(GetGlobalConfig(),
+	const float clampDist = config_get_double(App()->GetUserConfig(),
 						  "BasicWindow",
 						  "SnapDistance") /
 				main->previewScale;
@@ -995,10 +995,10 @@ void OBSBasicPreview::SnapItemMovement(vec2 &offset)
 
 	vec3 snapOffset = GetSnapOffset(data.tl, data.br);
 
-	const bool snap = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	const bool snap = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					  "SnappingEnabled");
 	const bool sourcesSnap = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SourceSnapping");
+		App()->GetUserConfig(), "BasicWindow", "SourceSnapping");
 	if (snap == false)
 		return;
 	if (sourcesSnap == false) {
@@ -1007,7 +1007,7 @@ void OBSBasicPreview::SnapItemMovement(vec2 &offset)
 		return;
 	}
 
-	const float clampDist = config_get_double(GetGlobalConfig(),
+	const float clampDist = config_get_double(App()->GetUserConfig(),
 						  "BasicWindow",
 						  "SnapDistance") /
 				main->previewScale;

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -53,9 +53,9 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 			OBSBasicProperties::SourceRenamed, this),
 	  oldSettings(obs_data_create())
 {
-	int cx = (int)config_get_int(App()->GlobalConfig(), "PropertiesWindow",
+	int cx = (int)config_get_int(App()->GetAppConfig(), "PropertiesWindow",
 				     "cx");
-	int cy = (int)config_get_int(App()->GlobalConfig(), "PropertiesWindow",
+	int cy = (int)config_get_int(App()->GetAppConfig(), "PropertiesWindow",
 				     "cy");
 
 	enum obs_source_type type = obs_source_get_type(source);
@@ -450,9 +450,9 @@ void OBSBasicProperties::DrawTransitionPreview(void *data, uint32_t cx,
 
 void OBSBasicProperties::Cleanup()
 {
-	config_set_int(App()->GlobalConfig(), "PropertiesWindow", "cx",
+	config_set_int(App()->GetAppConfig(), "PropertiesWindow", "cx",
 		       width());
-	config_set_int(App()->GlobalConfig(), "PropertiesWindow", "cy",
+	config_set_int(App()->GetAppConfig(), "PropertiesWindow", "cy",
 		       height());
 
 	obs_display_remove_draw_callback(ui->preview->GetDisplay(),

--- a/UI/window-basic-settings-a11y.cpp
+++ b/UI/window-basic-settings-a11y.cpp
@@ -43,7 +43,7 @@ QColor OBSBasicSettings::GetColor(uint32_t colorVal, QString label)
 
 void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 {
-	config_t *config = GetGlobalConfig();
+	config_t *config = App()->GetUserConfig();
 
 	loading = true;
 	if (!presetChange) {
@@ -109,7 +109,7 @@ void OBSBasicSettings::LoadA11ySettings(bool presetChange)
 
 void OBSBasicSettings::SaveA11ySettings()
 {
-	config_t *config = GetGlobalConfig();
+	config_t *config = App()->GetUserConfig();
 
 	config_set_bool(config, "Accessibility", "OverrideColors",
 			ui->colorsGroupBox->isChecked());
@@ -163,7 +163,7 @@ void OBSBasicSettings::UpdateA11yColors()
 
 void OBSBasicSettings::SetDefaultColors()
 {
-	config_t *config = GetGlobalConfig();
+	config_t *config = App()->GetUserConfig();
 	config_set_default_int(config, "Accessibility", "SelectRed", selectRed);
 	config_set_default_int(config, "Accessibility", "SelectGreen",
 			       selectGreen);

--- a/UI/window-basic-settings-appearance.cpp
+++ b/UI/window-basic-settings-appearance.cpp
@@ -107,7 +107,7 @@ void OBSBasicSettings::LoadAppearanceSettings(bool reload)
 
 void OBSBasicSettings::SaveAppearanceSettings()
 {
-	config_t *config = GetGlobalConfig();
+	config_t *config = App()->GetUserConfig();
 
 	OBSTheme *currentTheme = App()->GetTheme();
 	if (savedTheme != currentTheme) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -1032,8 +1032,9 @@ void OBSBasicSettings::on_server_currentIndexChanged(int /*index*/)
 
 void OBSBasicSettings::UpdateVodTrackSetting()
 {
-	bool enableForCustomServer = config_get_bool(
-		GetGlobalConfig(), "General", "EnableCustomServerVodTrack");
+	bool enableForCustomServer =
+		config_get_bool(App()->GetUserConfig(), "General",
+				"EnableCustomServerVodTrack");
 	bool enableVodTrack = ui->service->currentText() == "Twitch";
 	bool wasEnabled = !!vodTrackCheckbox;
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2136,12 +2136,16 @@ OBSBasicSettings::CreateEncoderPropertyView(const char *encoder,
 	OBSPropertiesView *view;
 
 	if (path) {
-		char encoderJsonPath[512];
-		int ret = GetProfilePath(encoderJsonPath,
-					 sizeof(encoderJsonPath), path);
-		if (ret > 0) {
+		const OBSBasic *basic =
+			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		const OBSProfile &currentProfile = basic->GetCurrentProfile();
+
+		const std::filesystem::path jsonFilePath =
+			currentProfile.path / std::filesystem::u8path(path);
+
+		if (!jsonFilePath.empty()) {
 			obs_data_t *data = obs_data_create_from_json_file_safe(
-				encoderJsonPath, "bak");
+				jsonFilePath.u8string().c_str(), "bak");
 			obs_data_apply(settings, data);
 			obs_data_release(data);
 		}
@@ -3748,17 +3752,22 @@ static inline const char *SplitFileTypeFromIdx(int idx)
 
 static void WriteJsonData(OBSPropertiesView *view, const char *path)
 {
-	char full_path[512];
-
 	if (!view || !WidgetChanged(view))
 		return;
 
-	int ret = GetProfilePath(full_path, sizeof(full_path), path);
-	if (ret > 0) {
+	const OBSBasic *basic =
+		reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	const OBSProfile &currentProfile = basic->GetCurrentProfile();
+
+	const std::filesystem::path jsonFilePath =
+		currentProfile.path / std::filesystem::u8path(path);
+
+	if (!jsonFilePath.empty()) {
 		obs_data_t *settings = view->GetSettings();
 		if (settings) {
-			obs_data_save_json_safe(settings, full_path, "tmp",
-						"bak");
+			obs_data_save_json_safe(settings,
+						jsonFilePath.u8string().c_str(),
+						"tmp", "bak");
 		}
 	}
 }
@@ -5691,14 +5700,16 @@ void OBSBasicSettings::AdvReplayBufferChanged()
 		if (!settings)
 			return;
 
-		char encoderJsonPath[512];
-		int ret = GetProfilePath(encoderJsonPath,
-					 sizeof(encoderJsonPath),
-					 "recordEncoder.json");
-		if (ret > 0) {
+		const OBSProfile &currentProfile = main->GetCurrentProfile();
+
+		const std::filesystem::path jsonFilePath =
+			currentProfile.path /
+			std::filesystem::u8path("recordEncoder.json");
+
+		if (!jsonFilePath.empty()) {
 			OBSDataAutoRelease data =
 				obs_data_create_from_json_file_safe(
-					encoderJsonPath, "bak");
+					jsonFilePath.u8string().c_str(), "bak");
 			obs_data_apply(settings, data);
 		}
 	}

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1333,8 +1333,8 @@ void OBSBasicSettings::LoadBranchesList()
 {
 #if defined(_WIN32) || defined(ENABLE_SPARKLE_UPDATER)
 	bool configBranchRemoved = true;
-	QString configBranch =
-		config_get_string(GetGlobalConfig(), "General", "UpdateBranch");
+	QString configBranch = config_get_string(App()->GetAppConfig(),
+						 "General", "UpdateBranch");
 
 	for (const UpdateBranch &branch : App()->GetBranches()) {
 		if (branch.name == configBranch)
@@ -1387,8 +1387,8 @@ void OBSBasicSettings::LoadGeneralSettings()
 	LoadLanguageList();
 
 #if defined(_WIN32) || defined(ENABLE_SPARKLE_UPDATER)
-	bool enableAutoUpdates = config_get_bool(GetGlobalConfig(), "General",
-						 "EnableAutoUpdates");
+	bool enableAutoUpdates = config_get_bool(
+		App()->GetUserConfig(), "General", "EnableAutoUpdates");
 	ui->enableAutoUpdates->setChecked(enableAutoUpdates);
 
 	LoadBranchesList();
@@ -1400,7 +1400,7 @@ void OBSBasicSettings::LoadGeneralSettings()
 #if defined(_WIN32)
 	if (ui->hideOBSFromCapture) {
 		bool hideWindowFromCapture =
-			config_get_bool(GetGlobalConfig(), "BasicWindow",
+			config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"HideOBSWindowsFromCapture");
 		ui->hideOBSFromCapture->setChecked(hideWindowFromCapture);
 
@@ -1415,129 +1415,136 @@ void OBSBasicSettings::LoadGeneralSettings()
 #endif
 
 	bool recordWhenStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "RecordWhenStreaming");
+		App()->GetUserConfig(), "BasicWindow", "RecordWhenStreaming");
 	ui->recordWhenStreaming->setChecked(recordWhenStreaming);
 
 	bool keepRecordStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepRecordingWhenStreamStops");
 	ui->keepRecordStreamStops->setChecked(keepRecordStreamStops);
 
-	bool replayWhileStreaming = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ReplayBufferWhileStreaming");
+	bool replayWhileStreaming =
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
+				"ReplayBufferWhileStreaming");
 	ui->replayWhileStreaming->setChecked(replayWhileStreaming);
 
 	bool keepReplayStreamStops =
-		config_get_bool(GetGlobalConfig(), "BasicWindow",
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepReplayBufferStreamStops");
 	ui->keepReplayStreamStops->setChecked(keepReplayStreamStops);
 
 	bool systemTrayEnabled = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SysTrayEnabled");
+		App()->GetUserConfig(), "BasicWindow", "SysTrayEnabled");
 	ui->systemTrayEnabled->setChecked(systemTrayEnabled);
 
 	bool systemTrayWhenStarted = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SysTrayWhenStarted");
+		App()->GetUserConfig(), "BasicWindow", "SysTrayWhenStarted");
 	ui->systemTrayWhenStarted->setChecked(systemTrayWhenStarted);
 
 	bool systemTrayAlways = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SysTrayMinimizeToTray");
+		App()->GetUserConfig(), "BasicWindow", "SysTrayMinimizeToTray");
 	ui->systemTrayAlways->setChecked(systemTrayAlways);
 
-	bool saveProjectors = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "SaveProjectors");
+	bool saveProjectors = config_get_bool(App()->GetUserConfig(),
+					      "BasicWindow", "SaveProjectors");
 	ui->saveProjectors->setChecked(saveProjectors);
 
-	bool closeProjectors = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool closeProjectors = config_get_bool(App()->GetUserConfig(),
+					       "BasicWindow",
 					       "CloseExistingProjectors");
 	ui->closeProjectors->setChecked(closeProjectors);
 
-	bool snappingEnabled = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					       "SnappingEnabled");
+	bool snappingEnabled = config_get_bool(
+		App()->GetUserConfig(), "BasicWindow", "SnappingEnabled");
 	ui->snappingEnabled->setChecked(snappingEnabled);
 
-	bool screenSnapping = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "ScreenSnapping");
+	bool screenSnapping = config_get_bool(App()->GetUserConfig(),
+					      "BasicWindow", "ScreenSnapping");
 	ui->screenSnapping->setChecked(screenSnapping);
 
-	bool centerSnapping = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "CenterSnapping");
+	bool centerSnapping = config_get_bool(App()->GetUserConfig(),
+					      "BasicWindow", "CenterSnapping");
 	ui->centerSnapping->setChecked(centerSnapping);
 
-	bool sourceSnapping = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "SourceSnapping");
+	bool sourceSnapping = config_get_bool(App()->GetUserConfig(),
+					      "BasicWindow", "SourceSnapping");
 	ui->sourceSnapping->setChecked(sourceSnapping);
 
-	double snapDistance = config_get_double(GetGlobalConfig(),
+	double snapDistance = config_get_double(App()->GetUserConfig(),
 						"BasicWindow", "SnapDistance");
 	ui->snapDistance->setValue(snapDistance);
 
-	bool warnBeforeStreamStart = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "WarnBeforeStartingStream");
+	bool warnBeforeStreamStart =
+		config_get_bool(App()->GetUserConfig(), "BasicWindow",
+				"WarnBeforeStartingStream");
 	ui->warnBeforeStreamStart->setChecked(warnBeforeStreamStart);
 
 	bool spacingHelpersEnabled = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "SpacingHelpersEnabled");
+		App()->GetUserConfig(), "BasicWindow", "SpacingHelpersEnabled");
 	ui->previewSpacingHelpers->setChecked(spacingHelpersEnabled);
 
-	bool warnBeforeStreamStop = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "WarnBeforeStoppingStream");
+	bool warnBeforeStreamStop = config_get_bool(App()->GetUserConfig(),
+						    "BasicWindow",
+						    "WarnBeforeStoppingStream");
 	ui->warnBeforeStreamStop->setChecked(warnBeforeStreamStop);
 
-	bool warnBeforeRecordStop = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "WarnBeforeStoppingRecord");
+	bool warnBeforeRecordStop = config_get_bool(App()->GetUserConfig(),
+						    "BasicWindow",
+						    "WarnBeforeStoppingRecord");
 	ui->warnBeforeRecordStop->setChecked(warnBeforeRecordStop);
 
 	bool hideProjectorCursor = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "HideProjectorCursor");
+		App()->GetUserConfig(), "BasicWindow", "HideProjectorCursor");
 	ui->hideProjectorCursor->setChecked(hideProjectorCursor);
 
 	bool projectorAlwaysOnTop = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
+		App()->GetUserConfig(), "BasicWindow", "ProjectorAlwaysOnTop");
 	ui->projectorAlwaysOnTop->setChecked(projectorAlwaysOnTop);
 
-	bool overflowHide = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					    "OverflowHidden");
+	bool overflowHide = config_get_bool(App()->GetUserConfig(),
+					    "BasicWindow", "OverflowHidden");
 	ui->overflowHide->setChecked(overflowHide);
 
 	bool overflowAlwaysVisible = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "OverflowAlwaysVisible");
+		App()->GetUserConfig(), "BasicWindow", "OverflowAlwaysVisible");
 	ui->overflowAlwaysVisible->setChecked(overflowAlwaysVisible);
 
-	bool overflowSelectionHide = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "OverflowSelectionHidden");
+	bool overflowSelectionHide = config_get_bool(App()->GetUserConfig(),
+						     "BasicWindow",
+						     "OverflowSelectionHidden");
 	ui->overflowSelectionHide->setChecked(overflowSelectionHide);
 
-	bool safeAreas = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool safeAreas = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "ShowSafeAreas");
 	ui->previewSafeAreas->setChecked(safeAreas);
 
-	bool automaticSearch = config_get_bool(GetGlobalConfig(), "General",
-					       "AutomaticCollectionSearch");
+	bool automaticSearch = config_get_bool(
+		App()->GetUserConfig(), "General", "AutomaticCollectionSearch");
 	ui->automaticSearch->setChecked(automaticSearch);
 
-	bool doubleClickSwitch = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "TransitionOnDoubleClick");
+	bool doubleClickSwitch = config_get_bool(App()->GetUserConfig(),
+						 "BasicWindow",
+						 "TransitionOnDoubleClick");
 	ui->doubleClickSwitch->setChecked(doubleClickSwitch);
 
 	bool studioPortraitLayout = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "StudioPortraitLayout");
+		App()->GetUserConfig(), "BasicWindow", "StudioPortraitLayout");
 	ui->studioPortraitLayout->setChecked(studioPortraitLayout);
 
-	bool prevProgLabels = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					      "StudioModeLabels");
+	bool prevProgLabels = config_get_bool(
+		App()->GetUserConfig(), "BasicWindow", "StudioModeLabels");
 	ui->prevProgLabelToggle->setChecked(prevProgLabels);
 
 	bool multiviewMouseSwitch = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "MultiviewMouseSwitch");
+		App()->GetUserConfig(), "BasicWindow", "MultiviewMouseSwitch");
 	ui->multiviewMouseSwitch->setChecked(multiviewMouseSwitch);
 
 	bool multiviewDrawNames = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "MultiviewDrawNames");
+		App()->GetUserConfig(), "BasicWindow", "MultiviewDrawNames");
 	ui->multiviewDrawNames->setChecked(multiviewDrawNames);
 
 	bool multiviewDrawAreas = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "MultiviewDrawAreas");
+		App()->GetUserConfig(), "BasicWindow", "MultiviewDrawAreas");
 	ui->multiviewDrawAreas->setChecked(multiviewDrawAreas);
 
 	ui->multiviewLayout->addItem(
@@ -1571,9 +1578,10 @@ void OBSBasicSettings::LoadGeneralSettings()
 		QTStr("Basic.Settings.General.MultiviewLayout.25Scene"),
 		static_cast<int>(MultiviewLayout::SCENES_ONLY_25_SCENES));
 
-	ui->multiviewLayout->setCurrentIndex(ui->multiviewLayout->findData(
-		QVariant::fromValue(config_get_int(
-			GetGlobalConfig(), "BasicWindow", "MultiviewLayout"))));
+	ui->multiviewLayout->setCurrentIndex(
+		ui->multiviewLayout->findData(QVariant::fromValue(
+			config_get_int(App()->GetUserConfig(), "BasicWindow",
+				       "MultiviewLayout"))));
 
 	prevLangIndex = ui->language->currentIndex();
 
@@ -1587,7 +1595,7 @@ void OBSBasicSettings::LoadRendererList()
 {
 #ifdef _WIN32
 	const char *renderer =
-		config_get_string(GetGlobalConfig(), "Video", "Renderer");
+		config_get_string(App()->GetUserConfig(), "Video", "Renderer");
 
 	ui->renderer->addItem(QT_UTF8("Direct3D 11"));
 	if (opt_allow_opengl || strcmp(renderer, "OpenGL") == 0)
@@ -2792,7 +2800,7 @@ void OBSBasicSettings::LoadAudioSettings()
 	uint32_t peakMeterTypeIdx =
 		config_get_uint(main->Config(), "Audio", "PeakMeterType");
 	bool enableLLAudioBuffering = config_get_bool(
-		GetGlobalConfig(), "Audio", "LowLatencyAudioBuffering");
+		App()->GetUserConfig(), "Audio", "LowLatencyAudioBuffering");
 
 	loading = true;
 
@@ -2918,13 +2926,13 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
 	const char *hotkeyFocusType = config_get_string(
-		App()->GlobalConfig(), "General", "HotkeyFocusType");
+		App()->GetUserConfig(), "General", "HotkeyFocusType");
 	bool dynBitrate =
 		config_get_bool(main->Config(), "Output", "DynamicBitrate");
 	const char *ipFamily =
 		config_get_string(main->Config(), "Output", "IPFamily");
-	bool confirmOnExit =
-		config_get_bool(GetGlobalConfig(), "General", "ConfirmOnExit");
+	bool confirmOnExit = config_get_bool(App()->GetUserConfig(), "General",
+					     "ConfirmOnExit");
 
 	loading = true;
 
@@ -2971,20 +2979,20 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	}
 
 #ifdef __APPLE__
-	bool disableOSXVSync = config_get_bool(App()->GlobalConfig(), "Video",
+	bool disableOSXVSync = config_get_bool(App()->GetUserConfig(), "Video",
 					       "DisableOSXVSync");
-	bool resetOSXVSync = config_get_bool(App()->GlobalConfig(), "Video",
+	bool resetOSXVSync = config_get_bool(App()->GetUserConfig(), "Video",
 					     "ResetOSXVSyncOnExit");
 	ui->disableOSXVSync->setChecked(disableOSXVSync);
 	ui->resetOSXVSync->setChecked(resetOSXVSync);
 	ui->resetOSXVSync->setEnabled(disableOSXVSync);
 #elif _WIN32
 	bool disableAudioDucking = config_get_bool(
-		App()->GlobalConfig(), "Audio", "DisableAudioDucking");
+		App()->GetUserConfig(), "Audio", "DisableAudioDucking");
 	ui->disableAudioDucking->setChecked(disableAudioDucking);
 
 	const char *processPriority = config_get_string(
-		App()->GlobalConfig(), "General", "ProcessPriority");
+		App()->GetAppConfig(), "General", "ProcessPriority");
 	bool enableNewSocketLoop = config_get_bool(main->Config(), "Output",
 						   "NewSocketLoopEnable");
 	bool enableLowLatencyMode =
@@ -3001,7 +3009,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 		QTStr("Basic.Settings.Advanced.Network.TCPPacing.Tooltip"));
 #endif
 #if defined(_WIN32) || defined(__APPLE__)
-	bool browserHWAccel = config_get_bool(App()->GlobalConfig(), "General",
+	bool browserHWAccel = config_get_bool(App()->GetUserConfig(), "General",
 					      "BrowserHWAccel");
 	ui->browserHWAccel->setChecked(browserHWAccel);
 	prevBrowserAccel = ui->browserHWAccel->isChecked();
@@ -3360,12 +3368,12 @@ void OBSBasicSettings::SaveGeneralSettings()
 	string language = langData.toString().toStdString();
 
 	if (WidgetChanged(ui->language))
-		config_set_string(GetGlobalConfig(), "General", "Language",
+		config_set_string(App()->GetUserConfig(), "General", "Language",
 				  language.c_str());
 
 #if defined(_WIN32) || defined(ENABLE_SPARKLE_UPDATER)
 	if (WidgetChanged(ui->enableAutoUpdates))
-		config_set_bool(GetGlobalConfig(), "General",
+		config_set_bool(App()->GetUserConfig(), "General",
 				"EnableAutoUpdates",
 				ui->enableAutoUpdates->isChecked());
 	int branchIdx = ui->updateChannelBox->currentIndex();
@@ -3373,15 +3381,15 @@ void OBSBasicSettings::SaveGeneralSettings()
 		ui->updateChannelBox->itemData(branchIdx).toString();
 
 	if (WidgetChanged(ui->updateChannelBox)) {
-		config_set_string(GetGlobalConfig(), "General", "UpdateBranch",
-				  QT_TO_UTF8(branchName));
+		config_set_string(App()->GetAppConfig(), "General",
+				  "UpdateBranch", QT_TO_UTF8(branchName));
 		forceUpdateCheck = true;
 	}
 #endif
 #ifdef _WIN32
 	if (ui->hideOBSFromCapture && WidgetChanged(ui->hideOBSFromCapture)) {
 		bool hide_window = ui->hideOBSFromCapture->isChecked();
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"HideOBSWindowsFromCapture", hide_window);
 
 		QWindowList windows = QGuiApplication::allWindows();
@@ -3399,80 +3407,80 @@ void OBSBasicSettings::SaveGeneralSettings()
 		config_set_bool(main->Config(), "General", "OpenStatsOnStartup",
 				ui->openStatsOnStartup->isChecked());
 	if (WidgetChanged(ui->snappingEnabled))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SnappingEnabled",
 				ui->snappingEnabled->isChecked());
 	if (WidgetChanged(ui->screenSnapping))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"ScreenSnapping",
 				ui->screenSnapping->isChecked());
 	if (WidgetChanged(ui->centerSnapping))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"CenterSnapping",
 				ui->centerSnapping->isChecked());
 	if (WidgetChanged(ui->sourceSnapping))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SourceSnapping",
 				ui->sourceSnapping->isChecked());
 	if (WidgetChanged(ui->snapDistance))
-		config_set_double(GetGlobalConfig(), "BasicWindow",
+		config_set_double(App()->GetUserConfig(), "BasicWindow",
 				  "SnapDistance", ui->snapDistance->value());
 	if (WidgetChanged(ui->overflowAlwaysVisible) ||
 	    WidgetChanged(ui->overflowHide) ||
 	    WidgetChanged(ui->overflowSelectionHide)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"OverflowAlwaysVisible",
 				ui->overflowAlwaysVisible->isChecked());
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"OverflowHidden",
 				ui->overflowHide->isChecked());
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"OverflowSelectionHidden",
 				ui->overflowSelectionHide->isChecked());
 		main->UpdatePreviewOverflowSettings();
 	}
 	if (WidgetChanged(ui->previewSafeAreas)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"ShowSafeAreas",
 				ui->previewSafeAreas->isChecked());
 		main->UpdatePreviewSafeAreas();
 	}
 
 	if (WidgetChanged(ui->previewSpacingHelpers)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SpacingHelpersEnabled",
 				ui->previewSpacingHelpers->isChecked());
 		main->UpdatePreviewSpacingHelpers();
 	}
 
 	if (WidgetChanged(ui->doubleClickSwitch))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"TransitionOnDoubleClick",
 				ui->doubleClickSwitch->isChecked());
 	if (WidgetChanged(ui->automaticSearch))
-		config_set_bool(GetGlobalConfig(), "General",
+		config_set_bool(App()->GetUserConfig(), "General",
 				"AutomaticCollectionSearch",
 				ui->automaticSearch->isChecked());
 
-	config_set_bool(GetGlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"WarnBeforeStartingStream",
 			ui->warnBeforeStreamStart->isChecked());
-	config_set_bool(GetGlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"WarnBeforeStoppingStream",
 			ui->warnBeforeStreamStop->isChecked());
-	config_set_bool(GetGlobalConfig(), "BasicWindow",
+	config_set_bool(App()->GetUserConfig(), "BasicWindow",
 			"WarnBeforeStoppingRecord",
 			ui->warnBeforeRecordStop->isChecked());
 
 	if (WidgetChanged(ui->hideProjectorCursor)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"HideProjectorCursor",
 				ui->hideProjectorCursor->isChecked());
 		main->UpdateProjectorHideCursor();
 	}
 
 	if (WidgetChanged(ui->projectorAlwaysOnTop)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"ProjectorAlwaysOnTop",
 				ui->projectorAlwaysOnTop->isChecked());
 #if defined(_WIN32) || defined(__APPLE__)
@@ -3484,25 +3492,25 @@ void OBSBasicSettings::SaveGeneralSettings()
 	}
 
 	if (WidgetChanged(ui->recordWhenStreaming))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"RecordWhenStreaming",
 				ui->recordWhenStreaming->isChecked());
 	if (WidgetChanged(ui->keepRecordStreamStops))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepRecordingWhenStreamStops",
 				ui->keepRecordStreamStops->isChecked());
 
 	if (WidgetChanged(ui->replayWhileStreaming))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"ReplayBufferWhileStreaming",
 				ui->replayWhileStreaming->isChecked());
 	if (WidgetChanged(ui->keepReplayStreamStops))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"KeepReplayBufferStreamStops",
 				ui->keepReplayStreamStops->isChecked());
 
 	if (WidgetChanged(ui->systemTrayEnabled)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SysTrayEnabled",
 				ui->systemTrayEnabled->isChecked());
 
@@ -3510,27 +3518,27 @@ void OBSBasicSettings::SaveGeneralSettings()
 	}
 
 	if (WidgetChanged(ui->systemTrayWhenStarted))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SysTrayWhenStarted",
 				ui->systemTrayWhenStarted->isChecked());
 
 	if (WidgetChanged(ui->systemTrayAlways))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SysTrayMinimizeToTray",
 				ui->systemTrayAlways->isChecked());
 
 	if (WidgetChanged(ui->saveProjectors))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"SaveProjectors",
 				ui->saveProjectors->isChecked());
 
 	if (WidgetChanged(ui->closeProjectors))
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"CloseExistingProjectors",
 				ui->closeProjectors->isChecked());
 
 	if (WidgetChanged(ui->studioPortraitLayout)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"StudioPortraitLayout",
 				ui->studioPortraitLayout->isChecked());
 
@@ -3538,7 +3546,7 @@ void OBSBasicSettings::SaveGeneralSettings()
 	}
 
 	if (WidgetChanged(ui->prevProgLabelToggle)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"StudioModeLabels",
 				ui->prevProgLabelToggle->isChecked());
 
@@ -3547,28 +3555,28 @@ void OBSBasicSettings::SaveGeneralSettings()
 
 	bool multiviewChanged = false;
 	if (WidgetChanged(ui->multiviewMouseSwitch)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"MultiviewMouseSwitch",
 				ui->multiviewMouseSwitch->isChecked());
 		multiviewChanged = true;
 	}
 
 	if (WidgetChanged(ui->multiviewDrawNames)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"MultiviewDrawNames",
 				ui->multiviewDrawNames->isChecked());
 		multiviewChanged = true;
 	}
 
 	if (WidgetChanged(ui->multiviewDrawAreas)) {
-		config_set_bool(GetGlobalConfig(), "BasicWindow",
+		config_set_bool(App()->GetUserConfig(), "BasicWindow",
 				"MultiviewDrawAreas",
 				ui->multiviewDrawAreas->isChecked());
 		multiviewChanged = true;
 	}
 
 	if (WidgetChanged(ui->multiviewLayout)) {
-		config_set_int(GetGlobalConfig(), "BasicWindow",
+		config_set_int(App()->GetUserConfig(), "BasicWindow",
 			       "MultiviewLayout",
 			       ui->multiviewLayout->currentData().toInt());
 		multiviewChanged = true;
@@ -3616,12 +3624,12 @@ void OBSBasicSettings::SaveAdvancedSettings()
 
 #ifdef _WIN32
 	if (WidgetChanged(ui->renderer))
-		config_set_string(App()->GlobalConfig(), "Video", "Renderer",
+		config_set_string(App()->GetUserConfig(), "Video", "Renderer",
 				  QT_TO_UTF8(ui->renderer->currentText()));
 
 	std::string priority =
 		QT_TO_UTF8(ui->processPriority->currentData().toString());
-	config_set_string(App()->GlobalConfig(), "General", "ProcessPriority",
+	config_set_string(App()->GetAppConfig(), "General", "ProcessPriority",
 			  priority.c_str());
 	if (main->Active())
 		SetProcessPriority(priority.c_str());
@@ -3631,25 +3639,25 @@ void OBSBasicSettings::SaveAdvancedSettings()
 #endif
 #if defined(_WIN32) || defined(__APPLE__)
 	bool browserHWAccel = ui->browserHWAccel->isChecked();
-	config_set_bool(App()->GlobalConfig(), "General", "BrowserHWAccel",
+	config_set_bool(App()->GetUserConfig(), "General", "BrowserHWAccel",
 			browserHWAccel);
 #endif
 
 	if (WidgetChanged(ui->hotkeyFocusType)) {
 		QString str = GetComboData(ui->hotkeyFocusType);
-		config_set_string(App()->GlobalConfig(), "General",
+		config_set_string(App()->GetUserConfig(), "General",
 				  "HotkeyFocusType", QT_TO_UTF8(str));
 	}
 
 #ifdef __APPLE__
 	if (WidgetChanged(ui->disableOSXVSync)) {
 		bool disable = ui->disableOSXVSync->isChecked();
-		config_set_bool(App()->GlobalConfig(), "Video",
+		config_set_bool(App()->GetUserConfig(), "Video",
 				"DisableOSXVSync", disable);
 		EnableOSXVSync(!disable);
 	}
 	if (WidgetChanged(ui->resetOSXVSync))
-		config_set_bool(App()->GlobalConfig(), "Video",
+		config_set_bool(App()->GetUserConfig(), "Video",
 				"ResetOSXVSyncOnExit",
 				ui->resetOSXVSync->isChecked());
 #endif
@@ -3669,14 +3677,15 @@ void OBSBasicSettings::SaveAdvancedSettings()
 #ifdef _WIN32
 	if (WidgetChanged(ui->disableAudioDucking)) {
 		bool disable = ui->disableAudioDucking->isChecked();
-		config_set_bool(App()->GlobalConfig(), "Audio",
+		config_set_bool(App()->GetUserConfig(), "Audio",
 				"DisableAudioDucking", disable);
 		DisableAudioDucking(disable);
 	}
 #endif
 
 	if (WidgetChanged(ui->confirmOnExit))
-		config_set_bool(GetGlobalConfig(), "General", "ConfirmOnExit",
+		config_set_bool(App()->GetUserConfig(), "General",
+				"ConfirmOnExit",
 				ui->confirmOnExit->isChecked());
 
 	SaveEdit(ui->filenameFormatting, "Output", "FilenameFormatting");
@@ -4049,7 +4058,7 @@ void OBSBasicSettings::SaveAudioSettings()
 	if (WidgetChanged(ui->lowLatencyBuffering)) {
 		bool enableLLAudioBuffering =
 			ui->lowLatencyBuffering->isChecked();
-		config_set_bool(GetGlobalConfig(), "Audio",
+		config_set_bool(App()->GetUserConfig(), "Audio",
 				"LowLatencyAudioBuffering",
 				enableLLAudioBuffering);
 	}
@@ -4159,7 +4168,7 @@ void OBSBasicSettings::SaveSettings()
 		main->ResetVideo();
 
 	config_save_safe(main->Config(), "tmp", nullptr);
-	config_save_safe(GetGlobalConfig(), "tmp", nullptr);
+	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 	main->SaveProject();
 
 	if (Changed()) {
@@ -4788,7 +4797,7 @@ void OBSBasicSettings::HideOBSWindowWarning(int state)
 	if (loading || state == Qt::Unchecked)
 		return;
 
-	if (config_get_bool(GetGlobalConfig(), "General",
+	if (config_get_bool(App()->GetUserConfig(), "General",
 			    "WarnedAboutHideOBSFromCapture"))
 		return;
 
@@ -4796,9 +4805,9 @@ void OBSBasicSettings::HideOBSWindowWarning(int state)
 		this, QTStr("Basic.Settings.General.HideOBSWindowsFromCapture"),
 		QTStr("Basic.Settings.General.HideOBSWindowsFromCapture.Message"));
 
-	config_set_bool(GetGlobalConfig(), "General",
+	config_set_bool(App()->GetUserConfig(), "General",
 			"WarnedAboutHideOBSFromCapture", true);
-	config_save_safe(GetGlobalConfig(), "tmp", nullptr);
+	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 }
 
 /*

--- a/UI/window-dock-youtube-app.cpp
+++ b/UI/window-dock-youtube-app.cpp
@@ -431,16 +431,16 @@ void YouTubeAppDock::CleanupYouTubeUrls()
 	// remove legacy YouTube Browser Docks (once)
 
 	bool youtube_cleanup_done = config_get_bool(
-		App()->GlobalConfig(), "General", "YtDockCleanupDone");
+		App()->GetUserConfig(), "General", "YtDockCleanupDone");
 
 	if (youtube_cleanup_done)
 		return;
 
-	config_set_bool(App()->GlobalConfig(), "General", "YtDockCleanupDone",
+	config_set_bool(App()->GetUserConfig(), "General", "YtDockCleanupDone",
 			true);
 
 	const char *jsonStr = config_get_string(
-		App()->GlobalConfig(), "BasicWindow", "ExtraBrowserDocks");
+		App()->GetUserConfig(), "BasicWindow", "ExtraBrowserDocks");
 	if (!jsonStr)
 		return;
 
@@ -472,7 +472,7 @@ void YouTubeAppDock::CleanupYouTubeUrls()
 		OBSMessageBox::warning(OBSBasic::Get(), msg_title, msg_text);
 
 		std::string output = save_array.dump();
-		config_set_string(App()->GlobalConfig(), "BasicWindow",
+		config_set_string(App()->GetUserConfig(), "BasicWindow",
 				  "ExtraBrowserDocks", output.c_str());
 	}
 }

--- a/UI/window-dock.cpp
+++ b/UI/window-dock.cpp
@@ -20,13 +20,14 @@ void OBSDock::closeEvent(QCloseEvent *event)
 		msgbox.exec();
 
 		if (cb->isChecked()) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"WarnedAboutClosingDocks", true);
-			config_save_safe(App()->GlobalConfig(), "tmp", nullptr);
+			config_save_safe(App()->GetUserConfig(), "tmp",
+					 nullptr);
 		}
 	};
 
-	bool warned = config_get_bool(App()->GlobalConfig(), "General",
+	bool warned = config_get_bool(App()->GetUserConfig(), "General",
 				      "WarnedAboutClosingDocks");
 	if (!OBSBasic::Get()->Closing() && !warned) {
 		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection,

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -473,7 +473,7 @@ void OBSBasic::ClearExtraBrowserDocks()
 void OBSBasic::LoadExtraBrowserDocks()
 {
 	const char *jsonStr = config_get_string(
-		App()->GlobalConfig(), "BasicWindow", "ExtraBrowserDocks");
+		App()->GetUserConfig(), "BasicWindow", "ExtraBrowserDocks");
 
 	std::string err;
 	Json json = Json::parse(jsonStr, err);
@@ -511,7 +511,7 @@ void OBSBasic::SaveExtraBrowserDocks()
 	}
 
 	std::string output = Json(array).dump();
-	config_set_string(App()->GlobalConfig(), "BasicWindow",
+	config_set_string(App()->GetUserConfig(), "BasicWindow",
 			  "ExtraBrowserDocks", output.c_str());
 }
 

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -437,7 +437,7 @@ OBSImporter::OBSImporter(QWidget *parent)
 
 	ImportersInit();
 
-	bool autoSearchPrompt = config_get_bool(App()->GlobalConfig(),
+	bool autoSearchPrompt = config_get_bool(App()->GetUserConfig(),
 						"General", "AutoSearchPrompt");
 
 	if (!autoSearchPrompt) {
@@ -446,18 +446,18 @@ OBSImporter::OBSImporter(QWidget *parent)
 			QTStr("Importer.AutomaticCollectionText"));
 
 		if (button == QMessageBox::Yes) {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"AutomaticCollectionSearch", true);
 		} else {
-			config_set_bool(App()->GlobalConfig(), "General",
+			config_set_bool(App()->GetUserConfig(), "General",
 					"AutomaticCollectionSearch", false);
 		}
 
-		config_set_bool(App()->GlobalConfig(), "General",
+		config_set_bool(App()->GetUserConfig(), "General",
 				"AutoSearchPrompt", true);
 	}
 
-	bool autoSearch = config_get_bool(App()->GlobalConfig(), "General",
+	bool autoSearch = config_get_bool(App()->GetUserConfig(), "General",
 					  "AutomaticCollectionSearch");
 
 	OBSImporterFiles f;

--- a/UI/window-permissions.cpp
+++ b/UI/window-permissions.cpp
@@ -96,7 +96,7 @@ void OBSPermissions::on_accessibilityPermissionButton_clicked()
 
 void OBSPermissions::on_continueButton_clicked()
 {
-	config_set_int(GetGlobalConfig(), "General",
+	config_set_int(App()->GetAppConfig(), "General",
 		       "MacOSPermissionsDialogLastShown",
 		       MACOS_PERMISSIONS_DIALOG_VERSION);
 	close();

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -28,7 +28,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor,
 				  "destroy", OBSSourceDestroyed, this);
 	}
 
-	isAlwaysOnTop = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	isAlwaysOnTop = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					"ProjectorAlwaysOnTop");
 
 	if (isAlwaysOnTop)
@@ -144,7 +144,7 @@ void OBSProjector::SetHideCursor()
 	if (savedMonitor == -1)
 		return;
 
-	bool hideCursor = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool hideCursor = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					  "HideProjectorCursor");
 
 	if (hideCursor && type != ProjectorType::Multiview)
@@ -331,20 +331,21 @@ void OBSProjector::EscapeTriggered()
 void OBSProjector::UpdateMultiview()
 {
 	MultiviewLayout multiviewLayout = static_cast<MultiviewLayout>(
-		config_get_int(GetGlobalConfig(), "BasicWindow",
+		config_get_int(App()->GetUserConfig(), "BasicWindow",
 			       "MultiviewLayout"));
 
-	bool drawLabel = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	bool drawLabel = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "MultiviewDrawNames");
 
-	bool drawSafeArea = config_get_bool(GetGlobalConfig(), "BasicWindow",
-					    "MultiviewDrawAreas");
+	bool drawSafeArea = config_get_bool(
+		App()->GetUserConfig(), "BasicWindow", "MultiviewDrawAreas");
 
-	mouseSwitching = config_get_bool(GetGlobalConfig(), "BasicWindow",
+	mouseSwitching = config_get_bool(App()->GetUserConfig(), "BasicWindow",
 					 "MultiviewMouseSwitch");
 
-	transitionOnDoubleClick = config_get_bool(
-		GetGlobalConfig(), "BasicWindow", "TransitionOnDoubleClick");
+	transitionOnDoubleClick = config_get_bool(App()->GetUserConfig(),
+						  "BasicWindow",
+						  "TransitionOnDoubleClick");
 
 	multiview->Update(multiviewLayout, drawLabel, drawSafeArea);
 }

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -287,8 +287,8 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth,
 	workerThread->start();
 
 	OBSBasic *main = OBSBasic::Get();
-	bool rememberSettings = config_get_bool(main->basicConfig, "YouTube",
-						"RememberSettings");
+	bool rememberSettings = config_get_bool(main->activeConfiguration,
+						"YouTube", "RememberSettings");
 	if (rememberSettings)
 		LoadSettings();
 
@@ -749,83 +749,85 @@ void OBSYoutubeActions::SaveSettings(BroadcastDescription &broadcast)
 {
 	OBSBasic *main = OBSBasic::Get();
 
-	config_set_string(main->basicConfig, "YouTube", "Title",
+	config_set_string(main->activeConfiguration, "YouTube", "Title",
 			  QT_TO_UTF8(broadcast.title));
-	config_set_string(main->basicConfig, "YouTube", "Description",
+	config_set_string(main->activeConfiguration, "YouTube", "Description",
 			  QT_TO_UTF8(broadcast.description));
-	config_set_string(main->basicConfig, "YouTube", "Privacy",
+	config_set_string(main->activeConfiguration, "YouTube", "Privacy",
 			  QT_TO_UTF8(broadcast.privacy));
-	config_set_string(main->basicConfig, "YouTube", "CategoryID",
+	config_set_string(main->activeConfiguration, "YouTube", "CategoryID",
 			  QT_TO_UTF8(broadcast.category.id));
-	config_set_string(main->basicConfig, "YouTube", "Latency",
+	config_set_string(main->activeConfiguration, "YouTube", "Latency",
 			  QT_TO_UTF8(broadcast.latency));
-	config_set_bool(main->basicConfig, "YouTube", "MadeForKids",
+	config_set_bool(main->activeConfiguration, "YouTube", "MadeForKids",
 			broadcast.made_for_kids);
-	config_set_bool(main->basicConfig, "YouTube", "AutoStart",
+	config_set_bool(main->activeConfiguration, "YouTube", "AutoStart",
 			broadcast.auto_start);
-	config_set_bool(main->basicConfig, "YouTube", "AutoStop",
+	config_set_bool(main->activeConfiguration, "YouTube", "AutoStop",
 			broadcast.auto_start);
-	config_set_bool(main->basicConfig, "YouTube", "DVR", broadcast.dvr);
-	config_set_bool(main->basicConfig, "YouTube", "ScheduleForLater",
-			broadcast.schedul_for_later);
-	config_set_string(main->basicConfig, "YouTube", "Projection",
+	config_set_bool(main->activeConfiguration, "YouTube", "DVR",
+			broadcast.dvr);
+	config_set_bool(main->activeConfiguration, "YouTube",
+			"ScheduleForLater", broadcast.schedul_for_later);
+	config_set_string(main->activeConfiguration, "YouTube", "Projection",
 			  QT_TO_UTF8(broadcast.projection));
-	config_set_string(main->basicConfig, "YouTube", "ThumbnailFile",
+	config_set_string(main->activeConfiguration, "YouTube", "ThumbnailFile",
 			  QT_TO_UTF8(thumbnailFile));
-	config_set_bool(main->basicConfig, "YouTube", "RememberSettings", true);
+	config_set_bool(main->activeConfiguration, "YouTube",
+			"RememberSettings", true);
 }
 
 void OBSYoutubeActions::LoadSettings()
 {
 	OBSBasic *main = OBSBasic::Get();
 
-	const char *title =
-		config_get_string(main->basicConfig, "YouTube", "Title");
+	const char *title = config_get_string(main->activeConfiguration,
+					      "YouTube", "Title");
 	ui->title->setText(QT_UTF8(title));
 
-	const char *desc =
-		config_get_string(main->basicConfig, "YouTube", "Description");
+	const char *desc = config_get_string(main->activeConfiguration,
+					     "YouTube", "Description");
 	ui->description->setPlainText(QT_UTF8(desc));
 
-	const char *priv =
-		config_get_string(main->basicConfig, "YouTube", "Privacy");
+	const char *priv = config_get_string(main->activeConfiguration,
+					     "YouTube", "Privacy");
 	int index = ui->privacyBox->findData(priv);
 	ui->privacyBox->setCurrentIndex(index);
 
-	const char *catID =
-		config_get_string(main->basicConfig, "YouTube", "CategoryID");
+	const char *catID = config_get_string(main->activeConfiguration,
+					      "YouTube", "CategoryID");
 	index = ui->categoryBox->findData(catID);
 	ui->categoryBox->setCurrentIndex(index);
 
-	const char *latency =
-		config_get_string(main->basicConfig, "YouTube", "Latency");
+	const char *latency = config_get_string(main->activeConfiguration,
+						"YouTube", "Latency");
 	index = ui->latencyBox->findData(latency);
 	ui->latencyBox->setCurrentIndex(index);
 
-	bool dvr = config_get_bool(main->basicConfig, "YouTube", "DVR");
+	bool dvr = config_get_bool(main->activeConfiguration, "YouTube", "DVR");
 	ui->checkDVR->setChecked(dvr);
 
-	bool forKids =
-		config_get_bool(main->basicConfig, "YouTube", "MadeForKids");
+	bool forKids = config_get_bool(main->activeConfiguration, "YouTube",
+				       "MadeForKids");
 	if (forKids)
 		ui->yesMakeForKids->setChecked(true);
 	else
 		ui->notMakeForKids->setChecked(true);
 
-	bool schedLater = config_get_bool(main->basicConfig, "YouTube",
+	bool schedLater = config_get_bool(main->activeConfiguration, "YouTube",
 					  "ScheduleForLater");
 	ui->checkScheduledLater->setChecked(schedLater);
 
-	bool autoStart =
-		config_get_bool(main->basicConfig, "YouTube", "AutoStart");
+	bool autoStart = config_get_bool(main->activeConfiguration, "YouTube",
+					 "AutoStart");
 	ui->checkAutoStart->setChecked(autoStart);
 
-	bool autoStop =
-		config_get_bool(main->basicConfig, "YouTube", "AutoStop");
+	bool autoStop = config_get_bool(main->activeConfiguration, "YouTube",
+					"AutoStop");
 	ui->checkAutoStop->setChecked(autoStop);
 
-	const char *projection =
-		config_get_string(main->basicConfig, "YouTube", "Projection");
+	const char *projection = config_get_string(main->activeConfiguration,
+						   "YouTube", "Projection");
 	if (projection && *projection) {
 		if (strcmp(projection, "360") == 0)
 			ui->check360Video->setChecked(true);
@@ -833,8 +835,8 @@ void OBSYoutubeActions::LoadSettings()
 			ui->check360Video->setChecked(false);
 	}
 
-	const char *thumbFile = config_get_string(main->basicConfig, "YouTube",
-						  "ThumbnailFile");
+	const char *thumbFile = config_get_string(main->activeConfiguration,
+						  "YouTube", "ThumbnailFile");
 	if (thumbFile && *thumbFile) {
 		QFileInfo tFile(thumbFile);
 		// Re-check validity before setting path again


### PR DESCRIPTION
### Description
This PR implements backend changes required to make the storage locations of settings, profiles, and scene collections configurable and decoupled from OBS' current default storage location for its settings, log files, crash logs, and other generated files.

This is achieved in 3 major parts:

1. The configuration is split up into an "app" configuration (mainly for information that pertains to the work of the app itself, e.g. actual location of user configuration, last time the app has checked for updates, etc.) and a "user" configuration (mainly for settings that are exposed to the user and can be changed according to their preference).
2. Profile storage location is decoupled from any default path for settings and as such all code that uses the settings' path to access profile information has been changed
3. Scene collection storage location is decoupled from any default path for settings, like for profiles, code that uses the settings' path to access them has been changed

The implementation also introduces additional changes:

* Changes rely on C++17 functionality, such as availability of `std::string_view`, `std::filesystem` and others.
* Reliance of `using namespace std` was avoided as much as possible as it's a bad design pattern, when functionality from `std` was used, it's made explicit
* Use of pointers was avoided in favour of either `std::optional` (where it's use of copies were deemed good enough) or reference types to keep using value semantics as much as possible
* Some names were changed to make their function more explicit, e.g. `basicConfig` was renamed to `activeConfiguration` because it represents the currently active configuration object in use by the application (it's a state-dependent variable).
* In some cases (e.g. deletion of profiles or scene collections) copies are used on purpose as the underlying references are removed from the owning collection container
* Exception handling is favoured over returning single error values or checking for validity of modified variables as favoured by modern C++ practices.

Architecturally an attempt was made to introduce some encapsulation to the management of profiles and scene collections. Available scene collections or profiles are discovered on disk and cached in memory (with refreshes from disk happening only when explicitly requested). 

Handling of encoder configuration (which is stored in separate JSON files next to the profile settings file) has not been changed, but should be moved out of the encoder configuration and into the profile management, but was out of scope for this PR.

### Motivation and Context
The long-term goal of this work is to enable placing configuration files as well as profiles and scene collections in arbitrary locations provided by the user, such as:

* A network drive
* A vendor-specific directory that is automatically synced with cloud services (e.g. iCloud Drive)
* (Future) Non-file based storage (e.g. cloud storage APIs)

### How Has This Been Tested?
Tested on macOS 14 with the following scenarios:

* Launched OBS with existing configuration, settings were migrated to `user.ini`
* Launched OBS with missing scene collection, new collection was created in-place
* Launched OBS with missing profile, profile was created in-place
* Created/duplicated/removed/renamed profiles with and without "invalid" characters (i.e. emoji)
* Created/duplicated/removed/renamed scene collections with and without "invalid" characters
* Checked that UUIDs of sources in duplicated scene collections were correctly changed
* Checked that name of renamed/duplicated scene collections was correctly changed
* Checked that currently active profiles or scene collections were saved before any change took place

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
