### PR TITLE
frontend: Refactor main window menus

### DIFF
--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -909,11 +909,6 @@
      <addaction name="actionSceneListMode"/>
      <addaction name="actionSceneGridMode"/>
     </widget>
-    <widget class="QMenu" name="multiviewProjectorMenu">
-     <property name="title">
-      <string>Projector.Open.Multiview</string>
-     </property>
-    </widget>
     <action name="resetUI">
      <property name="text">
       <string>Basic.MainMenu.View.ResetUI</string>
@@ -938,7 +933,6 @@
     <addaction name="separator"/>
     <addaction name="stats"/>
     <addaction name="separator"/>
-    <addaction name="multiviewProjectorMenu"/>
     <addaction name="separator"/>
     <addaction name="actionAlwaysOnTop"/>
    </widget>

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1285,14 +1285,6 @@ void OBSBasic::OBSInit()
 
 	OBSBasicStats::InitializeValues();
 
-	/* ----------------------- */
-	/* Add multiview menu      */
-
-	ui->viewMenu->addSeparator();
-
-	connect(ui->viewMenu->menuAction(), &QAction::hovered, this, &OBSBasic::updateMultiviewProjectorMenu);
-	OBSBasic::updateMultiviewProjectorMenu();
-
 	ui->sources->UpdateIcons();
 
 #if !defined(_WIN32)
@@ -1407,18 +1399,8 @@ void OBSBasic::applicationShutdown() noexcept
 		patronJsonThread->wait();
 
 	delete screenshotData;
-	delete previewProjectorSource;
-	delete previewProjectorMain;
-	delete sourceProjector;
-	delete sceneProjectorMenu;
-	delete scaleFilteringMenu;
-	delete blendingModeMenu;
-	delete colorMenu;
-	delete colorWidgetAction;
-	delete colorSelect;
-	delete deinterlaceMenu;
-	delete perSceneTransitionMenu;
 	delete shortcutFilter;
+	delete trayMenu;
 	delete programOptions;
 	delete program;
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -578,15 +578,7 @@ private:
 	QPointer<QWidget> importer;
 	QPointer<QAction> showHide;
 	QPointer<QAction> exit;
-
-	QPointer<QMenu> scaleFilteringMenu;
-	QPointer<QMenu> blendingMethodMenu;
-	QPointer<QMenu> blendingModeMenu;
-	QPointer<QMenu> colorMenu;
-	QPointer<QMenu> deinterlaceMenu;
-
-	QPointer<QWidgetAction> colorWidgetAction;
-	QPointer<ColorSelect> colorSelect;
+	QScopedPointer<QMenu> multiviewMenu;
 
 	QList<QDialog *> visDialogs;
 	QList<QDialog *> modalDialogs;
@@ -651,6 +643,7 @@ private slots:
 
 public slots:
 	void on_actionAdvAudioProperties_triggered();
+	void on_viewMenu_aboutToShow();
 
 public:
 	void ResetUI();
@@ -845,7 +838,9 @@ private:
 private slots:
 	void PreviewScalingModeChanged(int value);
 
-	void ColorChange();
+	void colorButtonClicked(QPushButton *button, int preset);
+	void customColorSelected();
+	void clearColors();
 
 	void EnablePreview();
 	void DisablePreview();
@@ -937,11 +932,7 @@ public slots:
 	 */
 private:
 	std::vector<OBSProjector *> projectors;
-	QPointer<QMenu> previewProjector;
-	QPointer<QMenu> previewProjectorSource;
-	QPointer<QMenu> previewProjectorMain;
 
-	void updateMultiviewProjectorMenu();
 	void ClearProjectors();
 	OBSProjector *OpenProjector(obs_source_t *source, int monitor, ProjectorType type);
 
@@ -951,30 +942,27 @@ private:
 private slots:
 	void OpenSavedProjector(SavedProjectorInfo *info);
 
-	void OpenPreviewProjector();
-	void OpenSourceProjector();
-	void OpenMultiviewProjector();
-	void OpenSceneProjector();
-
-	void OpenPreviewWindow();
-	void OpenSourceWindow();
-	void OpenSceneWindow();
-	void openMultiviewWindow();
-
 public:
 	void DeleteProjector(OBSProjector *projector);
 
 	static QList<QString> GetProjectorMenuMonitorsFormatted();
 	template<typename Receiver, typename... Args>
-	static void AddProjectorMenuMonitors(QMenu *parent, Receiver *target, void (Receiver::*slot)(Args...))
+	static QMenu *createProjectorMenu(const QString &name, Receiver *target, void (Receiver::*slot)(Args...),
+					  QWidget *parent = nullptr)
 	{
+		QMenu *menu = new QMenu(name, parent);
+
 		auto projectors = GetProjectorMenuMonitorsFormatted();
 		for (int i = 0; i < projectors.size(); i++) {
 			QString str = projectors[i];
-			QAction *action = parent->addAction(str, target, slot);
+			QAction *action = menu->addAction(str, target, slot);
 			action->setProperty("monitor", i);
 		}
+
+		return menu;
 	}
+
+	QMenu *createProjectorMenu(const QString &name, OBSSource source, ProjectorType type);
 
 	/* -------------------------------------
 	 * MARK: - OBSBasic_Recording
@@ -1152,7 +1140,6 @@ public slots:
 	 * -------------------------------------
 	 */
 private:
-	QPointer<QMenu> sourceProjector;
 	QPointer<QAction> renameSource;
 
 	void CreateFirstRunSources();
@@ -1181,13 +1168,11 @@ private slots:
 	void ReorderSources(OBSScene scene);
 	void RefreshSources(OBSScene scene);
 
-	void SetDeinterlacingMode();
-	void SetDeinterlacingOrder();
-
-	void SetScaleFilter();
-
-	void SetBlendingMethod();
-	void SetBlendingMode();
+	void setDeinterlacingMode(OBSSource source, obs_deinterlace_mode mode);
+	void setDeinterlacingOrder(OBSSource source, obs_deinterlace_field_order order);
+	void setScaleFilter(OBSSceneItem item, obs_scale_type type);
+	void setBlendingMethod(OBSSceneItem item, obs_blending_method mehod);
+	void setBlendingMode(OBSSceneItem item, obs_blending_type mode);
 
 	void on_actionRotate90CW_triggered();
 	void on_actionRotate90CCW_triggered();
@@ -1231,12 +1216,11 @@ private slots:
 public:
 	void ResetAudioDevice(const char *sourceId, const char *deviceId, const char *deviceDesc, int channel);
 
-	QMenu *AddDeinterlacingMenu(QMenu *menu, obs_source_t *source);
-	QMenu *AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item);
-	QMenu *AddBlendingMethodMenu(QMenu *menu, obs_sceneitem_t *item);
-	QMenu *AddBlendingModeMenu(QMenu *menu, obs_sceneitem_t *item);
-	QMenu *AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction, ColorSelect *select,
-				      obs_sceneitem_t *item);
+	QMenu *createDeinterlacingMenu(OBSSource source, QWidget *parent = nullptr);
+	QMenu *createScaleFilteringMenu(OBSSceneItem item, QWidget *parent = nullptr);
+	QMenu *createBlendingMethodMenu(OBSSceneItem item, QWidget *parent = nullptr);
+	QMenu *createBlendingModeMenu(OBSSceneItem item, QWidget *parent = nullptr);
+	QMenu *createBackgroundColorMenu(OBSSceneItem item, QWidget *parent = nullptr);
 	void CreateSourcePopupMenu(int idx, bool preview);
 
 	void actionOpenSourceFilters();
