### PR TITLE
obs-filters: Fix building of noise reduction

### DIFF
--- a/plugins/nv-filters/CMakeLists.txt
+++ b/plugins/nv-filters/CMakeLists.txt
@@ -7,7 +7,7 @@ if(OS_WINDOWS)
   option(ENABLE_NVVFX "Enable building with NVIDIA Video Effects SDK (requires redistributable to be installed)" ON)
 
   if(ENABLE_NVAFX)
-    target_enable_feature(nv-filters "NVIDIA Audio FX support" LIBNVAFX_ENABLED HAS_NOISEREDUCTION)
+    target_enable_feature(nv-filters "NVIDIA Audio FX support" LIBNVAFX_ENABLED)
     target_sources(nv-filters PRIVATE nvidia-audiofx-filter.c)
   else()
     target_disable_feature(nv-filters "NVIDIA Audio FX support")

--- a/plugins/obs-filters/CMakeLists.txt
+++ b/plugins/obs-filters/CMakeLists.txt
@@ -5,10 +5,6 @@ legacy_check()
 add_library(obs-filters MODULE)
 add_library(OBS::filters ALIAS obs-filters)
 
-if(OS_WINDOWS)
-  target_enable_feature(obs-filters "NVIDIA Audio FX support" LIBNVAFX_ENABLED HAS_NOISEREDUCTION)
-endif()
-
 target_sources(
   obs-filters
   PRIVATE
@@ -41,6 +37,7 @@ include(cmake/speexdsp.cmake)
 include(cmake/rnnoise.cmake)
 
 if(OS_WINDOWS)
+  include(cmake/nvidia.cmake)
   configure_file(cmake/windows/obs-module.rc.in obs-filters.rc)
   target_sources(obs-filters PRIVATE obs-filters.rc)
 endif()

--- a/plugins/obs-filters/cmake/nvidia.cmake
+++ b/plugins/obs-filters/cmake/nvidia.cmake
@@ -1,0 +1,4 @@
+if(ENABLE_NVAFX)
+  target_sources(obs-filters PRIVATE noise-suppress-filter.c)
+  target_compile_definitions(obs-filters PRIVATE LIBNVAFX_ENABLED HAS_NOISEREDUCTION)
+endif()


### PR DESCRIPTION
### Description
If speex and rnnoise are disabled but nvafx is enabled, the noise reduction filter still needs to be built. This fixes the issue.

### Motivation and Context
Enable building of nvafx even if speex & rnnoise are disabled.
This is useful for minimal test builds.
Bug discovered by @RytoEX ; fix found by @RytoEX 

### How Has This Been Tested?
obs builds even when  speex & rnnoise are disabled, while nvafx is enabled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
