### PR TITLE
obs-nvenc: Force at least 4 b-frames when using UHQ tune

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -274,6 +274,14 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings)
 
 	initialize_params(enc, &nv_preset, nv_tuning, voi->width, voi->height, voi->fps_num, voi->fps_den);
 
+#ifdef NVENC_12_2_OR_LATER
+	/* Force at least 4 b-frames when using the UHQ tune */
+	if (nv_tuning == NV_ENC_TUNING_INFO_ULTRA_HIGH_QUALITY && enc->props.bf < 4) {
+		warn("Forcing number of b-frames to 4 for UHQ tune.");
+		enc->props.bf = 4;
+	}
+#endif
+
 	config->gopLength = gop_size;
 	config->frameIntervalP = gop_size == 1 ? 0 : (int32_t)enc->props.bf + 1;
 


### PR DESCRIPTION
### Description

Forces the number of b-frames to 4 if it is below 4.

### Motivation and Context

Users running into non-descriptive errors when trying to use UHQ tune without setting the correct number of b-frames.

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
