### PR TITLE
frontend: Add support for TEB/Multitrack Video to macOS (arm64 only)

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -5588,7 +5588,9 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 			ui->enableMultitrackVideo->setChecked(false);
 	}
 
-#ifndef _WIN32
+	// Enhanced Broadcasting works on Windows and Apple Silicon Macs.
+	// For other OS variants, only enable the GUI controls if developer mode was invoked.
+#if !defined(_WIN32) && !(defined(__APPLE__) && defined(__aarch64__))
 	available = available && MultitrackVideoDeveloperModeEnabled();
 #endif
 

--- a/frontend/utility/system-info-macos.mm
+++ b/frontend/utility/system-info-macos.mm
@@ -1,6 +1,101 @@
 #include "system-info.hpp"
 
+#ifdef __aarch64__
+#import <util/platform.h>
+
+#import <Foundation/Foundation.h>
+#import <Foundation/NSProcessInfo.h>
+#import <sys/sysctl.h>
+#import <sys/types.h>
+
+namespace {
+    std::optional<std::string> getCpuName()
+    {
+        std::string name;
+        size_t size;
+        int ret;
+
+        ret = sysctlbyname("machdep.cpu.brand_string", nullptr, &size, nullptr, 0);
+        if (ret != 0)
+            return std::nullopt;
+
+        name.resize(size);
+
+        ret = sysctlbyname("machdep.cpu.brand_string", name.data(), &size, nullptr, 0);
+        if (ret != 0)
+            return std::nullopt;
+
+        // Remove null terminator
+        name.resize(name.find('\0'));
+        return name;
+    }
+
+    // Apple Silicon Macs have a single SoC that contains both GPU and CPU, the same information is valid for both.
+    void fillSoCInfo(GoLiveApi::Capabilities &capabilities)
+    {
+        capabilities.cpu.name = getCpuName();
+        // Getting the frequency is not supported on Apple Silicon.
+        capabilities.cpu.physical_cores = os_get_physical_cores();
+        capabilities.cpu.logical_cores = os_get_logical_cores();
+
+        capabilities.memory.total = os_get_sys_total_size();
+        capabilities.memory.free = os_get_sys_free_size();
+
+        // Apple Silicon does not support dGPUs, there's only going to be one (the SoC).
+        GoLiveApi::Gpu gpu;
+        gpu.model = capabilities.cpu.name.value_or("Unknown");
+        gpu.vendor_id = 0x106b;  // Always Apple
+        gpu.device_id = 0;       // Always 0 for Apple Silicon
+
+        std::vector<GoLiveApi::Gpu> gpus;
+        gpus.push_back(std::move(gpu));
+        capabilities.gpu = gpus;
+    }
+
+    void fillSystemInfo(GoLiveApi::System &sysinfo)
+    {
+        NSProcessInfo *procInfo = [NSProcessInfo processInfo];
+        NSOperatingSystemVersion versionObj = [procInfo operatingSystemVersion];
+
+        sysinfo.name = "macOS";
+        sysinfo.bits = 64;  // 32-bit macOS is long deprecated.
+        sysinfo.version = [[procInfo operatingSystemVersionString] UTF8String];
+
+        switch (versionObj.majorVersion) {
+            case 11:
+                sysinfo.release = "Big Sur";
+                break;
+            case 12:
+                sysinfo.release = "Monterey";
+                break;
+            case 13:
+                sysinfo.release = "Ventura";
+                break;
+            case 14:
+                sysinfo.release = "Sonoma";
+                break;
+            case 15:
+                sysinfo.release = "Sequoia";
+                break;
+            default:
+                sysinfo.release = "unknown";
+        }
+
+        sysinfo.arm = true;
+        sysinfo.armEmulation = false;
+    }
+}  // namespace
+
 void system_info(GoLiveApi::Capabilities &capabilities)
 {
-    UNUSED_PARAMETER(capabilities);
+    fillSoCInfo(capabilities);
+    fillSystemInfo(capabilities.system);
 }
+
+#else /* !__aarch64__ */
+
+void system_info(GoLiveApi::Capabilities &)
+{
+    /* Not implemented */
+}
+#endif


### PR DESCRIPTION
### Description

Adds TEB support for macOS on Apple Silicon.

### Motivation and Context

Want to support all users, including macOS/Linux (Linux tbd).
The small number of SKUs makes Apple Silicon easy, and since Intel Macs are losing support it seems fine to only support ARM.

**Note:** GetClientConfiguration API changes have not yet rolled out into production.

### How Has This Been Tested?

Locally with Twitch staging environment.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
