### PR TITLE
obs-nvenc: Only show UHQ tune on supported GPUs

### DIFF
--- a/plugins/obs-nvenc/nvenc-properties.c
+++ b/plugins/obs-nvenc/nvenc-properties.c
@@ -175,7 +175,10 @@ obs_properties_t *nvenc_properties_internal(enum codec_type codec)
 #define add_tune(val) \
 	obs_property_list_add_string(p, obs_module_text("Tuning." val), val)
 #ifdef NVENC_12_2_OR_LATER
-	if (codec == CODEC_HEVC)
+	/* The UHQ tune is only supported on Turing or later.
+	 * It uses the temporal filtering feature, so we can use its
+	 * availability as an indicator that we are on a supported GPU. */
+	if (codec == CODEC_HEVC && caps->temporal_filter)
 		add_tune("uhq");
 #endif
 	add_tune("hq");


### PR DESCRIPTION
### Description

Only show UHQ tune on supported GPUs.

### Motivation and Context

The UHQ tune is only supported on Turing or later, on earlier GPUs this would simply fail, so hide it if unsupported.

### How Has This Been Tested?

Verified it still shows up on an Ada GPU, don't have any GPUs predating Turing on hand.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
