### PR TITLE
libobs: Do not attempt to reconnect if stop event is set

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -3043,6 +3043,12 @@ static void output_reconnect(struct obs_output *output)
 {
 	int ret;
 
+	if (reconnecting(output) &&
+	    os_event_try(output->reconnect_stop_event) != EAGAIN) {
+		os_atomic_set_bool(&output->reconnecting, false);
+		return;
+	}
+
 	if (!reconnecting(output)) {
 		output->reconnect_retry_cur_msec =
 			output->reconnect_retry_sec * 1000;


### PR DESCRIPTION
### Description

Prevents the reconnect thread from being started up again after the output has been put into the "stopping" state and reconnects have been requested to stop. Also sets the reconnect state to `false` to prevent `obs_output_active()` from returning `true` which would prevent the multitrack output's stop handler from continuing.

### Motivation and Context

Should fix the crash reported on the EB Discord related to the output teardown not actually running due to the output still being in a reconnected state: https://discord.com/channels/1171528364000018442/1282992330604941365

This is a race condition that requires the right timing to trigger. It would also leave the `reconnect_thread` in a non-detached state while never being joined.

Technically it should also be possible to remove [this check](https://github.com/obsproject/obs-studio/blob/master/UI/multitrack-video-output.cpp#L1004-L1006) now that #11117 is merged without causing more issues, but I wanted to fix the underlying race condition in libobs first.

### How Has This Been Tested?

Locally with OBS connecting to FFmpeg in listener mode:

1. Start `ffmpeg -f flv -listen 1 -i rtmp://127.0.0.1:1935/live/test -c copy -f null -`
2. Connect with OBS
3. Stop/kill ffmpeg (e.g. by pressing "q" with the terminal in focus)
4. Wait for OBS to start reconnecting
5. Hit "Stop Streaming" at just the right time

WIthout this patch OBS will be in a bad state where the output hasn't been destroyed, and attempting to start it again will cause a crash. With this patch the output should be correctly cleaned up.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
