### PR TITLE
Remove min and max macro workaround

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -9068,10 +9068,10 @@ void OBSBasic::CenterSelectedSceneItems(const CenterType &centerType)
 
 		GetItemBox(item, tl, br);
 
-		left = (std::min)(tl.x, left);
-		top = (std::min)(tl.y, top);
-		right = (std::max)(br.x, right);
-		bottom = (std::max)(br.y, bottom);
+		left = std::min(tl.x, left);
+		top = std::min(tl.y, top);
+		right = std::max(br.x, right);
+		bottom = std::max(br.y, bottom);
 	}
 
 	center.x = (right + left) / 2.0f;

--- a/plugins/obs-vst/VSTPlugin.cpp
+++ b/plugins/obs-vst/VSTPlugin.cpp
@@ -96,7 +96,7 @@ void VSTPlugin::createChannelBuffers(size_t count)
 	cleanupChannelBuffers();
 
 	int blocksize = BLOCK_SIZE;
-	numChannels = (std::max)((size_t)0, count);
+	numChannels = std::max((size_t)0, count);
 
 	if (numChannels > 0) {
 		inputs = (float **)bmalloc(sizeof(float *) * numChannels);
@@ -170,8 +170,7 @@ void VSTPlugin::loadEffectFromPath(const std::string &path)
 			return;
 		}
 
-		int maxchans =
-			(std::max)(effect->numInputs, effect->numOutputs);
+		int maxchans = std::max(effect->numInputs, effect->numOutputs);
 		// sanity check
 		if (maxchans < 0 || maxchans > 256) {
 			blog(LOG_WARNING,

--- a/plugins/obs-vst/headers/EditorWidget.h
+++ b/plugins/obs-vst/headers/EditorWidget.h
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QWidget>
 
 #if defined(_WIN32)
+#define NOMINMAX
 #include <QWindow>
 #include <Windows.h>
 #elif defined(__linux__)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR removes legacy workaround for the `max` and `min` macros on the legacy Windows environment.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Now the SDK provides a switch `NOMINMAX` to avoid defining the macros so that we no longer require the workaround in the source code.

In another PR, someone follows the workaround as [discussed during the review](https://github.com/obsproject/obs-studio/pull/10997#discussion_r1688385006).
The existing code is an example of the coding style guideline for potential future contributors. The coding style should be consistent.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Confirmed the build flow shows no errors on Linux, macOS, and Windows.

Also checked the modification by eyes.

OS: Fedora 39
Tested the centering with selecting multiple scene items.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and replace `[ ]` with `[x]` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
  - (UI was tested but obs-vst was not tested.)
- [x] All commit messages are properly formatted and commits are squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
