### PR TITLE
UI: Fix outdated scene collection and profile method names

### DIFF
--- a/UI/api-interface.cpp
+++ b/UI/api-interface.cpp
@@ -202,7 +202,7 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	bool obs_frontend_add_scene_collection(const char *name) override
 	{
 		bool success = false;
-		QMetaObject::invokeMethod(main, "NewSceneCollection",
+		QMetaObject::invokeMethod(main, "CreateNewSceneCollection",
 					  WaitConnection(),
 					  Q_RETURN_ARG(bool, success),
 					  Q_ARG(QString, QT_UTF8(name)));
@@ -252,13 +252,13 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	void obs_frontend_create_profile(const char *name) override
 	{
-		QMetaObject::invokeMethod(main, "NewProfile",
+		QMetaObject::invokeMethod(main, "CreateNewProfile",
 					  Q_ARG(QString, name));
 	}
 
 	void obs_frontend_duplicate_profile(const char *name) override
 	{
-		QMetaObject::invokeMethod(main, "DuplicateProfile",
+		QMetaObject::invokeMethod(main, "CreateDuplicateProfile",
 					  Q_ARG(QString, name));
 	}
 


### PR DESCRIPTION
### Description
Fixes method names for certain scene collection and frontend methods exposed via the frontend API that had been renamed during review phase of #11055.

### Motivation and Context
Restores functionality of the corresponding frontend API methods.

> [!NOTE]
>
> Plugins which invoke public slot functions on the UI thread directly instead of using the frontend API will face the same issue. Luckily this should not result in crashes or other issues at runtime as Qt will just ignore the call and at worst post a log message about a non-existing method being invoked.

### How Has This Been Tested?
Tested with a simple plugin that invokes the corresponding frontend API functions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
