### PR TITLE
libobs: Add source profiler to public headers

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -371,6 +371,7 @@ set(
   util/simde/x86/mmx.h
   util/simde/x86/sse.h
   util/simde/x86/sse2.h
+  util/source-profiler.h
   util/sse-intrin.h
   util/task.h
   util/text-lookup.h


### PR DESCRIPTION
### Description
Add source profiler to public headers

### Motivation and Context
Want to use it in a plugin

### How Has This Been Tested?
-

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