@@ -1247,7 +1231,6 @@ public:
 	 * -------------------------------------
 	 */
 private:
-	QPointer<QMenu> sceneProjectorMenu;
 	QPointer<QAction> renameScene;
 	std::atomic<obs_scene_t *> currentScene = nullptr;
 	OBSWeakSource lastScene;
@@ -1401,7 +1384,6 @@ signals:
 	 * -------------------------------------
 	 */
 private:
-	QPointer<QMenu> studioProgramProjector;
 	QPointer<QWidget> programWidget;
 	QPointer<QVBoxLayout> programLayout;
 	QPointer<QLabel> programLabel;
@@ -1462,9 +1444,10 @@ private:
 	QPointer<QAction> sysTrayReplayBuffer;
 	QPointer<QAction> sysTrayVirtualCam;
 	QPointer<QMenu> trayMenu;
+	QScopedPointer<QMenu> previewProjector;
+	QScopedPointer<QMenu> studioProgramProjector;
 
 	bool sysTrayMinimizeToTray();
-	void updateSysTrayProjectorMenu();
 
 private slots:
 	void IconActivated(QSystemTrayIcon::ActivationReason reason);

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -44,6 +44,7 @@
 #include <utility/WhatsNewInfoThread.hpp>
 #endif
 #include <wizards/AutoConfig.hpp>
+#include <widgets/OBSProjector.hpp>
 
 #include <qt-wrappers.hpp>
 
@@ -682,4 +683,12 @@ void OBSBasic::on_OBSBasic_customContextMenuRequested(const QPoint &pos)
 	} else if (!className) {
 		ui->menuDocks->exec(globalPos);
 	}
+}
+
+void OBSBasic::on_viewMenu_aboutToShow()
+{
+	multiviewMenu.reset(createProjectorMenu(QTStr("Projector.Open.Multiview"), nullptr, ProjectorType::Multiview));
+
+	QAction *separatorAction = ui->viewMenu->actions().at(ui->viewMenu->actions().count() - 2);
+	ui->viewMenu->insertMenu(separatorAction, multiviewMenu.data());
 }

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -24,8 +24,6 @@
 
 #include <qt-wrappers.hpp>
 
-#include <QColorDialog>
-
 #include <sstream>
 
 extern void undo_redo(const std::string &data);
@@ -242,18 +240,12 @@ void OBSBasic::on_preview_customContextMenuRequested()
 void OBSBasic::on_previewDisabledWidget_customContextMenuRequested()
 {
 	QMenu popup(this);
-	delete previewProjectorMain;
 
 	QAction *action = popup.addAction(QTStr("Basic.Main.PreviewConextMenu.Enable"), this, &OBSBasic::TogglePreview);
 	action->setCheckable(true);
 	action->setChecked(obs_display_enabled(ui->preview->GetDisplay()));
 
-	previewProjectorMain = new QMenu(QTStr("Projector.Open.Preview"));
-	AddProjectorMenuMonitors(previewProjectorMain, this, &OBSBasic::OpenPreviewProjector);
-	previewProjectorMain->addSeparator();
-	previewProjectorMain->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenPreviewWindow);
-
-	popup.addMenu(previewProjectorMain);
+	popup.addMenu(createProjectorMenu(QTStr("Projector.Open.Preview"), nullptr, ProjectorType::Preview));
 	popup.exec(QCursor::pos());
 }
 
@@ -425,127 +417,6 @@ void OBSBasic::setPreviewScalingOutput()
 	int32_t approxScalingLevel = int32_t(round(log(scalingAmount) / log(ZOOM_SENSITIVITY)));
 	ui->preview->SetScalingLevelAndAmount(approxScalingLevel, scalingAmount);
 	emit ui->preview->DisplayResized();
-}
-
-static void ConfirmColor(SourceTree *sources, const QColor &color, QModelIndexList selectedItems)
-{
-	for (int x = 0; x < selectedItems.count(); x++) {
-		SourceTreeItem *treeItem = sources->GetItemWidget(selectedItems[x].row());
-		treeItem->setStyleSheet("background: " + color.name(QColor::HexArgb));
-		treeItem->style()->unpolish(treeItem);
-		treeItem->style()->polish(treeItem);
-
-		OBSSceneItem sceneItem = sources->Get(selectedItems[x].row());
-		OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
-		obs_data_set_int(privData, "color-preset", 1);
-		obs_data_set_string(privData, "color", QT_TO_UTF8(color.name(QColor::HexArgb)));
-	}
-}
-
-void OBSBasic::ColorChange()
-{
-	QModelIndexList selectedItems = ui->sources->selectionModel()->selectedIndexes();
-	QAction *action = qobject_cast<QAction *>(sender());
-	QPushButton *colorButton = qobject_cast<QPushButton *>(sender());
-
-	if (selectedItems.count() == 0)
-		return;
-
-	if (colorButton) {
-		int preset = colorButton->property("bgColor").value<int>();
-
-		for (int x = 0; x < selectedItems.count(); x++) {
-			SourceTreeItem *treeItem = ui->sources->GetItemWidget(selectedItems[x].row());
-			treeItem->setStyleSheet("");
-			treeItem->setProperty("bgColor", preset);
-			treeItem->style()->unpolish(treeItem);
-			treeItem->style()->polish(treeItem);
-
-			OBSSceneItem sceneItem = ui->sources->Get(selectedItems[x].row());
-			OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
-			obs_data_set_int(privData, "color-preset", preset + 1);
-			obs_data_set_string(privData, "color", "");
-		}
-
-		for (int i = 1; i < 9; i++) {
-			stringstream button;
-			button << "preset" << i;
-			QPushButton *cButton =
-				colorButton->parentWidget()->findChild<QPushButton *>(button.str().c_str());
-			cButton->setStyleSheet("border: 1px solid black");
-		}
-
-		colorButton->setStyleSheet("border: 2px solid black");
-	} else if (action) {
-		int preset = action->property("bgColor").value<int>();
-
-		if (preset == 1) {
-			OBSSceneItem curSceneItem = GetCurrentSceneItem();
-			SourceTreeItem *curTreeItem = GetItemWidgetFromSceneItem(curSceneItem);
-			OBSDataAutoRelease curPrivData = obs_sceneitem_get_private_settings(curSceneItem);
-
-			int oldPreset = obs_data_get_int(curPrivData, "color-preset");
-			const QString oldSheet = curTreeItem->styleSheet();
-
-			auto liveChangeColor = [=](const QColor &color) {
-				if (color.isValid()) {
-					curTreeItem->setStyleSheet("background: " + color.name(QColor::HexArgb));
-				}
-			};
-
-			auto changedColor = [this, selectedItems](const QColor &color) {
-				if (color.isValid()) {
-					ConfirmColor(ui->sources, color, selectedItems);
-				}
-			};
-
-			auto rejected = [=]() {
-				if (oldPreset == 1) {
-					curTreeItem->setStyleSheet(oldSheet);
-					curTreeItem->setProperty("bgColor", 0);
-				} else if (oldPreset == 0) {
-					curTreeItem->setStyleSheet("background: none");
-					curTreeItem->setProperty("bgColor", 0);
-				} else {
-					curTreeItem->setStyleSheet("");
-					curTreeItem->setProperty("bgColor", oldPreset - 1);
-				}
-
-				curTreeItem->style()->unpolish(curTreeItem);
-				curTreeItem->style()->polish(curTreeItem);
-			};
-
-			QColorDialog::ColorDialogOptions options = QColorDialog::ShowAlphaChannel;
-
-			const char *oldColor = obs_data_get_string(curPrivData, "color");
-			const char *customColor = *oldColor != 0 ? oldColor : "#55FF0000";
-#ifdef __linux__
-			// TODO: Revisit hang on Ubuntu with native dialog
-			options |= QColorDialog::DontUseNativeDialog;
-#endif
-
-			QColorDialog *colorDialog = new QColorDialog(this);
-			colorDialog->setOptions(options);
-			colorDialog->setCurrentColor(QColor(customColor));
-			connect(colorDialog, &QColorDialog::currentColorChanged, this, liveChangeColor);
-			connect(colorDialog, &QColorDialog::colorSelected, this, changedColor);
-			connect(colorDialog, &QColorDialog::rejected, this, rejected);
-			colorDialog->open();
-		} else {
-			for (int x = 0; x < selectedItems.count(); x++) {
-				SourceTreeItem *treeItem = ui->sources->GetItemWidget(selectedItems[x].row());
-				treeItem->setStyleSheet("background: none");
-				treeItem->setProperty("bgColor", preset);
-				treeItem->style()->unpolish(treeItem);
-				treeItem->style()->polish(treeItem);
-
-				OBSSceneItem sceneItem = ui->sources->Get(selectedItems[x].row());
-				OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
-				obs_data_set_int(privData, "color-preset", preset);
-				obs_data_set_string(privData, "color", "");
-			}
-		}
-	}
 }
 
 void OBSBasic::UpdateProjectorHideCursor()

