### PR TITLE
libobs: Fix crop values for new nested scene sources being incorrect

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -619,6 +619,9 @@ static inline void log_matrix(const struct matrix4 *mat, const char *name)
 static inline void update_nested_scene_crop(struct obs_scene_item *item,
 					    uint32_t width, uint32_t height)
 {
+	if (!item->last_height || !item->last_width)
+		return;
+
 	/* Use last size and new size to calculate factor to adjust crop by. */
 	float scale_x = (float)width / (float)item->last_width;
 	float scale_y = (float)height / (float)item->last_height;


### PR DESCRIPTION
### Description

Fixes crop values for new nested scene sources being incorrect due to `last_width`/`last_height` being 0 when first created, which causes a divide-by-zero error and invalid cropping values to be calculated. 

### Motivation and Context

Reported on Discord.

### How Has This Been Tested?

Created new sceneitem, no longer broken.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
