### PR TITLE
Remux path setting

### DIFF
--- a/UI/data/locale/en-US.ini
+++ b/UI/data/locale/en-US.ini
@@ -1295,6 +1295,8 @@ Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
 Basic.Settings.Advanced.AutoRemux="Automatically remux to %1"
 Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
+Basic.Settings.Advanced.AutoRemux.Prefix="Remuxed Filename Prefix"
+Basic.Settings.Advanced.AutoRemux.Suffix="Suffix"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -7918,7 +7918,49 @@
                      </property>
                     </widget>
                    </item>
+                   <item row="3" column="0">
+                    <widget class="QLabel" name="label_68">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.AutoRemux.Prefix</string>
+                     </property>
+                     <property name="buddy">
+                      <cstring>remuxPrefix</cstring>
+                     </property>
+                    </widget>
+                   </item>
                    <item row="3" column="1">
+                    <layout class="QHBoxLayout" name="horizontalLayout_33">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>0</number>
+                     </property>
+                     <item>
+                      <widget class="QLineEdit" name="remuxPrefix"/>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_69">
+                       <property name="text">
+                        <string>Basic.Settings.Advanced.AutoRemux.Suffix</string>
+                       </property>
+                       <property name="buddy">
+                        <cstring>remuxSuffix</cstring>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QLineEdit" name="remuxSuffix"/>
+                     </item>
+                    </layout>
+                   </item>
+                   <item row="4" column="1">
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
                      <property name="leftMargin">
                       <number>0</number>
@@ -7950,7 +7992,7 @@
                      </item>
                     </layout>
                    </item>
-                   <item row="3" column="0">
+                   <item row="4" column="0">
                     <widget class="QLabel" name="label_57">
                      <property name="text">
                       <string>Basic.Settings.Output.ReplayBuffer.Prefix</string>
@@ -8651,6 +8693,8 @@
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
   <tabstop>autoRemux</tabstop>
+  <tabstop>remuxPrefix</tabstop>
+  <tabstop>remuxSuffix</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
   <tabstop>streamDelayEnable</tabstop>

--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1868,6 +1868,34 @@ string GetFormatString(const char *format, const char *prefix,
 	return f;
 }
 
+string GetFullPathString(const char *filename, const char *prefix,
+			 const char *suffix)
+{
+	QFileInfo fi(filename);
+
+	QString output("");
+
+	if (prefix && *prefix) {
+		output += QT_UTF8(prefix);
+	}
+	output += fi.baseName();
+	if (suffix && *suffix) {
+		output += QT_UTF8(suffix);
+	}
+	output += "." + fi.suffix();
+
+	string f = QT_TO_UTF8(output);
+
+	remove_reserved_file_characters(f);
+
+	output = fi.path() + QDir::separator() + QString::fromStdString(f);
+
+	string path = QT_TO_UTF8(QFileInfo(output).path());
+	path += "/";
+
+	return output.toStdString();
+}
+
 string GetFormatExt(const char *container)
 {
 	string ext = container;

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -51,6 +51,8 @@ std::string GenerateSpecifiedFilename(const char *extension, bool noSpace,
 				      const char *format);
 std::string GetFormatString(const char *format, const char *prefix,
 			    const char *suffix);
+std::string GetFullPathString(const char *filename, const char *prefix,
+			      const char *suffix);
 std::string GetFormatExt(const char *container);
 std::string GetOutputFilename(const char *path, const char *container,
 			      bool noSpace, bool overwrite, const char *format);

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5607,8 +5607,13 @@ void OBSBasic::on_actionRemux_triggered()
 				   : config_get_string(activeConfiguration,
 						       "AdvOut", "RecFilePath");
 
+	const QString remuxSuffix =
+		QT_UTF8(config_get_string(basicConfig, "Video", "RemuxSuffix"));
+	const QString remuxPrefix =
+		QT_UTF8(config_get_string(basicConfig, "Video", "RemuxPrefix"));
+
 	OBSRemux *remuxDlg;
-	remuxDlg = new OBSRemux(path, this);
+	remuxDlg = new OBSRemux(path, this, false, remuxSuffix, remuxPrefix);
 	remuxDlg->show();
 	remux = remuxDlg;
 }
@@ -7876,10 +7881,20 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 		return;
 	}
 
-	QString path = fi.path();
+	QString output = fi.path() + "/";
+	const char *remuxPrefix =
+		config_get_string(config, "Video", "RemuxPrefix");
+	const char *remuxSuffix =
+		config_get_string(config, "Video", "RemuxSuffix");
 
