### PR TITLE
obs-nvenc: Fix reading uninitialized variable

### DIFF
--- a/plugins/obs-nvenc/nvenc-helpers.c
+++ b/plugins/obs-nvenc/nvenc-helpers.c
@@ -310,6 +310,7 @@ static bool nvenc_check(void)
 	os_process_args_t *args;
 	struct dstr caps_str = {0};
 	config_t *config = NULL;
+	bool success = false;
 
 	args = os_process_args_create(test_exe);
 
@@ -344,7 +345,7 @@ static bool nvenc_check(void)
 		goto fail;
 	}
 
-	bool success = config_get_bool(config, "general", "nvenc_supported");
+	success = config_get_bool(config, "general", "nvenc_supported");
 	if (!success) {
 		const char *error =
 			config_get_string(config, "general", "reason");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Define `success` = `false` at the beginning of the function `static bool nvenc_check()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I found a warning below as [commented](https://github.com/obsproject/obs-studio/pull/11153#issuecomment-2343562257) in the PR 11153.

```
[ 46%] Building C object plugins/obs-nvenc/CMakeFiles/obs-nvenc.dir/nvenc-helpers.c.o
obs-studio/plugins/obs-nvenc/nvenc-helpers.c: In function ‘nvenc_check’:
obs-studio/plugins/obs-nvenc/nvenc-helpers.c:385:16: warning: ‘success’ may be used uninitialized [-Wmaybe-uninitialized]
  385 |         return success;
      |                ^~~~~~~
obs-studio/plugins/obs-nvenc/nvenc-helpers.c:347:14: note: ‘success’ was declared here
  347 |         bool success = config_get_bool(config, "general", "nvenc_supported");
      |              ^~~~~~~

```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39 (GCC 13.3.1)

I ran these commands to hit the error.
```sh
ln -s libobs.so.30 lib64/libnvidia-encode.so.1
rm bin/obs-nvenc-test
ln -s /usr/bin/true bin/obs-nvenc-test
```

Then checked log file.

Log from master branch:
```text
---------------------------------                                                                                                               
Loading module: obs-nvenc.so                                                                                                                    
[NVENC] Seems the NVENC test subprocess crashed. Better there than here I guess.                                                                
---------------------------------                                                                                                               
```

Log from this branch:
```text
---------------------------------                                                                                                               
Loading module: obs-nvenc.so                                                                                                                    
[NVENC] Seems the NVENC test subprocess crashed. Better there than here I guess.                                                                
NVENC not supported                                                                                                                             
Failed to initialize module 'obs-nvenc.so'                                                                                                      
---------------------------------                                                                                                               
```

It shows `Failed to initialize module 'obs-nvenc.so'` so that I confirmed the function returns false.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
