### PR TITLE
text-freetype: Use the pixel format for reading pixels

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -251,10 +251,10 @@ struct glyph_info *init_glyph(FT_GlyphSlot slot, const uint32_t dx,
 	return glyph;
 }
 
-uint8_t get_pixel_value(const unsigned char *buf_row,
-			FT_Render_Mode render_mode, const uint32_t x)
+uint8_t get_pixel_value(const unsigned char *buf_row, FT_Pixel_Mode pixel_mode,
+			const uint32_t x)
 {
-	if (render_mode == FT_RENDER_MODE_NORMAL) {
+	if (pixel_mode == FT_PIXEL_MODE_GRAY) {
 		return buf_row[x];
 	}
 
@@ -264,8 +264,7 @@ uint8_t get_pixel_value(const unsigned char *buf_row,
 	return pixel_set ? 255 : 0;
 }
 
-void rasterize(struct ft2_source *srcdata, FT_GlyphSlot slot,
-	       const FT_Render_Mode render_mode, const uint32_t dx,
+void rasterize(struct ft2_source *srcdata, FT_GlyphSlot slot, const uint32_t dx,
 	       const uint32_t dy)
 {
 	/**
@@ -274,7 +273,7 @@ void rasterize(struct ft2_source *srcdata, FT_GlyphSlot slot,
 	 *
 	 * Source: https://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html
 	 */
-	const int pitch = abs(slot->bitmap.pitch);
+	const uint32_t pitch = abs(slot->bitmap.pitch);
 
 	for (uint32_t y = 0; y < slot->bitmap.rows; y++) {
 		const uint32_t row_start = y * pitch;
@@ -284,7 +283,7 @@ void rasterize(struct ft2_source *srcdata, FT_GlyphSlot slot,
 			const uint32_t row_pixel_position = dx + x;
 			const uint8_t pixel_value =
 				get_pixel_value(&slot->bitmap.buffer[row_start],
-						render_mode, x);
+						slot->bitmap.pixel_mode, x);
 			srcdata->texbuf[row_pixel_position + row] = pixel_value;
 		}
 	}
@@ -335,7 +334,7 @@ void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs)
 		}
 
 		src_glyph = init_glyph(slot, dx, dy, g_w, g_h);
-		rasterize(srcdata, slot, render_mode, dx, dy);
+		rasterize(srcdata, slot, dx, dy);
 
 		dx += (g_w + 1);
 		if (dx >= texbuf_w) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes rendering for terrible bitmap fonts.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Resolves a long standing issue where people replace their normal monospace font with fonts from the 60s. Our code previously only tried this if we asked for 1bit formats, but freetype will do this automatically for 1bit fonts when the glyph doesnt need to be resized. So we need to use the format of the actual resulting rendered bitmap.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Loaded up a sample font from a user and it renders at exact resolutions now.

I have no idea who setup the original 1bit rendering stuff but maybe we should test whatever fonts that was originally setup for.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
