### PR TITLE
UI: Set NV12 as preferred format for multitrack video encoders

### DIFF
--- a/UI/multitrack-video-output.cpp
+++ b/UI/multitrack-video-output.cpp
@@ -215,6 +215,8 @@ static void adjust_video_encoder_scaling(
 	obs_encoder_set_gpu_scale_type(
 		video_encoder,
 		encoder_config.gpu_scale_type.value_or(OBS_SCALE_BICUBIC));
+	obs_encoder_set_preferred_video_format(video_encoder,
+					       VIDEO_FORMAT_NV12);
 }
 
 static uint32_t closest_divisor(const obs_video_info &ovi,


### PR DESCRIPTION
### Description

Sets the preferred format for multitrack encoders.

### Motivation and Context

Twitch doesn't handle 444 or HDR content properly, and currently stream encoders are already always forced to NV12 (if not HDR): https://github.com/obsproject/obs-studio/blob/4dd3cf675834bbbd786a638f4427766021dd976d/UI/window-basic-main-outputs.cpp#L1873-L1883

This has been an issue for people that record 444 locally but still stream to Twitch (or other websites for that matter).

See TEB Discord thread: https://discord.com/channels/1171528364000018442/1286889511225393182

### How Has This Been Tested?

Streamed to Twitch, confirmed output is now 420.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
