### PR TITLE
CI: Use Windows 11 SDK 10.0.22621.0

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,7 +98,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "architecture": "x64,version=10.0.20348",
+      "architecture": "x64,version=10.0.22621",
       "binaryDir": "${sourceDir}/build_x64",
       "generator": "Visual Studio 17 2022",
       "cacheVariables": {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Before 6c590805e88755f70ad62ffbb217ad8ace09563b, builds on Windows would automatically select a Windows SDK using CMake's rules:

https://cmake.org/cmake/help/v3.25/variable/CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION.html https://cmake.org/cmake/help/v3.30/variable/CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION.html https://cmake.org/cmake/help/v3.30/policy/CMP0149.html

This meant that CI Windows builds would end up using SDK 10.0.20348.0 because that matched the runner's OS version exactly. Locally, if a Windows SDK version that exactly matched the host system version was not installed, CMake would select the latest Windows SDK available. This caused some observed differences in build success between CI and local builds if a newer SDK was used locally.

The Windows runners have the 10.0.22621.0 SDK installed, so let's specifically select that.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Unblock building on CI:
* #10471

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I've been building locally with the 10.0.22621 SDK for a while now. We might have even shipped 30.1 built with it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
