### PR TITLE
UI: Improve full and incremental compilation times via explicit inclusion of generated Qt header files

### DIFF
--- a/UI/absolute-slider.cpp
+++ b/UI/absolute-slider.cpp
@@ -1,4 +1,4 @@
-#include "absolute-slider.hpp"
+#include "moc_absolute-slider.cpp"
 
 AbsoluteSlider::AbsoluteSlider(QWidget *parent) : SliderIgnoreScroll(parent)
 {

--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -7,7 +7,7 @@
 #include <cmath>
 #include <qt-wrappers.hpp>
 #include "obs-app.hpp"
-#include "adv-audio-control.hpp"
+#include "moc_adv-audio-control.cpp"
 #include "window-basic-main.hpp"
 
 #ifndef NSEC_PER_MSEC

--- a/UI/auth-base.cpp
+++ b/UI/auth-base.cpp
@@ -1,4 +1,4 @@
-#include "auth-base.hpp"
+#include "moc_auth-base.cpp"
 #include "window-basic-main.hpp"
 
 #include <vector>

--- a/UI/auth-listener.cpp
+++ b/UI/auth-listener.cpp
@@ -1,4 +1,4 @@
-#include <auth-listener.hpp>
+#include "moc_auth-listener.cpp"
 
 #include <QRegularExpression>
 #include <QRegularExpressionMatch>

--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -1,4 +1,4 @@
-#include "auth-oauth.hpp"
+#include "moc_auth-oauth.cpp"
 
 #include <QPushButton>
 #include <QHBoxLayout>

--- a/UI/auth-restream.cpp
+++ b/UI/auth-restream.cpp
@@ -1,4 +1,4 @@
-#include "auth-restream.hpp"
+#include "moc_auth-restream.cpp"
 
 #include <QPushButton>
 #include <QHBoxLayout>

--- a/UI/auth-twitch.cpp
+++ b/UI/auth-twitch.cpp
@@ -1,4 +1,4 @@
-#include "auth-twitch.hpp"
+#include "moc_auth-twitch.cpp"
 
 #include <QRegularExpression>
 #include <QPushButton>

--- a/UI/auth-youtube.cpp
+++ b/UI/auth-youtube.cpp
@@ -1,4 +1,4 @@
-#include "auth-youtube.hpp"
+#include "moc_auth-youtube.cpp"
 
 #include <iostream>
 #include <QMessageBox>

--- a/UI/basic-controls.cpp
+++ b/UI/basic-controls.cpp
@@ -1,4 +1,4 @@
-#include "basic-controls.hpp"
+#include "moc_basic-controls.cpp"
 
 #include "window-basic-main.hpp"
 

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -1,5 +1,5 @@
 #include "window-basic-main.hpp"
-#include "context-bar-controls.hpp"
+#include "moc_context-bar-controls.cpp"
 #include "obs-app.hpp"
 
 #include <qt-wrappers.hpp>

--- a/UI/focus-list.cpp
+++ b/UI/focus-list.cpp
@@ -1,4 +1,4 @@
-#include "focus-list.hpp"
+#include "moc_focus-list.cpp"
 #include <QDragMoveEvent>
 
 FocusList::FocusList(QWidget *parent) : QListWidget(parent) {}

--- a/UI/horizontal-scroll-area.cpp
+++ b/UI/horizontal-scroll-area.cpp
@@ -1,5 +1,5 @@
 #include <QResizeEvent>
-#include "horizontal-scroll-area.hpp"
+#include "moc_horizontal-scroll-area.cpp"
 
 void HScrollArea::resizeEvent(QResizeEvent *event)
 {

--- a/UI/hotkey-edit.cpp
+++ b/UI/hotkey-edit.cpp
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include "window-basic-settings.hpp"
-#include "hotkey-edit.hpp"
+#include "moc_hotkey-edit.cpp"
 
 #include <util/dstr.hpp>
 #include <QPointer>

--- a/UI/lineedit-autoresize.cpp
+++ b/UI/lineedit-autoresize.cpp
@@ -1,4 +1,4 @@
-#include "lineedit-autoresize.hpp"
+#include "moc_lineedit-autoresize.cpp"
 
 LineEditAutoResize::LineEditAutoResize() : m_maxLength(32767)
 {

--- a/UI/log-viewer.cpp
+++ b/UI/log-viewer.cpp
@@ -10,7 +10,7 @@
 #include <string>
 #include <qt-wrappers.hpp>
 
-#include "log-viewer.hpp"
+#include "moc_log-viewer.cpp"
 
 OBSLogViewer::OBSLogViewer(QWidget *parent)
 	: QDialog(parent),

--- a/UI/media-controls.cpp
+++ b/UI/media-controls.cpp
@@ -1,5 +1,5 @@
 #include "window-basic-main.hpp"
-#include "media-controls.hpp"
+#include "moc_media-controls.cpp"
 #include "obs-app.hpp"
 #include <QToolTip>
 #include <QStyle>

--- a/UI/menu-button.cpp
+++ b/UI/menu-button.cpp
@@ -1,7 +1,7 @@
 #include <QMenu>
 #include <QKeyEvent>
 #include <QMouseEvent>
-#include "menu-button.hpp"
+#include "moc_menu-button.cpp"
 
 void MenuButton::keyPressEvent(QKeyEvent *event)
 {

--- a/UI/qt-display.cpp
+++ b/UI/qt-display.cpp
@@ -1,4 +1,4 @@
-#include "qt-display.hpp"
+#include "moc_qt-display.cpp"
 #include "display-helpers.hpp"
 #include <QWindow>
 #include <QScreen>

--- a/UI/remote-text.cpp
+++ b/UI/remote-text.cpp
@@ -18,7 +18,7 @@
 #include <util/curl/curl-helper.h>
 #include <qt-wrappers.hpp>
 #include "obs-app.hpp"
-#include "remote-text.hpp"
+#include "moc_remote-text.cpp"
 
 using namespace std;
 

--- a/UI/scene-tree.cpp
+++ b/UI/scene-tree.cpp
@@ -1,4 +1,4 @@
-#include "scene-tree.hpp"
+#include "moc_scene-tree.cpp"
 
 #include <QSizePolicy>
 #include <QScrollBar>

--- a/UI/source-label.cpp
+++ b/UI/source-label.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "source-label.hpp"
+#include "moc_source-label.cpp"
 
 void OBSSourceLabel::SourceRenamed(void *data, calldata_t *params)
 {

--- a/UI/ui-validation.cpp
+++ b/UI/ui-validation.cpp
@@ -1,4 +1,4 @@
-#include "ui-validation.hpp"
+#include "moc_ui-validation.cpp"
 
 #include <obs.hpp>
 #include <QString>

--- a/UI/undo-stack-obs.cpp
+++ b/UI/undo-stack-obs.cpp
@@ -1,4 +1,4 @@
-#include "undo-stack-obs.hpp"
+#include "moc_undo-stack-obs.cpp"
 
 #include <util/util.hpp>
 

--- a/UI/update/mac-update.cpp
+++ b/UI/update/mac-update.cpp
@@ -1,6 +1,6 @@
 #include "update-helpers.hpp"
 #include "shared-update.hpp"
-#include "mac-update.hpp"
+#include "moc_mac-update.cpp"
 #include "obs-app.hpp"
 
 #include <string>

--- a/UI/update/shared-update.cpp
+++ b/UI/update/shared-update.cpp
@@ -1,4 +1,4 @@
-#include "shared-update.hpp"
+#include "moc_shared-update.cpp"
 #include "crypto-helpers.hpp"
 #include "update-helpers.hpp"
 #include "obs-app.hpp"

--- a/UI/url-push-button.cpp
+++ b/UI/url-push-button.cpp
@@ -1,4 +1,4 @@
-#include "url-push-button.hpp"
+#include "moc_url-push-button.cpp"
 
 #include <QUrl>
 #include <QMouseEvent>

--- a/UI/visibility-item-widget.cpp
+++ b/UI/visibility-item-widget.cpp
@@ -1,4 +1,4 @@
-#include "visibility-item-widget.hpp"
+#include "moc_visibility-item-widget.cpp"
 #include "obs-app.hpp"
 #include "source-label.hpp"
 

--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1,5 +1,5 @@
 #include "window-basic-main.hpp"
-#include "volume-control.hpp"
+#include "moc_volume-control.cpp"
 #include "obs-app.hpp"
 #include "mute-checkbox.hpp"
 #include "absolute-slider.hpp"

--- a/UI/window-basic-about.cpp
+++ b/UI/window-basic-about.cpp
@@ -1,4 +1,4 @@
-#include "window-basic-about.hpp"
+#include "moc_window-basic-about.cpp"
 #include "window-basic-main.hpp"
 #include "remote-text.hpp"
 #include <qt-wrappers.hpp>

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -6,7 +6,7 @@
 
 #include <nlohmann/json.hpp>
 
-#include "window-basic-auto-config.hpp"
+#include "moc_window-basic-auto-config.cpp"
 #include "window-basic-main.hpp"
 #include "obs-app.hpp"
 #include "url-push-button.hpp"

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include "obs-app.hpp"
-#include "window-basic-interaction.hpp"
+#include "moc_window-basic-interaction.cpp"
 #include "window-basic-main.hpp"
 #include "display-helpers.hpp"
 

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -6,7 +6,7 @@
 #include <graphics/vec4.h>
 #include <graphics/matrix4.h>
 #include <util/dstr.hpp>
-#include "window-basic-preview.hpp"
+#include "moc_window-basic-preview.cpp"
 #include "window-basic-main.hpp"
 #include "obs-app.hpp"
 #include "platform.hpp"

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include "obs-app.hpp"
-#include "window-basic-properties.hpp"
+#include "moc_window-basic-properties.cpp"
 #include "window-basic-main.hpp"
 #include "display-helpers.hpp"
 

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -44,7 +44,7 @@
 #include "platform.hpp"
 #include "properties-view.hpp"
 #include "window-basic-main.hpp"
-#include "window-basic-settings.hpp"
+#include "moc_window-basic-settings.cpp"
 #include "window-basic-main-outputs.hpp"
 #include "window-projector.hpp"
 

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -18,7 +18,7 @@
 #include <QMessageBox>
 #include <qt-wrappers.hpp>
 #include "window-basic-main.hpp"
-#include "window-basic-source-select.hpp"
+#include "moc_window-basic-source-select.cpp"
 #include "obs-app.hpp"
 
 struct AddSourceData {

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -1,6 +1,6 @@
 #include "obs-frontend-api/obs-frontend-api.h"
 
-#include "window-basic-stats.hpp"
+#include "moc_window-basic-stats.cpp"
 #include "window-basic-main.hpp"
 #include "platform.hpp"
 #include "obs-app.hpp"

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -2,7 +2,7 @@
 #include <QPixmap>
 #include "obs-app.hpp"
 #include "window-basic-main.hpp"
-#include "window-basic-status-bar.hpp"
+#include "moc_window-basic-status-bar.cpp"
 #include "window-basic-main-outputs.hpp"
 #include "qt-wrappers.hpp"
 #include "platform.hpp"

--- a/UI/window-basic-vcam-config.cpp
+++ b/UI/window-basic-vcam-config.cpp
@@ -1,4 +1,4 @@
-#include "window-basic-vcam-config.hpp"
+#include "moc_window-basic-vcam-config.cpp"
 #include "window-basic-main.hpp"
 
 #include <qt-wrappers.hpp>

--- a/UI/window-dock-youtube-app.cpp
+++ b/UI/window-dock-youtube-app.cpp
@@ -2,7 +2,7 @@
 
 #include "window-basic-main.hpp"
 #include "youtube-api-wrappers.hpp"
-#include "window-dock-youtube-app.hpp"
+#include "moc_window-dock-youtube-app.cpp"
 
 #include "ui-config.h"
 #include "qt-wrappers.hpp"

--- a/UI/window-dock.cpp
+++ b/UI/window-dock.cpp
@@ -1,4 +1,4 @@
-#include "window-dock.hpp"
+#include "moc_window-dock.cpp"
 #include "obs-app.hpp"
 #include "window-basic-main.hpp"
 

--- a/UI/window-extra-browsers.cpp
+++ b/UI/window-extra-browsers.cpp
@@ -1,4 +1,4 @@
-#include "window-extra-browsers.hpp"
+#include "moc_window-extra-browsers.cpp"
 #include "window-dock-browser.hpp"
 #include "window-basic-main.hpp"
 

--- a/UI/window-importer.cpp
+++ b/UI/window-importer.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "window-importer.hpp"
+#include "moc_window-importer.cpp"
 
 #include "obs-app.hpp"
 

--- a/UI/window-log-reply.cpp
+++ b/UI/window-log-reply.cpp
@@ -19,7 +19,7 @@
 #include <QUrl>
 #include <QUrlQuery>
 #include <QDesktopServices>
-#include "window-log-reply.hpp"
+#include "moc_window-log-reply.cpp"
 #include "obs-app.hpp"
 
 OBSLogReply::OBSLogReply(QWidget *parent, const QString &url, const bool crash)

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "window-missing-files.hpp"
+#include "moc_window-missing-files.cpp"
 #include "window-basic-main.hpp"
 
 #include "obs-app.hpp"

--- a/UI/window-namedialog.cpp
+++ b/UI/window-namedialog.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "window-namedialog.hpp"
+#include "moc_window-namedialog.cpp"
 #include "obs-app.hpp"
 
 #include <qt-wrappers.hpp>

--- a/UI/window-permissions.cpp
+++ b/UI/window-permissions.cpp
@@ -16,7 +16,7 @@
 ******************************************************************************/
 
 #include <QLabel>
-#include "window-permissions.hpp"
+#include "moc_window-permissions.cpp"
 #include "obs-app.hpp"
 
 OBSPermissions::OBSPermissions(QWidget *parent, MacPermissionStatus capture,

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -4,6 +4,7 @@
 #include <QMenu>
 #include <QScreen>
 #include <qt-wrappers.hpp>
+#include "moc_window-projector.cpp"
 #include "obs-app.hpp"
 #include "window-basic-main.hpp"
 #include "display-helpers.hpp"

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "window-remux.hpp"
+#include "moc_window-remux.cpp"
 
 #include "obs-app.hpp"
 

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -1,5 +1,5 @@
 #include "window-basic-main.hpp"
-#include "window-youtube-actions.hpp"
+#include "moc_window-youtube-actions.cpp"
 
 #include "obs-app.hpp"
 #include "youtube-api-wrappers.hpp"

--- a/UI/youtube-api-wrappers.cpp
+++ b/UI/youtube-api-wrappers.cpp
@@ -1,4 +1,4 @@
-#include "youtube-api-wrappers.hpp"
+#include "moc_youtube-api-wrappers.cpp"
 
 #include <QUrl>
 #include <QMimeDatabase>

--- a/shared/properties-view/double-slider.cpp
+++ b/shared/properties-view/double-slider.cpp
@@ -1,4 +1,4 @@
-#include "double-slider.hpp"
+#include "moc_double-slider.cpp"
 
 #include <cmath>
 

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -27,7 +27,7 @@
 #include <QUuid>
 #include "double-slider.hpp"
 #include "spinbox-ignorewheel.hpp"
-#include "properties-view.hpp"
+#include "moc_properties-view.cpp"
 #include "properties-view.moc.hpp"
 
 #include <qt-wrappers.hpp>

--- a/shared/properties-view/spinbox-ignorewheel.cpp
+++ b/shared/properties-view/spinbox-ignorewheel.cpp
@@ -1,4 +1,4 @@
-#include "spinbox-ignorewheel.hpp"
+#include "moc_spinbox-ignorewheel.cpp"
 
 SpinBoxIgnoreScroll::SpinBoxIgnoreScroll(QWidget *parent) : QSpinBox(parent)
 {

--- a/shared/qt/plain-text-edit/plain-text-edit.cpp
+++ b/shared/qt/plain-text-edit/plain-text-edit.cpp
@@ -1,4 +1,4 @@
-#include <plain-text-edit.hpp>
+#include "moc_plain-text-edit.cpp"
 #include <QFontDatabase>
 
 OBSPlainTextEdit::OBSPlainTextEdit(QWidget *parent, bool monospace)

--- a/shared/qt/slider-ignorewheel/slider-ignorewheel.cpp
+++ b/shared/qt/slider-ignorewheel/slider-ignorewheel.cpp
@@ -1,4 +1,4 @@
-#include "slider-ignorewheel.hpp"
+#include "moc_slider-ignorewheel.cpp"
 
 SliderIgnoreScroll::SliderIgnoreScroll(QWidget *parent) : QSlider(parent)
 {

--- a/shared/qt/vertical-scroll-area/vertical-scroll-area.cpp
+++ b/shared/qt/vertical-scroll-area/vertical-scroll-area.cpp
@@ -1,5 +1,5 @@
 #include <QResizeEvent>
-#include "vertical-scroll-area.hpp"
+#include "moc_vertical-scroll-area.cpp"
 
 void VScrollArea::resizeEvent(QResizeEvent *event)
 {

--- a/shared/qt/wrappers/qt-wrappers.cpp
+++ b/shared/qt/wrappers/qt-wrappers.cpp
@@ -15,7 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
-#include "qt-wrappers.hpp"
+#include "moc_qt-wrappers.cpp"
 
 #include <graphics/graphics.h>
 #include <util/threading.h>


### PR DESCRIPTION
### Description
Changes include statements of compatible source files to use header files generated by Qt's `moc` precompiler to improve full and incremental build times.

### Motivation and Context
Every source file using certain Qt preprocessor statements (e.g. `Q_OBJECT`) require boilerplate code to be added for them to work.

To achieve this, CMake-based projects can use the `AUTOMOC` property on a target which will make CMake scan all header and source files associated with the target for instances of `Q_OBJECT` use (and a few other statements) and add a pre-build step for the target to generate the required boilerplate code.

By default this will lead to a single file called "mocs_compilation.cpp" to be generated (and added to the source list of the target) which itself includes _all_ files generated by `moc`.

The more source files use `Q_OBJECT` the longer this list will become and the longer the `moc` compilation step will take (especially as this step will be repeated for _every_ compilation and also for every configuration, so for Xcode and MSVC all source files are potentially compiled by `moc` up to 4 times).

Larger projects reliant on Qt thus prefer to explicitly include the file generated by `moc` for a specific source file instead of relying on the large global file to improve compilation times:

* Each source is associated with a single header generated by `moc`, thus the build system can better track if recompilation is necessary
* The global "mocs_compilation.cpp" file will shrink in size and require less time to compile on each compilation
* The compiler has potentially more code available for each compilation unit to create better output

Fortunately CMake supports this out of the box: As soon as it detects the use of a corresponding `moc` file included in a source file, it will omit it from the global file.

> [!NOTE]
> 
> While there are build-tools to automatically scan for and add the include to source files, this PR was created by hand. There are other source files that could potentially benefit from this change as well, but the current use of `Q_DECLARE_METATYPE` in OBS is incompatible with the change (the current source code violates Qt rules regarding meta types in a few places).
>
> It is also not required to immediately add the explicit include during development - CMake's AUTOMOC will still detect non-explicit use and generate the global header accordingly.

### How Has This Been Tested?
Tested with a full re-compilation and incremental compilations on macOS 14.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
