### PR TITLE
UI/libobs: Add warning/suffix if using a deprecated encoder

### DIFF
--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -2174,9 +2174,12 @@ void OBSBasicSettings::LoadAdvOutputStreamingEncoderProperties()
 	if (!SetComboByValue(ui->advOutEncoder, type)) {
 		uint32_t caps = obs_get_encoder_caps(type);
 		if ((caps & ENCODER_HIDE_FLAGS) != 0) {
-			const char *name = obs_encoder_get_display_name(type);
+			QString encName =
+				QT_UTF8(obs_encoder_get_display_name(type));
+			if (caps & OBS_ENCODER_CAP_DEPRECATED)
+				encName += " (" + QTStr("Deprecated") + ")";
 
-			ui->advOutEncoder->insertItem(0, QT_UTF8(name),
+			ui->advOutEncoder->insertItem(0, encName,
 						      QT_UTF8(type));
 			SetComboByValue(ui->advOutEncoder, type);
 		}
@@ -2292,9 +2295,12 @@ void OBSBasicSettings::LoadAdvOutputRecordingEncoderProperties()
 	if (!SetComboByValue(ui->advOutRecEncoder, type)) {
 		uint32_t caps = obs_get_encoder_caps(type);
 		if ((caps & ENCODER_HIDE_FLAGS) != 0) {
-			const char *name = obs_encoder_get_display_name(type);
+			QString encName =
+				QT_UTF8(obs_encoder_get_display_name(type));
+			if (caps & OBS_ENCODER_CAP_DEPRECATED)
+				encName += " (" + QTStr("Deprecated") + ")";
 
-			ui->advOutRecEncoder->insertItem(1, QT_UTF8(name),
+			ui->advOutRecEncoder->insertItem(1, encName,
 							 QT_UTF8(type));
 			SetComboByValue(ui->advOutRecEncoder, type);
 		} else {
@@ -5082,6 +5088,11 @@ static void DisableIncompatibleCodecs(QComboBox *cbox, const QString &format,
 		/* Something has gone horribly wrong and there's no encoder */
 		if (encoderId.empty())
 			continue;
+
+		if (obs_get_encoder_caps(encoderId.c_str()) &
+		    OBS_ENCODER_CAP_DEPRECATED) {
+			encDisplayName += " (" + QTStr("Deprecated") + ")";
+		}
 
 		const char *codec = obs_get_encoder_codec(encoderId.c_str());
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -122,6 +122,13 @@ create_encoder(const char *id, enum obs_encoder_type type, const char *name,
 	}
 
 	blog(LOG_DEBUG, "encoder '%s' (%s) created", name, id);
+
+	if (ei->caps & OBS_ENCODER_CAP_DEPRECATED) {
+		blog(LOG_WARNING,
+		     "Encoder ID '%s' is deprecated and may be removed in a future version.",
+		     id);
+	}
+
 	return encoder;
 }
 

--- a/plugins/obs-nvenc/nvenc-compat.c
+++ b/plugins/obs-nvenc/nvenc-compat.c
@@ -59,21 +59,21 @@ static void *nvenc_reroute(enum codec_type codec, obs_data_t *settings,
 static const char *h264_nvenc_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
-	return "NVIDIA NVENC H.264 (deprecated)";
+	return "NVIDIA NVENC H.264";
 }
 
 #ifdef ENABLE_HEVC
 static const char *hevc_nvenc_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
-	return "NVIDIA NVENC HEVC (deprecated)";
+	return "NVIDIA NVENC HEVC";
 }
 #endif
 
 static const char *av1_nvenc_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
-	return "NVIDIA NVENC AV1 (deprecated)";
+	return "NVIDIA NVENC AV1";
 }
 
 static void *h264_nvenc_create(obs_data_t *settings, obs_encoder_t *encoder)


### PR DESCRIPTION
### Description

- Adds a warning to the log if an encoder is deprecated
- Suffixes deprecated encoders in the settings combobox
- Removes hardcoded untranslated suffix from NVENC compat encoders

### Motivation and Context

Want to make it more obvious that things might stop working or be removed.

### How Has This Been Tested?

Selected deprecated encoder, took screenshot.

![2024-08-12_23-31-20_XreGqy](https://github.com/user-attachments/assets/31b5abe8-5828-4bfd-8196-e779fa16e8bf)

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
