### PR TITLE
CI: Set default values for have* outputs in macos-codesigning action

### DIFF
--- a/.github/actions/setup-macos-codesigning/action.yaml
+++ b/.github/actions/setup-macos-codesigning/action.yaml
@@ -27,13 +27,13 @@ outputs:
     value: ${{ steps.codesign.outputs.haveCodesignIdent }}
   haveProvisioningProfile:
     description: True if necessary provisioning profile credentials were found
-    value: ${{ steps.provisioning.outputs.haveProvisioningProfile }}
+    value: ${{ steps.provisioning.outputs.haveProvisioningProfile || steps.codesign.outputs.haveProvisioningProfile }}
   provisioningProfileUUID:
     description: UUID of imported provisioning profile
     value: ${{ steps.provisioning.outputs.provisioningProfileUUID }}
   haveNotarizationUser:
     description: True if necessary notarization credentials were found
-    value: ${{ steps.notarization.outputs.haveNotarizationUser }}
+    value: ${{ steps.notarization.outputs.haveNotarizationUser || steps.codesign.outputs.haveNotarizationUser }}
   codesignIdent:
     description: Code signing identity
     value: ${{ steps.codesign.outputs.codesignIdent }}
@@ -95,6 +95,8 @@ runs:
           print "codesignTeam=${team_id}" >> $GITHUB_OUTPUT
         } else {
           print 'haveCodesignIdent=false' >> $GITHUB_OUTPUT
+          print 'haveProvisioningProfile=false' >> $GITHUB_OUTPUT
+          print 'haveNotarizationUser=false' >> $GITHUB_OUTPUT
         }
 
     - name: Provisioning Profile 👤


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The `provisioning` and `notarization` steps that set the `haveProvisioningProfile` and `haveNotarizationUser` outputs respectively only run if `haveCodesignIdent` has evaluated to true in the prior `codesign` step.
This means that if `haveCodesignIdent` is false, the other two outputs are left unset, evaluating their `value` expressions (and as such the output of the action) to empty instead of false. To mitigate that, we can just add a `|| 'false'` to set the value to false in case it isn't set.
Strictly speaking it's unnecessary for `haveCodesignIdent` as that always runs but to me it makes sense just to set it to all.

I found this issue in the [equivalent action](https://github.com/obsproject/obs-plugintemplate/blob/e3688b7491c52ef6e37ac59daa93e7cf4d9e2b28/.github/actions/setup-macos-codesigning/action.yaml) in obs-plugintemplate. As that action is basically a mirror from the obs-studio action, let's fix it here too.

As there are [more](https://github.com/obsproject/obs-studio/commit/401aa7933ac6e88680cd0fe46456da48c33b2d73) [changes](https://github.com/obsproject/obs-studio/commit/a2c0d4969aa35067455814d20cc87f9f9486c370#diff-aaf7b09bfa61dd42dd6ea034c5645697aecd139321722b6eddcfc2e9db9955a4) that didn't make it into the plugintemplate yet (but are needed there), I plan to update that after this PR has been merged.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I noticed CI failures when updating a plugin to the current template's build system and CI setup without having signing and notarization secrets set (because I don't have any :p).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
On CI on a plugin based on the template.

Run Before: https://github.com/gxalpha/obs-properties-dock/actions/runs/10829574145/job/30047436956
Run After: https://github.com/gxalpha/obs-properties-dock/actions/runs/10830053045/job/30048940631

Commit: https://github.com/gxalpha/obs-properties-dock/commit/c5807d3d1050201de9d415ccbcd7b688c528933b (ignore the deletion below, that was code from an unsuccessful earlier attempt).


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
