### PR TITLE
UI: Explicitly convert profile config path via u8path

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -303,6 +303,7 @@ void OBSBasic::RefreshProfileCache()
 
 	const std::filesystem::path profilesPath =
 		App()->userProfilesLocation / std::filesystem::u8path(OBSProfilePath.substr(1));
+	const std::filesystem::path profileSettingsFile = std::filesystem::u8path(OBSProfileSettingsFile);
 
 	if (!std::filesystem::exists(profilesPath)) {
 		blog(LOG_WARNING, "Failed to get profiles config path");
@@ -314,13 +315,11 @@ void OBSBasic::RefreshProfileCache()
 			continue;
 		}
 
-		std::string profileCandidate;
-		profileCandidate.reserve(entry.path().u8string().size() + OBSProfileSettingsFile.size() + 1);
-		profileCandidate.append(entry.path().u8string()).append("/").append(OBSProfileSettingsFile);
+		const auto profileCandidate = entry.path() / profileSettingsFile;
 
 		ConfigFile config;
 
-		if (config.Open(profileCandidate.c_str(), CONFIG_OPEN_EXISTING) != CONFIG_SUCCESS) {
+		if (config.Open(profileCandidate.u8string().c_str(), CONFIG_OPEN_EXISTING) != CONFIG_SUCCESS) {
 			continue;
 		}
 


### PR DESCRIPTION
### Description

Fixes implicit conversion from `std::string` to `std::filesystem::path`, which is incorrect on Windows due to lack of UTF-8 to UTF-16 conversion.

### Motivation and Context

Fixes #11363

### How Has This Been Tested?

Created a profile with one of the names provided by the reporter.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
