### PR TITLE
shared/opts-parser: Fix crash when no options were given to the parser

### DIFF
--- a/shared/opts-parser/opts-parser.c
+++ b/shared/opts-parser/opts-parser.c
@@ -34,6 +34,12 @@ struct obs_options obs_parse_options(const char *options_string)
 	size_t input_option_count = 0;
 	for (char **input_word = input_words; *input_word; ++input_word)
 		input_option_count += 1;
+
+	if (!input_option_count) {
+		strlist_free(input_words);
+		goto failure;
+	}
+
 	char **ignored_words = bmalloc(input_option_count * sizeof(*ignored_words));
 	char **ignored_word = ignored_words;
 	struct obs_option *out_options = bmalloc(input_option_count * sizeof(*out_options));


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

In `obs_parse_options`, ensure `input_option_count` is not zero so that `bmalloc` is not called with 0.
When `input_option_count` is zero, goto `failure` so that the behavior of `obs_parse_options(" ")` is same as `obs_parse_options("")`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When passing just a space to `obs_parse_options`, the number of input options becomes 0. In this case, `bmalloc` was called with size 0, and OBS crashed.

After the PR #11181, `bmalloc` will crash when the given size is 0.

I found this bug while I was looking at each `bmalloc` usage by `git grep` such as
```sh
git grep '\<b[mz]alloc\>.* \* '
```
by assuming the multiplication-operator is there if a variable is passed to `bmalloc`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

1. Configure to use x264 encoder and put ` ` (just a space) to the setting `x264opts`.
   (I think it could be a possible scenario that a user accidentally left a space after some trial and errors of changing x264 options.)
2. Start recording.

Without the PR, OBS crashed.
Log file: https://obsproject.com/logs/8IKjBanXd3531LF5

Side note: The log file does not say the reason why OBS crashed.

With the PR, OBS did not crash and started to record.
Log file: https://obsproject.com/logs/ejtG6QO9YZbj33x8

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
