### PR TITLE
libobs: Fix source profiling inactive sources

### DIFF
--- a/libobs/util/source-profiler.c
+++ b/libobs/util/source-profiler.c
@@ -341,6 +341,9 @@ void source_profiler_frame_collect(void)
 					smp->render_cpu.array[0]);
 			ucirclebuf_push(&ent->render_cpu_sum, sum);
 			da_clear(smp->render_cpu);
+		} else {
+			ucirclebuf_push(&ent->render_cpu, 0);
+			ucirclebuf_push(&ent->render_cpu_sum, 0);
 		}
 
 		/* Note that we still check this even if GPU profiling has been
@@ -368,6 +371,9 @@ void source_profiler_frame_collect(void)
 				ucirclebuf_push(&ent->render_gpu_sum, sum);
 			}
 			da_clear(smp->render_timers);
+		} else {
+			ucirclebuf_push(&ent->render_gpu, 0);
+			ucirclebuf_push(&ent->render_gpu_sum, 0);
 		}
 
 		const obs_source_t *src = *(const obs_source_t **)smps->hh.key;
@@ -604,9 +610,6 @@ bool source_profiler_fill_result(obs_source_t *source,
 		return false;
 
 	memset(result, 0, sizeof(struct profiler_result));
-	/* No or only stale data available */
-	if (!obs_source_enabled(source))
-		return true;
 
 	pthread_rwlock_rdlock(&hm_rwlock);
 


### PR DESCRIPTION
### Description
fix source profiling inactive sources

### Motivation and Context
When filters are disabled the tick takes time, but the cpu and gpu render do not, so I would like to see that in `profiler_result_t`.
Before it would show the last status before it was disabled, now the cpu and gpu go to 0 in 5 seconds

### How Has This Been Tested?
With https://github.com/exeldro/obs-source-profiler by enabling and disabling a filter.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