-	QString output = input;
-	output.resize(output.size() - suffix.size());
+	if (remuxPrefix) {
+		output += QT_UTF8(remuxPrefix);
+	}
+	output += fi.baseName();
+	if (remuxSuffix) {
+		output += QT_UTF8(remuxSuffix);
+	}
+	output += ".";
 
 	const obs_encoder_t *videoEncoder =
 		obs_output_get_video_encoder(outputHandler->fileOutput);
@@ -7895,6 +7910,7 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 	} else {
 		output += "mp4";
 	}
+	QString path = QFileInfo(output).path();
 
 	OBSRemux *remux = new OBSRemux(QT_TO_UTF8(path), this, true);
 	if (!no_show)

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -5607,13 +5607,13 @@ void OBSBasic::on_actionRemux_triggered()
 				   : config_get_string(activeConfiguration,
 						       "AdvOut", "RecFilePath");
 
-	const QString remuxSuffix =
-		QT_UTF8(config_get_string(basicConfig, "Video", "RemuxSuffix"));
-	const QString remuxPrefix =
-		QT_UTF8(config_get_string(basicConfig, "Video", "RemuxPrefix"));
+	const char *remuxPrefix =
+		config_get_string(basicConfig, "Video", "RemuxPrefix");
+	const char *remuxSuffix =
+		config_get_string(basicConfig, "Video", "RemuxSuffix");
 
 	OBSRemux *remuxDlg;
-	remuxDlg = new OBSRemux(path, this, false, remuxSuffix, remuxPrefix);
+	remuxDlg = new OBSRemux(path, this, false, remuxPrefix, remuxSuffix);
 	remuxDlg->show();
 	remux = remuxDlg;
 }
@@ -7881,20 +7881,18 @@ void OBSBasic::AutoRemux(QString input, bool no_show)
 		return;
 	}
 
-	QString output = fi.path() + "/";
 	const char *remuxPrefix =
 		config_get_string(config, "Video", "RemuxPrefix");
 	const char *remuxSuffix =
 		config_get_string(config, "Video", "RemuxSuffix");
 
-	if (remuxPrefix) {
-		output += QT_UTF8(remuxPrefix);
-	}
-	output += fi.baseName();
-	if (remuxSuffix) {
-		output += QT_UTF8(remuxSuffix);
-	}
-	output += ".";
+	QString output = QString::fromStdString(
+		GetFullPathString(QT_TO_UTF8(input), remuxPrefix, remuxSuffix));
+	QDir dir(QFileInfo(output).path());
+	if (!dir.exists())
+		dir.mkpath(".");
+
+	output.resize(output.size() - suffix.length());
 
 	const obs_encoder_t *videoEncoder =
 		obs_output_get_video_encoder(outputHandler->fileOutput);

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -569,6 +569,8 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 #endif
 	HookWidget(ui->filenameFormatting,   EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->overwriteIfExists,    CHECK_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->remuxPrefix,          EDIT_CHANGED,   ADV_CHANGED);
+	HookWidget(ui->remuxSuffix,          EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBPrefix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->simpleRBSuffix,       EDIT_CHANGED,   ADV_CHANGED);
 	HookWidget(ui->streamDelayEnable,    CHECK_CHANGED,  ADV_CHANGED);
@@ -2929,6 +2931,10 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	int rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
+	const char *remuxPrefix =
+		config_get_string(main->Config(), "Video", "RemuxPrefix");
+	const char *remuxSuffix =
+		config_get_string(main->Config(), "Video", "RemuxSuffix");
 	const char *hotkeyFocusType = config_get_string(
 		App()->GetUserConfig(), "General", "HotkeyFocusType");
 	bool dynBitrate =
@@ -2951,6 +2957,8 @@ void OBSBasicSettings::LoadAdvancedSettings()
 
 	ui->filenameFormatting->setText(filename);
 	ui->overwriteIfExists->setChecked(overwriteIfExists);
+	ui->remuxPrefix->setText(remuxPrefix);
+	ui->remuxSuffix->setText(remuxSuffix);
 	ui->simpleRBPrefix->setText(rbPrefix);
 	ui->simpleRBSuffix->setText(rbSuffix);
 
@@ -3704,6 +3712,8 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveSpinBox(ui->reconnectMaxRetries, "Output", "MaxRetries");
 	SaveComboData(ui->bindToIP, "Output", "BindIP");
 	SaveComboData(ui->ipFamily, "Output", "IPFamily");
+	SaveEdit(ui->remuxPrefix, "Video", "RemuxPrefix");
+	SaveEdit(ui->remuxSuffix, "Video", "RemuxSuffix");
 	SaveCheckBox(ui->autoRemux, "Video", "AutoRemux");
 	SaveCheckBox(ui->dynBitrate, "Output", "DynamicBitrate");
 

