### PR TITLE
obs-qsv11: Add AV1 Screen Content Coding

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.h
+++ b/plugins/obs-qsv11/QSV_Encoder.h
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
 
+#define ONEVPL_EXPERIMENTAL
 #include <vpl/mfxstructures.h>
 #include <vpl/mfxadapter.h>
 #include <stdint.h>

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -54,6 +54,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #pragma once
+#define ONEVPL_EXPERIMENTAL
 #include <vpl/mfxstructures.h>
 #include <vpl/mfxvideo++.h>
 #include "QSV_Encoder.h"
@@ -121,6 +122,9 @@ private:
 	mfxExtCodingOption m_co;
 	mfxExtHEVCParam m_ExtHEVCParam{};
 	mfxExtAV1TileParam m_ExtAv1TileParam{};
+#if (MFX_VERSION_MAJOR >= 2 && MFX_VERSION_MINOR >= 11) || MFX_VERSION_MAJOR > 2
+	mfxExtAV1ScreenContentTools m_ExtAV1ScreenContentTools{};
+#endif
 	mfxExtVideoSignalInfo m_ExtVideoSignalInfo{};
 	mfxExtChromaLocInfo m_ExtChromaLocInfo{};
 	mfxExtMasteringDisplayColourVolume m_ExtMasteringDisplayColourVolume{};

--- a/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
+++ b/plugins/obs-qsv11/obs-qsv-test/obs-qsv-test.cpp
@@ -1,3 +1,4 @@
+#define ONEVPL_EXPERIMENTAL
 #include <vpl/mfxstructures.h>
 #include <vpl/mfxadapter.h>
 #include <vpl/mfxvideo++.h>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change adds AV1 SCC for new Intel platforms to improve quality. 
When tested, target usage target usage 4 had an average of a 20% quality gain (up to 40%) and target usage 6 had an average of a 25% quality gain (up to 40%).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change added quality improvements for future Intel platforms. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
new Intel platforms on various driver versions

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x ] My code is not on the master branch.
- [x ] The code has been tested.
- [x ] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
