### PR TITLE
win-capture: Avoid NULL deref when capture not initialized

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -279,7 +279,9 @@ static inline void d3d10_copy_texture(ID3D10Resource *dst, ID3D10Resource *src)
 
 static inline void d3d10_shtex_capture(ID3D10Resource *backbuffer)
 {
-	d3d10_copy_texture(data.texture, backbuffer);
+	if (data.texture) {
+		d3d10_copy_texture(data.texture, backbuffer);
+	}
 }
 
 static void d3d10_shmem_capture_copy(int i)

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -247,7 +247,9 @@ static inline void d3d11_copy_texture(ID3D11Resource *dst, ID3D11Resource *src)
 
 static inline void d3d11_shtex_capture(ID3D11Resource *backbuffer)
 {
-	d3d11_copy_texture(data.texture, backbuffer);
+	if (data.texture) {
+		d3d11_copy_texture(data.texture, backbuffer);
+	}
 }
 
 static void d3d11_shmem_capture_copy(int i)

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -271,6 +271,10 @@ static inline void d3d12_copy_texture(ID3D11Resource *dst, ID3D11Resource *src)
 
 static inline void d3d12_shtex_capture(IDXGISwapChain *swap)
 {
+	if (!data.device11on12) {
+		return;
+	}
+
 	bool dxgi_1_4 = data.dxgi_1_4;
 	UINT cur_idx;
 

--- a/shared/obs-hook-config/graphics-hook-ver.h
+++ b/shared/obs-hook-config/graphics-hook-ver.h
@@ -13,7 +13,7 @@
 
 #define HOOK_VER_MAJOR 1
 #define HOOK_VER_MINOR 8
-#define HOOK_VER_PATCH 5
+#define HOOK_VER_PATCH 6
 
 #ifndef STRINGIFY
 #define STRINGIFY(s) #s


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add a check to avoid a NULL dereference on backbuffer capture in the D3D10, D3D11, and D3D12 capture modules in case d3d10_data, d3d11_data, or d3d12_data has not yet been successfully configured. This is similar to NULL checks in other places in these modules, such as the d3d10_free, d3d11_free, and d3d12_free functions. This change is intended to fix a specific issue with D3D12 capture we are seeing the wild, but for completeness we added NULL checks to the D3D10 and D3D11 capture modules.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We were seeing an intermittent crash in graphics-hook when using OBS Studio to capture the Midnight Murder Club demo (https://store.steampowered.com/app/2698870/Midnight_Murder_Club/) on some laptops with multiple GPUs. We tracked it down to a NULL dereference when capturing the backbuffer in the D3D12 capture module.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
We were able to a user who could reliably replicate the crash on an Intel i7-11800H laptop running Windows 11 with an NVIDIA GeForce RTX 3060 Laptop GPU and a built-in Intel UHD GPU. The repro steps were as follows:

- Start the MMC demo and progress the main menu.
- Create two scenes in OBS Studio. The first scene is a static image. The second scene is the game window capture.
- Rapidly toggle between the two scenes until a crash occurs.

After applying implementing the NULL check fix and testing against a locally built OBS Studio, we were unable to reproduce any issue.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
