### PR TITLE
UI,libobs,obs-outputs: Remove HAVE_OBSCONFIG_H ifdefs

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1104,12 +1104,7 @@ string OBSApp::GetVersionString(bool platform) const
 {
 	stringstream ver;
 
-#ifdef HAVE_OBSCONFIG_H
 	ver << obs_get_version_string();
-#else
-	ver << LIBOBS_API_MAJOR_VER << "." << LIBOBS_API_MINOR_VER << "." << LIBOBS_API_PATCH_VER;
-
-#endif
 
 	if (platform) {
 		ver << " (";

--- a/frontend/dialogs/OBSAbout.cpp
+++ b/frontend/dialogs/OBSAbout.cpp
@@ -20,18 +20,13 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 	ui->setupUi(this);
 
 	QString bitness;
-	QString ver;
 
 	if (sizeof(void *) == 4)
 		bitness = " (32 bit)";
 	else if (sizeof(void *) == 8)
 		bitness = " (64 bit)";
 
-#ifdef HAVE_OBSCONFIG_H
-	ver += obs_get_version_string();
-#else
-	ver += LIBOBS_API_MAJOR_VER + "." + LIBOBS_API_MINOR_VER + "." + LIBOBS_API_PATCH_VER;
-#endif
+	QString ver = obs_get_version_string();
 
 	ui->version->setText(ver + bitness);
 

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -491,9 +491,7 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	QPoint newPos = curPos + statsDockPos;
 	statsDock->move(newPos);
 
-#ifdef HAVE_OBSCONFIG_H
 	ui->actionReleaseNotes->setVisible(true);
-#endif
 
 	ui->previewDisabledWidget->setContextMenuPolicy(Qt::CustomContextMenu);
 	connect(ui->enablePreviewButton, &QPushButton::clicked, this, &OBSBasic::TogglePreview);

--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -281,8 +281,6 @@ target_include_directories(
   PUBLIC "$<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/config>" "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
 )
 
-target_compile_definitions(libobs PUBLIC HAVE_OBSCONFIG_H)
-
 set(
   public_headers
   callback/calldata.h

--- a/libobs/cmake/libobsConfig.cmake.in
+++ b/libobs/cmake/libobsConfig.cmake.in
@@ -9,3 +9,5 @@ find_dependency(Threads REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
+
+set_property(TARGET OBS::libobs APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS HAVE_OBSCONFIG_H)

--- a/libobs/cmake/linux/libobs.pc.in
+++ b/libobs/cmake/linux/libobs.pc.in
@@ -10,4 +10,4 @@ Version: @OBS_VERSION_CANONICAL@
 Requires:
 Libs: -L${libdir} -lobs
 Libs.private: -pthread -lm
-Cflags: -I${includedir} -std=gnu@CMAKE_C_STANDARD@ -fPIC -fvisibility=hidden -fopenmp-simd -Werror
+Cflags: -I${includedir} -std=gnu@CMAKE_C_STANDARD@ -fPIC -fvisibility=hidden -fopenmp-simd -Werror -DHAVE_OBSCONFIG_H

--- a/libobs/obs-config.h
+++ b/libobs/obs-config.h
@@ -47,16 +47,6 @@
 
 #define LIBOBS_API_VER MAKE_SEMANTIC_VERSION(LIBOBS_API_MAJOR_VER, LIBOBS_API_MINOR_VER, LIBOBS_API_PATCH_VER)
 
-#ifdef HAVE_OBSCONFIG_H
 #include "obsconfig.h"
-#else
-#define OBS_VERSION "unknown"
-#define OBS_DATA_PATH "../../data"
-#define OBS_INSTALL_PREFIX ""
-#define OBS_PLUGIN_DESTINATION "obs-plugins"
-#define OBS_RELATIVE_PREFIX "../../"
-#define OBS_RELEASE_CANDIDATE 0
-#define OBS_BETA 0
-#endif
 
 #define OBS_INSTALL_DATA_PATH OBS_INSTALL_PREFIX "/" OBS_DATA_PATH

--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -230,11 +230,7 @@ static void build_flv_meta_data(obs_output_t *context, uint8_t **output, size_t 
 
 	dstr_printf(&encoder_name, "%s (libobs version ", MODULE_NAME);
 
-#ifdef HAVE_OBSCONFIG_H
 	dstr_cat(&encoder_name, obs_get_version_string());
-#else
-	dstr_catf(&encoder_name, "%d.%d.%d", LIBOBS_API_MAJOR_VER, LIBOBS_API_MINOR_VER, LIBOBS_API_PATCH_VER);
-#endif
 
 	dstr_cat(&encoder_name, ")");
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes `HAVE_OBSCONFIG_H` ifdef-checks and marks the definition for removal in 32.0 (as removing it could be considered a breaking change, in case there are any third-party plugins checking for it).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With the removal of all legacy code paths, `obsconfig.h` always exists and the `HAVE_OBSCONFIG_H` compile definition always gets set. As such, it's no longer necessary to check for it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested with CI that all builds still compile.
Tested with `git grep` that the definition line in cmake is now the only instance remaining of `HAVE_OBSCONFIG_H`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
