### PR TITLE
obs-outputs: Add cast to fix build with Clang 19

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -626,7 +626,7 @@ void flv_packet_metadata(enum video_id_t codec_id, uint8_t **output, size_t *siz
 	 * The default trackId is 0.
 	 */
 	if (is_multitrack) {
-		s_w8(&s, MULTITRACKTYPE_ONE_TRACK | PACKETTYPE_METADATA);
+		s_w8(&s, (uint8_t)MULTITRACKTYPE_ONE_TRACK | (uint8_t)PACKETTYPE_METADATA);
 		s_w4cc(&s, codec_id);
 		// trackId
 		s_w8(&s, (uint8_t)idx);


### PR DESCRIPTION
### Description

Add casts in flv-mux.c to fix build with latest Clang. Obtained from https://github.com/freebsd/freebsd-ports/commit/f0e9df3448bd5a567b9447dc711d0a5f0341a327.

### Motivation and Context

Clang 19 has become more strict about mixing different enum types, which resulted in an error building multimedia/obs-studio on FreeBSD:

/wrkdirs/usr/ports/multimedia/obs-studio/work/obs-studio-30.2.3/plugins/obs-outputs/flv-mux.c:659:37: error: bitwise operation between different enumeration types ('enum multitrack_type_t' and 'enum packet_type_t') [-Werror,-Wenum-enum-conversion]

### How Has This Been Tested?
Build tested on FreeBSD

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
