### PR TITLE
UI: Catch error from copy in MigrateGlobalSettings

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -768,7 +768,12 @@ bool OBSApp::MigrateGlobalSettings()
 		return false;
 	}
 
-	std::filesystem::copy(legacyGlobalConfigFile, userConfigFile);
+	try {
+		std::filesystem::copy(legacyGlobalConfigFile, userConfigFile);
+	} catch (const std::filesystem::filesystem_error &) {
+		OBSErrorBox(nullptr, "Unable to migrate global configuration - copy failed.");
+		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
### Description
Add try/catch around std::filesystem::copy in OBSApp::MigrateGlobalSettings

### Motivation and Context
During development on FreeBSD I encountered an uncaught exception abort from the copy in MigrateGlobalSettings.  Catch the error and print a decent user-facing error instead:

```
error: Unable to migrate global configuration - copy failed.
filesystem error: in copy: No such file or directory ["/home/user/obs-studio/global.ini"] ["/home/user/obs-studio/user.ini"]
```

### How Has This Been Tested?
Tested on FreeBSD 15 on my machine.

I haven't yet figured out the underlying issue (why the path that failed is .../obs-studio/ not .../.obs-studio/) but we should be defensive here.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
