### PR TITLE
libobs/util: Crash on bmalloc(0)

### DIFF
--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -101,10 +101,8 @@ static long num_allocs = 0;
 void *bmalloc(size_t size)
 {
 	if (!size) {
-		blog(LOG_ERROR, "bmalloc: Allocating 0 bytes is broken behavior, please "
-				"fix your code! This will crash in future versions of "
-				"OBS.");
-		size = 1;
+		os_breakpoint();
+		bcrash("bmalloc: Allocating 0 bytes is broken behavior, please fix your code!");
 	}
 
 	void *ptr = a_malloc(size);
@@ -124,10 +122,8 @@ void *brealloc(void *ptr, size_t size)
 		os_atomic_inc_long(&num_allocs);
 
 	if (!size) {
-		blog(LOG_ERROR, "brealloc: Allocating 0 bytes is broken behavior, please "
-				"fix your code! This will crash in future versions of "
-				"OBS.");
-		size = 1;
+		os_breakpoint();
+		bcrash("brealloc: Allocating 0 bytes is broken behavior, please fix your code!");
 	}
 
 	ptr = a_realloc(ptr, size);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
As outlined in c5965c8605ec8e20ae8a21caf723da94aec62049 (#6721), `bmalloc(0)` is pretty much always a mistake, possibly hiding other bugs. It's been two years since that commit introduced a warning announcing that this will crash in a future version of OBS, let's make that happen.

cc @notr1ch 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
People are breaking stuff (see other PRs), let's break everything at once.
This gives plugin developers who might (unknowingly) do this the opportunity to fix it.

*If* there are places where we're doing it in OBS itself, this is a great (and certainly loud) way to find out.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15
Launched OBS and played around, did not observe crashes.

Manually added a `malloc(0)` call, had OBS crash as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
