### PR TITLE
UI: Fix mem leak if --disable-missing-files-check

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1176,6 +1176,9 @@ void OBSBasic::Load(const char *file)
 
 static inline void AddMissingFiles(void *data, obs_source_t *source)
 {
+	if (!data)
+		return;
+
 	obs_missing_files_t *f = (obs_missing_files_t *)data;
 	obs_missing_files_t *sf = obs_source_get_missing_files(source);
 
@@ -1264,7 +1267,10 @@ void OBSBasic::LoadData(obs_data_t *data, const char *file)
 		obs_data_array_push_back_array(sources, groups);
 	}
 
-	obs_missing_files_t *files = obs_missing_files_create();
+	obs_missing_files_t *files = NULL;
+	if (!App()->IsMissingFilesCheckDisabled())
+		files = obs_missing_files_create();
+
 	obs_load_sources(sources, AddMissingFiles, files);
 
 	if (transitions)
@@ -1435,7 +1441,7 @@ retryScene:
 
 	LogScenes();
 
-	if (!App()->IsMissingFilesCheckDisabled())
+	if (files)
 		ShowMissingFilesDialog(files);
 
 	disableSaving--;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Make the --disable-missing-files-check flag actually inhibit the collection of a `files` list, not just the display of the missing files dialog.

Fixes a memory leak of the `files` list itself when the flag is used (and there are some missing files).

Closes: obsproject/obs-studio#11074

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix memory leak: https://github.com/obsproject/obs-studio/issues/11074

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manual testing of consistent behavior.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
