### PR TITLE
libobs-d3d11: Allow for arbitrary marker name lengths

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -3262,10 +3262,30 @@ extern "C" EXPORT void device_debug_marker_begin(gs_device_t *,
 				      (DWORD)(255.0f * color[1]),
 				      (DWORD)(255.0f * color[2]));
 
+#if _CPPUNWIND
+	// Allocate the correct buffer size on the stack to allow for arbitrary
+	// size strings. On some platforms, this will automatically swap to heap
+	// once a certain threshold is exceeded. Same performance as before, but
+	// much more versatile this way.
+	__try {
+		size_t len = os_utf8_to_wcs(markername, 0, nullptr, 0);
+		// This has a warning that is nonsense on MSVC.
+		wchar_t *wide = reinterpret_cast<wchar_t *>(
+			_malloca((len + 1) * sizeof(wchar_t)));
+		os_utf8_to_wcs(markername, 0, wide, len);
+
+		D3DPERF_BeginEvent(bgra, wide);
+
+		_freea(reinterpret_cast<void *>(wide));
+	} __except (GetExceptionCode() == STATUS_STACK_OVERFLOW) {
+		// Handle the stack overflow gracefully.
+		D3DPERF_BeginEvent(bgra, L"(stack overflow)");
+	}
+#else
 	wchar_t wide[64];
 	os_utf8_to_wcs(markername, 0, wide, _countof(wide));
-
 	D3DPERF_BeginEvent(bgra, wide);
+#endif
 }
 
 extern "C" EXPORT void device_debug_marker_end(gs_device_t *)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Allows using arbitrary marker name lengths with libobs-d3d11.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
When `gs_debug_marker_begin` is provided with a utf8 string that happens to exceeds 64 wchar_t's, the debug marker would have no name at all. ns
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I've compiled and tested this on Windows 10 22H2 with Microsoft Visual Studio 2022 (C++) on the `30.2.3` tag, as `master` is not buildable locally due to over 600 "already defined in" errors from Qt MOC files. Dunno what's causing them, tried a completely clean clone and it still happens.

I was unable to measure any noticable performance impact with stock plugins, not even with `#define GS_USE_DEBUG_MARKERS 1`. The expected behavior of being able to use arbitrarily long marker names also worked just fine, with the longest tested being just around 4k characters long.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate. *I think i did it correctly?*
- [x] I have included updates to all appropriate documentation.
