### PR TITLE
docs: Clarify obs_source_update can accept NULL for settings argument

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1024,8 +1024,11 @@ General Source Functions
    Updates the settings for a source and calls the
    :c:member:`obs_source_info.update` callback of the source.  If the
    source is a video source, the :c:member:`obs_source_info.update` will
-   be not be called immediately; instead, it will be deferred to the
-   video thread to prevent threading issues.
+   not be called immediately; instead, it will be deferred to the video
+   thread to prevent threading issues.
+
+   :param   settings:  The settings for the source, or *NULL* to call
+                       the callback without changing the settings.
 
 ---------------------
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds the parameter description of the API `obs_source_update`.

Also fixed a gramatical error; `will be not be called` --> `will not be called`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

In the implementation, `settings` can be NULL and it will be just ignored if it is NULL.
https://github.com/obsproject/obs-studio/blob/15e9242acb8cbbd5ccdcdc9e80fa1e96a22bd1b8/libobs/obs-source.c#L990-L992

Passing NULL as the `settings` argument is useful to trigger `update` callback.

I realized AJA source calls `obs_source_update` with the existing `settings`. This is redundant, we can just pass `NULL`.
https://github.com/obsproject/obs-studio/blob/master/plugins/aja/aja-source.cpp#L327

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

Called `obs_source_update` with the NULL argument and confirmed the settings was not changed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Sidenote:

When passing a valid `obs_data_t` object, elements that exists in the current settings but does not exist in the passed object are not removed.
This is because `obs_source_update` traverse each element in the given `obs_data_t` object and apply it to the current settings.
It would be good for the document to describe this behavior. However, I don't have a good idea to phrase this in concise sentence.
