### PR TITLE
libobs: Assure large enough buffer in dstr_from_cfstring

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -173,7 +173,9 @@ void log_system_info(void)
 static bool dstr_from_cfstring(struct dstr *str, CFStringRef ref)
 {
     CFIndex length = CFStringGetLength(ref);
-    CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
+    CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
+    assert(max_size > 0);
+
     dstr_reserve(str, max_size);
 
     if (!CFStringGetCString(ref, str->array, max_size, kCFStringEncodingUTF8))


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Per the [documentation of `CFStringGetCString`](https://developer.apple.com/documentation/corefoundation/1542721-cfstringgetcstring?language=objc), the buffer provided must be large enough not just for the string itself, but also for a NUL terminator. This space for the `NUL` terminator is currently ignored, and we just get lucky that CFStringGetMaximumSizeForEncoding often dramatically overestimates the space required. However, it is possible to actually hit the maximum with the string itself (for example by using strings that contain exclusively Chinese characters such as "我"), in which case the conversion fails. Adding the extra byte for the `NUL` terminator fixes this.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Investigated a [clang-analyzer warning](https://github.com/obsproject/obs-studio/security/code-scanning/663) on a line below about supposedly passing a null pointer into `strlen`.
https://github.com/obsproject/obs-studio/blob/b4137fa65ae10bbbd6747968a0672458ffbd6ac9/libobs/obs-cocoa.m#L176-L182
Essentially the warning assumed that `max_size` could be 0 and as a result the `dstr` would be uninitialized.

This lead me down a rabbit hole and the above description is its outcome. That fix itself doesn't actually fix the warning (and the PR would be correct without it as well), but somewhat incidentally we can now make the assertion that `max_size` will be larger than 0 since we add 1 to it (this assertion does fix the warning).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15

Test case:
```objectivec
struct dstr test_dstr = {0};
CFStringRef test_cfstring = CFSTR("我");
dstr_from_cfstring(&test_dstr, test_cfstring);
```

This fails without this fix and succeeds with it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
