### PR TITLE
cmake: Disable CCache for local builds and enable by default for CI

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -52,7 +52,8 @@
       "inherits": ["macos"],
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
+        "ENABLE_CCACHE": true
       }
     },
     {
@@ -83,7 +84,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "CMAKE_COLOR_DIAGNOSTICS": true
+        "CMAKE_COLOR_DIAGNOSTICS": true,
+        "ENABLE_CCACHE": true
       }
     },
     {
@@ -102,8 +104,7 @@
       "cacheVariables": {
         "GPU_PRIORITY_VAL": {"type": "STRING", "value": "$penv{GPU_PRIORITY_VAL}"},
         "VIRTUALCAM_GUID": {"type": "STRING", "value": "A3FCE0F5-3493-419F-958A-ABA1250EC20B"},
-        "ENABLE_BROWSER": true,
-        "ENABLE_CCACHE": false
+        "ENABLE_BROWSER": true
       }
     },
     {
@@ -113,8 +114,7 @@
       "inherits": ["windows-x64"],
       "warnings": {"dev": true, "deprecated": true},
       "cacheVariables": {
-        "CMAKE_COMPILE_WARNING_AS_ERROR": true,
-        "ENABLE_CCACHE": false
+        "CMAKE_COMPILE_WARNING_AS_ERROR": true
       }
     }
   ],

--- a/cmake/common/ccache.cmake
+++ b/cmake/common/ccache.cmake
@@ -11,7 +11,7 @@ endif()
 if(CCACHE_PROGRAM)
   message(DEBUG "Trying to find ccache on build host - done")
   message(DEBUG "Ccache found as ${CCACHE_PROGRAM}")
-  option(ENABLE_CCACHE "Enable compiler acceleration with ccache" ON)
+  option(ENABLE_CCACHE "Enable compiler acceleration with ccache" OFF)
 
   if(ENABLE_CCACHE)
     set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")


### PR DESCRIPTION
### Description
Disables Ccache by default for local builds and enables it by default for CI builds instead.

### Motivation and Context
For all the benefits Ccache brings, it can also introduce unexpected issues, particularly when lazier source file matching is used (e.g. for Xcode builds due to the use of modules and other ObjC features).

Using Ccache by default also breaks the use of address sanitizer (asan) and other runtime analytics features that can be enabled via Xcode schemas (as the compiler cannot be identified if a `COMPILER_LAUNCHER` shell script is used).

Thus disabling Ccache by default makes these (primarily local) workflows easier, but is still available for developers who have to opt-in explicitly (features that introduce possible unknown side-effects should be opt-in to begin with).

Existing projects are not affected by this change (if they were created with Ccache enabled they will continue to use it), as are CI builds (which get a "fresh" Ccache created by scheduled nightly runs, reducing the chance of false cache hits - releases are not affected by this as they use a different build configuration).

### How Has This Been Tested?
Tested locally on macOS 14, configuring with default settings and able to enable address sanitizer directly.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
