### PR TITLE
shared/bpm: Fixed crash when using Stream Delay

### DIFF
--- a/shared/bpm/bpm-internal.h
+++ b/shared/bpm/bpm-internal.h
@@ -98,7 +98,9 @@ struct output_metrics_link {
 	struct metrics_data *metrics_tracks[MAX_OUTPUT_VIDEO_ENCODERS];
 };
 
+static pthread_once_t bpm_once = PTHREAD_ONCE_INIT;
 static pthread_mutex_t bpm_metrics_mutex;
+
 /* This DARRAY is used for creating an association between the output_t
  * and the BPM metrics track data for each output that requires BPM injection.
  */


### PR DESCRIPTION
### Description
While testing BPM in the Twitch Enhanced Broadcasting beta build an issue was uncovered where OBS Studio will crash due to an uninitialized mutex in the new BPM code. This crash only happens if: 

- The stream delay feature is enabled
- The user starts streaming and stops the stream before it ever started streaming

With the official OBS Studio, the stream delay feature is not compatible with enhanced broadcasting and will be disabled if the streamer attempts to use stream delay, so there is currently no chance of running into this issue. However, once stream delay compatibility with enhanced broadcasting is upstreamed, the crash will occur in the case specified above, so best to eliminate it ahead of time.

The fix is very simple. Simply ensure the mutex is initialized once from either `bpm_inject()` or `bpm_destroy()`, instead of relying on `bpm_inject()` to always be called first.

### Motivation and Context
This is a bug fix for a very specific case that will cause OBS Studio to crash.

### How Has This Been Tested?
Tested locally with the enhanced broadcasting beta build (Twitch Enhanced Broadcasting). It is very easy to reproduce and the fix works in all iterations I've tried.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
