### PR TITLE
libobs: Do not allow reconnect if stop code is OBS_OUTPUT_INVALID_STREAM

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -3095,8 +3095,9 @@ static inline bool can_reconnect(const obs_output_t *output, int code)
 {
 	bool reconnect_active = output->reconnect_retry_max != 0;
 
-	return (reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||
-	       (reconnect_active && code == OBS_OUTPUT_DISCONNECTED);
+	return code != OBS_OUTPUT_INVALID_STREAM &&
+	       ((reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||
+		(reconnect_active && code == OBS_OUTPUT_DISCONNECTED));
 }
 
 void obs_output_signal_stop(obs_output_t *output, int code)


### PR DESCRIPTION
### Description

Stop attempting to reconnect if stop code was `OBS_OUTPUT_INVALID_STREAM`.

### Motivation and Context

If the stream key becomes invalid after a successful stream start and OBS gets disconnected it will get stuck in an indefinite loop trying to reconnect.

This issue has come up in relation to enhanced broadcasting on Twitch, which uses a signed stream key with a limited lifetime. For people running 24/7 streams OBS would get disconnected after the 48 hour limit, and subsequently attempt to (unsuccessfully) reconnect ad infinitum.

There probably is no scenario where a stream key is only temporarily rejected, so it should be fine to always give up on reconnecting once it expires. There will be some follow-up later (next week or so) to allow EB multitrack outputs to reconnect, which would require going through the entire flow as encoder settings may change when a new request is made, and simply fetching a new stream key is not possible.

### How Has This Been Tested?

Locally.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
