### PR TITLE
UI: Simplify FindTransition function

### DIFF
--- a/UI/window-basic-main-transitions.cpp
+++ b/UI/window-basic-main-transitions.cpp
@@ -237,17 +237,8 @@ obs_data_array_t *OBSBasic::SaveQuickTransitions()
 
 obs_source_t *OBSBasic::FindTransition(const char *name)
 {
-	for (int i = 0; i < ui->transitions->count(); i++) {
-		OBSSource tr = ui->transitions->itemData(i).value<OBSSource>();
-		if (!tr)
-			continue;
-
-		const char *trName = obs_source_get_name(tr);
-		if (strcmp(trName, name) == 0)
-			return tr;
-	}
-
-	return nullptr;
+	OBSSourceAutoRelease source = obs_get_transition_by_name(name);
+	return source.Get();
 }
 
 void OBSBasic::TransitionToScene(OBSScene scene, bool force)


### PR DESCRIPTION
### Description
This simplifies the FindTransition function by using obs_get_transition_by_name().

### Motivation and Context
Simpler code

### How Has This Been Tested?
Did stuff with transitions to make sure everything worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