--- a/frontend/widgets/OBSBasic_Projectors.cpp
+++ b/frontend/widgets/OBSBasic_Projectors.cpp
@@ -80,14 +80,6 @@ void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
 	}
 }
 
-void OBSBasic::updateMultiviewProjectorMenu()
-{
-	ui->multiviewProjectorMenu->clear();
-	AddProjectorMenuMonitors(ui->multiviewProjectorMenu, this, &OBSBasic::OpenMultiviewProjector);
-	ui->multiviewProjectorMenu->addSeparator();
-	ui->multiviewProjectorMenu->addAction(QTStr("Projector.Window"), this, &OBSBasic::openMultiviewWindow);
-}
-
 void OBSBasic::ClearProjectors()
 {
 	for (size_t i = 0; i < projectors.size(); i++) {
@@ -166,65 +158,6 @@ OBSProjector *OBSBasic::OpenProjector(obs_source_t *source, int monitor, Project
 	return projector;
 }
 
-void OBSBasic::OpenPreviewProjector()
-{
-	int monitor = sender()->property("monitor").toInt();
-	OpenProjector(nullptr, monitor, ProjectorType::Preview);
-}
-
-void OBSBasic::OpenSourceProjector()
-{
-	int monitor = sender()->property("monitor").toInt();
-	OBSSceneItem item = GetCurrentSceneItem();
-	if (!item)
-		return;
-
-	OpenProjector(obs_sceneitem_get_source(item), monitor, ProjectorType::Source);
-}
-
-void OBSBasic::OpenMultiviewProjector()
-{
-	int monitor = sender()->property("monitor").toInt();
-	OpenProjector(nullptr, monitor, ProjectorType::Multiview);
-}
-
-void OBSBasic::OpenSceneProjector()
-{
-	int monitor = sender()->property("monitor").toInt();
-	OBSScene scene = GetCurrentScene();
-	if (!scene)
-		return;
-
-	OpenProjector(obs_scene_get_source(scene), monitor, ProjectorType::Scene);
-}
-
-void OBSBasic::OpenPreviewWindow()
-{
-	OpenProjector(nullptr, -1, ProjectorType::Preview);
-}
-
-void OBSBasic::OpenSourceWindow()
-{
-	OBSSceneItem item = GetCurrentSceneItem();
-	if (!item)
-		return;
-
-	OBSSource source = obs_sceneitem_get_source(item);
-
-	OpenProjector(obs_sceneitem_get_source(item), -1, ProjectorType::Source);
-}
-
-void OBSBasic::OpenSceneWindow()
-{
-	OBSScene scene = GetCurrentScene();
-	if (!scene)
-		return;
-
-	OBSSource source = obs_scene_get_source(scene);
-
-	OpenProjector(obs_scene_get_source(scene), -1, ProjectorType::Scene);
-}
-
 void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
 {
 	if (info) {
@@ -261,7 +194,19 @@ void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)
 	}
 }
 
-void OBSBasic::openMultiviewWindow()
+QMenu *OBSBasic::createProjectorMenu(const QString &name, OBSSource source, ProjectorType type)
 {
-	OpenProjector(nullptr, -1, ProjectorType::Multiview);
+	QMenu *menu = new QMenu(name);
+
+	auto projectors = GetProjectorMenuMonitorsFormatted();
+	for (int i = 0; i < projectors.size(); i++) {
+		QString str = projectors[i];
+		menu->addAction(str, this, [this, source, i, type]() { OpenProjector(source, i, type); });
+	}
+
+	menu->addSeparator();
+
+	menu->addAction(QTStr("Projector.Window"), this, [this, source, type]() { OpenProjector(source, -1, type); });
+
+	return menu;
 }

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -30,6 +30,7 @@
 #include <qt-wrappers.hpp>
 
 #include <QWidgetAction>
+#include <QColorDialog>
 
 #include <sstream>
 
@@ -67,6 +68,21 @@ std::string getNewSourceName(std::string_view name)
 	}
 
 	return newName;
+}
+
+void confirmColor(SourceTree *sources, const QColor &color, QModelIndexList selectedItems)
+{
+	for (int x = 0; x < selectedItems.count(); x++) {
+		SourceTreeItem *treeItem = sources->GetItemWidget(selectedItems[x].row());
+		treeItem->setStyleSheet("background: " + color.name(QColor::HexArgb));
+		treeItem->style()->unpolish(treeItem);
+		treeItem->style()->polish(treeItem);
+
+		OBSSceneItem sceneItem = sources->Get(selectedItems[x].row());
+		OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
+		obs_data_set_int(privData, "color-preset", 1);
+		obs_data_set_string(privData, "color", QT_TO_UTF8(color.name(QColor::HexArgb)));
+	}
 }
 } // namespace
 
