### PR TITLE
shared: Make properties view "help" icon High DPI

### DIFF
--- a/shared/properties-view/CMakeLists.txt
+++ b/shared/properties-view/CMakeLists.txt
@@ -24,6 +24,10 @@ if(NOT TARGET OBS::qt-slider-ignorewheel)
   )
 endif()
 
+if(NOT TARGET OBS::qt-icon-label)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/shared/qt/icon-label" "${CMAKE_BINARY_DIR}/shared/qt/icon-label")
+endif()
+
 add_library(properties-view INTERFACE)
 add_library(OBS::properties-view ALIAS properties-view)
 
@@ -53,6 +57,7 @@ target_link_libraries(
     OBS::qt-plain-text-edit
     OBS::qt-vertical-scroll-area
     OBS::qt-slider-ignorewheel
+    OBS::qt-icon-label
     Qt::Core
     Qt::Widgets
 )

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -32,6 +32,7 @@
 #include <qt-wrappers.hpp>
 #include <plain-text-edit.hpp>
 #include <slider-ignorewheel.hpp>
+#include <icon-label.hpp>
 #include <cstdlib>
 #include <initializer_list>
 #include <obs-data.h>
@@ -276,15 +277,46 @@ QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
 {
 	const char *name = obs_property_name(prop);
 	const char *desc = obs_property_description(prop);
+	const char *long_desc = obs_property_long_description(prop);
 	bool val = obs_data_get_bool(settings, name);
 
 	QCheckBox *checkbox = new QCheckBox(QT_UTF8(desc));
 	checkbox->setCheckState(val ? Qt::Checked : Qt::Unchecked);
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-	return NewWidget(prop, checkbox, &QCheckBox::checkStateChanged);
+	QWidget *widget =
+		NewWidget(prop, checkbox, &QCheckBox::checkStateChanged);
 #else
-	return NewWidget(prop, checkbox, &QCheckBox::stateChanged);
+	QWidget *widget = NewWidget(prop, checkbox, &QCheckBox::stateChanged);
 #endif
+
+	if (!long_desc) {
+		return widget;
+	}
+
+	QString file = !obs_frontend_is_theme_dark()
+			       ? ":/res/images/help.svg"
+			       : ":/res/images/help_light.svg";
+
+	IconLabel *help = new IconLabel(checkbox);
+	help->setIcon(QIcon(file));
+	help->setToolTip(long_desc);
+
+#ifdef __APPLE__
+	checkbox->setAttribute(Qt::WA_LayoutUsesWidgetRect);
+#endif
+
+	widget = new QWidget();
+	QHBoxLayout *layout = new QHBoxLayout(widget);
+	layout->setContentsMargins(0, 0, 0, 0);
+	layout->setAlignment(Qt::AlignLeft);
+	layout->setSpacing(0);
+
+	layout->addWidget(checkbox);
+	layout->addWidget(help);
+	widget->setLayout(layout);
+
+	return widget;
 }
 
 QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout,
