### PR TITLE
linux-pipewire: Fix memory leaks

### DIFF
--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -221,6 +221,7 @@ static void camera_device_free(struct camera_device *device)
 
 	clear_params(&device->pending_list, SPA_ID_INVALID);
 	clear_params(&device->param_list, SPA_ID_INVALID);
+	g_clear_pointer(&device->info, pw_node_info_free);
 	g_clear_pointer(&device->proxy, pw_proxy_destroy);
 	g_clear_pointer(&device->properties, pw_properties_free);
 	bfree(device);

--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -173,6 +173,11 @@ static void teardown_pipewire(obs_pipewire *obs_pw)
 		pw_thread_loop_stop(obs_pw->thread_loop);
 	}
 
+	if (obs_pw->registry) {
+		pw_proxy_destroy((struct pw_proxy *)obs_pw->registry);
+		obs_pw->registry = NULL;
+	}
+
 	g_clear_pointer(&obs_pw->context, pw_context_destroy);
 	g_clear_pointer(&obs_pw->thread_loop, pw_thread_loop_destroy);
 


### PR DESCRIPTION
### Description
Fixes memory leaks in the linux-pipewire plugin.
1. `pw_node_info`s copied [here](https://github.com/obsproject/obs-studio/blob/edd7a387a4f278e004a5a40b1dc72916cc061421/plugins/linux-pipewire/camera-portal.c#L847) were never freed
2. `pw_registry` proxy created [here](https://github.com/obsproject/obs-studio/blob/edd7a387a4f278e004a5a40b1dc72916cc061421/plugins/linux-pipewire/pipewire.c#L1028) was never freed

### Motivation and Context
Memory leaks are bad.

### How Has This Been Tested?
Tried camera capture, unplugged and plugged in a camera several times, tried screen capturing, destroyed the sources. Everything works.
LeakSanitizer does not report the leaks anymore.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
