### PR TITLE
UI: Add TikTok Live Studio Virtual Camera to DLL blocklist

### DIFF
--- a/UI/win-dll-blocklist.c
+++ b/UI/win-dll-blocklist.c
@@ -186,6 +186,11 @@ static blocked_module_t blocked_modules[] = {
 	// that results in crashes.
 	// Reference: https://github.com/obsproject/obs-studio/issues/10245
 	{L"\\streamdeckplugin.dll", 0, 1706745600, TS_LESS_THAN},
+
+	// TikTok Live Studio Virtual Camera, causes freezing and other issues during enumeration
+	// Different versions seem to be installed in different places, so we have to match on DLL only.
+	// Reference: https://www.hanselman.com/blog/webcam-randomly-pausing-in-obs-discord-and-websites-lsvcam-and-tiktok-studio
+	{L"\\lsvcam.dll", 0, 0, TS_IGNORE},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
### Description
Per https://www.hanselman.com/blog/webcam-randomly-pausing-in-obs-discord-and-websites-lsvcam-and-tiktok-studio, TikTok's Virtual Camera DLL is apparently buggy and causing issues when it loads into OBS.

### Motivation and Context
There should be little reason why this virtual camera is needed in OBS, especially if it's broken in its current state. Should a fixed version be released, we can relax the timestamp check if there are use cases that need this.

### How Has This Been Tested?
Installed a random version of TT Live Studio in a VM and verified this DLL was installed, though at a different place than mentioned in the blog.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
