### PR TITLE
UI: Inline macOS 13 check

### DIFF
--- a/UI/platform-osx.mm
+++ b/UI/platform-osx.mm
@@ -133,15 +133,6 @@ void SetAlwaysOnTop(QWidget *window, bool enable)
     window->show();
 }
 
-bool shouldCreateDefaultAudioSource(void)
-{
-    if (@available(macOS 13, *)) {
-        return false;
-    } else {
-        return true;
-    }
-}
-
 bool SetDisplayAffinitySupported(void)
 {
     // Not implemented yet

--- a/UI/platform.hpp
+++ b/UI/platform.hpp
@@ -101,7 +101,6 @@ void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
 void SetMacOSDarkMode(bool dark);
-bool shouldCreateDefaultAudioSource();
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type,
 					      bool prompt_for_permission);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1023,7 +1023,11 @@ void OBSBasic::CreateFirstRunSources()
 	bool hasInputAudio = HasAudioDevices(App()->InputAudioSource());
 
 #ifdef __APPLE__
-	hasDesktopAudio = hasDesktopAudio && shouldCreateDefaultAudioSource();
+	/* On macOS 13 and above, the SCK based audio capture provides a
+	 * better alternative to the device-based audio capture. */
+	if (__builtin_available(macOS 13.0, *)) {
+		hasDesktopAudio = false;
+	}
 #endif
 
 	if (hasDesktopAudio)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Inlines the macOS 13 check for the default device.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When I closed #11127 I noticed that there is potential to clean this up.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15
New OBS Settings folder, new device does not get created.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
