### PR TITLE
libobs: Always explicitly check modifiers in macOS hotkey event handler

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -668,14 +668,13 @@ fail:
 
 static void handle_monitor_event(obs_hotkeys_platform_t *plat, NSEvent *event)
 {
-    if (event.type == NSEventTypeFlagsChanged) {
-        NSEventModifierFlags flags = event.modifierFlags;
-        plat->is_key_down[OBS_KEY_CAPSLOCK] = !!(flags & NSEventModifierFlagCapsLock);
-        plat->is_key_down[OBS_KEY_SHIFT] = !!(flags & NSEventModifierFlagShift);
-        plat->is_key_down[OBS_KEY_ALT] = !!(flags & NSEventModifierFlagOption);
-        plat->is_key_down[OBS_KEY_META] = !!(flags & NSEventModifierFlagCommand);
-        plat->is_key_down[OBS_KEY_CONTROL] = !!(flags & NSEventModifierFlagControl);
-    } else if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp) {
+    NSEventModifierFlags flags = event.modifierFlags;
+    plat->is_key_down[OBS_KEY_CAPSLOCK] = !!(flags & NSEventModifierFlagCapsLock);
+    plat->is_key_down[OBS_KEY_SHIFT] = !!(flags & NSEventModifierFlagShift);
+    plat->is_key_down[OBS_KEY_ALT] = !!(flags & NSEventModifierFlagOption);
+    plat->is_key_down[OBS_KEY_META] = !!(flags & NSEventModifierFlagCommand);
+    plat->is_key_down[OBS_KEY_CONTROL] = !!(flags & NSEventModifierFlagControl);
+    if (event.type == NSEventTypeKeyDown || event.type == NSEventTypeKeyUp) {
         plat->is_key_down[obs_key_from_virtual_key(event.keyCode)] = (event.type == NSEventTypeKeyDown);
     }
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the macOS hotkey system event handler to always explicitly register the state of the modifier keys, regardless of the event type that was received.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
It turns out that applications will not always receive a "flags changed" NSEvent from the system when a modifier key status is either pressed or let go of. These events seem particularly likely to be eaten by the system or other applications if the modifier is released, and that action results in the application losing focus (Command + Tab, for example), though it can also happen under some other circumstances. This means that OBS can often spuriously think that a modifier key is held when it is not, or, more rarely, that a modifier is not held when it is. This will in turn cause OBS's hotkey system to fail to properly register hotkey events.

Explicitly checking and registering the state of these modifier keys on every monitored keypress is slightly less efficient, but removes all reliance on these events, and means that OBS will always know accurately what modifier keys are held.

Should resolve https://github.com/obsproject/obs-studio/issues/4126, https://github.com/obsproject/obs-studio/issues/9023, possibly others.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Apple Silicon, macOS 15. Verified that both one-shot and "push-to" hotkeys now work much more reliably with OBS focused and unfocused, particularly when tabbing into and out of OBS.

### Other 

I thought about possibly basing this off of https://github.com/obsproject/obs-studio/pull/9583, in order to take advantage of the better TCC granularity of `CGEventTap` at the same time as fixing this bug. If maintainers think that that is a good idea, would be happy to rewrite this from there, or we could maybe even just merge this fix on top of that PR instead (@gxalpha @PatTheMav thoughts?)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
