### PR TITLE
frontend: Change clip level to 0.0 dB

### DIFF
--- a/frontend/widgets/VolumeMeter.cpp
+++ b/frontend/widgets/VolumeMeter.cpp
@@ -413,7 +413,7 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_volmeter_t *obs_volmeter, bool ver
 	minimumLevel = -60.0;                    // -60 dB
 	warningLevel = -20.0;                    // -20 dB
 	errorLevel = -9.0;                       //  -9 dB
-	clipLevel = -0.5;                        //  -0.5 dB
+	clipLevel = 0.0;                         //   0 dB
 	minimumInputLevel = -50.0;               // -50 dB
 	peakDecayRate = 11.76;                   //  20 dB / 1.7 sec
 	magnitudeIntegrationTime = 0.3;          //  99% in 300 ms
@@ -714,18 +714,17 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width, int he
 	int errorLength = maximumPosition - errorPosition;
 	locker.unlock();
 
-	if (clipping) {
-		peakPosition = maximumPosition;
-	}
+	if (clipping)
+		peak = clipLevel + 0.1f;
 
-	if (peakPosition < minimumPosition) {
+	if (peak < minimumLevel) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
 				 muted ? backgroundNominalColorDisabled : backgroundNominalColor);
 		painter.fillRect(warningPosition, y, warningLength, height,
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < warningPosition) {
+	} else if (peak < warningLevel) {
 		painter.fillRect(minimumPosition, y, peakPosition - minimumPosition, height,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(peakPosition, y, warningPosition - peakPosition, height,
@@ -734,7 +733,7 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width, int he
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < errorPosition) {
+	} else if (peak < errorLevel) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(warningPosition, y, peakPosition - warningPosition, height,
@@ -743,7 +742,7 @@ void VolumeMeter::paintHMeter(QPainter &painter, int x, int y, int width, int he
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(errorPosition, y, errorLength, height,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < maximumPosition) {
+	} else if (peak <= clipLevel) {
 		painter.fillRect(minimumPosition, y, nominalLength, height,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(warningPosition, y, warningLength, height,
@@ -798,18 +797,17 @@ void VolumeMeter::paintVMeter(QPainter &painter, int x, int y, int width, int he
 	int errorLength = maximumPosition - errorPosition;
 	locker.unlock();
 
-	if (clipping) {
-		peakPosition = maximumPosition;
-	}
+	if (clipping)
+		peak = clipLevel + 0.1f;
 
-	if (peakPosition < minimumPosition) {
+	if (peak < minimumLevel) {
 		painter.fillRect(x, minimumPosition, width, nominalLength,
 				 muted ? backgroundNominalColorDisabled : backgroundNominalColor);
 		painter.fillRect(x, warningPosition, width, warningLength,
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(x, errorPosition, width, errorLength,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < warningPosition) {
+	} else if (peak < warningLevel) {
 		painter.fillRect(x, minimumPosition, width, peakPosition - minimumPosition,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(x, peakPosition, width, warningPosition - peakPosition,
@@ -818,7 +816,7 @@ void VolumeMeter::paintVMeter(QPainter &painter, int x, int y, int width, int he
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(x, errorPosition, width, errorLength,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < errorPosition) {
+	} else if (peak < errorLevel) {
 		painter.fillRect(x, minimumPosition, width, nominalLength,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(x, warningPosition, width, peakPosition - warningPosition,
@@ -827,7 +825,7 @@ void VolumeMeter::paintVMeter(QPainter &painter, int x, int y, int width, int he
 				 muted ? backgroundWarningColorDisabled : backgroundWarningColor);
 		painter.fillRect(x, errorPosition, width, errorLength,
 				 muted ? backgroundErrorColorDisabled : backgroundErrorColor);
-	} else if (peakPosition < maximumPosition) {
+	} else if (peak <= clipLevel) {
 		painter.fillRect(x, minimumPosition, width, nominalLength,
 				 muted ? foregroundNominalColorDisabled : foregroundNominalColor);
 		painter.fillRect(x, warningPosition, width, warningLength,


### PR DESCRIPTION
### Description
This changes the clip level of the volume meters from -0.5 dB to 0.0 dB.

### Motivation and Context
I think the original intention was to tell users they had too loud of audio without actually clipping the audio. But if audio was intended to be this high of level, such as music, it would show it was clipping without it actually clipping. 

Brought up by @PatTheMav off thread.

### How Has This Been Tested?
Tested audio with a high dB level, but not clipping, to make sure the volume controls didn't show the clipping indicators.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
