### PR TITLE
UI: Fix low value of std::clamp gets greater than high value

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1005,7 +1005,7 @@ VolumeMeter::calculateBallisticsForChannel(int channelNr, uint64_t ts,
 		float decay = float(peakDecayRate * timeSinceLastRedraw);
 		displayPeak[channelNr] =
 			std::clamp(displayPeak[channelNr] - decay,
-				   currentPeak[channelNr], 0.f);
+				   std::min(currentPeak[channelNr], 0.f), 0.f);
 	}
 
 	if (currentPeak[channelNr] >= displayPeakHold[channelNr] ||


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

~~This commit partially reverts 60a45d3aa3 to avoid a runtime assertion failure on Windows that checks the low value of std::clamp is not greater than the high value.~~
Based on the comment, another fix was implemented; `displayPeak[channelNr]` is always clipped at 0.

To clarify the necessity to consider the priority, I didn't revert to use the `CLAMP` macro but use an if-else-if statement.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I modified to use `std::clamp` in the PR #11167.
However, @exeldro [reported it caused a runtime error](https://github.com/obsproject/obs-studio/pull/11167#issuecomment-2314419470) on Windows.

I confirmed the low value (`currentPeak[channelNr]`) gets greater than the high value (`0.f`) by applying a gain filter with a large gain.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS Fedora 39

Applied a gain filter to a audio source with a sine wave. Move the slider of the gain and see how the volume monitor behaves.

Checked the other `std::clamp` usage, I checked `minimumLevel` never gets larger than 0 by eyeball.
https://github.com/obsproject/obs-studio/blob/8251005ad3acb54a67b68e2cb0846a783f0aeed7/UI/volume-control.cpp#L1062-L1064

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
