### PR TITLE
UI: Set minimum version for nlohmann_json to 3.11

### DIFF
--- a/UI/cmake/feature-macos-update.cmake
+++ b/UI/cmake/feature-macos-update.cmake
@@ -1,6 +1,6 @@
 include_guard(DIRECTORY)
 
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json 3.11 REQUIRED)
 
 if(NOT TARGET OBS::blake2)
   add_subdirectory("${CMAKE_SOURCE_DIR}/deps/blake2" "${CMAKE_BINARY_DIR}/deps/blake2")

--- a/UI/cmake/feature-whatsnew.cmake
+++ b/UI/cmake/feature-whatsnew.cmake
@@ -9,7 +9,7 @@ if(ENABLE_WHATSNEW AND TARGET OBS::browser-panels)
     set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
     find_package(MbedTLS REQUIRED)
     set(CMAKE_FIND_PACKAGE_PREFER_CONFIG FALSE)
-    find_package(nlohmann_json REQUIRED)
+    find_package(nlohmann_json 3.11 REQUIRED)
 
     if(NOT TARGET OBS::blake2)
       add_subdirectory("${CMAKE_SOURCE_DIR}/deps/blake2" "${CMAKE_BINARY_DIR}/deps/blake2")

--- a/UI/cmake/os-windows.cmake
+++ b/UI/cmake/os-windows.cmake
@@ -10,7 +10,7 @@ set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
 find_package(MbedTLS REQUIRED)
 set(CMAKE_FIND_PACKAGE_PREFER_CONFIG FALSE)
 find_package(Detours REQUIRED)
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json 3.11 REQUIRED)
 
 configure_file(cmake/windows/obs.rc.in obs.rc)
 

--- a/UI/win-update/updater/CMakeLists.txt
+++ b/UI/win-update/updater/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.28...3.30)
 
 find_package(zstd)
-find_package(nlohmann_json 3 REQUIRED)
+find_package(nlohmann_json 3.11 REQUIRED)
 
 add_executable(updater WIN32)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

We know this is the minimum version that we require, so we can just fail during configure if somehow an older version is found.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

See:
* https://github.com/obsproject/obs-browser/pull/452

Although we no longer support Ubuntu 22.04 for building or running OBS Studio, we can make the dependency requirement here more obvious at configure time.

Either "UI: " or "cmake: " seemed like acceptable commit prefixes, but I went with UI for now.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on Windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