@@ -1616,53 +1648,30 @@ void OBSPropertiesView::AddProperty(obs_property_t *property,
 	if (!obs_property_enabled(property))
 		widget->setEnabled(false);
 
-	if (obs_property_long_description(property)) {
+	QWidget *leftWidget = label;
+	if (obs_property_long_description(property) && label) {
 		QString file = !obs_frontend_is_theme_dark()
 				       ? ":/res/images/help.svg"
 				       : ":/res/images/help_light.svg";
-		if (label) {
-			QString lStr = "<html>%1 <img src='%2' style=' \
-				vertical-align: bottom;  \
-				' /></html>";
 
-			label->setText(lStr.arg(label->text(), file));
-			label->setToolTip(
-				obs_property_long_description(property));
-		} else if (type == OBS_PROPERTY_BOOL) {
+		QWidget *newWidget = new QWidget();
+		newWidget->setToolTip(obs_property_long_description(property));
 
-			QString bStr = "<html> <img src='%1' style=' \
-				vertical-align: bottom;  \
-				' /></html>";
+		QHBoxLayout *boxLayout = new QHBoxLayout(newWidget);
+		boxLayout->setContentsMargins(0, 0, 0, 0);
+		boxLayout->setAlignment(Qt::AlignLeft);
+		boxLayout->setSpacing(0);
 
-			const char *desc = obs_property_description(property);
+		IconLabel *help = new IconLabel(newWidget);
+		help->setIcon(QIcon(file));
+		help->setToolTip(obs_property_long_description(property));
 
-			QWidget *newWidget = new QWidget();
-
-			QHBoxLayout *boxLayout = new QHBoxLayout(newWidget);
-			boxLayout->setContentsMargins(0, 0, 0, 0);
-			boxLayout->setAlignment(Qt::AlignLeft);
-			boxLayout->setSpacing(0);
-
-			QCheckBox *check = qobject_cast<QCheckBox *>(widget);
-			check->setText(desc);
-			check->setToolTip(
-				obs_property_long_description(property));
-#ifdef __APPLE__
-			check->setAttribute(Qt::WA_LayoutUsesWidgetRect);
-#endif
-
-			QLabel *help = new QLabel(check);
-			help->setText(bStr.arg(file));
-			help->setToolTip(
-				obs_property_long_description(property));
-
-			boxLayout->addWidget(check);
-			boxLayout->addWidget(help);
-			widget = newWidget;
-		}
+		boxLayout->addWidget(label);
+		boxLayout->addWidget(help);
+		leftWidget = newWidget;
 	}
 
-	layout->addRow(label, widget);
+	layout->addRow(leftWidget, widget);
 
 	if (!lastFocused.empty())
 		if (lastFocused.compare(name) == 0)

--- a/shared/qt/icon-label/CMakeLists.txt
+++ b/shared/qt/icon-label/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.22...3.25)
+
+find_package(Qt6 REQUIRED Core Widgets)
+
+add_library(qt-icon-label INTERFACE)
+add_library(OBS::qt-icon-label ALIAS qt-icon-label)
+
+target_sources(qt-icon-label INTERFACE icon-label.hpp)
+target_include_directories(qt-icon-label INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_link_libraries(qt-icon-label INTERFACE Qt::Core Qt::Widgets)

--- a/shared/qt/icon-label/icon-label.hpp
+++ b/shared/qt/icon-label/icon-label.hpp
@@ -1,0 +1,56 @@
+/******************************************************************************
+    Copyright (C) 2024 by Sebastian Beckmann
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+
+#include <QIcon>
+#include <QLabel>
+
+/**
+ * Widget to be used if a label is to be supplied a QIcon instead of a QPixmap,
+ * specifically so that qproperty-icon QSS styling (and as a result the OBS
+ * "themeID" property) works on it without having to first convert the icon to
+ * a fixed size PNG and then setting qproperty-pixmap in addition to the
+ * qproperty-icon statements.
+ */
+class IconLabel : public QLabel {
+	Q_OBJECT
+	Q_PROPERTY(QIcon icon READ icon WRITE setIcon)
+	Q_PROPERTY(int iconSize READ iconSize WRITE setIconSize)
+
+public:
+	inline IconLabel(QWidget *parent = nullptr)
+		: QLabel(parent),
+		  m_icon(),
+		  m_iconSize(16)
+	{
+	}
+
+	inline QIcon icon() const { return m_icon; }
+	void setIcon(const QIcon &icon)
+	{
+		m_icon = icon;
+		QLabel::setPixmap(icon.pixmap(m_iconSize));
+	}
+
+	inline int iconSize() const { return m_iconSize; }
+	void setIconSize(int newSize) { m_iconSize = newSize; }
+
+private:
+	QIcon m_icon;
+	int m_iconSize;
+};


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds an IconLabel widget (originally made as part of the [scene collection manager](https://github.com/obsproject/obs-studio/pull/8446)) which displays icons in High DPI.

Then changes the icon rendering for the properties view "question mark" icon
from Qt label HTML to use the IconLabel widget.

Before/After (From the Media Source, rows in between removed for demonstration):
<p>
<img width="448" alt="Bildschirmfoto 2024-08-18 um 04 12 13" src="https://github.com/user-attachments/assets/3a071a5f-c93b-43fb-af14-0db534c00947">
<img width="378" alt="Bildschirmfoto 2024-08-18 um 04 13 44" src="https://github.com/user-attachments/assets/658856a8-5f8c-4309-919e-ef5d9a6513f2">
</p>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The icon looked ugly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15
See the screenshots above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
