### PR TITLE
libobs: Preserve const qualifiers in UTF8 conversion functions

### DIFF
--- a/libobs/util/utf8.c
+++ b/libobs/util/utf8.c
@@ -133,7 +133,7 @@ static int utf8_forbidden(unsigned char octet)
 size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 		     size_t outsize, int flags)
 {
-	unsigned char *p, *lim;
+	const unsigned char *p, *lim;
 	wchar_t *wlim, high;
 	size_t n, total, i, n_bits;
 
@@ -141,8 +141,8 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 		return 0;
 
 	total = 0;
-	p = (unsigned char *)in;
-	lim = (insize != 0) ? (p + insize) : (unsigned char *)-1;
+	p = (const unsigned char *)in;
+	lim = (insize != 0) ? (p + insize) : (const unsigned char *)-1;
 	wlim = out == NULL ? NULL : out + outsize;
 
 	for (; p < lim; p += n) {
@@ -262,15 +262,16 @@ size_t utf8_to_wchar(const char *in, size_t insize, wchar_t *out,
 size_t wchar_to_utf8(const wchar_t *in, size_t insize, char *out,
 		     size_t outsize, int flags)
 {
-	wchar_t *w, *wlim, ch = 0;
+	const wchar_t *w, *wlim;
+	wchar_t ch = 0;
 	unsigned char *p, *lim, *oc;
 	size_t total, n;
 
 	if (in == NULL || (outsize == 0 && out != NULL))
 		return 0;
 
-	w = (wchar_t *)in;
-	wlim = (insize != 0) ? (w + insize) : (wchar_t *)-1;
+	w = in;
+	wlim = (insize != 0) ? (w + insize) : (const wchar_t *)-1;
 	p = (unsigned char *)out;
 	lim = out == NULL ? NULL : p + outsize;
 	total = 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Instead of type-casting, this commit adds const qualifiers to local variables, improving code clarity.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Removing const qualifiers through type-casting requires more attention when reading the code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

Confirmed the build was succeeded without errors or warnings.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
