### PR TITLE
UI: Only use preset2 in simple mode for legacy/FFmpeg NVENC

### DIFF
--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -819,6 +819,7 @@ void SimpleOutput::Update()
 					       "x264Settings");
 	const char *encoder = config_get_string(main->Config(), "SimpleOutput",
 						"StreamEncoder");
+	const char *encoder_id = obs_encoder_get_id(videoStreaming);
 	const char *presetType;
 	const char *preset;
 
@@ -855,11 +856,14 @@ void SimpleOutput::Update()
 	}
 
 	preset = config_get_string(main->Config(), "SimpleOutput", presetType);
-	obs_data_set_string(videoSettings,
-			    (strcmp(presetType, "NVENCPreset2") == 0)
-				    ? "preset2"
-				    : "preset",
-			    preset);
+
+	/* Only use preset2 for legacy/FFmpeg NVENC Encoder. */
+	if (strncmp(encoder_id, "ffmpeg_", 7) == 0 &&
+	    strcmp(presetType, "NVENCPreset2") == 0) {
+		obs_data_set_string(videoSettings, "preset2", preset);
+	} else {
+		obs_data_set_string(videoSettings, "preset", preset);
+	}
 
 	obs_data_set_string(videoSettings, "rate_control", "CBR");
 	obs_data_set_int(videoSettings, "bitrate", videoBitrate);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -5484,9 +5484,11 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 
 		const char *name =
 			get_simple_output_encoder(QT_TO_UTF8(encoder));
+		const bool isFFmpegEncoder = strncmp(name, "ffmpeg_", 7) == 0;
 		obs_properties_t *props = obs_get_encoder_properties(name);
 
-		obs_property_t *p = obs_properties_get(props, "preset2");
+		obs_property_t *p = obs_properties_get(
+			props, isFFmpegEncoder ? "preset2" : "preset");
 		size_t num = obs_property_list_item_count(p);
 		for (size_t i = 0; i < num; i++) {
 			const char *name = obs_property_list_item_name(p, i);


### PR DESCRIPTION
### Description

Fixes simple mode with new NVENC.

### Motivation and Context

New NVENC uses `preset` instead of `preset2`, this broke some assumptions the UI had made in simple mode.

### How Has This Been Tested?

Verified it works.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
