### PR TITLE
happy-eyeballs: Various bug fixes and improvements

### DIFF
--- a/shared/happy-eyeballs/happy-eyeballs.c
+++ b/shared/happy-eyeballs/happy-eyeballs.c
@@ -497,6 +497,7 @@ int happy_eyeballs_create(struct happy_eyeballs_ctx **context)
 
 	ctx->socket_fd = INVALID_SOCKET;
 	da_init(ctx->candidates);
+	da_reserve(ctx->candidates, HAPPY_EYEBALLS_MAX_ATTEMPTS);
 
 	/* race_completed_event will be signalled when there is a winner or all
 	 * attempts have failed */

--- a/shared/happy-eyeballs/happy-eyeballs.c
+++ b/shared/happy-eyeballs/happy-eyeballs.c
@@ -194,6 +194,7 @@ static int build_addr_list(const char *hostname, int port,
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_protocol = IPPROTO_TCP;
+	hints.ai_flags = AI_ADDRCONFIG;
 
 	if (context->bind_addr_len == sizeof(struct sockaddr_in))
 		hints.ai_family = AF_INET;


### PR DESCRIPTION
### Description
[b7f89de](https://github.com/obsproject/obs-studio/pull/11110/commits/b7f89dedf0e79b42e62a8c89f2da719ba55445af) reserves enough space in the candidates array to avoid reallocation during happy eyeballs execution. The code should ideally not rely on the darray being fixed in the first place, but a better refactor can come later.

[c699dce](https://github.com/obsproject/obs-studio/pull/11110/commits/c699dce3e9b5efbd32e23108f675c2b43bf1047c) fixes an issue on Windows where `RTMP_Connect` would block while calling `happy_eyeballs_destroy`, causing the entire RTMP connection to time out when there was a happy eyeballs candidate still in progress.

[241429c](https://github.com/obsproject/obs-studio/pull/11110/commits/241429c927a328449943fb39874b4343c2321c8b) adds a hint flag to `getaddrinfo` that should help reduce unusable IPs in the response:
> If hints.ai_flags includes the AI_ADDRCONFIG flag, then IPv4 addresses are returned in the list pointed to by res only if the local system has at least one IPv4 address configured, and IPv6 addresses are only returned if the local system has at least one IPv6 address configured. The loopback address is not considered for this case as valid as a configured address.

### Motivation and Context
Fixes user-reported disconnect issues, crashing and other undefined behavior.

### How Has This Been Tested?
Ran under ASAN, no more invalid memory accesses. Tested with an affected user and confirmed no more RTMP timeouts.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
