### PR TITLE
Use XDG config paths on FreeBSD

### DIFF
--- a/UI/cmake/os-linux.cmake
+++ b/UI/cmake/os-linux.cmake
@@ -1,7 +1,7 @@
 target_sources(obs-studio PRIVATE platform-x11.cpp)
 target_compile_definitions(
   obs-studio
-  PRIVATE USE_XDG OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}" $<$<BOOL:${ENABLE_PORTABLE_CONFIG}>:ENABLE_PORTABLE_CONFIG>
+  PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}" $<$<BOOL:${ENABLE_PORTABLE_CONFIG}>:ENABLE_PORTABLE_CONFIG>
 )
 target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus)
 

--- a/libobs/cmake/os-linux.cmake
+++ b/libobs/cmake/os-linux.cmake
@@ -20,7 +20,6 @@ target_sources(
 target_compile_definitions(
   libobs
   PRIVATE
-    USE_XDG
     OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}"
     $<$<COMPILE_LANG_AND_ID:C,GNU>:ENABLE_DARRAY_TYPE_TEST>
     $<$<COMPILE_LANG_AND_ID:CXX,GNU>:ENABLE_DARRAY_TYPE_TEST>

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -271,11 +271,9 @@ uint64_t os_gettime_ns(void)
 	return ((uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec);
 }
 
-/* should return $HOME/.[name], or when using XDG,
- * should return $HOME/.config/[name] as default */
+/* should return $HOME/.config/[name] as default */
 int os_get_config_path(char *dst, size_t size, const char *name)
 {
-#ifdef USE_XDG
 	char *xdg_ptr = getenv("XDG_CONFIG_HOME");
 
 	// If XDG_CONFIG_HOME is unset,
@@ -296,23 +294,11 @@ int os_get_config_path(char *dst, size_t size, const char *name)
 		else
 			return snprintf(dst, size, "%s/%s", xdg_ptr, name);
 	}
-#else
-	char *path_ptr = getenv("HOME");
-	if (path_ptr == NULL)
-		bcrash("Could not get $HOME\n");
-
-	if (!name || !*name)
-		return snprintf(dst, size, "%s", path_ptr);
-	else
-		return snprintf(dst, size, "%s/.%s", path_ptr, name);
-#endif
 }
 
-/* should return $HOME/.[name], or when using XDG,
- * should return $HOME/.config/[name] as default */
+/* should return $HOME/.config/[name] as default */
 char *os_get_config_path_ptr(const char *name)
 {
-#ifdef USE_XDG
 	struct dstr path;
 	char *xdg_ptr = getenv("XDG_CONFIG_HOME");
 
@@ -332,17 +318,6 @@ char *os_get_config_path_ptr(const char *name)
 		dstr_cat(&path, name);
 	}
 	return path.array;
-#else
-	char *path_ptr = getenv("HOME");
-	if (path_ptr == NULL)
-		bcrash("Could not get $HOME\n");
-
-	struct dstr path;
-	dstr_init_copy(&path, path_ptr);
-	dstr_cat(&path, "/.");
-	dstr_cat(&path, name);
-	return path.array;
-#endif
 }
 
 int os_get_program_data_path(char *dst, size_t size, const char *name)


### PR DESCRIPTION
### Description
We should use XDG config paths on FreeBSD. This could be done by adding `USE_XDG` in the os-freebsd.cmake files, but this would leave the `#else` case in `#ifdef USE_XDG` unused. It is also currently broken. Thus, just remove the `#else` case and `USE_XDG` references.

Also reintroduce `move_to_xdg` from ba02e065fe91 to migrate FreeBSD installs to XDG paths on upgrade.

### Motivation and Context
OBS currently fails to start if built without `USE_XDG`.
We should be following XDG config paths on FreeBSD anyway.

### How Has This Been Tested?
OBS starts correctly on FreeBSD with these patches applied. I ran `rm -rf ~/.obs-studio/ ~/.config/obs-studio/`, started again, and confirmed that default config is created under ~/.config/obs-studio. Removed the directories again, created config under ~/.obs-studio, started again, and confirmed that the config was moved to ~/.config/obs-studio.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