@@ -247,13 +263,8 @@ void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId, cons
 	}
 }
 
-void OBSBasic::SetDeinterlacingMode()
+void OBSBasic::setDeinterlacingMode(OBSSource source, obs_deinterlace_mode mode)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_deinterlace_mode mode = (obs_deinterlace_mode)action->property("mode").toInt();
-	OBSSceneItem sceneItem = GetCurrentSceneItem();
-	obs_source_t *source = obs_sceneitem_get_source(sceneItem);
-
 	obs_deinterlace_mode oldMode = obs_source_get_deinterlace_mode(source);
 	obs_source_set_deinterlace_mode(source, mode);
 
@@ -275,13 +286,8 @@ void OBSBasic::SetDeinterlacingMode()
 	}
 }
 
-void OBSBasic::SetDeinterlacingOrder()
+void OBSBasic::setDeinterlacingOrder(OBSSource source, obs_deinterlace_field_order order)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_deinterlace_field_order order = (obs_deinterlace_field_order)action->property("order").toInt();
-	OBSSceneItem sceneItem = GetCurrentSceneItem();
-	obs_source_t *source = obs_sceneitem_get_source(sceneItem);
-
 	obs_deinterlace_field_order oldOrder = obs_source_get_deinterlace_field_order(source);
 	obs_source_set_deinterlace_field_order(source, order);
 
@@ -303,52 +309,49 @@ void OBSBasic::SetDeinterlacingOrder()
 	}
 }
 
-QMenu *OBSBasic::AddDeinterlacingMenu(QMenu *menu, obs_source_t *source)
+QMenu *OBSBasic::createDeinterlacingMenu(OBSSource source, QWidget *parent)
 {
-	obs_deinterlace_mode deinterlaceMode = obs_source_get_deinterlace_mode(source);
-	obs_deinterlace_field_order deinterlaceOrder = obs_source_get_deinterlace_field_order(source);
-	QAction *action;
+	QMenu *menu = new QMenu(QTStr("Deinterlacing"), parent);
 
-#define ADD_MODE(name, mode)                                                             \
-	action = menu->addAction(QTStr("" name), this, &OBSBasic::SetDeinterlacingMode); \
-	action->setProperty("mode", (int)mode);                                          \
-	action->setCheckable(true);                                                      \
-	action->setChecked(deinterlaceMode == mode);
+	obs_deinterlace_mode currentMode = obs_source_get_deinterlace_mode(source);
+	obs_deinterlace_field_order currentOrder = obs_source_get_deinterlace_field_order(source);
 
-	ADD_MODE("Disable", OBS_DEINTERLACE_MODE_DISABLE);
-	ADD_MODE("Deinterlacing.Discard", OBS_DEINTERLACE_MODE_DISCARD);
-	ADD_MODE("Deinterlacing.Retro", OBS_DEINTERLACE_MODE_RETRO);
-	ADD_MODE("Deinterlacing.Blend", OBS_DEINTERLACE_MODE_BLEND);
-	ADD_MODE("Deinterlacing.Blend2x", OBS_DEINTERLACE_MODE_BLEND_2X);
-	ADD_MODE("Deinterlacing.Linear", OBS_DEINTERLACE_MODE_LINEAR);
-	ADD_MODE("Deinterlacing.Linear2x", OBS_DEINTERLACE_MODE_LINEAR_2X);
-	ADD_MODE("Deinterlacing.Yadif", OBS_DEINTERLACE_MODE_YADIF);
-	ADD_MODE("Deinterlacing.Yadif2x", OBS_DEINTERLACE_MODE_YADIF_2X);
-#undef ADD_MODE
+	auto addMode = [&](const QString &name, obs_deinterlace_mode mode) {
+		QAction *action =
+			menu->addAction(name, this, [this, source, mode]() { setDeinterlacingMode(source, mode); });
+		action->setCheckable(true);
+		action->setChecked(currentMode == mode);
+	};
+
+	addMode(QTStr("Disable"), OBS_DEINTERLACE_MODE_DISABLE);
+	addMode(QTStr("Deinterlacing.Discard"), OBS_DEINTERLACE_MODE_DISCARD);
+	addMode(QTStr("Deinterlacing.Retro"), OBS_DEINTERLACE_MODE_RETRO);
+	addMode(QTStr("Deinterlacing.Blend"), OBS_DEINTERLACE_MODE_BLEND);
+	addMode(QTStr("Deinterlacing.Blend2x"), OBS_DEINTERLACE_MODE_BLEND_2X);
+	addMode(QTStr("Deinterlacing.Linear"), OBS_DEINTERLACE_MODE_LINEAR);
+	addMode(QTStr("Deinterlacing.Linear2x"), OBS_DEINTERLACE_MODE_LINEAR_2X);
+	addMode(QTStr("Deinterlacing.Yadif"), OBS_DEINTERLACE_MODE_YADIF);
+	addMode(QTStr("Deinterlacing.Yadif2x"), OBS_DEINTERLACE_MODE_YADIF_2X);
 
 	menu->addSeparator();
 
-#define ADD_ORDER(name, order)                                                                          \
-	action = menu->addAction(QTStr("Deinterlacing." name), this, &OBSBasic::SetDeinterlacingOrder); \
-	action->setProperty("order", (int)order);                                                       \
-	action->setCheckable(true);                                                                     \
-	action->setChecked(deinterlaceOrder == order);
+	auto addOrder = [&](const QString &name, obs_deinterlace_field_order order) {
+		QAction *action =
+			menu->addAction(name, this, [this, source, order]() { setDeinterlacingOrder(source, order); });
+		action->setCheckable(true);
+		action->setChecked(currentOrder == order);
+	};
 
-	ADD_ORDER("TopFieldFirst", OBS_DEINTERLACE_FIELD_ORDER_TOP);
-	ADD_ORDER("BottomFieldFirst", OBS_DEINTERLACE_FIELD_ORDER_BOTTOM);
-#undef ADD_ORDER
+	addOrder(QTStr("Deinterlacing.TopFieldFirst"), OBS_DEINTERLACE_FIELD_ORDER_TOP);
+	addOrder(QTStr("Deinterlacing.BottomFieldFirst"), OBS_DEINTERLACE_FIELD_ORDER_BOTTOM);
 
 	return menu;
 }
 
-void OBSBasic::SetScaleFilter()
+void OBSBasic::setScaleFilter(OBSSceneItem item, obs_scale_type type)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_scale_type mode = (obs_scale_type)action->property("mode").toInt();
-	OBSSceneItem sceneItem = GetCurrentSceneItem();
-
-	obs_scale_type oldMode = obs_sceneitem_get_scale_filter(sceneItem);
-	obs_sceneitem_set_scale_filter(sceneItem, mode);
+	obs_scale_type oldType = obs_sceneitem_get_scale_filter(item);
+	obs_sceneitem_set_scale_filter(item, type);
 
 	auto undo_redo = [](const std::string &uuid, int64_t id, obs_scale_type val) {
 		OBSSourceAutoRelease s = obs_get_source_by_uuid(uuid.c_str());
@@ -358,52 +361,47 @@ void OBSBasic::SetScaleFilter()
 			obs_sceneitem_set_scale_filter(si, val);
 	};
 
