### PR TITLE
cmake: Remove WITH_MESSAGE from obs-qsv11

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -68,7 +68,6 @@ if(OBS_CMAKE_VERSION VERSION_GREATER_EQUAL 3.0.0)
     obs-qsv11
     PLATFORMS WINDOWS LINUX
     ARCHITECTURES x64 x86_64
-    WITH_MESSAGE
   )
   add_obs_plugin(obs-text PLATFORMS WINDOWS)
   add_obs_plugin(obs-transitions)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the `WITH_MESSAGE` parameter from `add_obs_plugin(obs-qsv11)`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
https://github.com/obsproject/obs-studio/commit/7d578c5cfb334d41aaa81cd00c1f1df5fbe8688e added `WITH_MESSAGE`.
This annoyed me because on macOS the module is obviously unavailable whatever you do, and the `add_custom_target` call leaves this confusing empty top-level target in the generated project:

<img width="248" alt="Bildschirmfoto 2024-08-17 um 20 03 02" src="https://github.com/user-attachments/assets/f2b791e1-52b8-4b07-9ab1-885041b20b49">

I don't see any value in `WITH_MESSAGE` here.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Reran cmake, target gone.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
