### PR TITLE
frontend: Remove unnecessary projector variable

### DIFF
--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -117,15 +117,12 @@ OBSProjector::~OBSProjector()
 	}
 
 	App()->DecrementSleepInhibition();
-
-	screen = nullptr;
 }
 
 void OBSProjector::SetMonitor(int monitor)
 {
 	savedMonitor = monitor;
-	screen = QGuiApplication::screens()[monitor];
-	setGeometry(screen->geometry());
+	setGeometry(QGuiApplication::screens()[monitor]->geometry());
 	showFullScreen();
 	SetHideCursor();
 }
@@ -428,7 +425,6 @@ void OBSProjector::OpenWindowedProjector()
 
 	OBSSource source = GetSource();
 	UpdateProjectorTitle(QT_UTF8(obs_source_get_name(source)));
-	screen = nullptr;
 }
 
 void OBSProjector::ResizeToContent()
@@ -486,11 +482,11 @@ void OBSProjector::SetIsAlwaysOnTop(bool isAlwaysOnTop, bool isOverridden)
 	SetAlwaysOnTop(this, isAlwaysOnTop);
 }
 
-void OBSProjector::ScreenRemoved(QScreen *screen_)
+void OBSProjector::ScreenRemoved(QScreen *screen)
 {
-	if (GetMonitor() < 0 || !screen)
+	if (GetMonitor() < 0)
 		return;
 
-	if (screen == screen_)
+	if (screen == this->screen())
 		EscapeTriggered();
 }

--- a/frontend/widgets/OBSProjector.hpp
+++ b/frontend/widgets/OBSProjector.hpp
@@ -43,15 +43,13 @@ private:
 	QRect prevGeometry;
 	void SetMonitor(int monitor);
 
-	QScreen *screen = nullptr;
-
 private slots:
 	void EscapeTriggered();
 	void OpenFullScreenProjector();
 	void ResizeToContent();
 	void OpenWindowedProjector();
 	void AlwaysOnTopToggled(bool alwaysOnTop);
-	void ScreenRemoved(QScreen *screen_);
+	void ScreenRemoved(QScreen *screen);
 	void RenameProjector(QString oldName, QString newName);
 
 public:


### PR DESCRIPTION
### Description
This variable is not needed, as there is a screen() function.

### Motivation and Context
Removes unneeded code.

### How Has This Been Tested?
Disconnected monitor and made sure projector was deleted

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
