### PR TITLE
UI: Restore frontend API events being dispatched during initialization

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -2192,6 +2192,15 @@ void OBSBasic::OBSInit()
 			SetupNewSceneCollection(sceneCollectionName);
 			disableSaving++;
 		}
+
+		disableSaving--;
+		if (foundCollection || configuredCollection) {
+			OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
+			OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
+		}
+		OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
+		OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
+		disableSaving++;
 	}
 
 	loaded = true;


### PR DESCRIPTION
### Description
Restore dispatch of frontend events that have not been dispatched due to prior refactor.

### Motivation and Context
The frontend API events "OBS_FRONTEND_EVENT_SCENE_CHANGED" and "OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED" are not dispatched if disableSaving has a value `> 0`. Prior code decremented disableSaving to `0` globally (regardless of whether saving was necessary, which is only the case if a new collection is created as a fallback for a missing scene collection).

Thus the updated code exhibits different event dispatch behavior then old code which some plugins might have relied on. To avoid introducing new behavior, explicitly create the environment to allow the dispatch to take place and remove/refactor the events in a later version.

### How Has This Been Tested?
Checked frontend dispatch taking place with existing scene collection, scene collection name provided via command-line argument as well as with missing scene collection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
