### PR TITLE
UI: Use OBSBasic::Get() in all places

### DIFF
--- a/UI/adv-audio-control.cpp
+++ b/UI/adv-audio-control.cpp
@@ -79,7 +79,7 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_)
 	labelL->setText("L");
 	labelR->setText("R");
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	QIcon sourceIcon = main->GetSourceIcon(obs_source_get_id(source));
 	QPixmap pixmap = sourceIcon.pixmap(QSize(16, 16));

--- a/UI/context-bar-controls.cpp
+++ b/UI/context-bar-controls.cpp
@@ -50,7 +50,7 @@ void SourceToolbar::SetUndoProperties(obs_source_t *source, bool repeatable)
 		return;
 	}
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSSource currentSceneSource = main->GetCurrentSceneSource();
 	if (!currentSceneSource)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1512,7 +1512,7 @@ bool OBSApp::notify(QObject *receiver, QEvent *e)
 	if (windowType == Qt::WindowType::Dialog ||
 	    windowType == Qt::WindowType::Window ||
 	    windowType == Qt::WindowType::Tool) {
-		OBSBasic *main = reinterpret_cast<OBSBasic *>(GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		if (main)
 			main->SetDisplayAffinity(window);
 	}
@@ -1798,7 +1798,7 @@ string GetFormatExt(const char *container)
 string GetOutputFilename(const char *path, const char *container, bool noSpace,
 			 bool overwrite, const char *format)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	os_dir_t *dir = path && path[0] ? os_opendir(path) : nullptr;
 
@@ -2563,7 +2563,7 @@ void OBSApp::ProcessSigInt(void)
 	char tmp;
 	recv(sigintFd[1], &tmp, sizeof(tmp), 0);
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	if (main)
 		main->close();
 #endif

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -24,7 +24,7 @@
 
 static inline OBSScene GetCurrentScene()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	return main->GetCurrentScene();
 }
 
@@ -56,7 +56,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_)
 		setStyleSheet("background: none");
 	}
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	const char *id = obs_source_get_id(source);
 
 	bool sourceVisible = obs_sceneitem_visible(sceneitem);
@@ -312,8 +312,7 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 		expand->setChecked(!expand->isChecked());
 	} else {
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		if (obs_source_configurable(source)) {
 			main->CreatePropertiesWindow(source);
 		}
@@ -383,7 +382,7 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 		return;
 	}
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 
 	newName = QT_TO_UTF8(editor->text());
@@ -1611,7 +1610,7 @@ bool SourceTree::GroupedItemsSelected() const
 
 void SourceTree::Remove(OBSSceneItem item, OBSScene scene)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	GetStm()->Remove(item);
 	main->SaveProject();
 

--- a/UI/window-basic-adv-audio.cpp
+++ b/UI/window-basic-adv-audio.cpp
@@ -40,7 +40,7 @@ OBSBasicAdvAudio::OBSBasicAdvAudio(QWidget *parent)
 
 OBSBasicAdvAudio::~OBSBasicAdvAudio()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 
 	for (size_t i = 0; i < controls.size(); ++i)
 		delete controls[i];

--- a/UI/window-basic-auto-config-test.cpp
+++ b/UI/window-basic-auto-config-test.cpp
@@ -241,7 +241,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 
 	obs_data_set_int(aencoder_settings, "bitrate", 32);
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	const char *bind_ip =
 		config_get_string(main->Config(), "Output", "BindIP");
 	obs_data_set_string(output_settings, "bind_ip", bind_ip);

--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -1027,7 +1027,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 	proc_handler_call(ph, "twitch_ingests_refresh", &cd);
 	calldata_free(&cd);
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(parent);
+	OBSBasic *main = OBSBasic::Get();
 	main->EnableOutputs(false);
 
 	installEventFilter(CreateShortcutFilter());
@@ -1158,7 +1158,7 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 
 AutoConfig::~AutoConfig()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	main->EnableOutputs(true);
 	EnableThreadedMessageBoxes(false);
 }
