### PR TITLE
UI: Update toolButton styling property to use class

### DIFF
--- a/UI/forms/OBSBasic.ui
+++ b/UI/forms/OBSBasic.ui
@@ -1415,10 +1415,7 @@
              <bool>false</bool>
             </property>
             <property name="class" stdset="0">
-             <string notr="true">icon-plus</string>
-            </property>
-            <property name="toolButton" stdset="0">
-             <bool>true</bool>
+             <string notr="true">btn-tool icon-plus</string>
             </property>
            </widget>
           </item>
@@ -1447,10 +1444,7 @@
              <bool>false</bool>
             </property>
             <property name="class" stdset="0">
-             <string notr="true">icon-trash</string>
-            </property>
-            <property name="toolButton" stdset="0">
-             <bool>true</bool>
+             <string notr="true">btn-tool icon-trash</string>
             </property>
            </widget>
           </item>
@@ -1479,10 +1473,7 @@
              <bool>false</bool>
             </property>
             <property name="class" stdset="0">
-             <string notr="true">icon-dots-vert</string>
-            </property>
-            <property name="toolButton" stdset="0">
-             <string notr="true">true</string>
+             <string notr="true">btn-tool icon-dots-vert</string>
             </property>
            </widget>
           </item>

--- a/UI/forms/OBSBasicFilters.ui
+++ b/UI/forms/OBSBasicFilters.ui
@@ -126,10 +126,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-plus</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-plus</string>
                </property>
               </widget>
              </item>
@@ -158,10 +155,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-trash</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-trash</string>
                </property>
               </widget>
              </item>
@@ -190,10 +184,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-up</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-up</string>
                </property>
               </widget>
              </item>
@@ -222,10 +213,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-down</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-down</string>
                </property>
               </widget>
              </item>
@@ -360,10 +348,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-plus</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-plus</string>
                </property>
               </widget>
              </item>
@@ -392,10 +377,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-trash</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-trash</string>
                </property>
               </widget>
              </item>
@@ -424,10 +406,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-up</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-up</string>
                </property>
               </widget>
              </item>
@@ -456,10 +435,7 @@
                 <bool>true</bool>
                </property>
                <property name="class" stdset="0">
-                <string>icon-down</string>
-               </property>
-               <property name="toolButton" stdset="0">
-                <bool>true</bool>
+                <string notr="true">btn-tool icon-down</string>
                </property>
               </widget>
              </item>

--- a/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
@@ -77,10 +77,7 @@
         <bool>true</bool>
        </property>
        <property name="class" stdset="0">
-        <string notr="true">icon-plus</string>
-       </property>
-       <property name="toolButton" stdset="0">
-        <bool>true</bool>
+        <string notr="true">btn-tool icon-plus</string>
        </property>
       </widget>
      </item>
@@ -96,10 +93,7 @@
         <bool>true</bool>
        </property>
        <property name="class" stdset="0">
-        <string notr="true">icon-trash</string>
-       </property>
-       <property name="toolButton" stdset="0">
-        <bool>true</bool>
+        <string notr="true">btn-tool icon-trash</string>
        </property>
       </widget>
      </item>

--- a/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/auto-scene-switcher.ui
@@ -77,7 +77,7 @@
         <bool>true</bool>
        </property>
        <property name="class" stdset="0">
-        <string notr="true">btn-tool icon-plus</string>
+        <string notr="true">icon-plus</string>
        </property>
       </widget>
      </item>
@@ -93,7 +93,7 @@
         <bool>true</bool>
        </property>
        <property name="class" stdset="0">
-        <string notr="true">btn-tool icon-trash</string>
+        <string notr="true">icon-trash</string>
        </property>
       </widget>
      </item>

--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -84,10 +84,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">icon-plus</string>
-             </property>
-             <property name="toolButton" stdset="0">
-              <bool>true</bool>
+              <string notr="true">btn-tool icon-plus</string>
              </property>
             </widget>
            </item>
@@ -118,10 +115,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">icon-trash</string>
-             </property>
-             <property name="toolButton" stdset="0">
-              <bool>true</bool>
+              <string notr="true">btn-tool icon-trash</string>
              </property>
             </widget>
            </item>
@@ -152,10 +146,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">icon-refresh</string>
-             </property>
-             <property name="toolButton" stdset="0">
-              <bool>true</bool>
+              <string notr="true">btn-tool icon-refresh</string>
              </property>
             </widget>
            </item>

--- a/UI/frontend-plugins/frontend-tools/forms/scripts.ui
+++ b/UI/frontend-plugins/frontend-tools/forms/scripts.ui
@@ -84,7 +84,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">btn-tool icon-plus</string>
+              <string notr="true">icon-plus</string>
              </property>
             </widget>
            </item>
@@ -115,7 +115,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">btn-tool icon-trash</string>
+              <string notr="true">icon-trash</string>
              </property>
             </widget>
            </item>
@@ -146,7 +146,7 @@
               <bool>true</bool>
              </property>
              <property name="class" stdset="0">
-              <string notr="true">btn-tool icon-refresh</string>
+              <string notr="true">icon-refresh</string>
              </property>
             </widget>
            </item>

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -691,9 +691,8 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 static void NewButton(QLayout *layout, WidgetInfo *info, const char *themeIcon, void (WidgetInfo::*method)())
 {
 	QPushButton *button = new QPushButton();
-	button->setProperty("class", themeIcon);
+	button->setProperty("class", "btn-tool " + QString(themeIcon));
 	button->setFlat(true);
-	button->setProperty("toolButton", true);
 
 	QObject::connect(button, &QPushButton::clicked, info, method);
 


### PR DESCRIPTION
### Description
#11226 updated widgets to use the special `class` custom property on widgets for their QSS styling. These instances of the `toolButton` property were missed.

This also removes the toolButton styling from the Scripts and Advanced Scene Switcher window in a separate commit as they are more appropriate without it.

### Motivation and Context
Fix up missed issues for consistency.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
