### PR TITLE
v4l2-input: Support VAAPI decoding for v4l2 (MJPEG/H264)

### DIFF
--- a/plugins/linux-v4l2/v4l2-decoder.c
+++ b/plugins/linux-v4l2/v4l2-decoder.c
@@ -23,6 +23,23 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define blog(level, msg, ...) \
 	blog(level, "v4l2-input: decoder: " msg, ##__VA_ARGS__)
 
+static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
+					const enum AVPixelFormat *pix_fmts)
+{
+	const struct v4l2_decoder *decoder = (struct v4l2_decoder *)ctx->opaque;
+
+	const enum AVPixelFormat *p;
+
+	for (p = pix_fmts; *p != -1; p++) {
+		if (*p == decoder->hw_pix_fmt) {
+			return *p;
+		}
+	}
+
+	blog(LOG_ERROR, "Failed to get HW surface format.");
+	return AV_PIX_FMT_NONE;
+}
+
 int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt)
 {
 	if (pixfmt == V4L2_PIX_FMT_MJPEG) {
@@ -55,6 +72,41 @@ int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt)
 	}
 
 	decoder->context->flags2 |= AV_CODEC_FLAG2_FAST;
+	decoder->context->opaque = decoder;
+
+	if (pixfmt == V4L2_PIX_FMT_MJPEG || pixfmt == V4L2_PIX_FMT_H264) {
+		for (int i = 0;; i++) {
+			const AVCodecHWConfig *config =
+				avcodec_get_hw_config(decoder->codec, i);
+			if (!config) {
+				blog(LOG_ERROR, "No hw decoding device");
+				break;
+			}
+
+			if (config->methods &
+				    AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX &&
+			    config->device_type == AV_HWDEVICE_TYPE_VAAPI) {
+
+				AVBufferRef *hw_device_ctx = NULL;
+				if (av_hwdevice_ctx_create(
+					    &hw_device_ctx,
+					    AV_HWDEVICE_TYPE_VAAPI, NULL, NULL,
+					    0) >= 0) {
+					decoder->hw_pix_fmt = config->pix_fmt;
+					decoder->context->get_format =
+						get_hw_format;
+					decoder->context->hw_device_ctx =
+						av_buffer_ref(hw_device_ctx);
+					av_buffer_unref(&hw_device_ctx);
+					blog(LOG_INFO,
+					     "Using VAAPI decoder hw_pix_fmt: %s",
+					     av_get_pix_fmt_name(
+						     decoder->hw_pix_fmt));
+					break;
+				}
+			}
+		}
+	}
 
 	if (avcodec_open2(decoder->context, decoder->codec, NULL) < 0) {
 		blog(LOG_ERROR, "failed to open codec");
@@ -100,12 +152,36 @@ int v4l2_decode_frame(struct obs_source_frame *out, uint8_t *data,
 		return -1;
 	}
 
+	enum AVPixelFormat pix_fmt = decoder->context->pix_fmt;
+	if (decoder->context->hw_device_ctx &&
+	    decoder->frame->format == decoder->hw_pix_fmt) {
+		AVFrame *tmpframe;
+		if (!(tmpframe = av_frame_alloc())) {
+			blog(LOG_ERROR, "failed to allocate frame");
+			return -1;
+		}
+		/* NV12 is the most compatible format for downloading */
+		tmpframe->format = AV_PIX_FMT_NV12;
+
+		/* retrieve data from GPU to CPU */
+		blog(LOG_DEBUG, "retrieve frame from GPU");
+		if (av_hwframe_transfer_data(tmpframe, decoder->frame, 0) < 0) {
+			blog(LOG_ERROR,
+			     "Error transferring the data to system memory\n");
+			av_frame_free(&tmpframe);
+			return -1;
+		}
+		av_frame_free(&decoder->frame);
+		decoder->frame = tmpframe;
+		pix_fmt = tmpframe->format;
+	}
+
 	for (uint_fast32_t i = 0; i < MAX_AV_PLANES; ++i) {
 		out->data[i] = decoder->frame->data[i];
 		out->linesize[i] = decoder->frame->linesize[i];
 	}
 
-	switch (decoder->context->pix_fmt) {
+	switch (pix_fmt) {
 	case AV_PIX_FMT_GRAY8:
 		out->format = VIDEO_FORMAT_Y800;
 		break;
@@ -120,6 +196,9 @@ int v4l2_decode_frame(struct obs_source_frame *out, uint8_t *data,
 	case AV_PIX_FMT_YUVJ444P:
 	case AV_PIX_FMT_YUV444P:
 		out->format = VIDEO_FORMAT_I444;
+		break;
+	case AV_PIX_FMT_NV12:
+		out->format = VIDEO_FORMAT_NV12;
 		break;
 	default:
 		break;

--- a/plugins/linux-v4l2/v4l2-decoder.c
+++ b/plugins/linux-v4l2/v4l2-decoder.c
@@ -40,7 +40,7 @@ static enum AVPixelFormat get_hw_format(AVCodecContext *ctx,
 	return AV_PIX_FMT_NONE;
 }
 
-int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt)
+int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt, bool hwaccel)
 {
 	if (pixfmt == V4L2_PIX_FMT_MJPEG) {
 		decoder->codec = avcodec_find_decoder(AV_CODEC_ID_MJPEG);
@@ -74,7 +74,8 @@ int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt)
 	decoder->context->flags2 |= AV_CODEC_FLAG2_FAST;
 	decoder->context->opaque = decoder;
 
-	if (pixfmt == V4L2_PIX_FMT_MJPEG || pixfmt == V4L2_PIX_FMT_H264) {
+	if (hwaccel &&
+	    (pixfmt == V4L2_PIX_FMT_MJPEG || pixfmt == V4L2_PIX_FMT_H264)) {
 		for (int i = 0;; i++) {
 			const AVCodecHWConfig *config =
 				avcodec_get_hw_config(decoder->codec, i);

--- a/plugins/linux-v4l2/v4l2-decoder.h
+++ b/plugins/linux-v4l2/v4l2-decoder.h
@@ -45,7 +45,7 @@ struct v4l2_decoder {
  * @param pixfmt which codec is used
  * @return non-zero on failure
  */
-int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt);
+int v4l2_init_decoder(struct v4l2_decoder *decoder, int pixfmt, bool hwaccel);
 
 /**
  * Free any data associated with the decoder.

--- a/plugins/linux-v4l2/v4l2-decoder.h
+++ b/plugins/linux-v4l2/v4l2-decoder.h
@@ -24,6 +24,7 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
 #include <libavutil/pixfmt.h>
+#include <libavutil/pixdesc.h>
 
 /**
  * Data structure for decoder
@@ -33,6 +34,7 @@ struct v4l2_decoder {
 	AVCodecContext *context;
 	AVPacket *packet;
 	AVFrame *frame;
+	enum AVPixelFormat hw_pix_fmt;
 };
 
 /**


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Use VAAPI MJPEG/H264 decoding if available, using v4l2 cameras in Linux.

### Motivation and Context
MJPEG decoding was using most of the OBS cpu, when I have two camera inputs in V4L2.

### How Has This Been Tested?
I tested it in NixOS x86_64, with the patch over 30.1.2, which is what I had at hand. Then I also tested it on recent master, at exact commit hash provided.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