@@ -1249,7 +1249,7 @@ inline const char *AutoConfig::GetEncoderId(Encoder enc)
 
 void AutoConfig::SaveStreamSettings()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	/* ---------------------------------- */
 	/* save service                       */
@@ -1326,7 +1326,7 @@ void AutoConfig::SaveStreamSettings()
 
 void AutoConfig::SaveSettings()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	if (recordingEncoder != Encoder::Stream)
 		config_set_string(main->Config(), "SimpleOutput", "RecEncoder",

--- a/UI/window-basic-filters.cpp
+++ b/UI/window-basic-filters.cpp
@@ -62,7 +62,7 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 			     OBSBasicFilters::SourceRenamed, this),
 	  noPreviewMargin(13)
 {
-	main = reinterpret_cast<OBSBasic *>(parent);
+	main = OBSBasic::Get();
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
@@ -281,8 +281,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 	OBSDataAutoRelease settings = obs_source_get_settings(filter);
 
 	auto disabled_undo = [](void *vp, obs_data_t *settings) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		main->undo_s.disable();
 		obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
 		obs_source_update(source, settings);
@@ -613,8 +612,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 
 		std::string parent_uuid(obs_source_get_uuid(source));
 		std::string scene_uuid = obs_source_get_uuid(
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->GetCurrentSceneSource());
+			OBSBasic::Get()->GetCurrentSceneSource());
 		/* In order to ensure that the UUID persists through undo/redo,
 		 * we save the source data rather than just recreating the
 		 * source from scratch. */
