### PR TITLE
obs-nvenc: Fix nvenc availability check always returning true

### DIFF
--- a/plugins/obs-nvenc/nvenc-helpers.c
+++ b/plugins/obs-nvenc/nvenc-helpers.c
@@ -381,7 +381,7 @@ fail:
 	dstr_free(&caps_str);
 	os_process_args_destroy(args);
 
-	return true;
+	return success;
 }
 
 static const char *nvenc_check_name = "nvenc_check";


### PR DESCRIPTION
### Description

Fix nvenc availability check always returning true

### Motivation and Context

This always returned true, probably due to an oversight during testing.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
