### PR TITLE
UI: Update profile encoder information after module load

### DIFF
--- a/UI/window-basic-main-profiles.cpp
+++ b/UI/window-basic-main-profiles.cpp
@@ -699,13 +699,11 @@ void OBSBasic::ActivateProfile(const OBSProfile &profile, bool reset)
 	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 
 	InitBasicConfigDefaults();
-	InitBasicConfigDefaults2();
 
 	if (reset) {
+		UpdateProfileEncoders();
 		ResetProfileData();
 	}
-
-	CheckForSimpleModeX264Fallback();
 
 	RefreshProfiles();
 
@@ -729,6 +727,12 @@ void OBSBasic::ActivateProfile(const OBSProfile &profile, bool reset)
 			close();
 		}
 	}
+}
+
+void OBSBasic::UpdateProfileEncoders()
+{
+	InitBasicConfigDefaults2();
+	CheckForSimpleModeX264Fallback();
 }
 
 void OBSBasic::ResetProfileData()

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -1900,7 +1900,7 @@ bool OBSBasic::InitBasicConfig()
 		return false;
 	}
 
-	return InitBasicConfigDefaults();
+	return true;
 }
 
 void OBSBasic::InitOBSCallbacks()
@@ -2125,9 +2125,7 @@ void OBSBasic::OBSInit()
 		emit VirtualCamEnabled();
 	}
 
-	InitBasicConfigDefaults2();
-
-	CheckForSimpleModeX264Fallback();
+	UpdateProfileEncoders();
 
 	LogEncoders();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1301,6 +1301,7 @@ private:
 	void RefreshProfiles(bool refreshCache = false);
 
 	void ActivateProfile(const OBSProfile &profile, bool reset = false);
+	void UpdateProfileEncoders();
 	std::vector<std::string> GetRestartRequirements(const ConfigFile &config) const;
 	void ResetProfileData();
 	void CheckForSimpleModeX264Fallback();


### PR DESCRIPTION
### Description
Splits the initialisation of encoder information for a loaded profile from the profile activation as encoder information is not available at the time of activation during program initialisation.

### Motivation and Context
The function `InitBasicConfigDefaults2`'s purpose is to set up encoder-related settings for a profile, which requires all available encoders to have been discovered first.

As encoders are added by runtime modules, this also means that discovery needs to be delayed until after modules have been loaded, but modules themselves require a valid profile to exist and be loaded.

This leads to the requirement of profiles needing to exist in a half-initialized state when modules are loaded and only becoming fully initialized after that.

This distinction is not necessary after the initial launch of obs-studio because runtime plugins are not hot-loadable, so the update can happen unconditionally at any time a plugin is changed, which implicitly couples every call to `ActivateProfile` with a call to `UpdateProfileEncoders`.

Fixes #11464.

### How Has This Been Tested?
Tested with profiles using hardware H264 and HEVC encoders and checked that their selection was retained after closing and opening OBS as well as switching between different profiles that had any encoder except for X264 configured and checked that those profiles' encoder settings were also kept.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
