### PR TITLE
win-capture: Fix segfault when calling data.free()

### DIFF
--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -48,7 +48,8 @@ static void STDMETHODCALLTYPE SwapChainDestructed(void *pData)
 		dxgi_possible_swap_queue_count = 0;
 		dxgi_present_attempted = false;
 
-		data.free();
+		if (data.free)
+			data.free();
 		data.free = nullptr;
 	}
 }
@@ -187,7 +188,8 @@ static void update_mismatch_count(bool match)
 			dxgi_possible_swap_queue_count = 0;
 			dxgi_present_attempted = false;
 
-			data.free();
+			if (data.free)
+				data.free();
 			data.free = nullptr;
 
 			swap_chain_mismatch_count = 0;


### PR DESCRIPTION

### Description

Trivial fix to avoid a segfault in `update_mismatch_count` when attempting to call `data.free` after it has been set to `nullptr`.

One possibility is that `update_mismatch_count` is called 16 times in a row without a match, then `data.free` is called and it is set to `nullptr`. If `update_mismatch_count` is called another 16 times in a row without a match, then `data.free` will be null this time and it will segfault.

Another possibility is that `update_mismatch_count` is called after `SwapChainDestructed`. I say this because the client experiencing the crashes recently upgraded OBS from a much older version that did not crash and 395ab0fbf54ee2692d6fe60036088580247d868c seems to be the only change to `dxgi-capture.cpp` in that time.

In any case, all calls to `data.free` should be guarded.

### Motivation and Context

We have a client who uses OBS to record our application and our app has started crashing in graphics-hook64.dll. We use Crashpad to generate minidumps which I can provide. The minidumps show the crash is an attempt to call `data.free` in `update_mismatch_count` when it is null.

### How Has This Been Tested?

Untested. I am not a user of OBS and my client is not in a position to run a custom build of OBS.

The client can't reliably cause the crash. For example, one crash occured after an hour of recording.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
