### PR TITLE
cmake: Use NOMINMAX on Windows

### DIFF
--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -78,6 +78,7 @@ add_compile_options(
 )
 
 add_compile_definitions(
+  NOMINMAX
   UNICODE
   _UNICODE
   _CRT_SECURE_NO_WARNINGS

--- a/deps/libdshowcapture/CMakeLists.txt
+++ b/deps/libdshowcapture/CMakeLists.txt
@@ -40,4 +40,4 @@ target_include_directories(
                             "${CMAKE_CURRENT_SOURCE_DIR}/src/external/capture-device-support/Library")
 
 target_compile_definitions(libdshowcapture INTERFACE _UP_WINDOWS=1)
-target_compile_options(libdshowcapture INTERFACE /wd4018)
+target_compile_options(libdshowcapture INTERFACE /wd4005 /wd4018)

--- a/frontend/updater/CMakeLists.txt
+++ b/frontend/updater/CMakeLists.txt
@@ -22,7 +22,7 @@ target_sources(
     updater.rc
 )
 
-target_compile_definitions(updater PRIVATE NOMINMAX "PSAPI_VERSION=2")
+target_compile_definitions(updater PRIVATE "PSAPI_VERSION=2")
 
 target_include_directories(updater PRIVATE "${CMAKE_SOURCE_DIR}/libobs" "${CMAKE_SOURCE_DIR}/frontend/utility")
 

--- a/frontend/utility/MultitrackVideoOutput.hpp
+++ b/frontend/utility/MultitrackVideoOutput.hpp
@@ -9,8 +9,6 @@
 #include <string>
 #include <vector>
 
-#define NOMINMAX
-
 class QString;
 class QWidget;
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -15,6 +15,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ******************************************************************************/
 
+#include <algorithm>
 #include <cassert>
 #include <cinttypes>
 #include <optional>
@@ -229,7 +230,7 @@ gs_swap_chain::gs_swap_chain(gs_device *device, const gs_init_data *data)
 
 	ComQIPtr<IDXGIFactory5> factory5 = device->factory;
 	if (factory5) {
-		initData.num_backbuffers = max(data->num_backbuffers, 2);
+		initData.num_backbuffers = std::max(data->num_backbuffers, (uint32_t)2);
 
 		effect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		flags |= DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;

--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -56,12 +56,12 @@ static bool get_client_box(HWND window, uint32_t width, uint32_t height, D3D11_B
 
 		uint32_t texture_width = 1;
 		if (width > left) {
-			texture_width = min(width - left, (uint32_t)client_rect.right);
+			texture_width = std::min(width - left, (uint32_t)client_rect.right);
 		}
 
 		uint32_t texture_height = 1;
 		if (height > top) {
-			texture_height = min(height - top, (uint32_t)client_rect.bottom);
+			texture_height = std::min(height - top, (uint32_t)client_rect.bottom);
 		}
 
 		client_box->right = left + texture_width;

--- a/plugins/decklink/CMakeLists.txt
+++ b/plugins/decklink/CMakeLists.txt
@@ -72,8 +72,6 @@ target_sources(
     util.hpp
 )
 
-target_compile_definitions(decklink PRIVATE $<$<PLATFORM_ID:Windows>:NOMINMAX>)
-
 target_link_libraries(
   decklink
   PRIVATE

--- a/plugins/obs-vst/headers/EditorWidget.h
+++ b/plugins/obs-vst/headers/EditorWidget.h
@@ -22,7 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QWidget>
 
 #if defined(_WIN32)
-#define NOMINMAX
 #include <QWindow>
 #include <Windows.h>
 #elif defined(__linux__)

--- a/plugins/win-dshow/cmake/libdshowcapture.cmake
+++ b/plugins/win-dshow/cmake/libdshowcapture.cmake
@@ -45,7 +45,7 @@ target_include_directories(
 )
 
 target_compile_definitions(libdshowcapture INTERFACE _UP_WINDOWS=1)
-target_compile_options(libdshowcapture INTERFACE /wd4018)
+target_compile_options(libdshowcapture INTERFACE /wd4005 /wd4018)
 
 get_target_property(target_sources libdshowcapture INTERFACE_SOURCES)
 set(target_headers ${target_sources})


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR makes a few changes.
1. Explicitly use std::min
2. Explicitly use std::max
3. Set `NOMINMAX` as a default compile definition on Windows to prevent defining min/max macros

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want to just use STL std::min/std::max and avoid shenanigans with min/max macros.

See also:
* https://github.com/obsproject/obs-studio/pull/10997

Also needs:
* https://github.com/elgatosf/capture-device-support/pull/6

Can remove the `/wd4005` additions later when other changes land in the Elgato submodule to properly guard NOMINMAX.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built locally on Windows 11. Still needs built with VS for/on WoA to make sure it works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
