### PR TITLE
obs-nvenc: Improve settings logging / legacy compatibility

### DIFF
--- a/plugins/obs-nvenc/nvenc-compat.c
+++ b/plugins/obs-nvenc/nvenc-compat.c
@@ -15,20 +15,10 @@
 /* ------------------------------------------------------------------------- */
 /* Actual redirector implementation.                                         */
 
-static void migrate_settings(obs_data_t *settings, enum codec_type codec)
+static void migrate_settings(obs_data_t *settings)
 {
-	struct encoder_caps *caps = get_encoder_caps(codec);
-
 	const char *preset = obs_data_get_string(settings, "preset2");
 	obs_data_set_string(settings, "preset", preset);
-
-	const char *rc = obs_data_get_string(settings, "rate_control");
-	/* Old NVENC allowed lossless even if unsupported,
-	 * and just emulated it via CQP 0, do the same here. */
-	if (!caps->lossless && strcmp(rc, "lossless") == 0) {
-		obs_data_set_string(settings, "rate_control", "CQP");
-		obs_data_set_int(settings, "cqp", 0);
-	}
 
 	obs_data_set_bool(settings, "adaptive_quantization",
 			  obs_data_get_bool(settings, "psycho_aq"));
@@ -44,7 +34,7 @@ static void *nvenc_reroute(enum codec_type codec, obs_data_t *settings,
 			   obs_encoder_t *encoder, bool texture)
 {
 	/* Update settings object to v2 encoder configuration */
-	migrate_settings(settings, codec);
+	migrate_settings(settings);
 
 	switch (codec) {
 	case CODEC_H264:


### PR DESCRIPTION
### Description

- Remove non-functional legacy lossless mode
- Omit irrelevant settings (e.g. CQP in CBR mode)
- Set rate control string to "lossless" in lossless mode

### Motivation and Context

Lossless mode issue discovered in testing, logging change suggested on Discord.

### How Has This Been Tested?

Recorded with different settings, made sure it works now.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
