### PR TITLE
linux-pipewire: Fix 10- and 16-bit captures

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -791,11 +791,10 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		g_clear_pointer(&obs_pw_stream->texture, gs_texture_destroy);
 
 		use_modifiers = obs_pw_stream->format.info.raw.modifier != DRM_FORMAT_MOD_INVALID;
-		obs_pw_stream->texture = gs_texture_create_from_dmabuf(obs_pw_stream->format.info.raw.size.width,
-								       obs_pw_stream->format.info.raw.size.height,
-								       obs_pw_video_format.drm_format, GS_BGRX, planes,
-								       fds, strides, offsets,
-								       use_modifiers ? modifiers : NULL);
+		obs_pw_stream->texture = gs_texture_create_from_dmabuf(
+			obs_pw_stream->format.info.raw.size.width, obs_pw_stream->format.info.raw.size.height,
+			obs_pw_video_format.drm_format, obs_pw_video_format.gs_format, planes, fds, strides, offsets,
+			use_modifiers ? modifiers : NULL);
 
 		if (obs_pw_stream->texture == NULL) {
 			remove_modifier_from_format(obs_pw_stream, obs_pw_stream->format.info.raw.format,
@@ -1310,8 +1309,20 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_sync_destroy(acquire_sync);
 	}
 
+	effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
+	gs_technique_t *tech = gs_effect_get_technique(effect, "DrawSrgbDecompress");
+	gs_technique_begin(tech);
+	gs_technique_begin_pass(tech, 0);
+
+	const bool linear_srgb = gs_get_linear_srgb();
+	const bool previous = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(linear_srgb);
+
 	image = gs_effect_get_param_by_name(effect, "image");
-	gs_effect_set_texture(image, obs_pw_stream->texture);
+	if (linear_srgb)
+		gs_effect_set_texture_srgb(image, obs_pw_stream->texture);
+	else
+		gs_effect_set_texture(image, obs_pw_stream->texture);
 
 	rotated = push_rotation(obs_pw_stream);
 
@@ -1345,13 +1356,21 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_matrix_push();
 		gs_matrix_translate3f(cursor_x, cursor_y, 0.0f);
 
-		gs_effect_set_texture(image, obs_pw_stream->cursor.texture);
+		if (linear_srgb)
+			gs_effect_set_texture_srgb(image, obs_pw_stream->cursor.texture);
+		else
+			gs_effect_set_texture(image, obs_pw_stream->cursor.texture);
 		gs_draw_sprite(obs_pw_stream->texture, 0, obs_pw_stream->cursor.width, obs_pw_stream->cursor.height);
 
 		gs_matrix_pop();
 	}
 
 	gs_blend_state_pop();
+
+	gs_enable_framebuffer_srgb(previous);
+
+	gs_technique_end_pass(tech);
+	gs_technique_end(tech);
 
 	if (obs_pw_stream->sync.set) {
 		gs_sync_t *release_sync = gs_sync_create();

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -736,7 +736,7 @@ void screencast_portal_load(void)
 	const struct obs_source_info screencast_portal_capture_info = {
 		.id = "pipewire-screen-capture-source",
 		.type = OBS_SOURCE_TYPE_INPUT,
-		.output_flags = OBS_SOURCE_VIDEO,
+		.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 		.get_name = screencast_portal_desktop_capture_get_name,
 		.create = screencast_portal_capture_create,
 		.destroy = screencast_portal_capture_destroy,


### PR DESCRIPTION
### Description
Tonemap textures from non-linear sRGB to linear sRGB when in 10-bit or higher color format and update texture format accordingly

### Motivation and Context
Fix white-tint when using a pipewire capture in a 10-bit or 16-bit color format regardless of monitor source bitdepth

### How Has This Been Tested?
Before/After in NV12, P010 and P416 color formats on both 10-bit and 8-bit monitors. Confirmed to work both in Preview (no white tint observed) and custom FFmpeg render (10-bit gradient is captured)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
