### PR TITLE
CI: Bump FreeBSD image to 14.1

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 freebsd_instance:
-  image: freebsd-13-2-release-amd64
+  image: freebsd-14-1-release-amd64-ufs
 
 env:
   CIRRUS_CLONE_DEPTH: 1


### PR DESCRIPTION
### Description
Switch to FreeBSD 14.1 as the most recent production version.

### Motivation and Context
FreeBSD 13.2 is now past EOL.

### How Has This Been Tested?
Local Cirrus-CI run here: https://cirrus-ci.com/build/4952213842296832

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
