### PR TITLE
obs-nvenc: Support new error code for too many sessions

### DIFF
--- a/plugins/obs-nvenc/nvenc-helpers.c
+++ b/plugins/obs-nvenc/nvenc-helpers.c
@@ -64,6 +64,7 @@ bool nv_failed2(obs_encoder_t *encoder, void *session, NVENCSTATUS err,
 
 	switch (err) {
 	case NV_ENC_ERR_OUT_OF_MEMORY:
+	case NV_ENC_ERR_INCOMPATIBLE_CLIENT_KEY:
 		obs_encoder_set_last_error(encoder,
 					   obs_module_text("TooManySessions"));
 		break;


### PR DESCRIPTION
### Description

At some point NVIDIA started using NV_ENC_ERR_INCOMPATIBLE_CLIENT_KEY instead of NV_ENC_ERR_OUT_OF_MEMORY to signal that the session limit has been exceeded.

### Motivation and Context

Want to provide users with more meaningful error message.

### How Has This Been Tested?

Verified this error code occurs when session limit is hit, and that the error message with this PR is accurate.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
