### PR TITLE
libobs: Create unique groups when duplicating scene

### DIFF
--- a/frontend/widgets/OBSBasic_Clipboard.cpp
+++ b/frontend/widgets/OBSBasic_Clipboard.cpp
@@ -278,6 +278,7 @@ OBS::ItemPasteType OBSBasic::getItemPasteType()
 		return OBS::ItemPasteType::Invalid;
 	}
 
+	bool allowPastingReference = true;
 	bool allowPastingDuplicate = true;
 	for (size_t i = clipboard.size(); i > 0; i--) {
 		const size_t idx = i - 1;
@@ -290,6 +291,19 @@ OBS::ItemPasteType OBSBasic::getItemPasteType()
 		if (allowPastingDuplicate && obs_source_get_output_flags(strong) & OBS_SOURCE_DO_NOT_DUPLICATE) {
 			allowPastingDuplicate = false;
 		}
+
+		if (allowPastingReference && obs_source_is_group(strong)) {
+			allowPastingReference = false;
+		}
 	}
-	return allowPastingDuplicate ? OBS::ItemPasteType::Both : OBS::ItemPasteType::Reference;
+
+	if (allowPastingReference && allowPastingDuplicate) {
+		return OBS::ItemPasteType::Both;
+	} else if (allowPastingReference) {
+		return OBS::ItemPasteType::Reference;
+	} else if (allowPastingDuplicate) {
+		return OBS::ItemPasteType::Duplicate;
+	}
+
+	return OBS::ItemPasteType::Invalid;
 }

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1961,7 +1961,8 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name, enum obs_
 
 	for (size_t i = 0; i < items.num; i++) {
 		item = items.array[i];
-		source = make_unique ? dup_child(&items, i, new_scene, make_private) : new_ref(item->source);
+		source = make_unique || item->is_group ? dup_child(&items, i, new_scene, make_private)
+						       : new_ref(item->source);
 
 		if (source) {
 			struct obs_scene_item *new_item = obs_scene_add(new_scene, source);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1961,7 +1961,8 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name, enum obs_
 
 	for (size_t i = 0; i < items.num; i++) {
 		item = items.array[i];
-		source = make_unique ? dup_child(&items, i, new_scene, make_private) : new_ref(item->source);
+		source = (make_unique || item->is_group) ? dup_child(&items, i, new_scene, make_private)
+							 : new_ref(item->source);
 
 		if (source) {
 			struct obs_scene_item *new_item = obs_scene_add(new_scene, source);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -641,8 +641,10 @@ obs_source_t *obs_source_duplicate(obs_source_t *source, const char *new_name, b
 		if (scene && !create_private) {
 			return obs_source_get_ref(source);
 		}
-		if (!scene)
+		if (!scene) {
 			scene = obs_group_from_source(source);
+			new_name = obs_source_get_name(source);
+		}
 		if (!scene)
 			return NULL;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Updates `obs_scene_duplicate` to always duplicate groups within the duplicated scene.

This fixes the weird behavior of groups in Studio Mode when Duplicate Scenes is ON and Duplicate Sources is OFF (These are the default settings)

### Motivation and Context
Studio mode allows users to modify a scene without the changes happening live in Program.

Since we default to Duplicate Scenes enabled and Duplicate Sources disabled, sources that are nested in a scene (or a group) still have their changes reflected immediately in program. In some cases, this is desirable behavior.

However, this has two drawbacks.

1. The size and position of a group updates based on its contents. This leads to extremely unpredictable behavior for groups with Studio Mode enabled on the default settings, as the groups size and position effectively desyncs
2. Most users don't realize that groups are scenes, and not a UI abstraction, meaning the nested scene behavior is usually confusing and undesirable

### How Has This Been Tested?
Adjusted the size and position of a group as well as it's contents in normal mode and studio mode.

Tested with all combinations of Duplicate Scenes and Duplicate Sources ON and OFF

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
