### PR TITLE
CI: Enable WebRTC on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ task:
     ffmpeg qt6-base qt6-svg jansson libsysinfo e2fsprogs-libuuid pulseaudio
     alsa-lib pipewire v4l_compat libpci librist srt nlohmann-json uthash
     qr-code-generator websocketpp asio vlc swig luajit jackit sndio fdk-aac
+    libdatachannel
   script:
   - cmake
     -S $(pwd)
@@ -23,7 +24,6 @@ task:
     -DENABLE_JACK:BOOL=ON
     -DENABLE_SNDIO:BOOL=ON
     -DENABLE_LIBFDK:BOOL=ON
-    -DENABLE_WEBRTC:BOOL=OFF
   - cmake
     --build build
     --config RelWithDebInfo


### PR DESCRIPTION
### Description

Install www/libdatachannel and leave ENABLE_WEBRTC at the default of ON.

### Motivation and Context

I'm not sure why the Cirrus-CI job previously set `-DENABLE_WEBRTC:BOOL=OFF` on FreeBSD; installing the `libdatachannel` package is all that's needed to leave this at the default of ON.

### How Has This Been Tested?

Build-tested via Cirrus-CI job: https://cirrus-ci.com/task/5539831604838400

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
