### PR TITLE
GS/GL Shenannigans (Prep for obs-browser hwaccel on Linux ?)

### DIFF
--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -978,7 +978,8 @@ void device_copy_texture_region(gs_device_t *device, gs_texture_t *dst,
 		goto fail;
 	}
 
-	if (dst->format != src->format) {
+	if (gs_generalize_format(dst->format) !=
+	    gs_generalize_format(src->format)) {
 		blog(LOG_ERROR, "Source and destination formats do not match");
 		goto fail;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Disclaimer: This is graphics code, do not consider that I know what I am doing.

- ~~Enable gs_shared_texture_available on all platforms, only Linux was missing which mainly use DMA-BUF.~~
  - ~~obs-browser relies on it to enable hardware accel~~
- Relax OpenGL texture format copy check
  - It allows to copy `_UNORM` to their non-`_UNORM` counterpart since CEF sends texture with SRGB.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Enable https://github.com/tytan652/obs-browser/tree/linux_hwaccel_2 to work without doing weird stuff like https://github.com/tytan652/obs-browser/commit/1ca22d27067df11c448aaa9b08ded40710dc80c6 or other in https://github.com/tytan652/obs-browser/tree/linux_hwaccel

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Just built and ran OBS with this PR and my second hwaccel browser branch and their is no more SRGB gamma issues.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
