### PR TITLE
UI: Fix crash when creating scene collections with "unsafe" names

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1246,10 +1246,6 @@ void OBSBasic::Load(const char *file, bool remigrate)
 			}
 		}
 
-		config_set_string(App()->GetUserConfig(), "Basic",
-				  "SceneCollection", name.c_str());
-		config_set_string(App()->GetUserConfig(), "Basic",
-				  "SceneCollectionFile", name.c_str());
 		blog(LOG_INFO, "No scene file found, creating default scene");
 
 		bool hasFirstRun = config_get_bool(App()->GetUserConfig(),


### PR DESCRIPTION
### Description
Fixes possible crash when a new scene collection is created with a name that consists "unsafe" characters.

### Motivation and Context
Scene collection names that are not considered "safe" by OBS Studio get a changed JSON file name with incompatible characters replaced.

The refactored scene collection implementation uses the `Load` function to either activate an existing scene collection or create a new one if it does not exist.

The `Load` function however overwrote the scene collection name set in the profile with its own variant based off the "safe" file name, which created a mismatch with the code that created the collection data model.

As the `Load` function is only called by `ActivateSceneCollection` (which itself already sets the name and filename for the collection), removal of this superfluous code in the Load function also fixes the issue.

### How Has This Been Tested?
Tested on Windows 11 with a scene collection named "New Collection" which will be automatically stored in "New_Collection.json".

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