--- a/UI/window-remux.cpp
+++ b/UI/window-remux.cpp
@@ -487,7 +487,8 @@ void RemuxQueueModel::checkInputPath(int row)
 		if (entry.state == RemuxEntryState::Ready)
 			entry.targetPath = QDir::toNativeSeparators(
 				fileInfo.path() + QDir::separator() +
-				fileInfo.completeBaseName() + newExt);
+				remuxSuffix + fileInfo.completeBaseName() +
+				remuxPrefix + newExt);
 	}
 
 	if (entry.state == RemuxEntryState::Ready && isProcessing)
@@ -642,9 +643,10 @@ void RemuxQueueModel::finishEntry(bool success)
   The actual remux window implementation
 **********************************************************/
 
-OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
+OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_,
+		   QString remuxSuffix_, QString remuxPrefix_)
 	: QDialog(parent),
-	  queueModel(new RemuxQueueModel),
+	  queueModel(new RemuxQueueModel(parent, remuxSuffix_, remuxPrefix_)),
 	  worker(new RemuxWorker()),
 	  ui(new Ui::OBSRemux),
 	  recPath(path),

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -61,7 +61,9 @@ class OBSRemux : public QDialog {
 
 public:
 	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr,
-			  bool autoRemux = false);
+			  bool autoRemux = false,
+			  QString remuxPrefix_ = QString(),
+			  QString remuxSuffix_ = QString());
 	virtual ~OBSRemux() override;
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
@@ -95,8 +97,12 @@ class RemuxQueueModel : public QAbstractTableModel {
 	friend class OBSRemux;
 
 public:
-	RemuxQueueModel(QObject *parent = 0)
+	RemuxQueueModel(QObject *parent = 0,
+			QString remuxPrefix_ = QString(),
+			QString remuxSuffix_ = QString())
 		: QAbstractTableModel(parent),
+		  remuxSuffix(remuxSuffix_),
+		  remuxPrefix(remuxPrefix_),
 		  isProcessing(false)
 	{
 	}
@@ -120,6 +126,8 @@ public:
 	void clearAll();
 
 	bool autoRemux = false;
+	QString remuxSuffix;
+	QString remuxPrefix;
 
 private:
 	struct RemuxQueueEntry {

--- a/UI/window-remux.hpp
+++ b/UI/window-remux.hpp
@@ -62,8 +62,8 @@ class OBSRemux : public QDialog {
 public:
 	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr,
 			  bool autoRemux = false,
-			  QString remuxPrefix_ = QString(),
-			  QString remuxSuffix_ = QString());
+			  const char *remuxPrefix_ = nullptr,
+			  const char *remuxSuffix_ = nullptr);
 	virtual ~OBSRemux() override;
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
@@ -97,12 +97,11 @@ class RemuxQueueModel : public QAbstractTableModel {
 	friend class OBSRemux;
 
 public:
-	RemuxQueueModel(QObject *parent = 0,
-			QString remuxPrefix_ = QString(),
-			QString remuxSuffix_ = QString())
+	RemuxQueueModel(QObject *parent = 0, const char *remuxPrefix_ = nullptr,
+			const char *remuxSuffix_ = nullptr)
 		: QAbstractTableModel(parent),
-		  remuxSuffix(remuxSuffix_),
 		  remuxPrefix(remuxPrefix_),
+		  remuxSuffix(remuxSuffix_),
 		  isProcessing(false)
 	{
 	}
@@ -126,8 +125,8 @@ public:
 	void clearAll();
 
 	bool autoRemux = false;
-	QString remuxSuffix;
-	QString remuxPrefix;
+	const char *remuxPrefix;
+	const char *remuxSuffix;
 
 private:
 	struct RemuxQueueEntry {


### PR DESCRIPTION
### Description
Added ability to save remuxed files with suffixes and prefixes, similar to Replay Buffer.
![image](https://github.com/user-attachments/assets/496a954e-3479-4024-be42-4d590004d97f)
![image](https://github.com/user-attachments/assets/ac2e8c6b-c425-48bb-a21a-045bb90ad9d1)


### Motivation and Context

This will make it easier to sort and search remuxed files.
Prefix will allow saving files in a separate folder (as it done in Replay Buffer Prefix).
This was a regular request on the OBS forum: [one](https://obsproject.com/forum/threads/setting-a-default-remux-folder.112425/), [two](https://ideas.obsproject.com/posts/834/automatically-remux-to-mp4-have-a-option-to-save-intermediate-mkv-to-different-folder-path-option),  [three](https://www.reddit.com/r/obs/comments/t4n5qc/changing_autoremux_directory/)

### How Has This Been Tested?
Added/removed settings while watching remux files being saved.

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
