### PR TITLE
libobs: Disable transform debug logging by default

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -601,7 +601,7 @@ static inline uint32_t calc_cy(const struct obs_scene_item *item,
 	return (crop_cy > height) ? 2 : (height - crop_cy);
 }
 
-#ifdef _DEBUG
+#ifdef DEBUG_TRANSFORM
 static inline void log_matrix(const struct matrix4 *mat, const char *name)
 {
 	blog(LOG_DEBUG,
@@ -695,7 +695,7 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 	matrix4_translate3f(&item->draw_transform, &item->draw_transform,
 			    position.x, position.y, 0.0f);
 
-#ifdef _DEBUG
+#ifdef DEBUG_TRANSFORM
 	blog(LOG_DEBUG, "Transform updated for \"%s\":",
 	     obs_source_get_name(item->source));
 	log_matrix(&item->draw_transform, "draw_transform");
@@ -729,7 +729,7 @@ static void update_item_transform(struct obs_scene_item *item, bool update_tex)
 	matrix4_translate3f(&item->box_transform, &item->box_transform,
 			    position.x, position.y, 0.0f);
 
-#ifdef _DEBUG
+#ifdef DEBUG_TRANSFORM
 	log_matrix(&item->draw_transform, "box_transform");
 #endif
 


### PR DESCRIPTION
### Description

Disables logging of transform matrices by default.

### Motivation and Context

Want less noisy debug builds unless required.

### How Has This Been Tested?

N/A

### Types of changes

- Tweak (non-breaking change to improve existing functionality) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
