### PR TITLE
CI: Minor update of build scripts and GitHub Actions workflows and actions

### DIFF
--- a/.github/actions/check-changes/action.yaml
+++ b/.github/actions/check-changes/action.yaml
@@ -45,6 +45,11 @@ runs:
         shopt -s extglob
         shopt -s dotglob
 
+        # 4b825dc642cb6eb9a060e54bf8d69288fbee4904 is a "hidden" sha1 hash of
+        # the "empty tree", retrived via 'git hash-object -t tree /dev/null',
+        # and used here as a last-resort fallback to always provide a valid
+        # git ref.
+
         if [[ "${GIT_BASE_REF}" ]]; then
           if ! git cat-file -e "${GIT_BASE_REF}" &> /dev/null; then
             echo "::warning::Provided base reference ${GIT_BASE_REF} is invalid"

--- a/.github/actions/flatpak-builder-lint/action.yaml
+++ b/.github/actions/flatpak-builder-lint/action.yaml
@@ -19,16 +19,10 @@ runs:
       working-directory: ${{ inputs.workingDirectory }}
       run: |
         : Check artifact input
-        case "${{ inputs.artifact }}" in
-          builddir);;
-          repo);;
-          manifest);;
-          appstream);;
-          *)
-            echo "::error::Given artifact type is incorrect"
-            exit 2
-            ;;
-        esac
+        if ! [[ "${{ inputs.artifact }}" =~ builddir|repo|manifest|appstream ]]; then
+          echo "::error::Given artifact type is incorrect"
+          exit 2
+        fi
 
     - name: Run flatpak-builder-lint
       id: result
@@ -36,31 +30,46 @@ runs:
       working-directory: ${{ inputs.workingDirectory }}
       run: |
         : Run flatpak-builder-lint
-        exit_code=0
-        ret=$(flatpak-builder-lint --exceptions ${{ inputs.artifact }} ${{ inputs.path }}) || exit_code=$?
-        if [[ $exit_code != 0 && -z "$ret" ]]; then
+
+        return=0
+        result="$(flatpak-builder-lint --exceptions ${{ inputs.artifact }} ${{ inputs.path }})" || return=$?
+
+        if [[ ${return} != 0 && -z "${result}" ]]; then
           echo "::error::Error while running flatpak-builder-lint"
           exit 2
         fi
 
-        if [[ ${{ inputs.artifact }} == "appstream" ]]; then
-          echo $ret
+        if [[ "${{ inputs.artifact }}" == "appstream" ]]; then
+          echo "${result}"
 
-          [[ $exit_code != 0 ]] && echo "::error::Flatpak appstream info is not valid"
+          if [[ ${return} != 0 ]]; then echo "::error::Flatpak appstream info is not valid"; fi
 
-          exit $exit_code
+          exit ${return}
         fi
 
-        n_warnings=$(echo $ret | jq '.warnings | length')
-        for ((i = 0 ; i < n_warnings ; i++)); do
-          warning=$(echo $ret | jq ".warnings[$i]")
-          echo "::warning::$warning found in the Flatpak ${{ inputs.artifact }}"
-        done
+        # This jq command selects any available array under the 'warnings' key in the JSON document
+        # or provides an empty array as a fallback if the key is not present. This array is then
+        # piped to the 'map' function to apply a transformation to every element in the array,
+        # converting it to a string prefixed with the output level, the actual element value, and
+        # finally the suffix string defined in 'template'.
+        #
+        # The result of this expression is concatenated with a similar expression doing the same
+        # but for the 'errors' key and its associated array.
+        #
+        # The second jq invocation then selects each element of the array and outputs it directly,
+        # which will be strings of the formats:
+        #
+        # * '::warning:: <original warning> <template text>'
+        # * '::error:: <original error> <template text>'
+        #
+        # If no warnings or errors were found, only empty arrays were used for 'map' and thus
+        # only an empty result array is generated.
 
-        n_errors=$(echo $ret | jq '.errors | length')
-        for ((i = 0 ; i < n_errors ; i++)); do
-          error=$(echo $ret | jq ".errors[$i]")
-          echo "::error::$error found in the Flatpak ${{ inputs.artifact }}"
-        done
+        template=" found in the Flatpak ${{ inputs.artifact }}"
+        while read -r log_line; do
+          if [[ "${log_line}" ]]; then echo "${log_line}"; fi
+        done <<< "$(echo "${result}" \
+          | jq -r '(.warnings // [] | try map("::warning:: " + . + "${template}")) + (.errors // [] | try map("::error:: " + . + "${template}"))' \
+          | jq -r '.[]')"
 
