### PR TITLE
obs-webrtc: Fix bug in whip-output.cpp to support stun or turn

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -324,7 +324,8 @@ void WHIPOutput::ParseLinkHeader(std::string val,
 			token = val.substr(0, pos);
 		}
 
-		if (token.find("<turn:", 0) == 0) {
+		if ((token.find("<stun:", 0) == 0) ||
+		    (token.find("<turn:", 0) == 0)) {
 			url = extractUrl(token);
 		} else if (token.find("username=") != std::string::npos) {
 			username = extractValue(token);


### PR DESCRIPTION
Description
The following change was added to fix a bug which stopped `stun` being supported; it previously worked as expected. Specific single line modification and addition is as follows:

Token at the beginning of a string has an OR added to allow `<stun:` in addition to `<turn:`

How Has This Been Tested?
It returns functionality that existed previously and is simplistic string token matching

Types of changes
Bug fix, feature restoral

Checklist:
 My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
 I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
 My code is not on the master branch.
 The code has NOT been directly tested.
 All commit messages are properly formatted and commits squashed where appropriate.
