### PR TITLE
libobs: Avoid xdg-screensaver log spam

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -772,7 +772,7 @@ os_inhibit_t *os_inhibit_sleep_create(const char *reason)
 
 extern char **environ;
 
-static void reset_screensaver(os_inhibit_t *info)
+static int reset_screensaver(os_inhibit_t *info)
 {
 	char *argv[3] = {(char *)"xdg-screensaver", (char *)"reset", NULL};
 	pid_t pid;
@@ -784,8 +784,10 @@ static void reset_screensaver(os_inhibit_t *info)
 		while (waitpid(pid, &status, 0) == -1)
 			;
 	} else {
-		blog(LOG_WARNING, "Failed to create xdg-screensaver: %d", err);
+		blog(LOG_WARNING, "Failed to reset xdg-screensaver: %s",
+		     strerror(err));
 	}
+	return err;
 }
 
 static void *screensaver_thread(void *param)
@@ -818,6 +820,10 @@ bool os_inhibit_sleep_set_active(os_inhibit_t *info, bool active)
 		return true;
 
 	if (active) {
+		ret = reset_screensaver(info);
+		if (ret)
+			return false;
+
 		ret = pthread_create(&info->screensaver_thread, NULL,
 				     &screensaver_thread, info);
 		if (ret < 0) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

On systems without xdg-screensaver installed, the screensaver_thread whines every 30 seconds as it repeatedly tries and fails to execute it, resulting in this log spam:
```
warning: Failed to create xdg-screensaver: 2
warning: Failed to create xdg-screensaver: 2
warning: Failed to create xdg-screensaver: 2
...
```

Instead, verify that xdg-screensaver can be executed before starting the screensaver_thread.  The (corrected) warning message appears only once if it can't, e.g.:
```
warning: Failed to reset xdg-screensaver: No such file or directory
```


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Closes: obsproject/obs-studio#5479

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manual testing on an installation without xdg-screensaver installed; logfile inspection.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
