### PR TITLE
obs-outputs: Enable eRTMP Flac and Opus support

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -85,6 +85,20 @@ static void s_wa4cc(struct serializer *s, enum audio_id_t id)
 		s_w8(s, '4');
 		s_w8(s, 'a');
 		break;
+
+	case AUDIO_CODEC_OPUS:
+		s_w8(s, 'O');
+		s_w8(s, 'p');
+		s_w8(s, 'u');
+		s_w8(s, 's');
+		break;
+
+	case AUDIO_CODEC_FLAC:
+		s_w8(s, 'f');
+		s_w8(s, 'L');
+		s_w8(s, 'a');
+		s_w8(s, 'C');
+		break;
 	}
 }
 

--- a/plugins/obs-outputs/flv-mux.h
+++ b/plugins/obs-outputs/flv-mux.h
@@ -24,6 +24,8 @@
 enum audio_id_t {
 	AUDIO_CODEC_NONE = 0,
 	AUDIO_CODEC_AAC = 1,
+	AUDIO_CODEC_FLAC = 2,
+	AUDIO_CODEC_OPUS = 3,
 };
 
 enum video_id_t {
@@ -37,6 +39,10 @@ static enum audio_id_t to_audio_type(const char *codec)
 {
 	if (strcmp(codec, "aac") == 0)
 		return AUDIO_CODEC_AAC;
+	if (strcmp(codec, "flac") == 0)
+		return AUDIO_CODEC_FLAC;
+	if (strcmp(codec, "opus") == 0)
+		return AUDIO_CODEC_OPUS;
 	return AUDIO_CODEC_NONE;
 }
 

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -671,7 +671,9 @@ static void *send_thread(void *data)
 		    (stream->video_codec[packet.track_idx] != CODEC_H264 ||
 		     (stream->video_codec[packet.track_idx] == CODEC_H264 && packet.track_idx != 0))) {
 			sent = send_packet_ex(stream, &packet, false, false, packet.track_idx);
-		} else if (packet.type == OBS_ENCODER_AUDIO && packet.track_idx != 0) {
+		} else if (packet.type == OBS_ENCODER_AUDIO &&
+			   (packet.track_idx != 0 || stream->audio_codec[packet.track_idx] == AUDIO_CODEC_FLAC ||
+			    stream->audio_codec[packet.track_idx] == AUDIO_CODEC_OPUS)) {
 			sent = send_audio_packet_ex(stream, &packet, false, packet.track_idx);
 		} else {
 			sent = send_packet(stream, &packet, false);
@@ -1803,7 +1805,7 @@ struct obs_output_info rtmp_output_info = {
 #else
 	.encoded_video_codecs = "h264;av1",
 #endif
-	.encoded_audio_codecs = "aac",
+	.encoded_audio_codecs = "aac;flac;opus",
 	.get_name = rtmp_stream_getname,
 	.create = rtmp_stream_create,
 	.destroy = rtmp_stream_destroy,

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -674,7 +674,9 @@ static void *send_thread(void *data)
 		    (stream->video_codec[packet.track_idx] != CODEC_H264 ||
 		     (stream->video_codec[packet.track_idx] == CODEC_H264 && packet.track_idx != 0))) {
 			sent = send_packet_ex(stream, &packet, false, false, packet.track_idx);
-		} else if (packet.type == OBS_ENCODER_AUDIO && packet.track_idx != 0) {
+		} else if (packet.type == OBS_ENCODER_AUDIO &&
+			   (packet.track_idx != 0 || stream->audio_codec[packet.track_idx] == AUDIO_CODEC_FLAC ||
+			    stream->audio_codec[packet.track_idx] == AUDIO_CODEC_OPUS)) {
 			sent = send_audio_packet_ex(stream, &packet, false, packet.track_idx);
 		} else {
 			sent = send_packet(stream, &packet, false);
@@ -1992,7 +1994,7 @@ struct obs_output_info rtmp_output_info = {
 #else
 	.encoded_video_codecs = "h264;av1",
 #endif
-	.encoded_audio_codecs = "aac",
+	.encoded_audio_codecs = "aac;flac;opus",
 	.get_name = rtmp_stream_getname,
 	.create = rtmp_stream_create,
 	.destroy = rtmp_stream_destroy,


### PR DESCRIPTION
### Description
This PR enables Flac and Opus audio codecs for the eRTMP protocol according [the spec](https://github.com/veovera/enhanced-rtmp/blob/main/docs/enhanced/enhanced-rtmp-v2.md#enhanced-audio).

Note: the eRTMP backend may not accept both codecs.

### Motivation and Context
Add more audio codecs to the stream.

### How Has This Been Tested?
It has been tested using:
1. OBS Studio as RTMP sender (Linux, Windows, macOS),
2. modified FFmpeg instance as eRTMP server (Linux only),
3. modified FFplay instance as RTMP client (Linux only).

The provided FFMpeg [patch](https://gist.github.com/yuriy-chumak/90775bcabb20319903b6ff2f9b52659d) makes the modified ffmpeg server accept flac and opus audio codecs inside the eRTMP stream.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

---
## Testing
The PR can be tested using a modified FFmpeg library. Modified FFmpeg accept flac and opus audio codecs inside the eRTMP stream.

The following steps are a working example of the testing pipeline.

#### Preparation
 * Clone the https://github.com/FFmpeg/FFmpeg repository,
 * Apply provided [patch](https://gist.github.com/yuriy-chumak/90775bcabb20319903b6ff2f9b52659d),
 * Build the FFmpeg library including FFmpeg and FFplay.

#### Configure and Run Backend (Linux)
 * Note empty rtmp port for a backend instance. Let it be `8889`.
 * Create next shell script to run the backend (change the `${port-number}` to the port number, change the `${the_folder_with_ffmpeg}` to the real modified FFmpeg path).
   ```shell
   #!/bin/sh
   export LD_LIBRARY_PATH=${the_folder_with_ffmpeg}
   export PATH=${the_folder_with_ffmpeg}:$PATH
   
   while true; do
   echo =============================== `date` ============================
   ffmpeg -f flv -listen 1 \
      -v trace -hide_banner \
      -i rtmp://localhost:${port-number}/live/app \
      -c:v copy -c:a copy \
      -f flv - \
   |  ffplay - -autoexit
   
      sleep 1
   done
   ```
 * Run backends by running `rtmp-server.sh`.

#### Configure and Run OBS Studio (any OS)
 * Run OBS Studio and change the next "Stream" settings:
   * Service: `Custom...`
   * Server: `rtmp://localhost:8889/live` (the port value must be a port of a backend)
   * Stream Key: "app"
   ![2024-02-15-21-17-49](https://github.com/yuriy-chumak/obs-studio.a4cc/assets/2684656/4b423949-fdb9-4f7a-a9e4-6e056cf7edea)
 * Change the next "Output" settings:
   * Select "Audio Encoder" to the "FLAC" or "Opus" with "Output Mode" set to "Advanced".
 * Start OBS-Studio Streaming.  
   We must see the running logs in the backend console, and a proper status notifications in the OBS-Studio.
![2024-02-15-21-19-48](https://github.com/yuriy-chumak/obs-studio.a4cc/assets/2684656/fe9d9df3-a852-4fe0-9907-df031861ae18)  
   We must hear the proper audio with automatically runned FFplay.
