### PR TITLE
UI: Fix config class mismatch in OBSApp class

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1116,7 +1116,7 @@ OBSApp::~OBSApp()
 {
 #ifdef _WIN32
 	bool disableAudioDucking =
-		config_get_bool(userConfig, "Audio", "DisableAudioDucking");
+		config_get_bool(appConfig, "Audio", "DisableAudioDucking");
 	if (disableAudioDucking)
 		DisableAudioDucking(false);
 #else
@@ -1127,9 +1127,9 @@ OBSApp::~OBSApp()
 
 #ifdef __APPLE__
 	bool vsyncDisabled =
-		config_get_bool(userConfig, "Video", "DisableOSXVSync");
+		config_get_bool(appConfig, "Video", "DisableOSXVSync");
 	bool resetVSync =
-		config_get_bool(userConfig, "Video", "ResetOSXVSyncOnExit");
+		config_get_bool(appConfig, "Video", "ResetOSXVSyncOnExit");
 	if (vsyncDisabled && resetVSync)
 		EnableOSXVSync(true);
 #endif
@@ -1304,13 +1304,13 @@ void OBSApp::AppInit()
 
 #ifdef _WIN32
 	bool disableAudioDucking =
-		config_get_bool(userConfig, "Audio", "DisableAudioDucking");
+		config_get_bool(appConfig, "Audio", "DisableAudioDucking");
 	if (disableAudioDucking)
 		DisableAudioDucking(true);
 #endif
 
 #ifdef __APPLE__
-	if (config_get_bool(userConfig, "Video", "DisableOSXVSync"))
+	if (config_get_bool(appConfig, "Video", "DisableOSXVSync"))
 		EnableOSXVSync(false);
 #endif
 
@@ -1326,7 +1326,7 @@ void OBSApp::AppInit()
 const char *OBSApp::GetRenderModule() const
 {
 	const char *renderer =
-		config_get_string(userConfig, "Video", "Renderer");
+		config_get_string(appConfig, "Video", "Renderer");
 
 	return (astrcmpi(renderer, "Direct3D 11") == 0) ? DL_D3D11 : DL_OPENGL;
 }

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1595,7 +1595,7 @@ void OBSBasicSettings::LoadRendererList()
 {
 #ifdef _WIN32
 	const char *renderer =
-		config_get_string(App()->GetUserConfig(), "Video", "Renderer");
+		config_get_string(App()->GetAppConfig(), "Video", "Renderer");
 
 	ui->renderer->addItem(QT_UTF8("Direct3D 11"));
 	if (opt_allow_opengl || strcmp(renderer, "OpenGL") == 0)
@@ -2983,16 +2983,16 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	}
 
 #ifdef __APPLE__
-	bool disableOSXVSync = config_get_bool(App()->GetUserConfig(), "Video",
+	bool disableOSXVSync = config_get_bool(App()->GetAppConfig(), "Video",
 					       "DisableOSXVSync");
-	bool resetOSXVSync = config_get_bool(App()->GetUserConfig(), "Video",
+	bool resetOSXVSync = config_get_bool(App()->GetAppConfig(), "Video",
 					     "ResetOSXVSyncOnExit");
 	ui->disableOSXVSync->setChecked(disableOSXVSync);
 	ui->resetOSXVSync->setChecked(resetOSXVSync);
 	ui->resetOSXVSync->setEnabled(disableOSXVSync);
 #elif _WIN32
 	bool disableAudioDucking = config_get_bool(
-		App()->GetUserConfig(), "Audio", "DisableAudioDucking");
+		App()->GetAppConfig(), "Audio", "DisableAudioDucking");
 	ui->disableAudioDucking->setChecked(disableAudioDucking);
 
 	const char *processPriority = config_get_string(
@@ -3628,7 +3628,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 
 #ifdef _WIN32
 	if (WidgetChanged(ui->renderer))
-		config_set_string(App()->GetUserConfig(), "Video", "Renderer",
+		config_set_string(App()->GetAppConfig(), "Video", "Renderer",
 				  QT_TO_UTF8(ui->renderer->currentText()));
 
 	std::string priority =
@@ -3656,12 +3656,12 @@ void OBSBasicSettings::SaveAdvancedSettings()
 #ifdef __APPLE__
 	if (WidgetChanged(ui->disableOSXVSync)) {
 		bool disable = ui->disableOSXVSync->isChecked();
-		config_set_bool(App()->GetUserConfig(), "Video",
+		config_set_bool(App()->GetAppConfig(), "Video",
 				"DisableOSXVSync", disable);
 		EnableOSXVSync(!disable);
 	}
 	if (WidgetChanged(ui->resetOSXVSync))
-		config_set_bool(App()->GetUserConfig(), "Video",
+		config_set_bool(App()->GetAppConfig(), "Video",
 				"ResetOSXVSyncOnExit",
 				ui->resetOSXVSync->isChecked());
 #endif
@@ -3681,7 +3681,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 #ifdef _WIN32
 	if (WidgetChanged(ui->disableAudioDucking)) {
 		bool disable = ui->disableAudioDucking->isChecked();
-		config_set_bool(App()->GetUserConfig(), "Audio",
+		config_set_bool(App()->GetAppConfig(), "Audio",
 				"DisableAudioDucking", disable);
 		DisableAudioDucking(disable);
 	}


### PR DESCRIPTION
### Description
Aligns the config type of several OS-specific settings across their implementations in the OBSApp class.

### Motivation and Context
Ensure selection of renderer on Windows and VSync settings on macOS are correctly retained and restored from settings.

### How Has This Been Tested?
Tested on macOS 15.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
