### PR TITLE
UI: Replace remaining SIGNAL/SLOT macros

### DIFF
--- a/UI/auth-oauth.cpp
+++ b/UI/auth-oauth.cpp
@@ -51,10 +51,10 @@ OAuthLogin::OAuthLogin(QWidget *parent, const std::string &url, bool token)
 		return;
 	}
 
-	connect(cefWidget, SIGNAL(titleChanged(const QString &)), this,
-		SLOT(setWindowTitle(const QString &)));
-	connect(cefWidget, SIGNAL(urlChanged(const QString &)), this,
-		SLOT(urlChanged(const QString &)));
+	connect(cefWidget, &QCefWidget::titleChanged, this,
+		&OAuthLogin::setWindowTitle);
+	connect(cefWidget, &QCefWidget::urlChanged, this,
+		&OAuthLogin::urlChanged);
 
 	QPushButton *close = new QPushButton(QTStr("Cancel"));
 	connect(close, &QAbstractButton::clicked, this, &QDialog::reject);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2836,8 +2836,8 @@ void OBSBasic::ShowWhatsNew(const QString &url)
 		return;
 	}
 
-	connect(cefWidget, SIGNAL(titleChanged(const QString &)), dlg,
-		SLOT(setWindowTitle(const QString &)));
+	connect(cefWidget, &QCefWidget::titleChanged, dlg,
+		&QDialog::setWindowTitle);
 
 	QPushButton *close = new QPushButton(QTStr("Close"));
 	connect(close, &QAbstractButton::clicked, dlg, &QDialog::accept);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the remaining instances of the `SIGNAL()`/`SLOT()` macro and replaces them with the new Qt connection style.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
These were previously left in as there used to be linker issues on Windows using the old cmake path (as `QCefWidget` is defined in `obs-browser`), meaning this didn't build.
Now the old cmake path doesn't exist there anymore, so we can replace this.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on my forks' CI that this now compiles and links on all operating systems.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
