### PR TITLE
UI: Fix error color at clipping is not displayed on horizontal meter

### DIFF
--- a/UI/volume-control.cpp
+++ b/UI/volume-control.cpp
@@ -1246,7 +1246,7 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width,
 				 maximumPosition - peakPosition, height,
 				 muted ? backgroundErrorColorDisabled
 				       : backgroundErrorColor);
-	} else if (int(magnitude) != 0) {
+	} else {
 		if (!clipping) {
 			QTimer::singleShot(CLIP_FLASH_DURATION_MS, this,
 					   [&]() { clipping = false; });


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Removed the condition `if (int(magnitude) != 0)`, which is not there in `VolumeMeter::paintVMeter`.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When the clipping happens on an audio source, the error color (red by default) is not displayed on the horizontal volume meter.

There are two rendering functions `VolumeMeter::paintHMeter` and `VolumeMeter::paintVMeter`. These functions should be identical except for the coordinate calculation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

1. Prepare an audio source that outputs continuous tone.
2. Apply a gain filter
3. Decrease and increase the gain and check the volume meter.

| master | this PR |
| ---- | ---- |
| https://github.com/user-attachments/assets/9b674f5c-ee40-4d4c-88cd-3250c7623adc | https://github.com/user-attachments/assets/1766d7c6-ce97-4d2c-8c7d-10df4f58a1e0 |




### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
