### PR TITLE
UI: Fix warning color

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -1390,7 +1390,7 @@ QLabel#errorLabel {
 }
 
 * [themeID="warning"] {
-    color: var(--danger);
+    color: var(--warning);
     font-weight: bold;
 }
 


### PR DESCRIPTION
### Description
Fix warning color

### Motivation and Context
Want difference between warning and error, like in OBS 30.1

### How Has This Been Tested?
On windows 64

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
