### PR TITLE
UI: Open active profile directory via File menu

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -167,8 +167,6 @@ template<typename T> static void SetOBSRef(QListWidgetItem *item, T &&val)
 	item->setData(static_cast<int>(QtDataRole::OBSRef), QVariant::fromValue(val));
 }
 
-constexpr std::string_view OBSProfilePath = "/obs-studio/basic/profiles/";
-
 static void AddExtraModulePaths()
 {
 	string plugins_path, plugins_data_path;
@@ -7618,13 +7616,14 @@ void OBSBasic::on_actionShowSettingsFolder_triggered()
 
 void OBSBasic::on_actionShowProfileFolder_triggered()
 {
-	std::string userProfilePath;
-	userProfilePath.reserve(App()->userProfilesLocation.u8string().size() + OBSProfilePath.size());
-	userProfilePath.append(App()->userProfilesLocation.u8string()).append(OBSProfilePath);
+	try {
+		const OBSProfile &currentProfile = GetCurrentProfile();
+		QString currentProfileLocation = QString::fromStdString(currentProfile.path.u8string());
 
-	const QString userProfileLocation = QString::fromStdString(userProfilePath);
-
-	QDesktopServices::openUrl(QUrl::fromLocalFile(userProfileLocation));
+		QDesktopServices::openUrl(QUrl::fromLocalFile(currentProfileLocation));
+	} catch (const std::invalid_argument &error) {
+		blog(LOG_ERROR, "%s", error.what());
+	}
 }
 
 int OBSBasic::GetTopSelectedSourceItem()


### PR DESCRIPTION
### Description

This corrects a regression of "File -> Show Profile Folder" opening the parent Profiles directory introduced in OBS 31. Now it opens the currently active profile's directory, as before.

Alternative solutions include (but are not limited to):

* A UX discussion about whether this should actually open the parent Profiles directory going forward, with alternate naming (eg. Show Profiles Folder)
* A UX discussion of moving this menu item into the Profiles menu instead, or removing it entirely

### Motivation and Context

Users expect existing behaviour to remain the same unless a change is explicitly documented.

Reported in #beta-testing on Discord.

### How Has This Been Tested?

I have verified going back as far as 17.0.2 that this menu item would open the currently active profile's directory.

Tested my changes on Windows 10.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
