### PR TITLE
UI: Fix missing support for portable configuration files

### DIFF
--- a/UI/cmake/os-linux.cmake
+++ b/UI/cmake/os-linux.cmake
@@ -1,5 +1,8 @@
 target_sources(obs-studio PRIVATE platform-x11.cpp)
-target_compile_definitions(obs-studio PRIVATE USE_XDG OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
+target_compile_definitions(
+  obs-studio
+  PRIVATE USE_XDG OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}" $<$<BOOL:${ENABLE_PORTABLE_CONFIG}>:ENABLE_PORTABLE_CONFIG>
+)
 target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus)
 
 target_sources(obs-studio PRIVATE system-info-posix.cpp)

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -720,12 +720,24 @@ bool OBSApp::InitGlobalConfig()
 	InitGlobalConfigDefaults();
 	InitGlobalLocationDefaults();
 
-	userConfigLocation = std::filesystem::u8path(
-		config_get_string(appConfig, "Locations", "Configuration"));
-	userScenesLocation = std::filesystem::u8path(
-		config_get_string(appConfig, "Locations", "SceneCollections"));
-	userProfilesLocation = std::filesystem::u8path(
-		config_get_string(appConfig, "Locations", "Profiles"));
+	if (IsPortableMode()) {
+		userConfigLocation = std::filesystem::u8path(
+			config_get_default_string(appConfig, "Locations",
+						  "Configuration"));
+		userScenesLocation = std::filesystem::u8path(
+			config_get_default_string(appConfig, "Locations",
+						  "SceneCollections"));
+		userProfilesLocation = std::filesystem::u8path(
+			config_get_default_string(appConfig, "Locations",
+						  "Profiles"));
+	} else {
+		userConfigLocation = std::filesystem::u8path(config_get_string(
+			appConfig, "Locations", "Configuration"));
+		userScenesLocation = std::filesystem::u8path(config_get_string(
+			appConfig, "Locations", "SceneCollections"));
+		userProfilesLocation = std::filesystem::u8path(
+			config_get_string(appConfig, "Locations", "Profiles"));
+	}
 
 	bool userConfigResult = InitUserConfig(userConfigLocation, lastVersion);
 
@@ -2434,7 +2446,7 @@ static void load_debug_privilege(void)
 
 #define CONFIG_PATH BASE_PATH "/config"
 
-#if defined(LINUX_PORTABLE) || defined(_WIN32)
+#if defined(ENABLE_PORTABLE_CONFIG) || defined(_WIN32)
 #define ALLOW_PORTABLE_MODE 1
 #else
 #define ALLOW_PORTABLE_MODE 0

--- a/cmake/linux/defaults.cmake
+++ b/cmake/linux/defaults.cmake
@@ -6,6 +6,7 @@ option(ENABLE_PULSEAUDIO "Enable PulseAudio support" ON)
 option(ENABLE_WAYLAND "Enable building with support for Wayland" ON)
 
 option(ENABLE_RELOCATABLE "Enable relocatable build" OFF)
+option(ENABLE_PORTABLE_CONFIG "Enable support for portable config file location" OFF)
 
 # Set default installation directories
 include(GNUInstallDirs)


### PR DESCRIPTION
### Description
Fixes broken support for portable mode on Linux and Windows.

### Motivation and Context
Windows and Linux allow the storage of configuration files relative to the binary location, which is enabled by default on Windows and has to be explicitly enabled on Linux.

This was originally conflated with the `LINUX_PORTABLE` build setting which also allowed the application itself to be run from non-default locations on a Linux system.

This change reintroduces the functionality behind the `ENABLE_PORTABLE_CONFIG` build setting on Linux.

It also adds necessary code to make this setting compatible with the recently introduced relocatable settings code changes:

When portable mode is enabled, user configuration, scene collections, and profiles are stored in the config directory created for portable mode.

### How Has This Been Tested?
Tested on Windows 11 with portable mode enabled and disabled and observed configuration files being created in different respective locations.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
