### PR TITLE
obs-outputs: Defer muxer destruction to task queue

### DIFF
--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -434,6 +434,12 @@ static void mp4_output_stop(void *data, uint64_t ts)
 	os_atomic_set_bool(&out->stopping, true);
 }
 
+static void mp4_mux_destroy_task(void *ptr)
+{
+	struct mp4_mux *muxer = ptr;
+	mp4_mux_destroy(muxer);
+}
+
 static void mp4_output_actual_stop(struct mp4_output *out, int code)
 {
 	os_atomic_set_bool(&out->active, false);
@@ -457,7 +463,8 @@ static void mp4_output_actual_stop(struct mp4_output *out, int code)
 
 	/* Flush/close output file and destroy muxer */
 	buffered_file_serializer_free(&out->serializer);
-	mp4_mux_destroy(out->muxer);
+	obs_queue_task(OBS_TASK_DESTROY, mp4_mux_destroy_task, out->muxer,
+		       false);
 	out->muxer = NULL;
 
 	/* Clear chapter data */


### PR DESCRIPTION
### Description

Defers destruction of the `mp4_mux` object to the destroy queue.

### Motivation and Context

Avoids a deadlock when the destruction attempts to free an encoder we're currently in the `send_packets` callback of.

Reported on Discord, deadlock figured out by R1CH.

### How Has This Been Tested?

Recorded and made sure stuff still works and there are no leaks.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
