### PR TITLE
CI: Remove openldap configuration files as part of Homebrew cleanup

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -87,6 +87,9 @@ jobs:
           print '::group::Clean Homebrew Environment'
           local -a to_remove=()
 
+          rm -rf /opt/homebrew/etc/openldap
+          rm -rf /usr/local/homebrew/etc/openldap
+
           for formula (curl) {
             if [[ -d ${HOMEBREW_PREFIX}/opt/${formula} ]] to_remove+=(${formula})
           }


### PR DESCRIPTION
### Description
Removes OpenLDAP orphaned configuration directories on macOS CI runners to prevent log spam from Homebrew.

In "Better to ask for forgiveness than permission" fashion, the change uses `rm -rf` to opportunistically delete the directories if they exist and fail quietly (i.e. without a non-zero return value) if they don't.

### Motivation and Context
Reduce clutter in CI output to keep only actionable warnings visible.

### How Has This Been Tested?
Needs to be tested on CI.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
