### PR TITLE
UI: Update order of profiles and scene collections in their menus

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -43,6 +43,30 @@ extern void DuplicateCurrentCookieProfile(ConfigFile &config);
 extern void CheckExistingCookieId();
 extern void DeleteCookies();
 
+// MARK: - Anonymous Namespace
+namespace {
+QList<QString> sortedProfiles{};
+
+void updateSortedProfiles(const OBSProfileCache &profiles)
+{
+	const QLocale locale = QLocale::system();
+	QList<QString> newList{};
+
+	for (auto [profileName, _] : profiles) {
+		QString entry = QString::fromStdString(profileName);
+		newList.append(entry);
+	}
+
+	std::sort(newList.begin(), newList.end(), [&locale](const QString &lhs, const QString &rhs) -> bool {
+		int result = QString::localeAwareCompare(locale.toLower(lhs), locale.toLower(rhs));
+
+		return (result < 0);
+	});
+
+	sortedProfiles.swap(newList);
+}
+} // namespace
+
 // MARK: - Main Profile Management Functions
 
 void OBSBasic::SetupNewProfile(const std::string &profileName, bool useWizard)
@@ -277,18 +301,27 @@ void OBSBasic::RefreshProfiles(bool refreshCache)
 	if (refreshCache) {
 		RefreshProfileCache();
 	}
+	updateSortedProfiles(profiles);
 
 	size_t numAddedProfiles = 0;
-	for (auto &[profileName, profile] : profiles) {
-		QAction *action = new QAction(QString().fromStdString(profileName), this);
-		action->setProperty("file_name", QString().fromStdString(profile.directoryName));
-		connect(action, &QAction::triggered, this, &OBSBasic::ChangeProfile);
-		action->setCheckable(true);
-		action->setChecked(profileName == currentProfileName);
+	for (auto &name : sortedProfiles) {
+		const std::string profileName = name.toStdString();
+		try {
+			OBSProfile &profile = profiles.at(profileName);
 
-		ui->profileMenu->addAction(action);
+			QAction *action = new QAction(QString().fromStdString(profileName), this);
+			action->setProperty("file_name", QString().fromStdString(profile.directoryName));
+			connect(action, &QAction::triggered, this, &OBSBasic::ChangeProfile);
+			action->setCheckable(true);
+			action->setChecked(profileName == currentProfileName);
 
-		numAddedProfiles += 1;
+			ui->profileMenu->addAction(action);
+
+			numAddedProfiles += 1;
+		} catch (const std::out_of_range &error) {
+			blog(LOG_ERROR, "No profile with name %s found in profile cache.\n%s", profileName.c_str(),
+			     error.what());
+		}
 	}
 
 	ui->actionRemoveProfile->setEnabled(numAddedProfiles > 1);

--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -258,7 +258,8 @@ void OBSBasic::ChangeProfile()
 	}
 
 	const std::string_view currentProfileName{config_get_string(App()->GetUserConfig(), "Basic", "Profile")};
-	const std::string selectedProfileName{action->text().toStdString()};
+	const QVariant qProfileName = action->property("profile_name");
+	const std::string selectedProfileName{qProfileName.toString().toStdString()};
 
 	if (currentProfileName == selectedProfileName) {
 		action->setChecked(true);
@@ -270,7 +271,7 @@ void OBSBasic::ChangeProfile()
 	if (!foundProfile) {
 		const std::string errorMessage{"Selected profile not found: "};
 
-		throw std::invalid_argument(errorMessage + currentProfileName.data());
+		throw std::invalid_argument(errorMessage + selectedProfileName.data());
 	}
 
 	const OBSProfile &selectedProfile = foundProfile.value();
@@ -307,9 +308,11 @@ void OBSBasic::RefreshProfiles(bool refreshCache)
 	for (auto &name : sortedProfiles) {
 		const std::string profileName = name.toStdString();
 		try {
-			OBSProfile &profile = profiles.at(profileName);
+			const OBSProfile &profile = profiles.at(profileName);
+			const QString qProfileName = QString().fromStdString(profileName);
 
-			QAction *action = new QAction(QString().fromStdString(profileName), this);
+			QAction *action = new QAction(qProfileName, this);
+			action->setProperty("profile_name", qProfileName);
 			action->setProperty("file_name", QString().fromStdString(profile.directoryName));
 			connect(action, &QAction::triggered, this, &OBSBasic::ChangeProfile);
 			action->setCheckable(true);

--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -261,7 +261,8 @@ void OBSBasic::ChangeSceneCollection()
 
 	const std::string_view currentCollectionName{
 		config_get_string(App()->GetUserConfig(), "Basic", "SceneCollection")};
-	const std::string selectedCollectionName{action->text().toStdString()};
+	const QVariant qCollectionName = action->property("collection_name");
+	const std::string selectedCollectionName{qCollectionName.toString().toStdString()};
 
 	if (currentCollectionName == selectedCollectionName) {
 		action->setChecked(true);
@@ -310,9 +311,11 @@ void OBSBasic::RefreshSceneCollections(bool refreshCache)
 	for (auto &name : sortedSceneCollections) {
 		const std::string collectionName = name.toStdString();
 		try {
-			OBSSceneCollection &collection = collections.at(collectionName);
+			const OBSSceneCollection &collection = collections.at(collectionName);
+			const QString qCollectionName = QString().fromStdString(collectionName);
 
-			QAction *action = new QAction(QString().fromStdString(collectionName), this);
+			QAction *action = new QAction(qCollectionName, this);
+			action->setProperty("collection_name", qCollectionName);
 			action->setProperty("file_name", QString().fromStdString(collection.fileName));
 			connect(action, &QAction::triggered, this, &OBSBasic::ChangeSceneCollection);
 			action->setCheckable(true);


### PR DESCRIPTION
### Description
Replicates the sorting of profiles and scene collection menu items provided by the Windows file system APIs with the new system.

### Motivation and Context
The old method to update the profile menu iterated over the directory entries of the profile directory in the order provided by the operating system.

The system calls used for this explicitly state that the order of items is "undefined" but seems to have followed a case-insensitive alphabetical order on Windows, an order which users have come to expect.

The new code uses a std::map to store discovered profiles and scene collections, which is ordered by key and with std::string used for keys this means a lexicographical sorting of keys which is case-sensitive.

To restore the old behavior, profiles and scene collections need to be added to their respective menus sorted by case-insensitive order, which has to be done manually before adding the items.

> [!NOTE]
> The implementation relies on Qt's internal locale-aware sorting using the system locale, which is why the entries are not sorted "at the source" but before creating the menu entries. While the C++ STL provides _some_ support for storing Unicode strings, it has no Unicode-aware built-in algorithms.

### How Has This Been Tested?
Tested on macOS 15 with profiles and scene collections using the following names in lower- and uppercase:

* `A`, `B`, `C`
* `Æ`, `Å`, `Ä`
* `てすと` (hiragana)
* `テスト` (katakana)
* `日本語` (kanji)

The lowercase variants were sorted to come right after their uppercase variants, European special characters came after the generic latin characters, non-latin characters were sorted by their code points, with katakana appearing before hiragana and kanji.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
