### PR TITLE
decklink: Fix frequent audio dropouts on output

### DIFF
--- a/plugins/decklink/decklink-device-instance.cpp
+++ b/plugins/decklink/decklink-device-instance.cpp
@@ -543,7 +543,7 @@ bool DeckLinkDeviceInstance::StartOutput(DeckLinkDeviceMode *mode_)
 	}
 
 	const HRESULT audioResult = output_->EnableAudioOutput(bmdAudioSampleRate48kHz, bmdAudioSampleType16bitInteger,
-							       2, bmdAudioOutputStreamTimestamped);
+							       2, bmdAudioOutputStreamContinuous);
 	if (audioResult != S_OK) {
 		LOG(LOG_ERROR, "Failed to enable audio output");
 		return false;
@@ -678,7 +678,7 @@ void DeckLinkDeviceInstance::ScheduleVideoFrame(IDeckLinkVideoFrame *frame)
 void DeckLinkDeviceInstance::WriteAudio(audio_data *frames)
 {
 	uint32_t sampleFramesWritten;
-	output->WriteAudioSamplesSync(frames->data[0], frames->frames, &sampleFramesWritten);
+	output->ScheduleAudioSamples(frames->data[0], frames->frames, 0, 0, &sampleFramesWritten);
 }
 
 #define TIME_BASE 1000000000


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Instead of WriteAudioSync() and bmdAudioOutputStreamTimestamped, use ScheduleAudioSamples and bmdAudioOutputStreamContinuous. This fixes audio distortion caused by very frequent, short drop-outs.

I believe this fixes #10731. It certainly fixes the issue I describe there, but I am not 100% sure it is the same issue the submitter has.

### Motivation and Context
As per BMD's documentation: 

> The WriteAudioSamplesSync method is used to play audio sample frames immediately. Audio output
must be configured with EnableAudioOutput. **WriteAudioSamplesSync should not be called during
scheduled playback.**

(https://documents.blackmagicdesign.com/UserManuals/DeckLinkSDKManual.pdf section 2.5.3.17)

However, OBS does use scheduled playback (decklink-device-instance.cpp:615) to output video. In this case, ScheduleAudioSamples should be used instead. So far as I can tell, when used with bmdAudioOutputStreamContinuous and setting the parameters streamTime and timeScale to 0, this should be functionally and semantically equivalent to using WriteAudioSamplesSync (section 2.5.3.20).

### How Has This Been Tested?
On a system (Win10 with Decklink Duo 2) that had the distorted audio problem reproducibly within 2 minutes, I have run the output at 60Hz for several hours without the issue popping up. I also tested every other supported frame rate, albeit for a shorter amount of time, and tested with two outputs active.

Edit: using the CI build I have tested this on macOS Sonoma with an Ultrastudio Monitor 3G as well.

(Note that the Decklink plugin is currently entirely broken on Windows because of some string conversion problem in DeckLinkStringToStdString).


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x]  I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
