### PR TITLE
frontend: Add audio properties to GetClientConfiguration request

### DIFF
--- a/frontend/utility/GoLiveAPI_PostData.cpp
+++ b/frontend/utility/GoLiveAPI_PostData.cpp
@@ -61,6 +61,14 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 		preferences.composition_gpu_index = ovi.adapter;
 	}
 
+	obs_audio_info2 oai2;
+	if (obs_get_audio_info2(&oai2)) {
+		preferences.audio_samples_per_sec = oai2.samples_per_sec;
+		preferences.audio_channels = get_audio_channels(oai2.speakers);
+		preferences.audio_fixed_buffering = oai2.fixed_buffering;
+		preferences.audio_max_buffering_ms = oai2.max_buffering_ms;
+	}
+
 	if (maximum_aggregate_bitrate.has_value())
 		preferences.maximum_aggregate_bitrate = maximum_aggregate_bitrate.value();
 	if (maximum_video_tracks.has_value())

--- a/frontend/utility/models/multitrack-video.hpp
+++ b/frontend/utility/models/multitrack-video.hpp
@@ -144,9 +144,15 @@ struct Preferences {
 	uint32_t canvas_width;
 	uint32_t canvas_height;
 	optional<uint32_t> composition_gpu_index;
+	uint32_t audio_samples_per_sec;
+	uint32_t audio_channels;
+	uint32_t audio_max_buffering_ms;
+	bool audio_fixed_buffering;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Preferences, maximum_aggregate_bitrate, maximum_video_tracks, vod_track_audio,
-				       width, height, framerate, canvas_width, canvas_height, composition_gpu_index)
+				       width, height, framerate, canvas_width, canvas_height, composition_gpu_index,
+				       audio_samples_per_sec, audio_channels, audio_max_buffering_ms,
+				       audio_fixed_buffering)
 };
 
 struct PostData {

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1609,6 +1609,23 @@ bool obs_get_audio_info(struct obs_audio_info *oai)
 	return true;
 }
 
+bool obs_get_audio_info2(struct obs_audio_info2 *oai2)
+{
+	struct obs_core_audio *audio = &obs->audio;
+	struct obs_audio_info oai;
+
+	if (!obs_get_audio_info(&oai) || !oai2 || !audio->audio) {
+		return false;
+	} else {
+		oai2->samples_per_sec = oai.samples_per_sec;
+		oai2->speakers = oai.speakers;
+		oai2->fixed_buffering = audio->fixed_buffer;
+		oai2->max_buffering_ms =
+			audio->max_buffering_ticks * AUDIO_OUTPUT_FRAMES * SEC_TO_MSEC / (int)oai2->samples_per_sec;
+		return true;
+	}
+}
+
 bool obs_enum_source_types(size_t idx, const char **id)
 {
 	if (idx >= obs->source_types.num)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -441,6 +441,12 @@ EXPORT void obs_set_video_levels(float sdr_white_level, float hdr_nominal_peak_l
 EXPORT bool obs_get_audio_info(struct obs_audio_info *oai);
 
 /**
+ * Gets the v2 audio settings that includes buffering information.
+ * Returns false if no audio.
+ */
+EXPORT bool obs_get_audio_info2(struct obs_audio_info2 *oai2);
+
+/**
  * Opens a plugin module directly from a specific path.
  *
  * If the module already exists then the function will return successful, and


### PR DESCRIPTION
### Description
Instead of transparently resampling audio to match [`GetClientConfiguration`'s request](https://github.com/obsproject/obs-studio/pull/10855) send information about local audio settings to `GetClientConfiguration`

[Currently this is only checked in OBS Studio](https://github.com/obsproject/obs-studio/pull/10874) after a configuration has already been received, which doesn't allow for potentially different configurations in case e.g. iOS support is not necessary for this particular stream

### Motivation and Context
The Twitch iOS app (and/or HLS playback on iOS in general?) requires audio to be stereo or mono; with this change the requested number of channels from the go live config is being honored, so users can still set up their recordings to contain audio in whichever speaker layout they desire, while the format for streamed audio adheres to service requirements

### How Has This Been Tested?
Verified audio settings are part of the `GetClientConfiguration` request

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
