### PR TITLE
linux-capture: Fix xcomposite null pointer derefence

### DIFF
--- a/libobs/util/dstr.h
+++ b/libobs/util/dstr.h
@@ -287,7 +287,9 @@ static inline const char *dstr_find(const struct dstr *str, const char *find)
 
 static inline int dstr_cmp(const struct dstr *str1, const char *str2)
 {
-	return strcmp(str1->array, str2);
+	const char *s1 = str1->array ? str1->array : "";
+	const char *s2 = str2 ? str2 : "";
+	return strcmp(s1, s2);
 }
 
 static inline int dstr_cmpi(const struct dstr *str1, const char *str2)

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -310,7 +310,7 @@ xcb_window_t xcomp_find_window(xcb_connection_t *conn, Display *disp, const char
 
 		struct dstr cwname = xcomp_window_name(conn, disp, cwin);
 		struct dstr cwcls = xcomp_window_class(conn, cwin);
-		bool found = strcmp(wname, cwname.array) == 0 && strcmp(wcls, cwcls.array) == 0;
+		bool found = dstr_cmp(&cwname, wname) == 0 && dstr_cmp(&cwcls, wcls) == 0;
 
 		dstr_free(&cwname);
 		dstr_free(&cwcls);


### PR DESCRIPTION
### Description

This fixes a null pointer dereference that can happen with `strcmp()` if the window class/name of a window being captured is null (which *can* happen and is *meant* to be handled, even if rare).

### Motivation and Context
Trying not to blow a blood vessel over yet another null pointer dereference in the code for this capture method. There are waay too many pointers being manipulated in this file.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.