### PR TITLE
rtmp-services: Add NFHS Network

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 260,
+    "version": 261,
     "files": [
         {
             "name": "services.json",
-            "version": 260
+            "version": 261
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2942,6 +2942,28 @@
                 "keyint": 1,
                 "bframes": 0
             }
+        },
+        {
+            "name": "NFHS Network",
+            "more_info_link": "https://support.nfhsnetwork.com/hc/en-us",
+            "stream_key_link": "https://console.nfhsnetwork.com/nfhs-events/",
+            "servers": [
+                {
+                    "name": "Manual Broadcasts",
+                    "url": "rtmp://video.nfhsnetwork.com/manual"
+                }
+            ],
+            "recommended": {
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "640x360"
+                ],
+                "max fps": 60
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Added rtmp service for the [NFHS Network](https://www.nfhsnetwork.com/).

We modified the `package.json` and `services.json` files inside of the `rtmp-services` plugin to include the primary RTMP endpoint for the NFHS Network. The changes to the plugin also include our supported resolutions and maximum frame rate.

### Motivation and Context
Our primary motivation for this was to simplify the process of getting our customers streaming to our service and prevent potential user errors when re-typing or pasting the RTMP URL.

### How Has This Been Tested?
- JSON Validation
- Built using cmake and compiled using XCode on a 2021 Macbook Pro (Apple M1 Pro) running MacOS Sonoma 14.4.1
- Performed a test stream to our service using the new NFHS Network service dropdown option
- Verified RTMP stream displayed on the service

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
