### PR TITLE
cmake: Disable discovery of Homebrew libraries for dependencies

### DIFF
--- a/cmake/finders/FindLuajit.cmake
+++ b/cmake/finders/FindLuajit.cmake
@@ -94,7 +94,7 @@ endif()
 
 find_library(
   Luajit_LIBRARY
-  NAMES luajit luajit-51 luajit-5.1 lua51
+  NAMES luajit-5.1 luajit-51 luajit lua51
   HINTS ${PC_Luajit_LIBRARY_DIRS}
   PATHS /usr/lib /usr/local/lib
   DOC "Luajit location"

--- a/cmake/macos/defaults.cmake
+++ b/cmake/macos/defaults.cmake
@@ -36,6 +36,8 @@ set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
 # Use common bundle-relative RPATH for installed targets
 set(CMAKE_INSTALL_RPATH "@executable_path/../Frameworks")
+# Ignore any dependent packages installed via Homebrew
+list(APPEND CMAKE_IGNORE_PREFIX_PATH "/opt/homebrew" "/usr/local")
 
 # Used for library exports only (obs-frontend-api)
 set(OBS_LIBRARY_DESTINATION "lib")


### PR DESCRIPTION
### Description
Adds the default installation location of Homebrew packages to list of ignored paths for CMake to resolve dependencies on macOS.

### Motivation and Context
macOS builds should only use dependencies built via the obs-deps build scripts. Default variants of the same dependencies are not compatible with our app packaging requirements and thus will create issues when creating the app bundle.

This is specifically an issue when MbedTLS is installed via Homebrew which ships a CMake package config by default and is picked up by our code ever since we switched to prefer CMake packages.

### How Has This Been Tested?
Tested on macOS 15 with MbedTLS installed via Homebrew and observed that CMake will only pick up MbedTLS provided by obs-deps.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
