### PR TITLE
frontend: Simplify how projectors are saved/loaded

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -915,7 +915,6 @@ public slots:
 	 * -------------------------------------
 	 */
 private:
-	std::vector<SavedProjectorInfo *> savedProjectorsArray;
 	std::vector<OBSProjector *> projectors;
 	QPointer<QMenu> previewProjector;
 	QPointer<QMenu> previewProjectorSource;
@@ -942,7 +941,6 @@ private slots:
 	void OpenSceneWindow();
 
 public:
-	void OpenSavedProjectors();
 	void DeleteProjector(OBSProjector *projector);
 
 	static QList<QString> GetProjectorMenuMonitorsFormatted();

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -566,7 +566,6 @@ void OBSBasic::ResetProjectors()
 	OBSDataArrayAutoRelease savedProjectorList = SaveProjectors();
 	ClearProjectors();
 	LoadSavedProjectors(savedProjectorList);
-	OpenSavedProjectors();
 }
 
 void OBSBasic::UpdatePreviewSafeAreas()

--- a/frontend/widgets/OBSBasic_Projectors.cpp
+++ b/frontend/widgets/OBSBasic_Projectors.cpp
@@ -63,25 +63,20 @@ obs_data_array_t *OBSBasic::SaveProjectors()
 
 void OBSBasic::LoadSavedProjectors(obs_data_array_t *array)
 {
-	for (SavedProjectorInfo *info : savedProjectorsArray) {
-		delete info;
-	}
-	savedProjectorsArray.clear();
-
 	size_t num = obs_data_array_count(array);
 
 	for (size_t i = 0; i < num; i++) {
 		OBSDataAutoRelease data = obs_data_array_item(array, i);
+		SavedProjectorInfo info = {};
 
-		SavedProjectorInfo *info = new SavedProjectorInfo();
-		info->monitor = obs_data_get_int(data, "monitor");
-		info->type = static_cast<ProjectorType>(obs_data_get_int(data, "type"));
-		info->geometry = std::string(obs_data_get_string(data, "geometry"));
-		info->name = std::string(obs_data_get_string(data, "name"));
-		info->alwaysOnTop = obs_data_get_bool(data, "alwaysOnTop");
-		info->alwaysOnTopOverridden = obs_data_get_bool(data, "alwaysOnTopOverridden");
+		info.monitor = obs_data_get_int(data, "monitor");
+		info.type = static_cast<ProjectorType>(obs_data_get_int(data, "type"));
+		info.geometry = std::string(obs_data_get_string(data, "geometry"));
+		info.name = std::string(obs_data_get_string(data, "name"));
+		info.alwaysOnTop = obs_data_get_bool(data, "alwaysOnTop");
+		info.alwaysOnTopOverridden = obs_data_get_bool(data, "alwaysOnTopOverridden");
 
-		savedProjectorsArray.emplace_back(info);
+		OpenSavedProjector(&info);
 	}
 }
 
@@ -223,13 +218,6 @@ void OBSBasic::OpenSceneWindow()
 	OBSSource source = obs_scene_get_source(scene);
 
 	OpenProjector(obs_scene_get_source(scene), -1, ProjectorType::Scene);
-}
-
-void OBSBasic::OpenSavedProjectors()
-{
-	for (SavedProjectorInfo *info : savedProjectorsArray) {
-		OpenSavedProjector(info);
-	}
 }
 
 void OBSBasic::OpenSavedProjector(SavedProjectorInfo *info)

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1279,7 +1279,6 @@ retryScene:
 
 		if (savedProjectors) {
 			LoadSavedProjectors(savedProjectors);
-			OpenSavedProjectors();
 			activateWindow();
 		}
 	}


### PR DESCRIPTION
### Description
This removes unnecessary code when loading and saving projectors.

### Motivation and Context
A vector is not needed here

### How Has This Been Tested?
Saved/loaded projectors

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
