### PR TITLE
frontend: Resize Output to Source Size using rounded up values

### DIFF
--- a/frontend/widgets/OBSBasic_OutputHandler.cpp
+++ b/frontend/widgets/OBSBasic_OutputHandler.cpp
@@ -76,6 +76,9 @@ void OBSBasic::ResizeOutputSizeOfSource()
 	int width = obs_source_get_width(source);
 	int height = obs_source_get_height(source);
 
+	width = ((width + 3) / 4) * 4;   // Round width up to the nearest multiple of 4
+	height = ((height + 1) / 2) * 2; // Round height up to the nearest multiple of 2
+
 	config_set_uint(activeConfiguration, "Video", "BaseCX", width);
 	config_set_uint(activeConfiguration, "Video", "BaseCY", height);
 	config_set_uint(activeConfiguration, "Video", "OutputCX", width);


### PR DESCRIPTION
### Description
Round resolution up to closest multiple of 4 for width, and 2 for height

### Motivation and Context
Fixes #11201 

Prevents odd numbered resolutions, and conforms to https://github.com/obsproject/obs-studio/commit/21ec81ebcc43e465160fcc880e4088c64d407a23

### How Has This Been Tested?
Win 10 22H2. Created a color source with `1111x1133` resolution, and rescaled. Observed resolution being set to `1112x1134`.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.