### PR TITLE
shared/qt: Remove unused libobs includes/linkage

### DIFF
--- a/shared/qt/slider-ignorewheel/CMakeLists.txt
+++ b/shared/qt/slider-ignorewheel/CMakeLists.txt
@@ -8,4 +8,4 @@ add_library(OBS::qt-slider-ignorewheel ALIAS qt-slider-ignorewheel)
 target_sources(qt-slider-ignorewheel INTERFACE slider-ignorewheel.cpp slider-ignorewheel.hpp)
 target_include_directories(qt-slider-ignorewheel INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
-target_link_libraries(qt-slider-ignorewheel INTERFACE Qt::Core Qt::Widgets OBS::libobs)
+target_link_libraries(qt-slider-ignorewheel INTERFACE Qt::Core Qt::Widgets)

--- a/shared/qt/slider-ignorewheel/slider-ignorewheel.hpp
+++ b/shared/qt/slider-ignorewheel/slider-ignorewheel.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <obs.hpp>
 #include <QSlider>
 #include <QInputEvent>
 #include <QtCore/QObject>

--- a/shared/qt/wrappers/qt-wrappers.cpp
+++ b/shared/qt/wrappers/qt-wrappers.cpp
@@ -17,7 +17,6 @@
 
 #include "moc_qt-wrappers.cpp"
 
-#include <graphics/graphics.h>
 #include <util/threading.h>
 #include <QWidget>
 #include <QLayout>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Some libobs headers are included in the shared qt module although they are not used.
Let's remove them.

In the case of slider-ignorewheel, this completely removes the need for the linkage against libobs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed this while working on something else.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15.
Still compiles.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