-	OBSSource source = obs_sceneitem_get_source(sceneItem);
-	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(sceneItem));
-	int64_t id = obs_sceneitem_get_id(sceneItem);
+	OBSSource source = obs_sceneitem_get_source(item);
+	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(item));
+	int64_t id = obs_sceneitem_get_id(item);
 	const char *name = obs_source_get_name(sceneSource);
 	const char *uuid = obs_source_get_uuid(sceneSource);
 
 	if (uuid && *uuid) {
 		QString actionString = QTStr("Undo.ScaleFiltering").arg(obs_source_get_name(source), name);
 
-		auto undoFunction = std::bind(undo_redo, std::placeholders::_1, id, oldMode);
-		auto redoFunction = std::bind(undo_redo, std::placeholders::_1, id, mode);
+		auto undoFunction = std::bind(undo_redo, std::placeholders::_1, id, oldType);
+		auto redoFunction = std::bind(undo_redo, std::placeholders::_1, id, type);
 
 		undo_s.add_action(actionString, undoFunction, redoFunction, uuid, uuid);
 	}
 }
 
-QMenu *OBSBasic::AddScaleFilteringMenu(QMenu *menu, obs_sceneitem_t *item)
+QMenu *OBSBasic::createScaleFilteringMenu(OBSSceneItem item, QWidget *parent)
 {
-	obs_scale_type scaleFilter = obs_sceneitem_get_scale_filter(item);
-	QAction *action;
+	QMenu *menu = new QMenu(QTStr("ScaleFiltering"), parent);
+	obs_scale_type currentType = obs_sceneitem_get_scale_filter(item);
 
-#define ADD_MODE(name, mode)                                                       \
-	action = menu->addAction(QTStr("" name), this, &OBSBasic::SetScaleFilter); \
-	action->setProperty("mode", (int)mode);                                    \
-	action->setCheckable(true);                                                \
-	action->setChecked(scaleFilter == mode);
+	auto addMode = [&](const QString &name, obs_scale_type type) {
+		QAction *action = menu->addAction(name, this, [this, item, type]() { setScaleFilter(item, type); });
+		action->setCheckable(true);
+		action->setChecked(currentType == type);
+	};
 
-	ADD_MODE("Disable", OBS_SCALE_DISABLE);
-	ADD_MODE("ScaleFiltering.Point", OBS_SCALE_POINT);
-	ADD_MODE("ScaleFiltering.Bilinear", OBS_SCALE_BILINEAR);
-	ADD_MODE("ScaleFiltering.Bicubic", OBS_SCALE_BICUBIC);
-	ADD_MODE("ScaleFiltering.Lanczos", OBS_SCALE_LANCZOS);
-	ADD_MODE("ScaleFiltering.Area", OBS_SCALE_AREA);
-#undef ADD_MODE
+	addMode(QTStr("Disable"), OBS_SCALE_DISABLE);
+	addMode(QTStr("ScaleFiltering.Point"), OBS_SCALE_POINT);
+	addMode(QTStr("ScaleFiltering.Bilinear"), OBS_SCALE_BILINEAR);
+	addMode(QTStr("ScaleFiltering.Bicubic"), OBS_SCALE_BICUBIC);
+	addMode(QTStr("ScaleFiltering.Lanczos"), OBS_SCALE_LANCZOS);
+	addMode(QTStr("ScaleFiltering.Area"), OBS_SCALE_AREA);
 
 	return menu;
 }
 
-void OBSBasic::SetBlendingMethod()
+void OBSBasic::setBlendingMethod(OBSSceneItem item, obs_blending_method method)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_blending_method method = (obs_blending_method)action->property("method").toInt();
-	OBSSceneItem sceneItem = GetCurrentSceneItem();
-
-	obs_blending_method oldMethod = obs_sceneitem_get_blending_method(sceneItem);
-	obs_sceneitem_set_blending_method(sceneItem, method);
+	obs_blending_method oldMethod = obs_sceneitem_get_blending_method(item);
+	obs_sceneitem_set_blending_method(item, method);
 
 	auto undo_redo = [](const std::string &uuid, int64_t id, obs_blending_method val) {
 		OBSSourceAutoRelease s = obs_get_source_by_uuid(uuid.c_str());
@@ -413,9 +411,9 @@ void OBSBasic::SetBlendingMethod()
 			obs_sceneitem_set_blending_method(si, val);
 	};
 
-	OBSSource source = obs_sceneitem_get_source(sceneItem);
-	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(sceneItem));
-	int64_t id = obs_sceneitem_get_id(sceneItem);
+	OBSSource source = obs_sceneitem_get_source(item);
+	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(item));
+	int64_t id = obs_sceneitem_get_id(item);
 	const char *name = obs_source_get_name(sceneSource);
 	const char *uuid = obs_source_get_uuid(sceneSource);
 
@@ -429,32 +427,28 @@ void OBSBasic::SetBlendingMethod()
 	}
 }
 
-QMenu *OBSBasic::AddBlendingMethodMenu(QMenu *menu, obs_sceneitem_t *item)
+QMenu *OBSBasic::createBlendingMethodMenu(OBSSceneItem item, QWidget *parent)
 {
+	QMenu *menu = new QMenu(QTStr("BlendingMethod"), parent);
 	obs_blending_method blendingMethod = obs_sceneitem_get_blending_method(item);
-	QAction *action;
 
-#define ADD_MODE(name, method)                                                        \
-	action = menu->addAction(QTStr("" name), this, &OBSBasic::SetBlendingMethod); \
-	action->setProperty("method", (int)method);                                   \
-	action->setCheckable(true);                                                   \
-	action->setChecked(blendingMethod == method);
+	auto addMode = [&](const QString &name, obs_blending_method method) {
+		QAction *action =
+			menu->addAction(name, this, [this, item, method]() { setBlendingMethod(item, method); });
+		action->setCheckable(true);
+		action->setChecked(blendingMethod == method);
+	};
 
-	ADD_MODE("BlendingMethod.Default", OBS_BLEND_METHOD_DEFAULT);
-	ADD_MODE("BlendingMethod.SrgbOff", OBS_BLEND_METHOD_SRGB_OFF);
-#undef ADD_MODE
+	addMode(QTStr("BlendingMethod.Default"), OBS_BLEND_METHOD_DEFAULT);
+	addMode(QTStr("BlendingMethod.SrgbOff"), OBS_BLEND_METHOD_SRGB_OFF);
 
 	return menu;
 }
 
