### PR TITLE
libobs: Deselect scene item before removing

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2668,6 +2668,7 @@ static void obs_sceneitem_remove_internal(obs_sceneitem_t *item)
 	obs_scene_t *parent = item->parent;
 	item->removed = true;
 
+	obs_sceneitem_select(item, false);
 	set_visibility(item, false);
 
 	detach_sceneitem(item);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Makes sure that a scene item that gets removed is in the "not selected" state, no matter whether it was selected before. This causes the "item_deselect" signal to be sent if the item is selected while being removed.

I think that semantically it makes sense that a selected item has the `item_deselect` signal sent if it is being removed, as it is selected before and not selected after (because it doesn't exist anymore); I'd consider current behavior to be a bug (or at least not work as one might expect).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
While making a plugin, I noticed that if you listen to the select/deselect signals, an item that gets removed via the UI will not have the deselect signal when being removed.
This can lead to weird states if you count selections/deselections to track how many items are selected (and you can't trust that the `item_remove` signal means that an item gets deselected, as it might be removed by other means).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15
Tested (with the custom plugin) that when removing an item via the UI, the deselect signal gets sent.

Tested that undo/redo (of item deletion) didn't break as that makes use of selected items.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
