### PR TITLE
libobs: Always set initial scene item pos to top-left corner

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2558,6 +2558,10 @@ static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene,
 	matrix4_identity(&item->draw_transform);
 	matrix4_identity(&item->box_transform);
 
+	/* Ensure initial position is still top-left corner in relative mode. */
+	if (!item->absolute_coordinates)
+		pos_from_absolute(&item->pos, &item->pos, item);
+
 	if (source_has_audio(source)) {
 		item->visible = false;
 		da_push_back(item->audio_actions, &action);


### PR DESCRIPTION
### Description

Fixes the initial position of a newly created scene item not being the top left corner when in relative mode.

### Motivation and Context

In relative mode (0, 0) is the center of the screen, so in order to maintain previous behaviour we need to convert the value here.

### How Has This Been Tested?

Created a colour source, confirmed now in top left.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
