### PR TITLE
librtmp: Use /etc/ssl/certs/ path on FreeBSD

### DIFF
--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -339,7 +339,7 @@ RTMP_TLS_LoadCerts(RTMP *r) {
 
     CFRelease(anchors);
 
-#elif defined(__linux__)
+#elif defined(__linux__) || defined(__FreeBSD__)
     if (mbedtls_x509_crt_parse_path(chain, "/etc/ssl/certs/") < 0) {
         RTMP_Log(RTMP_LOGERROR, "mbedtls_x509_crt_parse_path: Couldn't parse "
             "/etc/ssl/certs");


### PR DESCRIPTION
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Use the same `mbedtls_x509_crt_parse_path` call on FreeBSD as on Linux.

### Motivation and Context
Older FreeBSD versions did not include a cert bundle in the base system and required installation of the security/ca_root_nss port or package.  All currently supported FreeBSD releases include a root certificate bundle in the base system, in the same path as Linux.

### How Has This Been Tested?
Ad-hoc end-to-end tested by streaming to Facebook. Without the change, failed with "The RTMP server sent an invalid SSL certificate."  With the change, successfully streamed a test pattern.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
