### PR TITLE
UI: Fix broken module paths provided via environment on macOS

### DIFF
--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -181,10 +181,16 @@ static void AddExtraModulePaths()
 		plugins_data_path = s;
 
 	if (!plugins_path.empty() && !plugins_data_path.empty()) {
+#if defined(__APPLE__)
+		plugins_path += "/%module%.plugin/Contents/MacOS";
+		plugins_data_path += "/%module%.plugin/Contents/Resources";
+		obs_add_module_path(plugins_path.c_str(), plugins_data_path.c_str());
+#else
 		string data_path_with_module_suffix;
 		data_path_with_module_suffix += plugins_data_path;
 		data_path_with_module_suffix += "/%module%";
 		obs_add_module_path(plugins_path.c_str(), data_path_with_module_suffix.c_str());
+#endif
 	}
 
 	if (portable_mode)


### PR DESCRIPTION
### Description
Fix macOS-specific paths added to list of module paths when custom environment variables are provided to OBS Studio at launch.

### Motivation and Context
When custom module and module data paths are provided via environment variables, the module paths generated by current code will not be compatible with the plugin bundle structure used on macOS.

Using environment variables is a simple way to test plugins, as this allows OBS to discover them from alternative user-provided locations.

### How Has This Been Tested?
Tested on macOS with plugins put into a custom location and provided the same directory as `OBS_PLUGINS_PATH` and `OBS_PLUGINS_DATA_PATH` via Xcode launch options.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
