### PR TITLE
UI: Split out Whats New dialog to fix shutdown crash on Linux

### DIFF
--- a/UI/cmake/ui-windows.cmake
+++ b/UI/cmake/ui-windows.cmake
@@ -58,4 +58,6 @@ target_sources(
     window-projector.hpp
     window-remux.cpp
     window-remux.hpp
+    window-whats-new.cpp
+    window-whats-new.hpp
 )

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -68,6 +68,7 @@
 #include "window-youtube-actions.hpp"
 #include "youtube-api-wrappers.hpp"
 #endif
+#include "window-whats-new.hpp"
 #include "context-bar-controls.hpp"
 #include "obs-proxy-style.hpp"
 #include "display-helpers.hpp"
@@ -127,6 +128,8 @@ extern std::string opt_starting_collection;
 void DestroyPanelCookieManager();
 
 namespace {
+
+QPointer<OBSWhatsNew> obsWhatsNew;
 
 template<typename OBSRef> struct SignalContainer {
 	OBSRef ref;
@@ -2544,37 +2547,11 @@ void OBSBasic::ShowWhatsNew(const QString &url)
 	if (closing)
 		return;
 
-	std::string info_url = QT_TO_UTF8(url);
-
-	QDialog *dlg = new QDialog(this);
-	dlg->setAttribute(Qt::WA_DeleteOnClose, true);
-	dlg->setWindowTitle("What's New");
-	dlg->resize(700, 600);
-
-	Qt::WindowFlags flags = dlg->windowFlags();
-	Qt::WindowFlags helpFlag = Qt::WindowContextHelpButtonHint;
-	dlg->setWindowFlags(flags & (~helpFlag));
-
-	QCefWidget *cefWidget = cef->create_widget(nullptr, info_url);
-	if (!cefWidget) {
-		return;
+	if (obsWhatsNew) {
+		obsWhatsNew->close();
 	}
 
-	connect(cefWidget, &QCefWidget::titleChanged, dlg, &QDialog::setWindowTitle);
-
-	QPushButton *close = new QPushButton(QTStr("Close"));
-	connect(close, &QAbstractButton::clicked, dlg, &QDialog::accept);
-
-	QHBoxLayout *bottomLayout = new QHBoxLayout();
-	bottomLayout->addStretch();
-	bottomLayout->addWidget(close);
-	bottomLayout->addStretch();
-
-	QVBoxLayout *topLayout = new QVBoxLayout(dlg);
-	topLayout->addWidget(cefWidget);
-	topLayout->addLayout(bottomLayout);
-
-	dlg->show();
+	obsWhatsNew = new OBSWhatsNew(this, QT_TO_UTF8(url));
 #else
 	UNUSED_PARAMETER(url);
 #endif

--- a/UI/window-whats-new.cpp
+++ b/UI/window-whats-new.cpp
@@ -1,0 +1,74 @@
+#include "moc_window-whats-new.cpp"
+
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+
+#include "window-basic-main.hpp"
+
+#ifdef BROWSER_AVAILABLE
+#include <browser-panel.hpp>
+extern QCef *cef;
+#endif
+
+/* ------------------------------------------------------------------------- */
+
+OBSWhatsNew::OBSWhatsNew(QWidget *parent, const std::string &url) : QDialog(parent)
+{
+#ifdef BROWSER_AVAILABLE
+	if (!cef) {
+		return;
+	}
+
+	setWindowTitle("What's New");
+	setAttribute(Qt::WA_DeleteOnClose, true);
+	resize(700, 600);
+
+	Qt::WindowFlags flags = windowFlags();
+	Qt::WindowFlags helpFlag = Qt::WindowContextHelpButtonHint;
+	setWindowFlags(flags & (~helpFlag));
+
+	OBSBasic::InitBrowserPanelSafeBlock();
+
+	cefWidget = cef->create_widget(nullptr, url);
+	if (!cefWidget) {
+		return;
+	}
+
+	connect(cefWidget, &QCefWidget::titleChanged, this, &OBSWhatsNew::setWindowTitle);
+
+	QPushButton *close = new QPushButton(QTStr("Close"));
+	connect(close, &QAbstractButton::clicked, this, &QDialog::accept);
+
+	QHBoxLayout *bottomLayout = new QHBoxLayout();
+	bottomLayout->addStretch();
+	bottomLayout->addWidget(close);
+	bottomLayout->addStretch();
+
+	QVBoxLayout *topLayout = new QVBoxLayout(this);
+	topLayout->addWidget(cefWidget);
+	topLayout->addLayout(bottomLayout);
+
+	show();
+#else
+	UNUSED_PARAMETER(url);
+#endif
+}
+
+OBSWhatsNew::~OBSWhatsNew() {}
+
+void OBSWhatsNew::reject()
+{
+#ifdef BROWSER_AVAILABLE
+	delete cefWidget;
+#endif
+	QDialog::reject();
+}
+
+void OBSWhatsNew::accept()
+{
+#ifdef BROWSER_AVAILABLE
+	delete cefWidget;
+#endif
+	QDialog::accept();
+}

--- a/UI/window-whats-new.hpp
+++ b/UI/window-whats-new.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QPointer>
+#include <QDialog>
+#include <string>
+
+class QCefWidget;
+
+class OBSWhatsNew : public QDialog {
+	Q_OBJECT
+
+	QCefWidget *cefWidget = nullptr;
+
+public:
+	OBSWhatsNew(QWidget *parent, const std::string &url);
+	~OBSWhatsNew();
+
+	virtual void reject() override;
+	virtual void accept() override;
+};


### PR DESCRIPTION
### Description

CEF crashes on shutdown if any browser window remains open during the shutdown flow. 

This particular crash flow is reproducible 100% of the time on Linux with What's New and our modern CEF version.

The previous implementation of the What's New dialog correctly deleted all the Qt widgets, but the CEF internal event flow would only call the "preparing to close" function, and never the "window safely closed" function. All attempts to fix this with minimal changes went nowhere.

Moving the existing What's New code (practically unchanged) to a custom QDialog solves the problem entirely, and is more consistent with other uses (namely OAuth).

I don't believe this issue is new to Chromium 127 (therefore OBS 32.0), the crash just occurs late enough in the shutdown chain that user data (eg. scene edits) are unlikely to be lost, and as we don't use What's New often, may have been difficult to pin down via user reports.

Note: I am unsure if this also fixes the long-standing hang on shutdown if you try to close OBS while the What's New window is attempting to open on startup. It might, but I doubt it.

### Motivation and Context

Crashes are bad, especially if their cause is entirely unclear to the user.

### How Has This Been Tested?

* Defined a custom What's New API response on Linux to trigger the window opening from the Help menu
* Verified both X and 'Close' correctly call all the right functions in Qt and CEF, and that no crash on shutdown occurs

Built on both Ubuntu 24.04 and Windows 10.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)
 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
