### PR TITLE
libobs: Deprecate obs_get_transition_by_[name|uuid]

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -351,6 +351,9 @@ Libobs Objects
    Increments the source reference counter, use
    :c:func:`obs_source_release()` to release it when complete.
 
+   .. deprecated:: 31.1
+      Use :c:func:`obs_frontend_get_transitions` from the Frontend API or :c:func:`obs_get_source_by_uuid` instead.
+
 ---------------------
 
 .. function:: obs_source_t *obs_get_transition_by_uuid(const char *uuid)
@@ -361,6 +364,9 @@ Libobs Objects
    :c:func:`obs_source_release()` to release it when complete.
 
    .. versionadded:: 29.1
+
+   .. deprecated:: 31.1
+      Use :c:func:`obs_get_source_by_uuid` instead.
 
 ---------------------
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -699,10 +699,10 @@ EXPORT obs_source_t *obs_get_source_by_name(const char *name);
 EXPORT obs_source_t *obs_get_source_by_uuid(const char *uuid);
 
 /** Get a transition source by its name. */
-EXPORT obs_source_t *obs_get_transition_by_name(const char *name);
+OBS_DEPRECATED EXPORT obs_source_t *obs_get_transition_by_name(const char *name);
 
 /** Get a transition source by its UUID. */
-EXPORT obs_source_t *obs_get_transition_by_uuid(const char *uuid);
+OBS_DEPRECATED EXPORT obs_source_t *obs_get_transition_by_uuid(const char *uuid);
 
 /** Gets an output by its name. */
 EXPORT obs_output_t *obs_get_output_by_name(const char *name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`obs_get_transition_by_name` is very problematic because transitions are always private and their names aren't unique. This means that the method iterates over all private sources and then takes the first that both is a transition and matches the name we're looking for. However, this could be from anywhere - it could be a frontend transition, but also a source transition, quick transition, or even one from third-party plugins. This is always never what is intended.

As such, this method (which should never have been added in the first place) needs to go. In its place, `obs_frontend_get_transitions` returns a list of all frontend transitions (which is usually what people are looking for), and alternatively `obs_get_source_by_uuid` also provides access to private sources.

While we're at it, `obs_get_transition_by_uuid` is basically a wrapper for `obs_get_source_by_uuid` and not really necessary. UUID's are unique and a source doesn't suddenly change its type, so if you have a transition's UUID you can be pretty sure that when you do `obs_get_source_by_uuid`, it will still be a transition.

I optimistically set 31.0 as the deprecation version in the docs but will update once that is no longer possible.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
#11200 revealed that this method did make it in (#5504, c36a5ae92b32d7b8401c468c7f20fabeb05d775f). While its usages were quickly removed after the accompanying browser PR got merged (because of the aforementioned problems), the method stayed (I really should have removed it, this is my fault. Or better yet, not even have written it. Three years ago me was a bad programmer (me in three years will probably say the same about current me!)).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Checked GitHub code search to find no usages of these methods (besides the usual forks and bindings), which is good.
Checked the PR build of the documentation, looks correct.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