-        [[ -z $n_errors || $n_errors == 0 ]] || exit 2
+        exit ${return}

--- a/.github/actions/generate-docs/action.yaml
+++ b/.github/actions/generate-docs/action.yaml
@@ -23,11 +23,24 @@ runs:
         : "${minor:=}"
         : "${patch:=}"
 
+        # This expression will first try to match all the LIBOBS_API_[...]_VER
+        # lines in 'obs-config.h', before removing the '#define ' prefix and
+        # trimming away whitespace characters and linebreaks.
+        # This will yield a single line with the each major, minor, and patch
+        # version variable name followed by its value, so every even item
+        # in this string will contain a version part.
+
         read -r _ major _ minor _ patch _ <<< \
           "$(grep -E -e "#define LIBOBS_API_(MAJOR|MINOR|PATCH)_VER *" libobs/obs-config.h \
             | sed 's/#define //g' \
             | tr -s ' ' \
             | tr '\n' ' ')"
+
+        # This expression simply replaces the definition of the 'version' and
+        # 'release' variables in the Python script with updated variants using
+        # the version tokens set by the previous expression.
+        # The copyright variable assignment is updated to use the current
+        # local year as the second year value.
 
         sed -i -E \
           -e "s/version = '([0-9]+\.[0-9]+\.[0-9]+)'/version = '${major}.${minor}.${patch}'/g" \

--- a/.github/actions/generate-docs/action.yaml
+++ b/.github/actions/generate-docs/action.yaml
@@ -59,7 +59,7 @@ runs:
         echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
 
     - name: Install Sphinx 📜
-      uses: totaldebug/sphinx-publish-action@1.2.0
+      uses: totaldebug/sphinx-publish-action@cdbb304b4b8aa1fd36015e3c459c1f122804bd6b
       with:
         sphinx_src: ${{ inputs.sourceDirectory }}/docs/sphinx
         build_only: true

--- a/.github/actions/qt-xml-validator/action.yaml
+++ b/.github/actions/qt-xml-validator/action.yaml
@@ -35,35 +35,27 @@ runs:
     - name: Register Annotations 📝
       uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0
 
+    - name: Check for Changed Files ✅
+      uses: ./.github/actions/check-changes
+      id: checks
+      with:
+        checkGlob: 'UI/forms/**/*.ui'
+
     - name: Validate XML 💯
+      if: fromJSON(steps.checks.outputs.hasChangedFiles)
+      id: result
       shell: bash
       env:
-        GITHUB_EVENT_FORCED: ${{ github.event.forced }}
-        GITHUB_REF_BEFORE: ${{ github.event.before }}
+        CHANGED_FILES: ${{ steps.checks.outputs.changedFiles }}
       run: |
         : Validate XML 💯
         if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
-        shopt -s extglob
-        shopt -s globstar
 
-        if ! git cat-file -e "${GITHUB_REF_BEFORE}" &> /dev/null; then
-          GITHUB_REF_BEFORE='4b825dc642cb6eb9a060e54bf8d69288fbee4904'
-        fi
+        CHANGED_FILES=($(echo "${CHANGED_FILES//[\[\]\'\"]/}" | tr "," "\n"))
 
