### PR TITLE
frontend: Log sceneitem and filter enabled

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -136,8 +136,13 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 			OBSSourceAutoRelease s = obs_get_source_by_uuid(uuid.c_str());
 			obs_scene_t *sc = obs_group_or_scene_from_source(s);
 			obs_sceneitem_t *si = obs_scene_find_sceneitem_by_id(sc, id);
-			if (si)
+			if (si) {
 				obs_sceneitem_set_visible(si, val);
+				const char *item_name = obs_source_get_name(obs_sceneitem_get_source(si));
+				const char *name = obs_source_get_name(s);
+				blog(LOG_INFO, "User set sceneitem '%s' (%li) on scene '%s' to %s (undo_redo)",
+				     item_name, (long)id, name, val ? "enabled" : "disabled");
+			}
 		};
 
 		QString str = QTStr(val ? "Undo.ShowSceneItem" : "Undo.HideSceneItem");
@@ -149,6 +154,10 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 
 		QSignalBlocker sourcesSignalBlocker(this);
 		obs_sceneitem_set_visible(sceneitem, val);
+
+		const char *item_name = obs_source_get_name(obs_sceneitem_get_source(sceneitem));
+		blog(LOG_INFO, "User set sceneitem '%s' (%li) on scene '%s' to %s", item_name, (long)id, name,
+		     val ? "enabled" : "disabled");
 	};
 
 	auto setItemLocked = [this](bool checked) {

--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -134,11 +134,15 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 
 		auto undo_redo = [](const std::string &uuid, int64_t id, bool val) {
-			OBSSourceAutoRelease s = obs_get_source_by_uuid(uuid.c_str());
-			obs_scene_t *sc = obs_group_or_scene_from_source(s);
-			obs_sceneitem_t *si = obs_scene_find_sceneitem_by_id(sc, id);
-			if (si) {
-				obs_sceneitem_set_visible(si, val);
+			OBSSourceAutoRelease sceneSource = obs_get_source_by_uuid(uuid.c_str());
+			obs_scene_t *scene = obs_group_or_scene_from_source(sceneSource);
+			obs_sceneitem_t *sceneItem = obs_scene_find_sceneitem_by_id(scene, id);
+			if (sceneItem) {
+				obs_sceneitem_set_visible(sceneItem, val);
+				const char *itemName = obs_source_get_name(obs_sceneitem_get_source(sceneItem));
+				const char *name = obs_source_get_name(sceneSource);
+				blog(LOG_INFO, "User set sceneitem '%s' (%li) on scene '%s' to %s (undo_redo)",
+				     itemName, (long)id, name, val ? "enabled" : "disabled");
 			}
 		};
 
@@ -151,6 +155,10 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 
 		QSignalBlocker sourcesSignalBlocker(this);
 		obs_sceneitem_set_visible(sceneitem, val);
+
+		const char *itemName = obs_source_get_name(obs_sceneitem_get_source(sceneitem));
+		blog(LOG_INFO, "User set sceneitem '%s' (%li) on scene '%s' to %s", itemName, (long)id, name,
+		     val ? "enabled" : "disabled");
 	};
 
 	auto setItemLocked = [this](bool checked) {

--- a/frontend/components/VisibilityItemWidget.cpp
+++ b/frontend/components/VisibilityItemWidget.cpp
@@ -28,7 +28,14 @@ VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 
 	setLayout(itemLayout);
 
-	connect(vis, &QCheckBox::clicked, this, [this](bool visible) { obs_source_set_enabled(source, visible); });
+	connect(vis, &QCheckBox::clicked, this, [this](bool visible) {
+		obs_source_set_enabled(source, visible);
+		const char *filter_name = obs_source_get_name(source);
+		obs_source_t *parent = obs_filter_get_parent(source);
+		const char *source_name = obs_source_get_name(parent);
+		blog(LOG_INFO, "User set filter '%s' on source '%s' to %s", filter_name, source_name,
+		     visible ? "enabled" : "disabled");
+	});
 }
 
 void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)

--- a/frontend/components/VisibilityItemWidget.cpp
+++ b/frontend/components/VisibilityItemWidget.cpp
@@ -28,7 +28,14 @@ VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 
 	setLayout(itemLayout);
 
-	connect(vis, &QCheckBox::clicked, this, [this](bool visible) { obs_source_set_enabled(source, visible); });
+	connect(vis, &QCheckBox::clicked, this, [this](bool visible) {
+		obs_source_set_enabled(source, visible);
+		const char *filterName = obs_source_get_name(source);
+		obs_source_t *parent = obs_filter_get_parent(source);
+		const char *sourceName = obs_source_get_name(parent);
+		blog(LOG_INFO, "User set filter '%s' on source '%s' to %s", filterName, sourceName,
+		     visible ? "enabled" : "disabled");
+	});
 }
 
 void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1055,7 +1055,8 @@ static void LogFilter(obs_source_t *, obs_source_t *filter, void *v_val)
 	for (int i = 0; i < val; i++)
 		indent += "    ";
 
-	blog(LOG_INFO, "%s- filter: '%s' (%s)", indent.c_str(), name, id);
+	blog(LOG_INFO, "%s- filter: '%s' (%s)%s", indent.c_str(), name, id,
+	     obs_source_enabled(filter) ? "" : " (disabled)");
 }
 
 static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
@@ -1069,7 +1070,8 @@ static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
 	for (int i = 0; i < indent_count; i++)
 		indent += "    ";
 
-	blog(LOG_INFO, "%s- source: '%s' (%s)", indent.c_str(), name, id);
+	blog(LOG_INFO, "%s- source: '%s' (%s)%s", indent.c_str(), name, id,
+	     obs_sceneitem_visible(item) ? "" : " (disabled)");
 
 	obs_monitoring_type monitoring_type = obs_source_get_monitoring_type(source);
 

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1064,7 +1064,8 @@ static void LogFilter(obs_source_t *, obs_source_t *filter, void *v_val)
 		indent += "    ";
 	}
 
-	blog(LOG_INFO, "%s- filter: '%s' (%s)", indent.c_str(), name, id);
+	blog(LOG_INFO, "%s- filter: '%s' (%s)%s", indent.c_str(), name, id,
+	     obs_source_enabled(filter) ? "" : " (disabled)");
 }
 
 static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
@@ -1079,7 +1080,8 @@ static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
 		indent += "    ";
 	}
 
-	blog(LOG_INFO, "%s- source: '%s' (%s)", indent.c_str(), name, id);
+	blog(LOG_INFO, "%s- source: '%s' (%s)%s", indent.c_str(), name, id,
+	     obs_sceneitem_visible(item) ? "" : " (disabled)");
 
 	obs_monitoring_type monitoring_type = obs_source_get_monitoring_type(source);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This logs whether sceneitems and filters are enabled on scene collection load.
Inactive ones are prefaced with a `o` and active ones by a `*`.
An example log can be found [here](https://obsproject.com/logs/KMZMUjXiwl12Xg9d)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Whether or not sceneitems/filters are enabled is often an important matter in support, having it logged would greatly simplify some support workflows.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Running obs, checking it logs correctly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
