### PR TITLE
libobs: Fix sending unclamped audio to output handler

### DIFF
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -312,9 +312,10 @@ bool audio_output_connect(audio_t *audio, size_t mi,
 
 	if (audio_get_input_idx(audio, mi, callback, param) == DARRAY_INVALID) {
 		struct audio_mix *mix = &audio->mixes[mi];
-		struct audio_input input;
-		input.callback = callback;
-		input.param = param;
+		struct audio_input input = {
+			.callback = callback,
+			.param = param,
+		};
 
 		if (conversion) {
 			input.conversion = *conversion;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The variable `input.conversion.allow_clipping` was left uninitialized. This could result in randomly sending unclamped audio to the output handlers that did not request the conversion.

To avoid the same initialized variables again when adding a new variable to the structure, I initialized `audio` at the declaration so that all other variables are initialized to zero.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The member variable `allow_clipping` was introduced by the commit dcee4fc61a54 in #8289.

In the function `audio_output_connect`, which allows the parameter `conversion` to be null to indicate no conversion is requested,
the variable `allow_clipping` was not initialized when the conversion was not requested.

I'm writing a plugin that calls `audio_output_connect` through `obs_add_raw_audio_callback` like [this](https://github.com/norihiro/obs-loudness-dock/blob/1b9aaa6b4c962104b3c5fbb3ec92d5a9eb13f53e/src/loudness.c#L67).
When following the code to see what is the default value of `allow_clipping`, I realized it was never initialized.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Had a modification below to log `allow_clipping` just before it was used.

```patch
diff --git a/libobs/media-io/audio-io.c b/libobs/media-io/audio-io.c
index 18911ea58..06b922a13 100644
--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -117,6 +117,8 @@ static inline void do_audio_output(struct audio_output *audio, size_t mix_idx,
 	for (size_t i = mix->inputs.num; i > 0; i--) {
 		struct audio_input *input = mix->inputs.array + (i - 1);
 
+		blog(LOG_INFO, "%s: i=%zu: allow_clipping=%d", __func__, i, (int)input->conversion.allow_clipping);
+
 		float(*buf)[AUDIO_OUTPUT_FRAMES] =
 			input->conversion.allow_clipping ? mix->buffer_unclamped
 							 : mix->buffer;
```

Then, called `obs_add_raw_audio_callback` twice with `conversion` = `NULL`.

Checked the log and saw `allow_clipping` is uninitialized.

Without this commit, `allow_clipping` sometimes get non-zero value.
```text
info: do_audio_output: i=1: allow_clipping=0
info: do_audio_output: i=2: allow_clipping=255
```

With this commit, I confirmed `allow_clipping` is always 0.
```text
do_audio_output: i=1: allow_clipping=0
do_audio_output: i=2: allow_clipping=0
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
