### PR TITLE
rtmp-services: Remove outdated Dolby Millicast locations

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 262,
+    "version": 263,
     "files": [
         {
             "name": "services.json",
-            "version": 262
+            "version": 263
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3469,14 +3469,6 @@
                     "url": "rtmp://rtmp-auto.millicast.com:1935/v2/pub"
                 },
                 {
-                    "name": "Amsterdam, Netherlands (RTMPS)",
-                    "url": "rtmps://rtmp-ams-1.millicast.com:443/v2/pub"
-                },
-                {
-                    "name": "Amsterdam, Netherlands (RTMP)",
-                    "url": "rtmp://rtmp-ams-1.millicast.com:1935/v2/pub"
-                },
-                {
                     "name": "Bangalore, India (RTMPS)",
                     "url": "rtmps://rtmp-blr-1.millicast.com:443/v2/pub"
                 },


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Remove outdated [Dolby Millicast](https://dolby.io) locations from the RTMP Services list.

### Motivation and Context
Update support for "Dolby Millicast" in RTMP Services.

### How Has This Been Tested?
Local Build & CI Build

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