@@ -629,8 +627,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		auto undo = [scene_uuid](const std::string &data) {
 			OBSSourceAutoRelease ssource =
 				obs_get_source_by_uuid(scene_uuid.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
+			OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 			OBSDataAutoRelease dat =
 				obs_data_create_from_json(data.c_str());
@@ -646,8 +643,7 @@ void OBSBasicFilters::AddNewFilter(const char *id)
 		auto redo = [scene_uuid](const std::string &data) {
 			OBSSourceAutoRelease ssource =
 				obs_get_source_by_uuid(scene_uuid.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
+			OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 			OBSDataAutoRelease dat =
 				obs_data_create_from_json(data.c_str());
@@ -1083,14 +1079,12 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 		obs_source_set_name(filter, name.c_str());
 
 		std::string scene_uuid = obs_source_get_uuid(
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->GetCurrentSceneSource());
+			OBSBasic::Get()->GetCurrentSceneSource());
 		auto undo = [scene_uuid, prev = std::string(prevName),
 			     name](const std::string &uuid) {
 			OBSSourceAutoRelease ssource =
 				obs_get_source_by_uuid(scene_uuid.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
+			OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 			OBSSourceAutoRelease filter =
 				obs_get_source_by_uuid(uuid.c_str());
@@ -1101,8 +1095,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 			     name](const std::string &uuid) {
 			OBSSourceAutoRelease ssource =
 				obs_get_source_by_uuid(scene_uuid.c_str());
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-				->SetCurrentScene(ssource.Get(), true);
+			OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 			OBSSourceAutoRelease filter =
 				obs_get_source_by_uuid(uuid.c_str());
@@ -1193,14 +1186,12 @@ void OBSBasicFilters::delete_filter(OBSSource filter)
 	std::string parent_uuid(obs_source_get_uuid(source));
 	obs_data_set_string(wrapper, "undo_uuid", parent_uuid.c_str());
 
-	std::string scene_uuid = obs_source_get_uuid(
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->GetCurrentSceneSource());
+	std::string scene_uuid =
+		obs_source_get_uuid(OBSBasic::Get()->GetCurrentSceneSource());
 	auto undo = [scene_uuid](const std::string &data) {
 		OBSSourceAutoRelease ssource =
 			obs_get_source_by_uuid(scene_uuid.c_str());
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(ssource.Get(), true);
+		OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 		OBSDataAutoRelease dat =
 			obs_data_create_from_json(data.c_str());
@@ -1216,8 +1207,7 @@ void OBSBasicFilters::delete_filter(OBSSource filter)
 	auto redo = [scene_uuid](const std::string &data) {
 		OBSSourceAutoRelease ssource =
 			obs_get_source_by_uuid(scene_uuid.c_str());
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(ssource.Get(), true);
+		OBSBasic::Get()->SetCurrentScene(ssource.Get(), true);
 
 		OBSDataAutoRelease dat =
 			obs_data_create_from_json(data.c_str());

--- a/UI/window-basic-interaction.cpp
+++ b/UI/window-basic-interaction.cpp
@@ -35,7 +35,7 @@ using namespace std;
 
 OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 	: QDialog(parent),
-	  main(qobject_cast<OBSBasic *>(parent)),
+	  main(OBSBasic::Get()),
 	  ui(new Ui::OBSBasicInteraction),
 	  source(source_),
 	  removedSignal(obs_source_get_signal_handler(source), "remove",

--- a/UI/window-basic-main-dropfiles.cpp
+++ b/UI/window-basic-main-dropfiles.cpp
@@ -119,7 +119,7 @@ void OBSBasic::AddDropURL(const char *url, QString &name, obs_data_t *settings,
 
 void OBSBasic::AddDropSource(const char *data, DropType image)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSDataAutoRelease settings = obs_data_create();
 	const char *type = nullptr;
 	QString name;

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -231,7 +231,7 @@ void OBSBasic::RefreshSceneCollections()
 
 	ui->actionRemoveSceneCollection->setEnabled(count > 1);
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	main->ui->actionPasteFilters->setEnabled(false);
 	main->ui->actionPasteRef->setEnabled(false);

--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -93,8 +93,7 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 	auto quickTransition = [](void *data, obs_hotkey_id, obs_hotkey_t *,
 				  bool pressed) {
 		int id = (int)(uintptr_t)data;
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 
 		if (pressed)
 			QMetaObject::invokeMethod(main,
@@ -1143,8 +1142,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 	duration->setValue(curDuration);
 
 	auto setTransition = [this](QAction *action, bool visible) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 
 		QString id = action->property("transition_id").toString();
 		OBSSceneItem sceneItem = main->GetCurrentSceneItem();
@@ -1218,8 +1216,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 				undo_redo, undo_redo, undo_data, redo_data);
 	};
 	auto setDuration = [visible](int duration) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 
 		OBSSceneItem item = main->GetCurrentSceneItem();
 		obs_sceneitem_set_transition_duration(item, visible, duration);
@@ -1259,8 +1256,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 	}
 
 	auto copyTransition = [this](QAction *, bool visible) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		OBSSceneItem item = main->GetCurrentSceneItem();
 		obs_source_t *tr = obs_sceneitem_get_transition(item, visible);
 		int trDur =
@@ -1275,8 +1271,7 @@ QMenu *OBSBasic::CreateVisibilityTransitionMenu(bool visible)
 		std::bind(copyTransition, action, visible));
 
 	auto pasteTransition = [this](QAction *, bool show) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		OBSSource tr = OBSGetStrongRef(main->copySourceTransition);
 		int trDuration = main->copySourceTransitionDuration;
 		if (!tr)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -3347,8 +3347,7 @@ void OBSBasic::AddScene(OBSSource source)
 		source, "OBSBasic.SelectScene",
 		Str("Basic.Hotkeys.SelectScene"),
 		[](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
-			OBSBasic *main = reinterpret_cast<OBSBasic *>(
-				App()->GetMainWindow());
+			OBSBasic *main = OBSBasic::Get();
 
 			auto potential_source =
 				static_cast<obs_source_t *>(data);
@@ -8719,8 +8718,7 @@ void undo_redo(const std::string &data)
 	OBSDataAutoRelease dat = obs_data_create_from_json(data.c_str());
 	OBSSourceAutoRelease source =
 		obs_get_source_by_uuid(obs_data_get_string(dat, "scene_uuid"));
-	reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-		->SetCurrentScene(source.Get(), true);
+	OBSBasic::Get()->SetCurrentScene(source.Get(), true);
 
 	obs_scene_load_transform_states(data.c_str());
 }
@@ -8729,13 +8727,13 @@ void OBSBasic::on_actionPasteTransform_triggered()
 {
 	OBSDataAutoRelease wrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);
-	auto func = [](obs_scene_t *, obs_sceneitem_t *item, void *data) {
+	auto func = [](obs_scene_t *, obs_sceneitem_t *item, void *) {
 		if (!obs_sceneitem_selected(item))
 			return true;
 		if (obs_sceneitem_locked(item))
 			return true;
 
-		OBSBasic *main = reinterpret_cast<OBSBasic *>(data);
+		OBSBasic *main = OBSBasic::Get();
 
 		obs_sceneitem_defer_update_begin(item);
 		obs_sceneitem_set_info2(item, &main->copiedTransformInfo);
@@ -8745,7 +8743,7 @@ void OBSBasic::on_actionPasteTransform_triggered()
 		return true;
 	};
 
-	obs_scene_enum_items(GetCurrentScene(), func, this);
+	obs_scene_enum_items(GetCurrentScene(), func, nullptr);
 
 	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(GetCurrentScene(), false);

--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -50,7 +50,7 @@ void OBSBasicPreview::Init()
 
 vec2 OBSBasicPreview::GetMouseEventPos(QMouseEvent *event)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	float pixelRatio = main->GetDevicePixelRatio();
 	float scale = pixelRatio / main->previewScale;
 	QPoint qtPos = event->pos();
@@ -186,7 +186,7 @@ static inline vec2 GetOBSScreenSize()
 
 vec3 OBSBasicPreview::GetSnapOffset(const vec3 &tl, const vec3 &br)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	vec2 screenSize = GetOBSScreenSize();
 	vec3 clampOffset;
 
@@ -238,7 +238,7 @@ vec3 OBSBasicPreview::GetSnapOffset(const vec3 &tl, const vec3 &br)
 
 OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos, bool selectBelow)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 	if (!scene)
@@ -296,7 +296,7 @@ static bool CheckItemSelected(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 
 bool OBSBasicPreview::SelectedAtPos(const vec2 &pos)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 	if (!scene)
@@ -472,7 +472,7 @@ static vec2 GetItemSize(obs_sceneitem_t *item)
 
 void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 	if (!scene)
@@ -608,7 +608,7 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 		return;
 	}
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	float pixelRatio = main->GetDevicePixelRatio();
 	float x = pos.x() - main->previewX / pixelRatio;
 	float y = pos.y() - main->previewY / pixelRatio;
@@ -739,7 +739,7 @@ static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 
 void OBSBasicPreview::DoSelect(const vec2 &pos)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 	OBSSceneItem item = GetItemAtPos(pos, true);
@@ -835,7 +835,7 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		hoveredPreviewItems.push_back(item);
 		selectedItems.clear();
 	}
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSDataAutoRelease rwrapper =
 		obs_scene_save_transform_states(main->GetCurrentScene(), true);
 
@@ -844,8 +844,7 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 			obs_data_create_from_json(data.c_str());
 		OBSSourceAutoRelease source = obs_get_source_by_uuid(
 			obs_data_get_string(dat, "scene_uuid"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
+		OBSBasic::Get()->SetCurrentScene(source.Get(), true);
 
 		obs_scene_load_transform_states(data.c_str());
 	};
@@ -982,7 +981,7 @@ static bool GetSourceSnapOffset(obs_scene_t * /* scene */,
 
 void OBSBasicPreview::SnapItemMovement(vec2 &offset)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 
 	SelectedItemBounds data;
@@ -1064,7 +1063,7 @@ static bool move_items(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 void OBSBasicPreview::MoveItems(const vec2 &pos)
 {
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 
 	vec2 offset, moveOffset;
@@ -1253,7 +1252,7 @@ static bool FindItemsInBox(obs_scene_t * /* scene */, obs_sceneitem_t *item,
 
 void OBSBasicPreview::BoxItems(const vec2 &startPos, const vec2 &pos)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 	if (!scene)
@@ -1603,7 +1602,7 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 
 void OBSBasicPreview::RotateItem(const vec2 &pos)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
 	bool shiftDown = (modifiers & Qt::ShiftModifier);
@@ -1652,7 +1651,7 @@ void OBSBasicPreview::RotateItem(const vec2 &pos)
 
 void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	changed = true;
 
 	QPointF qtPos = event->position();
@@ -1735,8 +1734,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 
 		if (!mouseMoved && hoveredPreviewItems.size() > 0) {
 			mousePos = pos;
-			OBSBasic *main = reinterpret_cast<OBSBasic *>(
-				App()->GetMainWindow());
+			OBSBasic *main = OBSBasic::Get();
 			float scale = main->GetDevicePixelRatio();
 			float x = qtPos.x() - main->previewX / scale;
 			float y = qtPos.y() - main->previewY / scale;
@@ -2251,7 +2249,7 @@ void OBSBasicPreview::DrawOverflow()
 		overflow = gs_texture_create_from_file(path.c_str());
 	}
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
 
@@ -2274,7 +2272,7 @@ void OBSBasicPreview::DrawSceneEditing()
 
 	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawSceneEditing");
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	gs_effect_t *solid = obs_get_base_effect(OBS_EFFECT_SOLID);
 	gs_technique_t *tech = gs_effect_get_technique(solid, "Solid");

--- a/UI/window-basic-properties.cpp
+++ b/UI/window-basic-properties.cpp
@@ -44,7 +44,7 @@ static void CreateTransitionScene(OBSSource scene, const char *text,
 OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	: QDialog(parent),
 	  ui(new Ui::OBSBasicProperties),
-	  main(qobject_cast<OBSBasic *>(parent)),
+	  main(OBSBasic::Get()),
 	  acceptClicked(false),
 	  source(source_),
 	  removedSignal(obs_source_get_signal_handler(source), "remove",

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -354,7 +354,7 @@ void RestrictResetBitrates(initializer_list<QComboBox *> boxes, int maxbitrate);
 
 OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	: QDialog(parent),
-	  main(qobject_cast<OBSBasic *>(parent)),
+	  main(OBSBasic::Get()),
 	  ui(new Ui::OBSBasicSettings)
 {
 	string path;

--- a/UI/window-basic-source-select.cpp
+++ b/UI/window-basic-source-select.cpp
@@ -54,8 +54,7 @@ bool OBSBasicSourceSelect::EnumGroups(void *data, obs_source_t *source)
 	const char *id = obs_source_get_unversioned_id(source);
 
 	if (strcmp(id, window->id) == 0) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		OBSScene scene = main->GetCurrentScene();
 
 		obs_sceneitem_t *existing = obs_scene_get_group(scene, name);
@@ -158,7 +157,7 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate,
 			obs_blending_method *blend_method,
 			obs_blending_type *blend_mode)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 	if (!scene)
 		return;
@@ -203,7 +202,7 @@ static void AddExisting(const char *name, bool visible, bool duplicate,
 bool AddNew(QWidget *parent, const char *id, const char *name,
 	    const bool visible, OBSSource &newSource)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 	bool success = false;
 	if (!scene)
@@ -258,8 +257,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		AddExisting(QT_TO_UTF8(source_name), visible, false, nullptr,
 			    nullptr, nullptr, nullptr);
 
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		const char *scene_name =
 			obs_source_get_name(main->GetCurrentSceneSource());
 
@@ -308,8 +306,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 			    visible, newSource))
 			return;
 
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		std::string scene_name =
 			obs_source_get_name(main->GetCurrentSceneSource());
 		auto undo = [scene_name, main](const std::string &data) {
@@ -429,8 +426,7 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_,
 	});
 
 	if (strcmp(id_, "scene") == 0) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		OBSSource curSceneSource = main->GetCurrentSceneSource();
 
 		ui->selectExisting->setChecked(true);

--- a/UI/window-basic-stats.cpp
+++ b/UI/window-basic-stats.cpp
@@ -200,7 +200,7 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closable)
 			 &OBSBasicStats::RecordingTimeLeft);
 	recTimeLeft.setInterval(REC_TIME_LEFT_INTERVAL);
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	const char *geometry =
 		config_get_string(main->Config(), "Stats", "geometry");
@@ -227,7 +227,7 @@ OBSBasicStats::OBSBasicStats(QWidget *parent, bool closable)
 
 void OBSBasicStats::closeEvent(QCloseEvent *event)
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	if (isVisible()) {
 		config_set_string(main->Config(), "Stats", "geometry",
 				  saveGeometry().toBase64().constData());
@@ -282,7 +282,7 @@ void OBSBasicStats::InitializeValues()
 
 void OBSBasicStats::Update()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 
 	/* TODO: Un-hardcode */
 

--- a/UI/window-basic-status-bar.cpp
+++ b/UI/window-basic-status-bar.cpp
@@ -112,7 +112,7 @@ void OBSBasicStatusBar::Activate()
 
 void OBSBasicStatusBar::Deactivate()
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 	if (!main)
 		return;
 
@@ -231,7 +231,7 @@ void OBSBasicStatusBar::UpdateBandwidth()
 
 void OBSBasicStatusBar::UpdateCPUUsage()
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 	if (!main)
 		return;
 
@@ -423,7 +423,7 @@ void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data, calldata_t *)
 
 void OBSBasicStatusBar::Reconnect(int seconds)
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 
 	if (!retries)
 		main->SysTrayNotify(
@@ -457,7 +457,7 @@ void OBSBasicStatusBar::ReconnectClear()
 
 void OBSBasicStatusBar::ReconnectSuccess()
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 
 	QString msg = QTStr("Basic.StatusBar.ReconnectSuccessful");
 	showMessage(msg, 4000);
@@ -478,7 +478,7 @@ void OBSBasicStatusBar::ReconnectSuccess()
 
 void OBSBasicStatusBar::UpdateStatusBar()
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 
 	UpdateBandwidth();
 
@@ -513,7 +513,7 @@ void OBSBasicStatusBar::UpdateStatusBar()
 
 void OBSBasicStatusBar::StreamDelayStarting(int sec)
 {
-	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	OBSBasic *main = OBSBasic::Get();
 	if (!main || !main->outputHandler)
 		return;
 

--- a/UI/window-basic-transform.cpp
+++ b/UI/window-basic-transform.cpp
@@ -111,8 +111,7 @@ OBSBasicTransform::~OBSBasicTransform()
 			obs_data_create_from_json(data.c_str());
 		OBSSourceAutoRelease source = obs_get_source_by_uuid(
 			obs_data_get_string(dat, "scene_uuid"));
-		reinterpret_cast<OBSBasic *>(App()->GetMainWindow())
-			->SetCurrentScene(source.Get(), true);
+		OBSBasic::Get()->SetCurrentScene(source.Get(), true);
 		obs_scene_load_transform_states(data.c_str());
 	};
 

--- a/UI/window-missing-files.cpp
+++ b/UI/window-missing-files.cpp
@@ -268,8 +268,7 @@ QVariant MissingFilesModel::data(const QModelIndex &index, int role) const
 		}
 	} else if (role == Qt::DecorationRole &&
 		   index.column() == MissingFilesColumn::Source) {
-		OBSBasic *main =
-			reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		OBSBasic *main = OBSBasic::Get();
 		OBSSourceAutoRelease source = obs_get_source_by_name(
 			files[index.row()].source.toStdString().c_str());
 

--- a/UI/window-projector.cpp
+++ b/UI/window-projector.cpp
@@ -169,7 +169,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 	if (!window->ready)
 		return;
 
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	OBSSource source = window->GetSource();
 
 	uint32_t targetCX;
@@ -323,7 +323,7 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 
 void OBSProjector::EscapeTriggered()
 {
-	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+	OBSBasic *main = OBSBasic::Get();
 	main->DeleteProjector(this);
 }
 


### PR DESCRIPTION
### Description
This reduces duplicated code when getting the OBSBasic context.

### Motivation and Context
I don't like duplicated code

### How Has This Been Tested?
Made sure everything worked as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
