### PR TITLE
UI: Fix crash and UX issues with updated profile and scene collection management

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -677,8 +677,6 @@ bool OBSApp::InitGlobalConfig()
 
 bool OBSApp::InitUserConfig(std::filesystem::path &userConfigLocation, uint32_t lastVersion)
 {
-	bool hasChanges = false;
-
 	const std::string userConfigFile = userConfigLocation.u8string() + "/obs-studio/user.ini";
 
 	int errorCode = userConfig.Open(userConfigFile.c_str(), CONFIG_OPEN_ALWAYS);
@@ -688,45 +686,13 @@ bool OBSApp::InitUserConfig(std::filesystem::path &userConfigLocation, uint32_t 
 		return false;
 	}
 
-	hasChanges = MigrateLegacySettings(lastVersion);
-
-	if (!opt_starting_collection.empty()) {
-		const OBSBasic *basic = reinterpret_cast<OBSBasic *>(GetMainWindow());
-		const std::optional<OBSSceneCollection> foundCollection =
-			basic->GetSceneCollectionByName(opt_starting_collection);
-
-		if (foundCollection) {
-			config_set_string(userConfig, "Basic", "SceneCollection", foundCollection.value().name.c_str());
-			config_set_string(userConfig, "Basic", "SceneCollectionFile",
-					  foundCollection.value().fileName.c_str());
-			hasChanges = true;
-		}
-	}
-
-	if (!opt_starting_profile.empty()) {
-		const OBSBasic *basic = reinterpret_cast<OBSBasic *>(GetMainWindow());
-
-		const std::optional<OBSProfile> foundProfile = basic->GetProfileByName(opt_starting_profile);
-
-		if (foundProfile) {
-			config_set_string(userConfig, "Basic", "Profile", foundProfile.value().name.c_str());
-			config_set_string(userConfig, "Basic", "ProfileDir",
-					  foundProfile.value().directoryName.c_str());
-
-			hasChanges = true;
-		}
-	}
-
-	if (hasChanges) {
-		config_save_safe(userConfig, "tmp", nullptr);
-	}
-
+	MigrateLegacySettings(lastVersion);
 	InitUserConfigDefaults();
 
 	return true;
 }
 
-bool OBSApp::MigrateLegacySettings(const uint32_t lastVersion)
+void OBSApp::MigrateLegacySettings(const uint32_t lastVersion)
 {
 	bool hasChanges = false;
 
@@ -766,7 +732,9 @@ bool OBSApp::MigrateLegacySettings(const uint32_t lastVersion)
 		hasChanges = true;
 	}
 
-	return hasChanges;
+	if (hasChanges) {
+		userConfig.SaveSafe("tmp");
+	}
 }
 
 static constexpr string_view OBSGlobalIniPath = "/obs-studio/global.ini";

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -113,7 +113,7 @@ private:
 	bool InitGlobalLocationDefaults();
 
 	bool MigrateGlobalSettings();
-	bool MigrateLegacySettings(uint32_t lastVersion);
+	void MigrateLegacySettings(uint32_t lastVersion);
 
 	bool InitUserConfig(std::filesystem::path &userConfigLocation, uint32_t lastVersion);
 	void InitUserConfigDefaults();

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -498,7 +498,7 @@ void OBSBasic::on_actionRemoveProfile_triggered(bool skipConfirmation)
 		blog(LOG_ERROR, "%s", error.what());
 	}
 
-	const OBSProfile &newProfile = profiles.rbegin()->second;
+	const OBSProfile &newProfile = profiles.begin()->second;
 
 	ActivateProfile(newProfile, true);
 	RemoveProfile(currentProfile);

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -507,7 +507,7 @@ void OBSBasic::on_actionRemoveSceneCollection_triggered(bool skipConfirmation)
 		blog(LOG_ERROR, "%s", error.what());
 	}
 
-	const OBSSceneCollection &newCollection = collections.rbegin()->second;
+	const OBSSceneCollection &newCollection = collections.begin()->second;
 
 	ActivateSceneCollection(newCollection);
 	RemoveSceneCollection(currentCollection);

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -165,12 +165,8 @@ const OBSSceneCollection &OBSBasic::CreateSceneCollection(const std::string &col
 
 void OBSBasic::RemoveSceneCollection(OBSSceneCollection collection)
 {
-	std::filesystem::path collectionBackupFile{collection.collectionFile};
-	collectionBackupFile.replace_extension("json.bak");
-
 	try {
 		std::filesystem::remove(collection.collectionFile);
-		std::filesystem::remove(collectionBackupFile);
 	} catch (const std::filesystem::filesystem_error &error) {
 		blog(LOG_DEBUG, "%s", error.what());
 		throw std::logic_error("Failed to remove scene collection file: " + collection.fileName);


### PR DESCRIPTION
### Description
Fixes several issues introduced by the updated profile and scene collection management:

* After deleting a scene collection or profile, the last remaining item is automatically activated instead of the first item (regression)
* After deleting a scene collection, its associated backup copy is also deleted (regression)
* Launching OBS with a `--profile` or `--collection` command line argument crashes the app (bug)

### Motivation and Context
First two bugs were oversights during development of the update, last one has an architectural reason: As profile and scene collections are now managed by `OBSBasic` (and not by code directly interfacing with the file system), an instance of the class needs to exist to do so.

The command line arguments were handled at an early point on `OBSApp`'s initialisation, at which point `OBSBasic` did not exist yet.

Moving the handling of each respective command line parameter into the parts of `OBSBasic` that take care of loading the initial profile or scene collection thus not only fixes the bug, but is also more elegant from an architectural point of view.

### How Has This Been Tested?
Tested on macOS 15 with provided scene collection and profile names for:

* Non-existing profile
* Non-existing scene collection
* Existing scene collection
* Existing profile _with_ associated service connection
* Existing profile _without_ associated service connection

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
