### PR TITLE
Fix display/window capture on Windows capturing on creation

### DIFF
--- a/plugins/win-capture/data/locale/en-US.ini
+++ b/plugins/win-capture/data/locale/en-US.ini
@@ -42,6 +42,7 @@ Mode="Mode"
 CaptureAudio="Capture Audio (BETA)"
 CaptureAudio.TT="When enabled, creates an \"Application Audio Capture\" source that automatically updates to the currently captured window/application.\nNote that if Desktop Audio is configured, this could result in doubled audio."
 AudioSuffix="Audio"
+SelectAWindow="[Select a window to capture]"
 
 # Generic compatibility messages
 Compatibility.GameCapture.Admin="%name% may require OBS to be run as admin to use Game Capture."

--- a/plugins/win-capture/data/locale/en-US.ini
+++ b/plugins/win-capture/data/locale/en-US.ini
@@ -43,6 +43,7 @@ CaptureAudio="Capture Audio (BETA)"
 CaptureAudio.TT="When enabled, creates an \"Application Audio Capture\" source that automatically updates to the currently captured window/application.\nNote that if Desktop Audio is configured, this could result in doubled audio."
 AudioSuffix="Audio"
 SelectAWindow="[Select a window to capture]"
+SelectADisplay="[Select a display to capture]"
 
 # Generic compatibility messages
 Compatibility.GameCapture.Admin="%name% may require OBS to be run as admin to use Game Capture."

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -38,6 +38,8 @@
 
 #define RESET_INTERVAL_SEC 3.0f
 
+#define INVALID_DISPLAY "DUMMY"
+
 typedef BOOL (*PFN_winrt_capture_supported)();
 typedef BOOL (*PFN_winrt_capture_cursor_toggle_supported)();
 typedef struct winrt_capture *(*PFN_winrt_capture_init_monitor)(
@@ -416,7 +418,7 @@ static void duplicator_capture_destroy(void *data)
 static void duplicator_capture_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "method", METHOD_AUTO);
-	obs_data_set_default_string(settings, "monitor_id", "DUMMY");
+	obs_data_set_default_string(settings, "monitor_id", INVALID_DISPLAY);
 	obs_data_set_default_int(settings, "monitor_wgc", 0);
 	obs_data_set_default_bool(settings, "capture_cursor", true);
 	obs_data_set_default_bool(settings, "force_sdr", false);
@@ -904,6 +906,13 @@ static obs_properties_t *duplicator_capture_properties(void *data)
 	obs_property_t *monitors = obs_properties_add_list(
 		props, "monitor_id", TEXT_MONITOR, OBS_COMBO_TYPE_LIST,
 		OBS_COMBO_FORMAT_STRING);
+
+	if (capture && strcmp(capture->monitor_id, INVALID_DISPLAY) == 0) {
+		obs_property_list_add_string(monitors,
+					     obs_module_text("SelectADisplay"),
+					     INVALID_DISPLAY);
+		obs_property_list_item_disable(monitors, 0, true);
+	}
 
 	obs_properties_add_bool(props, "capture_cursor", TEXT_CAPTURE_CURSOR);
 	obs_properties_add_bool(props, "force_sdr", TEXT_FORCE_SDR);

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -567,6 +567,15 @@ static obs_properties_t *wc_properties(void *data)
 	p = obs_properties_add_list(ppts, "window", TEXT_WINDOW,
 				    OBS_COMBO_TYPE_LIST,
 				    OBS_COMBO_FORMAT_STRING);
+
+	/* Add "[Select a window]" on first use to prevent the properties list
+	 * widget from selecting the first one in the list automatically */
+	if (wc && (!wc->title || !wc->class || !wc->executable)) {
+		obs_property_list_add_string(
+			p, obs_module_text("SelectAWindow"), "");
+		obs_property_list_item_disable(p, 0, true);
+	}
+
 	ms_fill_window_list(p, EXCLUDE_MINIMIZED, NULL);
 	obs_property_set_modified_callback(p, wc_window_changed);
 


### PR DESCRIPTION
### Description
Fixes an issue where window and display capture on Windows would capture the first window or display on first creation. This is actually due to a design flaw in the properties view, but we need to fix it in the sources themselves to display the appropriate text to the user anyway.

### Motivation and Context
It's not good to capture something without explicitly selecting it.

### How Has This Been Tested?
Tested locally, seems fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.