### PR TITLE
libobs: Add experimental API to retrieve next audio timestamp on source

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1217,6 +1217,20 @@ General Source Functions
 
 ---------------------
 
+.. function:: uint64_t obs_source_get_next_audio_timestamp(const obs_source_t *source)
+
+   Gets the next audio timestamp.
+   This timestamp indicates the timestamp that the the next call of
+   :c:member:`obs_source_output_audio` should provide. If the difference
+   between the timestamp provided by :c:member:`obs_source_output_audio`
+   and the next audio timestamp is less than 70 ms, the audio will be
+   placed seamlessly.
+
+.. deprecated:: experimental
+   This is a stopgap solution until a complete solution is implemented.
+
+---------------------
+
 .. function:: void obs_source_set_audio_active(obs_source_t *source, bool active)
               bool obs_source_audio_active(const obs_source_t *source)
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5833,6 +5833,13 @@ void obs_source_get_audio_mix(const obs_source_t *source,
 	}
 }
 
+uint64_t obs_source_get_next_audio_timestamp(const obs_source_t *source)
+{
+	return obs_source_valid(source, "obs_source_get_next_audio_timestamp")
+		       ? source->next_audio_ts_min
+		       : 0;
+}
+
 void obs_source_add_audio_pause_callback(obs_source_t *source,
 					 signal_callback_t callback,
 					 void *param)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1591,6 +1591,11 @@ EXPORT uint64_t obs_source_get_audio_timestamp(const obs_source_t *source);
 EXPORT void obs_source_get_audio_mix(const obs_source_t *source,
 				     struct obs_source_audio_mix *audio);
 
+/** Gets next_audio_ts_min as a stopgap solution until a complete solution to
+ * process the asynchronous audio is implemented. */
+OBS_DEPRECATED EXPORT uint64_t
+obs_source_get_next_audio_timestamp(const obs_source_t *source);
+
 EXPORT void obs_source_set_async_unbuffered(obs_source_t *source,
 					    bool unbuffered);
 EXPORT bool obs_source_async_unbuffered(const obs_source_t *source);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds a new API `obs_source_get_next_audio_timestamp`, which returns the timestamp `struct obs_source::next_audio_ts_min`.

This PR will make the PR below obsolete.
- #6351

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The timetamp indicates the timestamp that the the next call of `obs_source_output_audio` should provide, assuming if there is no delay in the audio filters.

This should be helpful for my plugin [async-audio-filter](https://github.com/norihiro/obs-async-audio-filter). The usage will be like [this PR](https://github.com/norihiro/obs-async-audio-filter/pull/10). Without this API, the plugin need to estimate `next_audio_ts_min` by a complicated code and still it is not always accurate.

I originally hoped the PR #6351 but the PR looks stale. Instead, I suggest to just add an API and let the plugin to do the similar job of #6351.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

Tested with the modified plugin.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and replace `[ ]` with `[x]` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits are squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
