### PR TITLE
UI/importers: Translate capture sources depending on display server

### DIFF
--- a/UI/importers/studio.cpp
+++ b/UI/importers/studio.cpp
@@ -16,6 +16,9 @@
 ******************************************************************************/
 
 #include "importers.hpp"
+#if !defined(_WIN32) && !defined(__APPLE__)
+#include <obs-nix-platform.h>
+#endif
 
 using namespace std;
 using namespace json11;
@@ -109,7 +112,13 @@ void TranslateOSStudio(Json &res)
 		ClearTranslation("av_capture_input", "v4l2_input");
 		ClearTranslation("dshow_input", "v4l2_input");
 
-		ClearTranslation("window_capture", "xcomposite_input");
+		if (obs_get_nix_platform() == OBS_NIX_PLATFORM_X11_EGL) {
+			ClearTranslation("game_capture", "xcomposite_input");
+			ClearTranslation("window_capture", "xcomposite_input");
+		} else {
+			ClearTranslation("game_capture", "pipewire-screen-capture-source");
+			ClearTranslation("window_capture", "pipewire-screen-capture-source");
+		}
 
 		if (id == "monitor_capture") {
 			source["id"] = "xshm_input";


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Fixes a crash when importing scenes from Windows by translating window and game capture sources to `xcomposite` or `pipewire` depending on the display server used.
This change prevents `xcomposite` from being assigned on non-X11 systems, which causes the crash due to the module not being loaded.

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #5323

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested under Ubuntu 24.10 with KDE Plasma 6.1.5 under both Wayland and X11

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