-void OBSBasic::SetBlendingMode()
+void OBSBasic::setBlendingMode(OBSSceneItem item, obs_blending_type mode)
 {
-	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_blending_type mode = (obs_blending_type)action->property("mode").toInt();
-	OBSSceneItem sceneItem = GetCurrentSceneItem();
-
-	obs_blending_type oldMode = obs_sceneitem_get_blending_mode(sceneItem);
-	obs_sceneitem_set_blending_mode(sceneItem, mode);
+	obs_blending_type oldMode = obs_sceneitem_get_blending_mode(item);
+	obs_sceneitem_set_blending_mode(item, mode);
 
 	auto undo_redo = [](const std::string &uuid, int64_t id, obs_blending_type val) {
 		OBSSourceAutoRelease s = obs_get_source_by_uuid(uuid.c_str());
@@ -464,9 +458,9 @@ void OBSBasic::SetBlendingMode()
 			obs_sceneitem_set_blending_mode(si, val);
 	};
 
-	OBSSource source = obs_sceneitem_get_source(sceneItem);
-	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(sceneItem));
-	int64_t id = obs_sceneitem_get_id(sceneItem);
+	OBSSource source = obs_sceneitem_get_source(item);
+	OBSSource sceneSource = obs_scene_get_source(obs_sceneitem_get_scene(item));
+	int64_t id = obs_sceneitem_get_id(item);
 	const char *name = obs_source_get_name(sceneSource);
 	const char *uuid = obs_source_get_uuid(sceneSource);
 
@@ -480,32 +474,145 @@ void OBSBasic::SetBlendingMode()
 	}
 }
 
-QMenu *OBSBasic::AddBlendingModeMenu(QMenu *menu, obs_sceneitem_t *item)
+QMenu *OBSBasic::createBlendingModeMenu(OBSSceneItem item, QWidget *parent)
 {
-	obs_blending_type blendingMode = obs_sceneitem_get_blending_mode(item);
-	QAction *action;
+	QMenu *menu = new QMenu(QTStr("BlendingMode"), parent);
+	obs_blending_type currentMode = obs_sceneitem_get_blending_mode(item);
 
-#define ADD_MODE(name, mode)                                                        \
-	action = menu->addAction(QTStr("" name), this, &OBSBasic::SetBlendingMode); \
-	action->setProperty("mode", (int)mode);                                     \
-	action->setCheckable(true);                                                 \
-	action->setChecked(blendingMode == mode);
+	auto addMode = [&](const QString &name, obs_blending_type mode) {
+		QAction *action = menu->addAction(name, this, [this, item, mode]() { setBlendingMode(item, mode); });
+		action->setCheckable(true);
+		action->setChecked(currentMode == mode);
+	};
 
-	ADD_MODE("BlendingMode.Normal", OBS_BLEND_NORMAL);
-	ADD_MODE("BlendingMode.Additive", OBS_BLEND_ADDITIVE);
-	ADD_MODE("BlendingMode.Subtract", OBS_BLEND_SUBTRACT);
-	ADD_MODE("BlendingMode.Screen", OBS_BLEND_SCREEN);
-	ADD_MODE("BlendingMode.Multiply", OBS_BLEND_MULTIPLY);
-	ADD_MODE("BlendingMode.Lighten", OBS_BLEND_LIGHTEN);
-	ADD_MODE("BlendingMode.Darken", OBS_BLEND_DARKEN);
-#undef ADD_MODE
+	addMode(QTStr("BlendingMode.Normal"), OBS_BLEND_NORMAL);
+	addMode(QTStr("BlendingMode.Additive"), OBS_BLEND_ADDITIVE);
+	addMode(QTStr("BlendingMode.Subtract"), OBS_BLEND_SUBTRACT);
+	addMode(QTStr("BlendingMode.Screen"), OBS_BLEND_SCREEN);
+	addMode(QTStr("BlendingMode.Multiply"), OBS_BLEND_MULTIPLY);
+	addMode(QTStr("BlendingMode.Lighten"), OBS_BLEND_LIGHTEN);
+	addMode(QTStr("BlendingMode.Darken"), OBS_BLEND_DARKEN);
 
 	return menu;
 }
 
-QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction, ColorSelect *select,
-					obs_sceneitem_t *item)
+void OBSBasic::colorButtonClicked(QPushButton *button, int preset)
 {
+	QModelIndexList selectedItems = ui->sources->selectionModel()->selectedIndexes();
+
+	if (selectedItems.count() == 0)
+		return;
+
+	for (int x = 0; x < selectedItems.count(); x++) {
+		SourceTreeItem *treeItem = ui->sources->GetItemWidget(selectedItems[x].row());
+		treeItem->setStyleSheet("");
+		treeItem->setProperty("bgColor", preset);
+		treeItem->style()->unpolish(treeItem);
+		treeItem->style()->polish(treeItem);
+
+		OBSSceneItem sceneItem = ui->sources->Get(selectedItems[x].row());
+		OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
+		obs_data_set_int(privData, "color-preset", preset + 1);
+		obs_data_set_string(privData, "color", "");
+	}
+
+	for (int i = 1; i < 9; i++) {
+		std::stringstream preset;
+		preset << "preset" << i;
+		QPushButton *cButton = button->parentWidget()->findChild<QPushButton *>(preset.str().c_str());
+		cButton->setStyleSheet("border: 1px solid black");
+	}
+
+	button->setStyleSheet("border: 2px solid black");
+}
+
+void OBSBasic::customColorSelected()
+{
+	QModelIndexList selectedItems = ui->sources->selectionModel()->selectedIndexes();
+
+	if (selectedItems.count() == 0)
+		return;
+
+	OBSSceneItem curSceneItem = GetCurrentSceneItem();
+	SourceTreeItem *curTreeItem = GetItemWidgetFromSceneItem(curSceneItem);
+	OBSDataAutoRelease curPrivData = obs_sceneitem_get_private_settings(curSceneItem);
+
+	int oldPreset = obs_data_get_int(curPrivData, "color-preset");
+	const QString oldSheet = curTreeItem->styleSheet();
+
+	auto liveChangeColor = [=](const QColor &color) {
+		if (color.isValid()) {
+			curTreeItem->setStyleSheet("background: " + color.name(QColor::HexArgb));
+		}
+	};
+
+	auto changedColor = [=](const QColor &color) {
+		if (color.isValid()) {
+			confirmColor(ui->sources, color, selectedItems);
+		}
+	};
+
+	auto rejected = [=]() {
+		if (oldPreset == 1) {
+			curTreeItem->setStyleSheet(oldSheet);
+			curTreeItem->setProperty("bgColor", 0);
+		} else if (oldPreset == 0) {
+			curTreeItem->setStyleSheet("background: none");
+			curTreeItem->setProperty("bgColor", 0);
+		} else {
+			curTreeItem->setStyleSheet("");
+			curTreeItem->setProperty("bgColor", oldPreset - 1);
+		}
+
+		curTreeItem->style()->unpolish(curTreeItem);
+		curTreeItem->style()->polish(curTreeItem);
+	};
+
+	QColorDialog::ColorDialogOptions options = QColorDialog::ShowAlphaChannel;
+
+	const char *oldColor = obs_data_get_string(curPrivData, "color");
+	const char *customColor = *oldColor != 0 ? oldColor : "#55FF0000";
+#ifdef __linux__
+	// TODO: Revisit hang on Ubuntu with native dialog
+	options |= QColorDialog::DontUseNativeDialog;
+#endif
+
+	QColorDialog colorDialog(this);
+	colorDialog.setOptions(options);
+	colorDialog.setCurrentColor(QColor(customColor));
+	connect(&colorDialog, &QColorDialog::currentColorChanged, this, liveChangeColor);
+	connect(&colorDialog, &QColorDialog::colorSelected, this, changedColor);
+	connect(&colorDialog, &QColorDialog::rejected, this, rejected);
+	colorDialog.exec();
+}
+
+void OBSBasic::clearColors()
+{
+	QModelIndexList selectedItems = ui->sources->selectionModel()->selectedIndexes();
+
+	if (selectedItems.count() == 0)
+		return;
+
+	for (int x = 0; x < selectedItems.count(); x++) {
+		SourceTreeItem *treeItem = ui->sources->GetItemWidget(selectedItems[x].row());
+		treeItem->setStyleSheet("background: none");
+		treeItem->setProperty("bgColor", 0);
+		treeItem->style()->unpolish(treeItem);
+		treeItem->style()->polish(treeItem);
+
+		OBSSceneItem sceneItem = ui->sources->Get(selectedItems[x].row());
+		OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(sceneItem);
+		obs_data_set_int(privData, "color-preset", 0);
+		obs_data_set_string(privData, "color", "");
+	}
+}
+
+QMenu *OBSBasic::createBackgroundColorMenu(OBSSceneItem item, QWidget *parent)
+{
+	QMenu *menu = new QMenu(QTStr("ChangeBG"), parent);
+	QWidgetAction *widgetAction = new QWidgetAction(menu);
+	ColorSelect *select = new ColorSelect(menu);
+
 	QAction *action;
 
 	menu->setStyleSheet(QString("*[bgColor=\"1\"]{background-color:rgba(255,68,68,33%);}"
@@ -517,20 +624,17 @@ QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction
 				    "*[bgColor=\"7\"]{background-color:rgba(68,68,68,33%);}"
 				    "*[bgColor=\"8\"]{background-color:rgba(255,255,255,33%);}"));
 
-	obs_data_t *privData = obs_sceneitem_get_private_settings(item);
-	obs_data_release(privData);
+	OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(item);
 
 	obs_data_set_default_int(privData, "color-preset", 0);
 	int preset = obs_data_get_int(privData, "color-preset");
 
-	action = menu->addAction(QTStr("Clear"), this, &OBSBasic::ColorChange);
+	action = menu->addAction(QTStr("Clear"), this, &OBSBasic::clearColors);
 	action->setCheckable(true);
-	action->setProperty("bgColor", 0);
 	action->setChecked(preset == 0);
 
-	action = menu->addAction(QTStr("CustomColor"), this, &OBSBasic::ColorChange);
+	action = menu->addAction(QTStr("CustomColor"), this, &OBSBasic::customColorSelected);
 	action->setCheckable(true);
-	action->setProperty("bgColor", 1);
 	action->setChecked(preset == 1);
 
 	menu->addSeparator();
@@ -538,14 +642,15 @@ QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction
 	widgetAction->setDefaultWidget(select);
 
 	for (int i = 1; i < 9; i++) {
-		stringstream button;
+		std::stringstream button;
 		button << "preset" << i;
 		QPushButton *colorButton = select->findChild<QPushButton *>(button.str().c_str());
+		colorButton->setProperty("bgColor", i);
 		if (preset == i + 1)
 			colorButton->setStyleSheet("border: 2px solid black");
 
-		colorButton->setProperty("bgColor", i);
-		connect(colorButton, &QPushButton::released, this, &OBSBasic::ColorChange);
+		select->connect(colorButton, &QPushButton::released, this,
+				[this, colorButton, i]() { colorButtonClicked(colorButton, i); });
 	}
 
 	menu->addAction(widgetAction);
@@ -556,15 +661,6 @@ QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction
 void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 {
 	QMenu popup(this);
-	delete previewProjectorSource;
-	delete sourceProjector;
-	delete scaleFilteringMenu;
-	delete blendingMethodMenu;
-	delete blendingModeMenu;
-	delete colorMenu;
-	delete colorWidgetAction;
-	delete colorSelect;
-	delete deinterlaceMenu;
 
 	OBSSceneItem sceneItem;
 	obs_source_t *source;
@@ -611,23 +707,11 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	}
 
 	// Projector menu entries
-	if (preview) {
-		previewProjectorSource = new QMenu(QTStr("Projector.Open.Preview"));
-		AddProjectorMenuMonitors(previewProjectorSource, this, &OBSBasic::OpenPreviewProjector);
-		previewProjectorSource->addSeparator();
-		previewProjectorSource->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenPreviewWindow);
+	if (preview)
+		popup.addMenu(createProjectorMenu(QTStr("Projector.Open.Preview"), nullptr, ProjectorType::Preview));
 
-		popup.addMenu(previewProjectorSource);
-	}
-
-	if (hasVideo) {
-		sourceProjector = new QMenu(QTStr("Projector.Open.Source"));
-		AddProjectorMenuMonitors(sourceProjector, this, &OBSBasic::OpenSourceProjector);
-		sourceProjector->addSeparator();
-		sourceProjector->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenSourceWindow);
-
-		popup.addMenu(sourceProjector);
-	}
+	if (hasVideo)
+		popup.addMenu(createProjectorMenu(QTStr("Projector.Open.Source"), source, ProjectorType::Source));
 
 	popup.addSeparator();
 
