### PR TITLE
CI: Remove game capture dual-signing

### DIFF
--- a/.github/actions/windows-signing/action.yaml
+++ b/.github/actions/windows-signing/action.yaml
@@ -90,13 +90,6 @@ runs:
         Ensure-Location "${{ github.workspace }}/old_builds"
         rclone copy --transfers 100 ":gcs:obs-latest/${{ inputs.channel }}" .
 
-    - name: Download Presigned Game Capture Files (REMOVE AFTER 30.2!!)
-      shell: pwsh
-      env:
-        RCLONE_GCS_ENV_AUTH: 'true'
-      run: |
-        rclone copy :gcs:obs-game-capture "${{ github.workspace }}/build/data/obs-plugins/win-capture"
-
     - name: Run bouf
       shell: pwsh
       run: |

--- a/.github/actions/windows-signing/config.toml
+++ b/.github/actions/windows-signing/config.toml
@@ -24,8 +24,7 @@ sign_kms_key_id = "projects/ci-signing/locations/global/keyRings/production/cryp
 sign_digest = "sha384"
 sign_ts_serv = "http://timestamp.digicert.com"
 sign_exts = ['exe', 'dll', 'pyd']
-sign_append = true
-sign_ts_algo = "sha256"
+sign_append = false
 
 [prepare.strip_pdbs]
 # PDBs to not strip

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -207,7 +207,7 @@ jobs:
 
   sign-windows-build:
     name: Windows Signing ✍️
-    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@d2b05a6e0c6a0f51c42f247efd581bed8f4a1877
+    uses: obsproject/obs-studio/.github/workflows/sign-windows.yaml@dc7a58484d3ef2c610a5184dd05d1d02dbd3e549
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
     needs: build-project
     permissions:


### PR DESCRIPTION
### Description

Remove step copying legacy game capture DLLs for dual-signing.

### Motivation and Context

Per https://obsproject.com/kb/capture-hook-certificate-update we want to switch exclusively to the new cert starting with 31.0.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
