### PR TITLE
libobs: Add NULL check to encoder deprecation warning

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -123,7 +123,7 @@ create_encoder(const char *id, enum obs_encoder_type type, const char *name,
 
 	blog(LOG_DEBUG, "encoder '%s' (%s) created", name, id);
 
-	if (ei->caps & OBS_ENCODER_CAP_DEPRECATED) {
+	if (ei && ei->caps & OBS_ENCODER_CAP_DEPRECATED) {
 		blog(LOG_WARNING,
 		     "Encoder ID '%s' is deprecated and may be removed in a future version.",
 		     id);


### PR DESCRIPTION
### Description

Add NULL check to encoder deprecation warning

### Motivation and Context

If an encoder ID no longer exists `ei` will be `NULL`.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
