### PR TITLE
CI: Fix rclone env var formatting in Windows Patches action

### DIFF
--- a/.github/actions/windows-patches/action.yaml
+++ b/.github/actions/windows-patches/action.yaml
@@ -74,7 +74,7 @@ runs:
       env:
         RCLONE_TRANSFERS: '100'
         RCLONE_FAST_LIST: 'true'
-        RCLONE_EXCLUDE: '{pdbs/**,**/${{ inputs.tagName }}/**}'
+        RCLONE_EXCLUDE: '"{pdbs/**,**/${{ inputs.tagName }}/**}"'
         RCLONE_S3_PROVIDER: 'GCS'
         RCLONE_S3_ACCESS_KEY_ID: '${{ inputs.gcsAccessKeyId }}'
         RCLONE_S3_SECRET_ACCESS_KEY: '${{ inputs.gcsAccessKeySecret }}'


### PR DESCRIPTION
### Description

Fixes patch download failing due to a change in how rclone parses command line variables. Anything containing a comma (`,`) now needs to be quoted.

### Motivation and Context

This appeared to be a regression but according to https://github.com/rclone/rclone/issues/8063#issuecomment-2344718575 this is a deliberate (breaking) change. Unfortunately not documented (e.g. in the changelog).

### How Has This Been Tested?

Ran rclone 1.68 locally with new format.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
