### PR TITLE
CONTRIBUTING.rst: Update Coding Guidelines for 120 column limit

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -54,7 +54,7 @@ Coding Guidelines
 - Tabs for indentation, spaces for alignment.  Tabs are treated as 8
   columns wide.
 
-- 80 columns max
+- 120 columns max
 
 - Comments and names of variables/functions/etc. must be in English
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Reflect apparent change to use 120 column lines in the Coding Guidelines in CONTRIBUTING.rst

### Motivation and Context
Commit a1fbf1015f40 updated .clang-format and existing code for 120 columns, so change Coding Guidelines to match.

(I recently had a change to submit, and manually wrapped it at 80 columns. I was surprised to find clang-format unwrapping it to put it on one line.)

### How Has This Been Tested?
n/a

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
