### PR TITLE
UI: Don't create default desktop audio at all on macOS

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -133,15 +133,6 @@ void SetAlwaysOnTop(QWidget *window, bool enable)
     window->show();
 }
 
-bool shouldCreateDefaultAudioSource(void)
-{
-    if (@available(macOS 13, *)) {
-        return false;
-    } else {
-        return true;
-    }
-}
-
 bool SetDisplayAffinitySupported(void)
 {
     // Not implemented yet

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -104,7 +104,6 @@ void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
 void SetMacOSDarkMode(bool dark);
-bool shouldCreateDefaultAudioSource();
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type,
 					      bool prompt_for_permission);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -994,16 +994,16 @@ static inline bool HasAudioDevices(const char *source_id)
 
 void OBSBasic::CreateFirstRunSources()
 {
+#ifndef __APPLE__
 	bool hasDesktopAudio = HasAudioDevices(App()->OutputAudioSource());
-	bool hasInputAudio = HasAudioDevices(App()->InputAudioSource());
-
-#ifdef __APPLE__
-	hasDesktopAudio = hasDesktopAudio && shouldCreateDefaultAudioSource();
-#endif
 
 	if (hasDesktopAudio)
 		ResetAudioDevice(App()->OutputAudioSource(), "default",
 				 Str("Basic.DesktopDevice1"), 1);
+#endif
+
+	bool hasInputAudio = HasAudioDevices(App()->InputAudioSource());
+
 	if (hasInputAudio)
 		ResetAudioDevice(App()->InputAudioSource(), "default",
 				 Str("Basic.AuxDevice1"), 3);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Follow-up to #10992, just removes this on all versions of macOS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The desktop audio device source on macOS is practically non-functional on macOS without additional system configuration. In a previous commit, 1b25acd18450401b96e1c92767f4c8d039f0b8a2, it was removed from the scene configuration on macOS 13 or higher as the macOS Audio Source exists there and can be added to scenes. However, there was agreement that if the source is broken on lower versions as well, we should not add it there either.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15. On a new OBS configuration, only the default microphone source gets added.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