-        changes=($(git diff --name-only HEAD~1 HEAD -- UI/forms/**/*.ui))
-        case "${GITHUB_EVENT_NAME}" in
-          pull_request) changes=($(git diff --name-only origin/"${GITHUB_BASE_REF}" HEAD -- UI/forms/**/*.ui)) ;;
-          push)
-            if [[ "${GITHUB_EVENT_FORCED}" == false ]]; then
-              changes=($(git diff --name-only ${GITHUB_REF_BEFORE} HEAD -- UI/forms/**/*.ui))
-            fi
-            ;;
-          *) ;;
-        esac
-
-        if (( ${#changes[@]} )); then
+        if (( ${#CHANGED_FILES[@]} )); then
           if [[ '${{ inputs.failCondition }}' == never ]]; then set +e; fi
           xmllint \
             --schema ${{ github.workspace }}/UI/forms/XML-Schema-Qt5.15.xsd \
-            --noout "${changes[@]}"
+            --noout "${CHANGED_FILES[@]}"
         fi

--- a/.github/actions/sparkle-appcast/action.yaml
+++ b/.github/actions/sparkle-appcast/action.yaml
@@ -110,6 +110,23 @@ runs:
         hdiutil detach ${mount_point}
 
         curl -s -L -O ${feed_url}
+
+        # The Xpath Xplained:
+        #
+        # //rss/channel/item              - Select every <item> node, under a
+        #                                   <channel> node, under a <rss> node,
+        #                                   which:
+        # [*...]                          - Has a child node, which
+        # [local-name()='channel']        - Has the local name "channel"
+        #                                   (required to match the
+        #                                   namespaced sparkle:channel node),
+        #                                   which in turn has
+        # [text()='${{ inputs.channel}']  - A text node that contains the
+        #                                   content of inputs.channel
+        # /enclosure/@url                 - Then select the "url" attribute of
+        #                                   every <enclosure> node under
+        #                                   these matching <item> nodes
+
         local -a artifacts=($(\
           xmllint \
             -xpath "//rss/channel/item[*[local-name()='channel'][text()='${{ inputs.channel }}']]/enclosure/@url" \

--- a/.github/actions/sparkle-appcast/appcast_adjust.xslt
+++ b/.github/actions/sparkle-appcast/appcast_adjust.xslt
@@ -5,18 +5,39 @@ xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
 <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no"/>
 <xsl:strip-space elements="*"/>
 
+<!-- Select /rss/channel/title and store it as default value for 'pCustomTitle' -->
 <xsl:param name="pCustomTitle" select="/rss/channel/title" />
+<!-- Select /rss/channel/link and store it as default value for 'pCustomLink' -->
 <xsl:param name="pCustomLink" select="/rss/channel/link" />
+<!-- Set empty strings as default values for pSparkleUrl and pDeltaUrl -->
 <xsl:param name="pSparkleUrl" select="''" />
 <xsl:param name="pDeltaUrl" select="''" />
 
+<!-- XSLT identity rule - copy all nodes and their child nodes as well as attributes
+     (attributes are _not_ descendants of the nodes they belong to).
+     This copy rule is applied as the "default" transformation for all nodes.
+-->
 <xsl:template match="@* | node()">
     <xsl:copy>
         <xsl:apply-templates select="@* | node()" />
     </xsl:copy>
 </xsl:template>
+<!-- Match the <title> under <channel> and <rss> and do not translate it
+     (effectively removes it).
+-->
 <xsl:template match="/rss/channel/title" />
+<!-- Match the <link> under <channel> and <rss> and do not translate it
+     (effectively removes it).
+ -->
 <xsl:template match="/rss/channel/link" />
+<!-- Match the <channel> under <rss> and apply a copy translation, which
+     * Creates a new <title> element with a text child node and the text content
+       of the pCustomTitle variable
+     * Creates a new <link> element with a text child node and the text content
+       of the pCustomLink variable
+     * Copies all child nodes and attributes of the original <channel> node
+       (this is why <title> and <link> were explicitly not translated before)
+-->
 <xsl:template match="/rss/channel">
     <xsl:copy>
         <xsl:element name="title"><xsl:value-of select="$pCustomTitle" /></xsl:element>
@@ -24,6 +45,18 @@ xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
         <xsl:apply-templates select="@* | node()" />
     </xsl:copy>
 </xsl:template>
+<!-- Match every url attribute of <enclosure> nodes in <sparkle:deltas> nodes
+     (which themselves are under <item>, <channel>, and <rss> nodes respectively).
+
+     Create a new attribute with the name "url" and then set its content to either
+     * The original value of the attribute if it starts with the value of the
+       pDeltaUrl variable, OR
+     * The actual value of the pDeltaUrl variable, with the value of the
+       pSparkleUrl variable removed in front of the current url value added after
+
+     This effectively updates every url attribute on a delta <enclosure> node
+     that does not start with the current delta url path.
+-->
 <xsl:template match="/rss/channel/item/sparkle:deltas/enclosure/@url">
     <xsl:attribute name="url">
         <xsl:choose>
@@ -37,6 +70,11 @@ xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
         </xsl:choose>
     </xsl:attribute>
 </xsl:template>
+<!-- Match any <sparkle:fullReleaseNotesLink> node under <item>, <channel>,
+     and <rss> respectively, and replace it with a new node named
+     <sparkle:releaseNotesLink> and populate it with all child nodes and
+        attributes of the original node.
+-->
 <xsl:template match="/rss/channel/item/sparkle:fullReleaseNotesLink">
     <xsl:element name="sparkle:releaseNotesLink"><xsl:apply-templates select="@* | node()" /></xsl:element>
 </xsl:template>

--- a/.github/actions/sparkle-appcast/appcast_legacy.xslt
+++ b/.github/actions/sparkle-appcast/appcast_legacy.xslt
@@ -5,12 +5,29 @@ xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
 <xsl:output method="xml" encoding="UTF-8" omit-xml-declaration="no"/>
 <xsl:strip-space elements="*"/>
 
+<!-- XSLT identity rule - copy all nodes and their child nodes as well as attributes
+     (attributes are _not_ descendants of the nodes they belong to).
+     This copy rule is applied as the "default" transformation for all nodes.
+-->
 <xsl:template match="@* | node()">
     <xsl:copy>
         <xsl:apply-templates select="@* | node()" />
     </xsl:copy>
 </xsl:template>
+<!-- Select every <item> node under a <channel> and <rss> node respectively,
+     which has a <sparkle:channel> child node whose text child node's value
+     is not equal to 'stable', then apply to translation, effectively removing
+     it.
+-->
 <xsl:template match="/rss/channel/item[sparkle:channel[text()!='stable']]" />
+<!-- Select every <sparkle:channel> node under a <item> node which sits under a
+     <channel> and <rss> node respectively, then apply no translation, effectively
+     removing it.
+-->
 <xsl:template match="/rss/channel/item/sparkle:channel" />
+<!-- Select every <sparkle:deltas> node under a <item> node which sits under a
+     <channel> and <rss> node respectively, then apply no translation, effectively
+     removing it.
+-->
 <xsl:template match="/rss/channel/item/sparkle:deltas" />
 </xsl:stylesheet>

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -21,8 +21,8 @@ if (( ! ${+CI} )) {
   exit 1
 }
 
-autoload -Uz is-at-least && if ! is-at-least 5.2; then
-  print -u2 -PR "%F{1}${funcstack[1]##*/}:%f Running on Zsh version %B${ZSH_VERSION}%b, but Zsh %B5.2%b is the minimum supported version. Upgrade Zsh to fix this issue."
+autoload -Uz is-at-least && if ! is-at-least 5.9; then
+  print -u2 -PR "%F{1}${funcstack[1]##*/}:%f Running on Zsh version %B${ZSH_VERSION}%b, but Zsh %B5.9%b is the minimum supported version. Upgrade Zsh to fix this issue."
   exit 1
 fi
 

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -57,7 +57,6 @@ build() {
     macos-x86_64
     macos-arm64
     ubuntu-x86_64
-    ubuntu-aarch64
   )
 
   local config='RelWithDebInfo'
@@ -215,8 +214,6 @@ build() {
         -DENABLE_BROWSER:BOOL=ON
         -DCEF_ROOT_DIR:PATH="${project_root}/.deps/cef_binary_${CEF_VERSION}_${target//ubuntu-/linux_}"
       )
-
-      if [[ ${target##*-} == aarch64 ]] cmake-args+=(-DENABLE_QSV11:BOOL=OFF)
 
       cmake_build_args+=(build_${target%%-*} --config ${config} --parallel)
       cmake_install_args+=(build_${target%%-*} --prefix ${project_root}/build_${target%%-*}/install/${config})

--- a/.github/scripts/.build.zsh
+++ b/.github/scripts/.build.zsh
@@ -210,7 +210,6 @@ build() {
       local cmake_bin='/usr/bin/cmake'
       cmake_args+=(
         --preset ubuntu-ci
-        --toolchain ${project_root}/cmake/linux/toolchain-${target##*-}-gcc.cmake
         -DENABLE_BROWSER:BOOL=ON
         -DCEF_ROOT_DIR:PATH="${project_root}/.deps/cef_binary_${CEF_VERSION}_${target//ubuntu-/linux_}"
       )

--- a/.github/scripts/.package.zsh
+++ b/.github/scripts/.package.zsh
@@ -21,8 +21,8 @@ if (( ! ${+CI} )) {
   exit 1
 }
 
-autoload -Uz is-at-least && if ! is-at-least 5.2; then
-  print -u2 -PR "%F{1}${funcstack[1]##*/}:%f Running on Zsh version %B${ZSH_VERSION}%b, but Zsh %B5.2%b is the minimum supported version. Upgrade Zsh to fix this issue."
+autoload -Uz is-at-least && if ! is-at-least 5.9; then
+  print -u2 -PR "%F{1}${funcstack[1]##*/}:%f Running on Zsh version %B${ZSH_VERSION}%b, but Zsh %B5.9%b is the minimum supported version. Upgrade Zsh to fix this issue."
   exit 1
 fi
 

--- a/.github/scripts/utils.zsh/check_ubuntu
+++ b/.github/scripts/utils.zsh/check_ubuntu
@@ -13,6 +13,12 @@ if [[ -f /etc/os-release ]] {
     log_group
     return 2
   }
+
+  autoload -Uz is-at-least && if ! is-at-least 24.04 ${dist_version}; then
+    log_error "Not running on a recent-enough Ubuntu distribution. Aborting"
+    log_group
+    return 2
+  fi
 } else {
   log_error "Unable to determine local Linux distribution, but Ubuntu is required. Aborting"
   log_group

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -64,18 +64,6 @@ popd
 
 log_group 'Installing obs-studio build dependencies from apt...'
 
-local suffix
-if [[ ${CPUTYPE} != ${target##*-} ]] {
-  local -A arch_mappings=(
-    aarch64 arm64
-    x86_64 amd64
-  )
-
-  suffix=":${arch_mappings[${target##*-}]}"
-  sudo apt-get install -y --no-install-recommends \
-    gcc-${${target##*-}//_/-}-linux-gnu g++-${${target##*-}//_/-}-linux-gnu
-}
-
 sudo apt-get install -y --no-install-recommends \
   build-essential libglib2.0-dev \
   lsb-release dh-cmake \

--- a/.github/scripts/utils.zsh/setup_ubuntu
+++ b/.github/scripts/utils.zsh/setup_ubuntu
@@ -14,12 +14,6 @@ local -a curl_opts=(--show-error --silent --location -O ${@})
 
 pushd ${project_root}
 
-typeset -g QT_VERSION
-read -r QT_VERSION <<< \
-  "$(jq -r --arg target "${target}" \
-    '.platformConfig[$target] | { qtVersion } | join(" ")' \
-    ${buildspec_file})"
-
 log_group 'Installing obs-studio build dependencies...'
 
 mkdir -p ${project_root}/.deps
@@ -90,21 +84,6 @@ sudo apt-get install -y --no-install-recommends \
   libpulse-dev libsndio-dev libspeexdsp-dev libudev-dev libv4l-dev libva-dev libvlc-dev \
   libpci-dev libdrm-dev \
   nlohmann-json3-dev libwebsocketpp-dev libasio-dev libqrcodegencpp-dev \
-  libffmpeg-nvenc-dev librist-dev libsrt-openssl-dev
-
-if [[ ${target##*-} == x86_64 ]] sudo apt-get install -y --no-install-recommends libvpl-dev libvpl2
-
-local -a _qt_packages=()
-
-if (( QT_VERSION == 6 )) {
-  _qt_packages+=(
-    qt6-base-dev
-    libqt6svg6-dev
-    qt6-base-private-dev
-  )
-} else {
-  log_error "Unsupported Qt version '${QT_VERSION}' specified."
-  return 2
-}
-
-sudo apt-get install -y --no-install-recommends ${_qt_packages}
+  libffmpeg-nvenc-dev librist-dev libsrt-openssl-dev \
+  qt6-base-dev libqt6svg6-dev qt6-base-private-dev \
+  libvpl-dev libvpl2

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -80,8 +80,8 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 15.2'
-          sudo xcode-select --switch /Applications/Xcode_15.2.app/Contents/Developer
+          print '::group::Enable Xcode 15.4'
+          sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -340,15 +340,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: actions/cache@v4
-        id: ccache-cache
-        if: github.event_name == 'pull_request'
-        with:
-          path: ${{ github.workspace }}/.ccache
-          key: ${{ runner.os }}-ccache-x86_64-${{ needs.check-event.outputs.config }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-x86_64-
-
       - name: Build OBS Studio 🧱
         uses: ./.github/actions/build-obs
         env:

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -129,7 +129,7 @@ jobs:
           echo "/previous/:major.:minor https://:major-:minor.${{ vars.CF_PAGES_PROJECT }}.pages.dev 302" >> docs/_redirects
 
       - name: Publish to Live Page
-        uses: cloudflare/wrangler-action@4c10c1822abba527d820b29e6333e7f5dac2cabd
+        uses: cloudflare/wrangler-action@f84a562284fc78278ff9052435d9526f9c718361
         with:
           workingDirectory: docs
           apiToken: ${{ secrets.CF_API_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -45,6 +45,15 @@ jobs:
         run: |
           : Remove Stale Ccache Caches
 
+          # The jq expressions below use multiple 'select' calls to filter
+          # each item in the array with the 'actions_caches' key.
+          # First it only selects objects whose 'ref' element has the value
+          # 'refs/heads/master', of those objects only those whose 'key'
+          # value matches the specifies expression, before finally only
+          # selecting the 'id' and 'key' elements for a new object.
+          # The final 'join' command combines both elements with a semicolon
+          # into a raw string which can then be parsed directly.
+
           echo '::group::Processing master branch cache entries'
           while IFS=";" read -r cache_id cache_name; do
             if [[ "${cache_name}" ]]; then
@@ -114,6 +123,17 @@ jobs:
           : Check Nightly Runs ☑️
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
+          # This 'gh' command retrieves the last 2 runs of the workflow defined
+          # by 'scheduled.yaml' and retrieve only the 'headSha' value of the
+          # JSON response payload.
+          #
+          # As this job runs in context of the same workflow, the first element
+          # of the workflow list will be the currently active run.
+          #
+          # The jq expression then selects the 'headSha' element of the second
+          # element in the array, which is the SHA-1 hash of the commit used
+          # for the immediately prior run of this workflow.
+
           last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
 
           if [[ "${GITHUB_SHA}" == "${last_nightly}" ]]; then
@@ -156,6 +176,17 @@ jobs:
         run: |
           : Check Nightly Runs ☑️
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+
+          # This 'gh' command retrieves the last 2 runs of the workflow defined
+          # by 'scheduled.yaml' and retrieve only the 'headSha' value of the
+          # JSON response payload.
+          #
+          # As this job runs in context of the same workflow, the first element
+          # of the workflow list will be the currently active run.
+          #
+          # The jq expression then selects the 'headSha' element of the second
+          # element in the array, which is the SHA-1 hash of the commit used
+          # for the immediately prior run of this workflow.
 
           local last_nightly=$(gh run list --workflow scheduled.yaml --limit 2 --json headSha --jq '.[1].headSha')
 

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -152,7 +152,7 @@ jobs:
           checkGlob: '**/en-US.ini'
 
       - name: Upload US English Language Files 🇺🇸
-        if: fromJSON(steps.checks.outputs.hasChangedFiles)
+        if: steps.checks.outcome == 'success' && fromJSON(steps.checks.outputs.hasChangedFiles)
         uses: obsproject/obs-crowdin-sync/upload@30b5446e3b5eb19595aa68a81ddf896a857302cf
         env:
           CROWDIN_PAT: ${{ secrets.CROWDIN_SYNC_CROWDIN_PAT }}

--- a/buildspec.json
+++ b/buildspec.json
@@ -49,15 +49,5 @@
             "hash": "ca59770e9f46b59d6bec6e7036a17a27d601a0a5a0a721fe8e03fea734ccf732"
         }
     },
-    "platformConfig": {
-        "ubuntu-x86_64": {
-            "qtVersion": 6,
-            "generator": "Ninja"
-        },
-        "ubuntu-aarch64": {
-            "qtVersion": 6,
-            "generator": "Ninja"
-        }
-    },
     "name": "obs-studio"
 }


### PR DESCRIPTION
### Description
Updates the following aspects of the current build scripts and GitHub Actions workflows and actions:

* Build scripts on Linux require Ubuntu 24.04 and x86_64 - any preliminary/experimental support for aarch64 was removed
* Qt6 is used by Ubuntu builds by defaults, associated build spec settings are thus superfluous and have been removed
* Build scripts on macOS and Linux require Zsh 5.9
* macOS builds use Xcode 15.4 by default
* Experimental support for CCache on Windows was removed
* `qt-xml-validator` now uses the `check-changes` action to check for and get a list of changed UI files
* Several complex shell script snippets have been documented in-line
* XSLT stylesheets used by `sparkle-appcast` action have been updated with doc comments to explain how they work (XSLT and XPATH are remnants of a past age of Java, SOAP, and XHTML, so not many might be familiar with these)
* `sphinx-publish-action` has been updated to use the precise commit hash of version 1.2.0
* `wrangler-action` has been updated to commit hash of version 3.7.0

### Motivation and Context
Regular maintenance of CI workflows and build scripts.

### How Has This Been Tested?
Will need some actual CI runs to test.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
