### PR TITLE
UI: Force UpdateEditMenu on UI Thread

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1993,7 +1993,7 @@ void OBSBasic::InitOBSCallbacks()
 {
 	ProfileScope("OBSBasic::InitOBSCallbacks");
 
-	signalHandlers.reserve(signalHandlers.size() + 7);
+	signalHandlers.reserve(signalHandlers.size() + 9);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_create",
 				    OBSBasic::SourceCreated, this);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_remove",
@@ -2014,13 +2014,17 @@ void OBSBasic::InitOBSCallbacks()
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_add",
 		[](void *data, calldata_t *) {
-			static_cast<OBSBasic *>(data)->UpdateEditMenu();
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data),
+						  "UpdateEditMenu",
+						  Qt::QueuedConnection);
 		},
 		this);
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_remove",
 		[](void *data, calldata_t *) {
-			static_cast<OBSBasic *>(data)->UpdateEditMenu();
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data),
+						  "UpdateEditMenu",
+						  Qt::QueuedConnection);
 		},
 		this);
 }

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -749,6 +749,8 @@ public slots:
 	void PauseRecording();
 	void UnpauseRecording();
 
+	void UpdateEditMenu();
+
 private slots:
 
 	void on_actionMainUndo_triggered();
@@ -1044,8 +1046,6 @@ public:
 					     obs_source_t *source,
 					     obs_data_array_t *undo_array,
 					     obs_data_array_t *redo_array);
-
-	void UpdateEditMenu();
 
 	void SetDisplayAffinity(QWindow *window);
 


### PR DESCRIPTION
### Description
Force UpdateEditMenu on UI Thread

### Motivation and Context
UpdateEditMenu should always be called on the UI Thread
broken since #10725

Fixes #11116

### How Has This Been Tested?
On windows by removing and adding filters via not UI

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
