### PR TITLE
cmake: Install desktop files and icons on FreeBSD

### DIFF
--- a/UI/cmake/os-freebsd.cmake
+++ b/UI/cmake/os-freebsd.cmake
@@ -9,3 +9,36 @@ if(TARGET OBS::python)
   target_link_libraries(obs-studio PRIVATE Python::Python)
   target_link_options(obs-studio PRIVATE LINKER:-no-as-needed)
 endif()
+
+configure_file(cmake/linux/com.obsproject.Studio.metainfo.xml.in com.obsproject.Studio.metainfo.xml)
+
+install(
+  FILES "${CMAKE_CURRENT_BINARY_DIR}/com.obsproject.Studio.metainfo.xml"
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/metainfo"
+)
+
+install(FILES cmake/linux/com.obsproject.Studio.desktop DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/applications")
+
+install(
+  FILES cmake/linux/icons/obs-logo-128.png
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/128x128/apps"
+  RENAME com.obsproject.Studio.png
+)
+
+install(
+  FILES cmake/linux/icons/obs-logo-256.png
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/256x256/apps"
+  RENAME com.obsproject.Studio.png
+)
+
+install(
+  FILES cmake/linux/icons/obs-logo-512.png
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/512x512/apps"
+  RENAME com.obsproject.Studio.png
+)
+
+install(
+  FILES cmake/linux/icons/obs-logo-scalable.svg
+  DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/scalable/apps"
+  RENAME com.obsproject.Studio.svg
+)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Copy the desktop file and icon routine from `os-linux.cmake` so that FreeBSD gets these installed too.

### Motivation and Context
FreeBSD can generally run the same desktop environments that use these files as Linux. Without these files, icons and application launchers do not populate in these desktops. These files were previously installed prior to the CMake refactor here.

### How Has This Been Tested?
Built as usual on FreeBSD-CURRENT.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
