### PR TITLE
libobs: Add obs_encoder_get_mixer_index

### DIFF
--- a/docs/sphinx/reference-encoders.rst
+++ b/docs/sphinx/reference-encoders.rst
@@ -443,6 +443,12 @@ General Encoder Functions
 
 ---------------------
 
+.. function:: size_t obs_encoder_get_mixer_index(const obs_encoder_t *encoder)
+
+   :return: The mixer index for the audio track which is encoded by the encoder
+
+---------------------
+
 .. function:: void obs_encoder_set_preferred_video_format(obs_encoder_t *encoder, enum video_format format)
               enum video_format obs_encoder_get_preferred_video_format(const obs_encoder_t *encoder)
 

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1113,6 +1113,22 @@ size_t obs_encoder_get_frame_size(const obs_encoder_t *encoder)
 	return encoder->framesize;
 }
 
+size_t obs_encoder_get_mixer_index(const obs_encoder_t *encoder)
+{
+	if (!obs_encoder_valid(encoder, "obs_encoder_get_mixer_index"))
+		return 0;
+
+	if (encoder->info.type != OBS_ENCODER_AUDIO) {
+		blog(LOG_WARNING,
+		     "obs_encoder_get_mixer_index: "
+		     "encoder '%s' is not an audio encoder",
+		     obs_encoder_get_name(encoder));
+		return 0;
+	}
+
+	return encoder->mixer_idx;
+}
+
 void obs_encoder_set_video(obs_encoder_t *encoder, video_t *video)
 {
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2481,6 +2481,9 @@ EXPORT uint32_t obs_encoder_get_sample_rate(const obs_encoder_t *encoder);
 /** For audio encoders, returns the frame size of the audio packet */
 EXPORT size_t obs_encoder_get_frame_size(const obs_encoder_t *encoder);
 
+/** For audio encoders, returns the mixer index */
+EXPORT size_t obs_encoder_get_mixer_index(const obs_encoder_t *encoder);
+
 /**
  * Sets the preferred video format for a video encoder.  If the encoder can use
  * the format specified, it will force a conversion to that format if the

--- a/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-audio-encoders.c
@@ -288,9 +288,11 @@ static void *enc_create(obs_data_t *settings, obs_encoder_t *encoder,
 
 	char buf[256];
 	av_channel_layout_describe(&enc->context->ch_layout, buf, 256);
-	info("bitrate: %" PRId64 ", channels: %d, channel_layout: %s\n",
+	info("bitrate: %" PRId64
+	     ", channels: %d, channel_layout: %s, track: %d\n",
 	     (int64_t)enc->context->bit_rate / 1000,
-	     (int)enc->context->ch_layout.nb_channels, buf);
+	     (int)enc->context->ch_layout.nb_channels, buf,
+	     (int)obs_encoder_get_mixer_index(enc->encoder) + 1);
 	init_sizes(enc, audio);
 
 	/* enable experimental FFmpeg encoder if the only one available */


### PR DESCRIPTION
### Description
Add obs_encoder_get_mixer_index

### Motivation and Context
Have a way to find out what audio track is used for an audio encoder

### How Has This Been Tested?
On windows 11 by logging the audio track .

### Types of changes
- Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
