### PR TITLE
UI: Fix initialization bug when launching without existing profile

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1889,7 +1889,8 @@ bool OBSBasic::InitBasicConfig()
 		} else if (currentProfile) {
 			ActivateProfile(currentProfile.value());
 		} else {
-			SetupNewProfile(currentProfileName);
+			const OBSProfile &newProfile = CreateProfile(currentProfileName);
+			ActivateProfile(newProfile);
 		}
 	} catch (const std::logic_error &) {
 		OBSErrorBox(NULL, "Failed to open basic.ini: %d", -1);


### PR DESCRIPTION
### Description
Change the way a new profile is initialised during OBS initialization to a void mistakenly resetting services that have not been added to program state yet.

### Motivation and Context
SetupNewProfile is used to create new profiles when OBS is already running, which requires resetting program state for the new profile.

This function cannot be used to create a new profile as a fallback for either a non-existing profile or for a fresh installation of OBS Studio because by the point this is called from `OBSBasic::OBSInit`, the runtime modules are not loaded yet and as such no services exist.

Activating the new profile without a profile reset fixes this issue as the reset will be done explicitly by `OBSBasic::OBSInit` later.


### How Has This Been Tested?
Tested by launching OBS Studio without an existing settings directory on macOS 15.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
