### PR TITLE
UI/themes: Fix selectors in Yami Light

### DIFF
--- a/UI/data/themes/Yami_Light.ovt
+++ b/UI/data/themes/Yami_Light.ovt
@@ -186,13 +186,13 @@ QGroupBox::indicator:unchecked:disabled {
     image: url(theme:Light/checkbox_unchecked_disabled.svg);
 }
 
-QCheckBox[lockCheckBox=true]::indicator:checked,
-QCheckBox[lockCheckBox=true]::indicator:checked:hover {
+.indicator-lock::indicator:checked,
+.indicator-lock::indicator:checked:hover {
     image: url(theme:Light/locked.svg);
 }
 
-QCheckBox[visibilityCheckBox=true]::indicator:checked,
-QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
+.indicator-visibility::indicator:checked,
+.indicator-visibility::indicator:checked:hover {
     image: url(theme:Light/visible.svg);
 }
 
@@ -228,13 +228,13 @@ MuteCheckBox::indicator:unchecked:disabled {
     image: url(theme:Light/settings/audio.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:checked,
-QCheckBox[sourceTreeSubItem=true]::indicator:checked:hover {
+.indicator-expand::indicator:checked,
+.indicator-expand::indicator:checked:hover {
     image: url(theme:Light/expand.svg);
 }
 
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked,
-QCheckBox[sourceTreeSubItem=true]::indicator:unchecked:hover {
+.indicator-expand::indicator:unchecked,
+.indicator-expand::indicator:unchecked:hover {
     image: url(theme:Light/collapse.svg);
 }
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a few QSS selectors in Yami Light.

Amends cb026964b00c366943a3c16dfb1511eafc24c035 ([#11226](https://github.com/obsproject/obs-studio/pull/11226)).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Found when investigating an issue raised in the beta-testing on Discord.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Before/After:

<p>
<img width="283" alt="Bildschirmfoto 2024-10-09 um 19 33 18" src="https://github.com/user-attachments/assets/f411a125-0b0a-453b-8ac7-e5f6bf569025">
<img width="283" alt="Bildschirmfoto 2024-10-09 um 19 36 25" src="https://github.com/user-attachments/assets/c174f365-e2df-4259-ae07-2e2a55cbe880">
</p>

`git grep`'ed for `=true]` to make sure this type selector wasn't used anywhere else.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
