### PR TITLE
libobs: Fix global transition source signals

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1055,6 +1055,19 @@ static inline void obs_source_dosignal_canvas(struct obs_source *source, struct 
 		signal_handler_signal(source->context.signals, signal_source, &data);
 }
 
+static inline void obs_transition_dosignal(struct obs_source *source, const char *signal_obs, const char *signal_source)
+{
+	struct calldata data;
+	uint8_t stack[128];
+
+	calldata_init_fixed(&data, stack, sizeof(stack));
+	calldata_set_ptr(&data, "source", source);
+	if (signal_obs)
+		signal_handler_signal(obs->signals, signal_obs, &data);
+	if (signal_source)
+		signal_handler_signal(source->context.signals, signal_source, &data);
+}
+
 /* maximum timestamp variance in nanoseconds */
 #define MAX_TS_VAR 2000000000ULL
 

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -374,7 +374,7 @@ bool obs_transition_start(obs_source_t *transition, enum obs_transition_mode mod
 		transition->transitioning_audio = true;
 	}
 
-	obs_source_dosignal(transition, "source_transition_start", "transition_start");
+	obs_transition_dosignal(transition, "source_transition_start", "transition_start");
 
 	recalculate_transition_size(transition);
 	recalculate_transition_matrices(transition);
@@ -657,7 +657,7 @@ static inline void handle_stop(obs_source_t *transition)
 {
 	if (transition->info.transition_stop)
 		transition->info.transition_stop(transition->context.data);
-	obs_source_dosignal(transition, "source_transition_stop", "transition_stop");
+	obs_transition_dosignal(transition, "source_transition_stop", "transition_stop");
 }
 
 void obs_transition_force_stop(obs_source_t *transition)
@@ -757,7 +757,7 @@ void obs_transition_video_render2(obs_source_t *transition, obs_transition_video
 	obs_source_release(state.s[1]);
 
 	if (video_stopped)
-		obs_source_dosignal(transition, "source_transition_video_stop", "transition_video_stop");
+		obs_transition_dosignal(transition, "source_transition_video_stop", "transition_video_stop");
 	if (stopped)
 		handle_stop(transition);
 }
@@ -845,7 +845,7 @@ bool obs_transition_video_render_direct(obs_source_t *transition, enum obs_trans
 	obs_source_release(state.s[1]);
 
 	if (video_stopped)
-		obs_source_dosignal(transition, "source_transition_video_stop", "transition_video_stop");
+		obs_transition_dosignal(transition, "source_transition_video_stop", "transition_video_stop");
 	if (stopped)
 		handle_stop(transition);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This ensures the global transition source signals, `source_transition_start`, `source_transition_stop` and `source_transition_video_stop` actually get fired properly on the global signal handler.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Due to the use of `obs_source_dosignal` and to all transitions being created as private sources, those global signals were not fired, despite being implemented, and documented. This felt like an oversight.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 22.04, verified all signals got properly fired.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