@@ -645,10 +729,7 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	if (sourceSelected) {
 		// Sources list menu entries
 		if (!preview) {
-			colorMenu = new QMenu(QTStr("ChangeBG"));
-			colorWidgetAction = new QWidgetAction(colorMenu);
-			colorSelect = new ColorSelect(colorMenu);
-			popup.addMenu(AddBackgroundColorMenu(colorMenu, colorWidgetAction, colorSelect, sceneItem));
+			popup.addMenu(createBackgroundColorMenu(sceneItem));
 
 			if (hasAudio) {
 				bool isHidden = isHiddenInMixer(source);
@@ -668,15 +749,11 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 
 		// Scene item menu entries
 		if (hasVideo && source) {
-			scaleFilteringMenu = new QMenu(QTStr("ScaleFiltering"));
-			popup.addMenu(AddScaleFilteringMenu(scaleFilteringMenu, sceneItem));
-			blendingModeMenu = new QMenu(QTStr("BlendingMode"));
-			popup.addMenu(AddBlendingModeMenu(blendingModeMenu, sceneItem));
-			blendingMethodMenu = new QMenu(QTStr("BlendingMethod"));
-			popup.addMenu(AddBlendingMethodMenu(blendingMethodMenu, sceneItem));
+			popup.addMenu(createScaleFilteringMenu(sceneItem));
+			popup.addMenu(createBlendingModeMenu(sceneItem));
+			popup.addMenu(createBlendingMethodMenu(sceneItem));
 			if (isAsyncVideo) {
-				deinterlaceMenu = new QMenu(QTStr("Deinterlacing"));
-				popup.addMenu(AddDeinterlacingMenu(deinterlaceMenu, source));
+				popup.addMenu(createDeinterlacingMenu(source));
 			}
 
 			popup.addMenu(CreateVisibilityTransitionMenu(true));

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -567,13 +567,9 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
-		delete sceneProjectorMenu;
-		sceneProjectorMenu = new QMenu(QTStr("Projector.Open.Scene"));
-		AddProjectorMenuMonitors(sceneProjectorMenu, this, &OBSBasic::OpenSceneProjector);
-		sceneProjectorMenu->addSeparator();
-		sceneProjectorMenu->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenSceneWindow);
+		OBSSource source = GetCurrentSceneSource();
+		popup.addMenu(createProjectorMenu(QTStr("Projector.Open.Scene"), source, ProjectorType::Scene));
 
-		popup.addMenu(sceneProjectorMenu);
 		popup.addSeparator();
 
 		popup.addAction(QTStr("Screenshot.Scene"), this, &OBSBasic::ScreenshotScene);
@@ -582,15 +578,12 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 		popup.addSeparator();
 
-		delete perSceneTransitionMenu;
-		perSceneTransitionMenu = CreatePerSceneTransitionMenu();
-		popup.addMenu(perSceneTransitionMenu);
+		popup.addMenu(CreatePerSceneTransitionMenu());
 
 		/* ---------------------- */
 
 		QAction *multiviewAction = popup.addAction(QTStr("ShowInMultiview"));
 
-		OBSSource source = GetCurrentSceneSource();
 		OBSDataAutoRelease data = obs_source_get_private_settings(source);
 
 		obs_data_set_default_bool(data, "show_in_multiview", true);

--- a/frontend/widgets/OBSBasic_StudioMode.cpp
+++ b/frontend/widgets/OBSBasic_StudioMode.cpp
@@ -368,14 +368,8 @@ OBSSource OBSBasic::GetProgramSource()
 void OBSBasic::ProgramViewContextMenuRequested()
 {
 	QMenu popup(this);
-	QPointer<QMenu> studioProgramProjector;
 
-	studioProgramProjector = new QMenu(QTStr("Projector.Open.Program"));
-	AddProjectorMenuMonitors(studioProgramProjector, this, &OBSBasic::OpenStudioProgramProjector);
-	studioProgramProjector->addSeparator();
-	studioProgramProjector->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenStudioProgramWindow);
-
-	popup.addMenu(studioProgramProjector);
+	popup.addMenu(createProjectorMenu(QTStr("Projector.Open.Program"), nullptr, ProjectorType::StudioProgram));
 
 	popup.addSeparator();
 	popup.addAction(QTStr("Screenshot.StudioProgram"), this, &OBSBasic::ScreenshotProgram);

--- a/frontend/widgets/OBSBasic_SysTray.cpp
+++ b/frontend/widgets/OBSBasic_SysTray.cpp
@@ -18,6 +18,7 @@
 ******************************************************************************/
 
 #include "OBSBasic.hpp"
+#include <widgets/OBSProjector.hpp>
 
 extern bool opt_minimize_tray;
 
@@ -47,14 +48,10 @@ void OBSBasic::SystemTrayInit()
 					trayMenu);
 	exit = new QAction(QTStr("Exit"), trayMenu);
 
-	previewProjector = new QMenu(QTStr("Projector.Open.Preview"), trayMenu);
-	studioProgramProjector = new QMenu(QTStr("Projector.Open.Program"), trayMenu);
-	OBSBasic::updateSysTrayProjectorMenu();
+	trayMenu = new QMenu;
 
 	trayMenu->addAction(showHide);
-	trayMenu->addSeparator();
-	trayMenu->addMenu(previewProjector);
-	trayMenu->addMenu(studioProgramProjector);
+	QAction *projectorSeparator = trayMenu->addSeparator();
 	trayMenu->addSeparator();
 	trayMenu->addAction(sysTrayStream);
 	trayMenu->addAction(sysTrayRecord);
@@ -80,12 +77,23 @@ void OBSBasic::SystemTrayInit()
 	connect(sysTrayReplayBuffer.data(), &QAction::triggered, this, &OBSBasic::ReplayBufferActionTriggered);
 	connect(sysTrayVirtualCam.data(), &QAction::triggered, this, &OBSBasic::VirtualCamActionTriggered);
 	connect(exit, &QAction::triggered, this, &OBSBasic::close);
+
+	auto menuShown = [this, projectorSeparator]() {
+		// Refresh projector list
+		previewProjector.reset(
+			createProjectorMenu(QTStr("Projector.Open.Preview"), nullptr, ProjectorType::Preview));
+		studioProgramProjector.reset(
+			createProjectorMenu(QTStr("Projector.Open.Program"), nullptr, ProjectorType::StudioProgram));
+
+		trayMenu->insertMenu(projectorSeparator, previewProjector.data());
+		trayMenu->insertMenu(projectorSeparator, studioProgramProjector.data());
+	};
+
+	connect(trayMenu, &QMenu::aboutToShow, this, menuShown);
 }
 
 void OBSBasic::IconActivated(QSystemTrayIcon::ActivationReason reason)
 {
-	OBSBasic::updateSysTrayProjectorMenu();
-
 #ifdef __APPLE__
 	UNUSED_PARAMETER(reason);
 #else
@@ -139,16 +147,4 @@ void OBSBasic::SystemTray(bool firstStarted)
 bool OBSBasic::sysTrayMinimizeToTray()
 {
 	return config_get_bool(App()->GetUserConfig(), "BasicWindow", "SysTrayMinimizeToTray");
-}
-
-void OBSBasic::updateSysTrayProjectorMenu()
-{
-	previewProjector->clear();
-	studioProgramProjector->clear();
-	AddProjectorMenuMonitors(previewProjector, this, &OBSBasic::OpenPreviewProjector);
-	previewProjector->addSeparator();
-	previewProjector->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenPreviewWindow);
-	AddProjectorMenuMonitors(studioProgramProjector, this, &OBSBasic::OpenStudioProgramProjector);
-	studioProgramProjector->addSeparator();
-	studioProgramProjector->addAction(QTStr("Projector.Window"), this, &OBSBasic::OpenStudioProgramWindow);
 }

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -251,11 +251,9 @@ void OBSProjector::mousePressEvent(QMouseEvent *event)
 	OBSQTDisplay::mousePressEvent(event);
 
 	if (event->button() == Qt::RightButton) {
-		QMenu *projectorMenu = new QMenu(QTStr("Fullscreen"));
-		OBSBasic::AddProjectorMenuMonitors(projectorMenu, this, &OBSProjector::OpenFullScreenProjector);
-
 		QMenu popup(this);
-		popup.addMenu(projectorMenu);
+		popup.addMenu(OBSBasic::createProjectorMenu(QTStr("Fullscreen"), this,
+							    &OBSProjector::OpenFullScreenProjector));
 
 		if (GetMonitor() > -1) {
 			popup.addAction(QTStr("Windowed"), this, &OBSProjector::OpenWindowedProjector);


### PR DESCRIPTION
### Description
This makes it so we don't have to manually delete each menu each time they are shown, they are now created on demand, saving some memory. This also moves the menu code to a separate file.

### Motivation and Context
The menu code has always bothered me

### How Has This Been Tested?
Clicked through each menu to made sure they still worked

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
