### PR TITLE
libobs: Move encoders to being fully reference counted

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -379,7 +379,7 @@ static inline void free_audio_buffers(struct obs_encoder *encoder)
 	}
 }
 
-static void obs_encoder_actually_destroy(obs_encoder_t *encoder)
+void obs_encoder_destroy(obs_encoder_t *encoder)
 {
 	if (encoder) {
 		pthread_mutex_lock(&encoder->outputs_mutex);
@@ -417,28 +417,6 @@ static void obs_encoder_actually_destroy(obs_encoder_t *encoder)
 			video_output_free_frame_rate_divisor(
 				encoder->fps_override);
 		bfree(encoder);
-	}
-}
-
-/* does not actually destroy the encoder until all connections to it have been
- * removed. (full reference counting really would have been superfluous) */
-void obs_encoder_destroy(obs_encoder_t *encoder)
-{
-	if (encoder) {
-		bool destroy;
-
-		obs_context_data_remove(&encoder->context);
-
-		pthread_mutex_lock(&encoder->init_mutex);
-		pthread_mutex_lock(&encoder->callbacks_mutex);
-		destroy = encoder->callbacks.num == 0;
-		if (!destroy)
-			encoder->destroy_on_stop = true;
-		pthread_mutex_unlock(&encoder->callbacks_mutex);
-		pthread_mutex_unlock(&encoder->init_mutex);
-
-		if (destroy)
-			obs_encoder_actually_destroy(encoder);
 	}
 }
 
@@ -815,9 +793,6 @@ void obs_encoder_stop(obs_encoder_t *encoder,
 		pthread_mutex_unlock(&encoder->init_mutex);
 
 		struct obs_encoder_group *group = encoder->encoder_group;
-
-		if (encoder->destroy_on_stop)
-			obs_encoder_actually_destroy(encoder);
 
 		/* Destroying the group all the way back here prevents a race
 		 * where destruction of the group can prematurely destroy the

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1315,7 +1315,7 @@ struct obs_encoder {
 	 * up at the specific timestamp.  if this is the audio encoder,
 	 * it waits until it's ready to sync up with video */
 	bool first_received;
-	DARRAY(struct obs_encoder *) paired_encoders;
+	DARRAY(struct obs_weak_encoder *) paired_encoders;
 	int64_t offset_usec;
 	uint64_t first_raw_ts;
 	uint64_t start_ts;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1326,8 +1326,6 @@ struct obs_encoder {
 	pthread_mutex_t outputs_mutex;
 	DARRAY(obs_output_t *) outputs;
 
-	bool destroy_on_stop;
-
 	/* stores the video/audio media output pointer.  video_t *or audio_t **/
 	void *media;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2656,8 +2656,12 @@ static inline void pair_encoders(obs_output_t *output)
 
 		pthread_mutex_lock(&audio->init_mutex);
 		if (!audio->active && !audio->paired_encoders.num) {
-			da_push_back(video->paired_encoders, &audio);
-			da_push_back(audio->paired_encoders, &video);
+			obs_weak_encoder_t *weak_audio =
+				obs_encoder_get_weak_encoder(audio);
+			obs_weak_encoder_t *weak_video =
+				obs_encoder_get_weak_encoder(video);
+			da_push_back(video->paired_encoders, &weak_audio);
+			da_push_back(audio->paired_encoders, &weak_video);
 		}
 		pthread_mutex_unlock(&audio->init_mutex);
 	}

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -290,6 +290,7 @@ void obs_output_destroy(obs_output_t *output)
 			if (output->video_encoders[i]) {
 				obs_encoder_remove_output(
 					output->video_encoders[i], output);
+				obs_encoder_release(output->video_encoders[i]);
 			}
 			if (output->caption_tracks[i]) {
 				destroy_caption_track(
@@ -301,6 +302,7 @@ void obs_output_destroy(obs_output_t *output)
 			if (output->audio_encoders[i]) {
 				obs_encoder_remove_output(
 					output->audio_encoders[i], output);
+				obs_encoder_release(output->audio_encoders[i]);
 			}
 		}
 
@@ -970,14 +972,18 @@ void obs_output_remove_encoder_internal(struct obs_output *output,
 	if (encoder->info.type == OBS_ENCODER_VIDEO) {
 		for (size_t i = 0; i < MAX_OUTPUT_VIDEO_ENCODERS; i++) {
 			obs_encoder_t *video = output->video_encoders[i];
-			if (video == encoder)
+			if (video == encoder) {
 				output->video_encoders[i] = NULL;
+				obs_encoder_release(video);
+			}
 		}
 	} else if (encoder->info.type == OBS_ENCODER_AUDIO) {
 		for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
 			obs_encoder_t *audio = output->audio_encoders[i];
-			if (audio == encoder)
+			if (audio == encoder) {
 				output->audio_encoders[i] = NULL;
+				obs_encoder_release(audio);
+			}
 		}
 	}
 }
@@ -1041,8 +1047,10 @@ void obs_output_set_video_encoder2(obs_output_t *output, obs_encoder_t *encoder,
 		return;
 
 	obs_encoder_remove_output(output->video_encoders[idx], output);
-	obs_encoder_add_output(encoder, output);
-	output->video_encoders[idx] = encoder;
+	obs_encoder_release(output->video_encoders[idx]);
+
+	output->video_encoders[idx] = obs_encoder_get_ref(encoder);
+	obs_encoder_add_output(output->video_encoders[idx], output);
 
 	destroy_caption_track(&output->caption_tracks[idx]);
 	if (encoder != NULL) {
@@ -1104,8 +1112,10 @@ void obs_output_set_audio_encoder(obs_output_t *output, obs_encoder_t *encoder,
 		return;
 
 	obs_encoder_remove_output(output->audio_encoders[idx], output);
-	obs_encoder_add_output(encoder, output);
-	output->audio_encoders[idx] = encoder;
+	obs_encoder_release(output->audio_encoders[idx]);
+
+	output->audio_encoders[idx] = obs_encoder_get_ref(encoder);
+	obs_encoder_add_output(output->audio_encoders[idx], output);
 }
 
 obs_encoder_t *obs_output_get_video_encoder2(const obs_output_t *output,


### PR DESCRIPTION
### Description

Switch from the old `destroy_on_stop` mechanism to proper reference counting for encoders.

### Motivation and Context

Fixes the same deadlock as #11111 but more holistically rather than just working around it.

Encoders originally were implemented without reference counting in 6da26a3a1c31d211082c5477ea95d985f5281c94 which was later added in ba0b8eb0e1173c045ba91df4c077a8ffddd050c4 without removing the error-prone `destroy_on_stop` mechanism that would result in encoders potentially being destroyed before all references to them are released.

### How Has This Been Tested?

Streaming (multitrack) + recording, no more deadlocks. No leaks.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
