### PR TITLE
UI/themes: Consistently select indicator-mute instead of MuteCheckBox

### DIFF
--- a/UI/data/themes/System.obt
+++ b/UI/data/themes/System.obt
@@ -84,7 +84,7 @@
     qproperty-icon: url(:res/images/revert.svg);
 }
 
-MuteCheckBox {
+.indicator-mute {
     outline: none;
 }
 

--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -1413,7 +1413,7 @@ VolControl #volLabel {
     margin-right: var(--padding_xlarge);
 }
 
-#vMixerScrollArea VolControl MuteCheckBox {
+#vMixerScrollArea VolControl .indicator-mute {
     margin-left: var(--padding_xlarge);
 }
 
@@ -1624,7 +1624,7 @@ QGroupBox::indicator:unchecked:disabled {
 
 /* Mute CheckBox */
 
-MuteCheckBox {
+.indicator-mute {
     outline: none;
 }
 

--- a/UI/data/themes/Yami_Acri.ovt
+++ b/UI/data/themes/Yami_Acri.ovt
@@ -103,21 +103,21 @@ QToolButton:pressed:hover {
     border-color: var(--toolbutton_bg_down);
 }
 
-MuteCheckBox::indicator,
-MuteCheckBox::indicator:unchecked,
-MuteCheckBox::indicator:focus {
+.indicator-mute::indicator,
+.indicator-mute::indicator:unchecked,
+.indicator-mute::indicator:focus {
     background-color: var(--toolbutton_bg);
     border: 1px solid var(--toolbutton_bg);
 }
 
-MuteCheckBox::indicator:hover,
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:hover,
+.indicator-mute::indicator:unchecked:hover {
     background-color: var(--toolbutton_bg_hover);
     border: 1px solid var(--toolbutton_bg_hover);
 }
 
-MuteCheckBox::indicator:pressed,
-MuteCheckBox::indicator:pressed:hover {
+.indicator-mute::indicator:pressed,
+.indicator-mute::indicator:pressed:hover {
     background-color: var(--toolbutton_bg_down);
     border-color: var(--toolbutton_bg_down);
 }

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -270,8 +270,8 @@ QPushButton[toolButton="true"] {
   font-size: var(--font_base);
 }
 
-MuteCheckBox::indicator,
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator,
+.indicator-mute::indicator:unchecked {
     background-color: var(--bg_base);
     border: none;
     width: var(--icon_base_mixer);
@@ -279,17 +279,17 @@ MuteCheckBox::indicator:unchecked {
     icon-size: var(--icon_base_mixer);
 }
 
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     background-color: var(--bg_base);
 }
 
-MuteCheckBox::indicator:checked:hover,
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:checked:hover,
+.indicator-mute::indicator:unchecked:hover {
     background-color: var(--bg_base);
 }
 
-MuteCheckBox::indicator:hover,
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:hover,
+.indicator-mute::indicator:unchecked:hover {
     icon-size: var(--icon_base_mixer);
     border: none;
 }

--- a/UI/data/themes/Yami_Light.ovt
+++ b/UI/data/themes/Yami_Light.ovt
@@ -196,35 +196,35 @@ QCheckBox[visibilityCheckBox=true]::indicator:checked:hover {
     image: url(theme:Light/visible.svg);
 }
 
-MuteCheckBox::indicator:checked {
+.indicator-mute::indicator:checked {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked {
+.indicator-mute::indicator:unchecked {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:unchecked:hover {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:unchecked:focus {
+.indicator-mute::indicator:unchecked:focus {
     image: url(theme:Light/settings/audio.svg);
 }
 
-MuteCheckBox::indicator:checked:hover {
+.indicator-mute::indicator:checked:hover {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:focus {
+.indicator-mute::indicator:checked:focus {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:checked:disabled {
+.indicator-mute::indicator:checked:disabled {
     image: url(theme:Light/mute.svg);
 }
 
-MuteCheckBox::indicator:unchecked:disabled {
+.indicator-mute::indicator:unchecked:disabled {
     image: url(theme:Light/settings/audio.svg);
 }
 

--- a/UI/data/themes/Yami_Rachni.ovt
+++ b/UI/data/themes/Yami_Rachni.ovt
@@ -141,21 +141,21 @@ QToolButton:pressed:hover {
     border-color: var(--toolbutton_bg_down);
 }
 
-MuteCheckBox::indicator,
-MuteCheckBox::indicator:unchecked,
-MuteCheckBox::indicator:focus {
+.indicator-mute::indicator,
+.indicator-mute::indicator:unchecked,
+.indicator-mute::indicator:focus {
     background-color: var(--toolbutton_bg);
     border: 1px solid var(--toolbutton_bg);
 }
 
-MuteCheckBox::indicator:hover,
-MuteCheckBox::indicator:unchecked:hover {
+.indicator-mute::indicator:hover,
+.indicator-mute::indicator:unchecked:hover {
     background-color: var(--toolbutton_bg_hover);
     border: 1px solid var(--toolbutton_bg_hover);
 }
 
-MuteCheckBox::indicator:pressed,
-MuteCheckBox::indicator:pressed:hover {
+.indicator-mute::indicator:pressed,
+.indicator-mute::indicator:pressed:hover {
     background-color: var(--toolbutton_bg_down);
     border-color: var(--toolbutton_bg_down);
 }


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
cb026964b00c366943a3c16dfb1511eafc24c035 changed most instances of MuteCheckBox as a selector for the button that mutes/unmutes a source in the mixer to indicator-mute, but left a few instances of the old selector, especially in variant themes while the base theme got changed. This lead to competing selections where apparently indicator-mute won which meant that the variant themes wouldn't override the base. Changing all instances of MuteCheckBox to to indicator-mute fixes this and hopefully prevents future uses of MuteCheckBox as a selector anywhere.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed when working on https://github.com/obsproject/obs-studio/pull/11376.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Before/After for light theme:

<p>
<img width="254" alt="Bildschirmfoto 2024-10-09 um 19 36 45" src="https://github.com/user-attachments/assets/4c422b88-b916-4f9d-8667-31e0f368737b">
<img width="254" alt="Bildschirmfoto 2024-10-09 um 20 04 14" src="https://github.com/user-attachments/assets/ba38f262-7036-4d6c-85f5-a2ca1e7b38e2">
</p>

Also checked that in e.g. Rachni, the color when the button is being pressed is now dim-rachni-red instead of Yami-gray.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
