### PR TITLE
obs-nvenc: Check if device index in settings object is actually set

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -888,13 +888,14 @@ static void *nvenc_create_base(enum codec_type codec, obs_data_t *settings,
 	 * option as it may cause issues for people.
 	 */
 	const int gpu = (int)obs_data_get_int(settings, "device");
+	const bool gpu_set = obs_data_has_user_value(settings, "device");
 #ifndef _WIN32
 	const bool force_tex = obs_data_get_bool(settings, "force_cuda_tex");
 #else
 	const bool force_tex = false;
 #endif
 
-	if (gpu != -1 && texture && !force_tex) {
+	if (gpu_set && gpu != -1 && texture && !force_tex) {
 		blog(LOG_INFO,
 		     "[obs-nvenc] different GPU selected by user, falling back "
 		     "to non-texture encoder");


### PR DESCRIPTION
### Description

Adds a check to see if the value for the `device` setting is actually set.

### Motivation and Context

When using the redirect from the legacy ID this would not be set and `0` would be treated as an override resulting in the non-texture fallback being enabled. By checking if the value is explicitly set we avoid that.

### How Has This Been Tested?

Locally with a quick test recording.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
