### PR TITLE
UI: Add ability to format YouTube title and description

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -1603,6 +1603,39 @@ static void get_last_log(bool has_prefix, const char *subdir_to_use, std::string
 	}
 }
 
+QString GetFormatToolTip()
+{
+	static const char *format_list[][2] = {
+		{"CCYY", "FilenameFormatting.TT.CCYY"}, {"YY", "FilenameFormatting.TT.YY"},
+		{"MM", "FilenameFormatting.TT.MM"},     {"DD", "FilenameFormatting.TT.DD"},
+		{"hh", "FilenameFormatting.TT.hh"},     {"mm", "FilenameFormatting.TT.mm"},
+		{"ss", "FilenameFormatting.TT.ss"},     {"%", "FilenameFormatting.TT.Percent"},
+		{"a", "FilenameFormatting.TT.a"},       {"A", "FilenameFormatting.TT.A"},
+		{"b", "FilenameFormatting.TT.b"},       {"B", "FilenameFormatting.TT.B"},
+		{"d", "FilenameFormatting.TT.d"},       {"H", "FilenameFormatting.TT.H"},
+		{"I", "FilenameFormatting.TT.I"},       {"m", "FilenameFormatting.TT.m"},
+		{"M", "FilenameFormatting.TT.M"},       {"p", "FilenameFormatting.TT.p"},
+		{"s", "FilenameFormatting.TT.s"},       {"S", "FilenameFormatting.TT.S"},
+		{"y", "FilenameFormatting.TT.y"},       {"Y", "FilenameFormatting.TT.Y"},
+		{"z", "FilenameFormatting.TT.z"},       {"Z", "FilenameFormatting.TT.Z"},
+		{"FPS", "FilenameFormatting.TT.FPS"},   {"CRES", "FilenameFormatting.TT.CRES"},
+		{"ORES", "FilenameFormatting.TT.ORES"}, {"VF", "FilenameFormatting.TT.VF"},
+	};
+
+	QString html = "<table>";
+
+	for (auto f : format_list) {
+		html += "<tr><th align='left'>%";
+		html += f[0];
+		html += "</th><td>";
+		html += QTStr(f[1]);
+		html += "</td></tr>";
+	}
+
+	html += "</table>";
+	return html;
+}
+
 string GenerateTimeDateFilename(const char *extension, bool noSpace)
 {
 	time_t now = time(0);

--- a/UI/obs-app.hpp
+++ b/UI/obs-app.hpp
@@ -52,6 +52,7 @@ std::string GetFormatExt(const char *container);
 std::string GetOutputFilename(const char *path, const char *container, bool noSpace, bool overwrite,
 			      const char *format);
 QObject *CreateShortcutFilter();
+QString GetFormatToolTip();
 
 struct BaseLexer {
 	lexer lex;

--- a/UI/window-basic-settings.cpp
+++ b/UI/window-basic-settings.cpp
@@ -1788,39 +1788,6 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 	SimpleStreamingEncoderChanged();
 }
 
-static inline QString makeFormatToolTip()
-{
-	static const char *format_list[][2] = {
-		{"CCYY", "FilenameFormatting.TT.CCYY"}, {"YY", "FilenameFormatting.TT.YY"},
-		{"MM", "FilenameFormatting.TT.MM"},     {"DD", "FilenameFormatting.TT.DD"},
-		{"hh", "FilenameFormatting.TT.hh"},     {"mm", "FilenameFormatting.TT.mm"},
-		{"ss", "FilenameFormatting.TT.ss"},     {"%", "FilenameFormatting.TT.Percent"},
-		{"a", "FilenameFormatting.TT.a"},       {"A", "FilenameFormatting.TT.A"},
-		{"b", "FilenameFormatting.TT.b"},       {"B", "FilenameFormatting.TT.B"},
-		{"d", "FilenameFormatting.TT.d"},       {"H", "FilenameFormatting.TT.H"},
-		{"I", "FilenameFormatting.TT.I"},       {"m", "FilenameFormatting.TT.m"},
-		{"M", "FilenameFormatting.TT.M"},       {"p", "FilenameFormatting.TT.p"},
-		{"s", "FilenameFormatting.TT.s"},       {"S", "FilenameFormatting.TT.S"},
-		{"y", "FilenameFormatting.TT.y"},       {"Y", "FilenameFormatting.TT.Y"},
-		{"z", "FilenameFormatting.TT.z"},       {"Z", "FilenameFormatting.TT.Z"},
-		{"FPS", "FilenameFormatting.TT.FPS"},   {"CRES", "FilenameFormatting.TT.CRES"},
-		{"ORES", "FilenameFormatting.TT.ORES"}, {"VF", "FilenameFormatting.TT.VF"},
-	};
-
-	QString html = "<table>";
-
-	for (auto f : format_list) {
-		html += "<tr><th align='left'>%";
-		html += f[0];
-		html += "</th><td>";
-		html += QTStr(f[1]);
-		html += "</td></tr>";
-	}
-
-	html += "</table>";
-	return html;
-}
-
 void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 {
 	const char *rescaleRes = config_get_string(main->Config(), "AdvOut", "RescaleRes");
@@ -1839,7 +1806,7 @@ void OBSBasicSettings::LoadAdvOutputStreamingSettings()
 	specCompleter->setCaseSensitivity(Qt::CaseSensitive);
 	specCompleter->setFilterMode(Qt::MatchContains);
 	ui->filenameFormatting->setCompleter(specCompleter);
-	ui->filenameFormatting->setToolTip(makeFormatToolTip());
+	ui->filenameFormatting->setToolTip(GetFormatToolTip());
 
 	switch (trackIndex) {
 	case 1:

--- a/UI/window-youtube-actions.cpp
+++ b/UI/window-youtube-actions.cpp
@@ -26,6 +26,10 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth, bool broadcast
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 	ui->setupUi(this);
 
+	QString toolTip = GetFormatToolTip();
+	ui->title->setToolTip(toolTip);
+	ui->description->setTooltip(toolTip);
+
 	ui->privacyBox->addItem(QTStr("YouTube.Actions.Privacy.Public"), "public");
 	ui->privacyBox->addItem(QTStr("YouTube.Actions.Privacy.Unlisted"), "unlisted");
 	ui->privacyBox->addItem(QTStr("YouTube.Actions.Privacy.Private"), "private");
@@ -387,7 +391,11 @@ bool OBSYoutubeActions::CreateEventAction(YoutubeApiWrappers *api, BroadcastDesc
 		blog(LOG_DEBUG, "No broadcast created.");
 		return false;
 	}
-	if (!apiYouTube->SetVideoCategory(broadcast.id, broadcast.title, broadcast.description,
+
+	std::string title = GenerateSpecifiedFilename(nullptr, false, broadcast.title);
+	std::string description = GenerateSpecifiedFilename(nullptr, false, broadcast.description);
+
+	if (!apiYouTube->SetVideoCategory(broadcast.id, QT_UTF8(title.c_str()), QT_UTF8(description.c_str()),
 					  broadcast.category.id)) {
 		blog(LOG_DEBUG, "No category set.");
 		return false;


### PR DESCRIPTION
### Description
This adds the ability to format the YouTube title and description, such as setting the date and time.

### Motivation and Context
Makes it easier to create titles and descriptions.

### How Has This Been Tested?
Created formatted title and descriptions for YouTube broadcasts. 

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
