### PR TITLE
aja: Remove holding source settings

### DIFF
--- a/plugins/aja/aja-source.cpp
+++ b/plugins/aja/aja-source.cpp
@@ -314,8 +314,6 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 	AudioOffsets offsets;
 	ResetAudioBufferOffsets(card, audioSystem, offsets);
 
-	obs_data_t *settings = obs_source_get_settings(ajaSource->mSource);
-
 	AudioRepacker *audioRepacker = new AudioRepacker(
 		ConvertRepackFormat(sourceProps.SpeakerLayout(),
 				    sourceProps.swapFrontCenterLFE),
@@ -324,7 +322,7 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 	while (ajaSource->IsCapturing()) {
 		if (card->GetModelName() == "(Not Found)") {
 			os_sleep_ms(250);
-			obs_source_update(ajaSource->mSource, settings);
+			obs_source_update(ajaSource->mSource, nullptr);
 			break;
 		}
 
@@ -359,7 +357,7 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 			     NTV2VideoFormatToString(newVideoFormat, true)
 				     .c_str());
 			os_sleep_ms(250);
-			obs_source_update(ajaSource->mSource, settings);
+			obs_source_update(ajaSource->mSource, nullptr);
 			break;
 		}
 
@@ -450,8 +448,6 @@ void AJASource::CaptureThread(AJAThread *thread, void *data)
 	ajaSource->GenerateTestPattern(sourceProps.videoFormat,
 				       sourceProps.pixelFormat,
 				       NTV2_TestPatt_Black);
-
-	obs_data_release(settings);
 }
 
 void AJASource::Deactivate()


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR removes `AJASource::CaptureThread` to hold the settings of the source.

Waiting
- #11189

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The API `obs_source_update` accept nullptr for the argument `settings` and it will just call the `update` callback without changing the settings.

The usages of `obs_source_update` seems to trigger the `update` callback in the graphics thread.
For that purpose, it is sufficient to pass nullptr as the 2nd argument.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I haven't test it as I couldn't reached the branch.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
