### PR TITLE
libobs,UI: Replace and deprecate obs_scene_sceneitem_from_source

### DIFF
--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -326,6 +326,11 @@ Scene Item Functions
 
    :return: The sceneitem associated with a source in a scene. Returns NULL if not found.
 
+   .. deprecated:: 31.0
+      This function is problematic because there can be multiple items of the same source in a scene.
+      In that case, which of those this function will return is undefined.
+      If this is the behavior you need, manually use :c:func:`obs_scene_enum_items` instead.
+
 ---------------------
 
 .. function:: void obs_sceneitem_set_id(obs_sceneitem_t *item);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1806,8 +1806,8 @@ EXPORT void obs_sceneitem_save(obs_sceneitem_t *item, obs_data_array_t *arr);
 EXPORT void obs_sceneitem_set_id(obs_sceneitem_t *sceneitem, int64_t id);
 
 /** Tries to find the sceneitem of the source in a given scene. Returns NULL if not found */
-EXPORT obs_sceneitem_t *obs_scene_sceneitem_from_source(obs_scene_t *scene,
-							obs_source_t *source);
+OBS_DEPRECATED EXPORT obs_sceneitem_t *
+obs_scene_sceneitem_from_source(obs_scene_t *scene, obs_source_t *source);
 
 /** Save all the transform states for a current scene's sceneitems */
 EXPORT obs_data_t *obs_scene_save_transform_states(obs_scene_t *scene,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`obs_scene_sceneitem_from_source` is problematic because there can be multiple items of the same source in a scene, which the function doesn't account for. In such a case, it would return the first item it finds, which often might not be what a developer expects. 
It was originally added for the undo/redo-operation of "Add New Source" where the UI guarantees that the item is unique, but for a general case it's not suitable.

In the one UI use, instead of first creating the scene item and then finding it again , we can just remember the scene item in AddNew after we create it, similar to the source itself.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The existence of the method was discussed on Discord, and I think it shouldn't exist.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15
Added and undo/redo'd (redid?) new sources without problems.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
