### PR TITLE
obs-qsv11: Remove old MSDK 1.6 code

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -1069,7 +1069,6 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 	bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
 	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
 	int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
-	//int64_t interval = obsqsv->params.nbFrames + 1;
 
 	info("parse packet:\n"
 		"\tFrameType: %d\n"
@@ -1162,7 +1161,6 @@ static void parse_packet_hevc(struct obs_qsv *obsqsv, struct encoder_packet *pac
 	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
 
 	int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
-	int64_t interval = obsqsv->params.nbFrames + 1;
 
 	info("parse packet:\n"
 		"\tFrameType: %d\n"

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -107,9 +107,6 @@ struct obs_qsv {
 static pthread_mutex_t g_QsvLock = PTHREAD_MUTEX_INITIALIZER;
 static unsigned short g_verMajor;
 static unsigned short g_verMinor;
-static int64_t g_pts2dtsShift;
-static int64_t g_prevDts;
-static bool g_bFirst;
 
 static const char *obs_qsv_getname_v1(void *type_data)
 {
@@ -824,31 +821,12 @@ static void *obs_qsv_create(enum qsv_codec codec, obs_data_t *settings, obs_enco
 	     "\tminor:          %d",
 	     g_verMajor, g_verMinor);
 
-	// MSDK 1.6 or less doesn't have automatic DTS calculation
-	// including early SandyBridge.
-	// Need to add manual DTS from PTS.
-	if (g_verMajor == 1 && g_verMinor < 7) {
-		int64_t interval = obsqsv->params.nbFrames + 1;
-		int64_t GopPicSize =
-			(int64_t)(obsqsv->params.nKeyIntSec * obsqsv->params.nFpsNum / (float)obsqsv->params.nFpsDen);
-		g_pts2dtsShift = GopPicSize - (GopPicSize / interval) * interval;
-
-		blog(LOG_INFO,
-		     "\tinterval:       %" PRId64 "\n"
-		     "\tGopPictSize:    %" PRId64 "\n"
-		     "\tg_pts2dtsShift: %" PRId64,
-		     interval, GopPicSize, g_pts2dtsShift);
-	} else
-		g_pts2dtsShift = -1;
-
 	if (!obsqsv->context) {
 		bfree(obsqsv);
 		return NULL;
 	}
 
 	obsqsv->performance_token = os_request_high_performance("qsv encoding");
-
-	g_bFirst = true;
 
 	return obsqsv;
 }
@@ -1086,25 +1064,11 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 
 	//bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
 	//bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
-	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
+	//bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
 	//int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
 	//int64_t interval = obsqsv->params.nbFrames + 1;
 
-	// In case MSDK doesn't support automatic DecodeTimeStamp, do manual
-	// calculation
-	if (g_pts2dtsShift >= 0) {
-		if (g_bFirst) {
-			packet->dts = packet->pts - 3 * obsqsv->params.nFpsDen;
-		} else if (pFrame) {
-			packet->dts = packet->pts - 10 * obsqsv->params.nFpsDen;
-			g_prevDts = packet->dts;
-		} else {
-			packet->dts = g_prevDts + obsqsv->params.nFpsDen;
-			g_prevDts = packet->dts;
-		}
-	} else {
-		packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
-	}
+	packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
 
 #if 0
 	info("parse packet:\n"
@@ -1116,8 +1080,6 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 
 	*received_packet = true;
 	pBS->DataLength = 0;
-
-	g_bFirst = false;
 }
 
 static void parse_packet_av1(struct obs_qsv *obsqsv, struct encoder_packet *packet, mfxBitstream *pBS,
@@ -1161,8 +1123,6 @@ static void parse_packet_av1(struct obs_qsv *obsqsv, struct encoder_packet *pack
 
 	*received_packet = true;
 	pBS->DataLength = 0;
-
-	g_bFirst = false;
 }
 
 static void parse_packet_hevc(struct obs_qsv *obsqsv, struct encoder_packet *packet, mfxBitstream *pBS,
@@ -1196,23 +1156,9 @@ static void parse_packet_hevc(struct obs_qsv *obsqsv, struct encoder_packet *pac
 
 	//bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
 	//bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
-	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
+	//bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
 
-	// In case MSDK doesn't support automatic DecodeTimeStamp, do manual
-	// calculation
-	if (g_pts2dtsShift >= 0) {
-		if (g_bFirst) {
-			packet->dts = packet->pts - 3 * obsqsv->params.nFpsDen;
-		} else if (pFrame) {
-			packet->dts = packet->pts - 10 * obsqsv->params.nFpsDen;
-			g_prevDts = packet->dts;
-		} else {
-			packet->dts = g_prevDts + obsqsv->params.nFpsDen;
-			g_prevDts = packet->dts;
-		}
-	} else {
-		packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
-	}
+	packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
 
 #if 0
 	int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
@@ -1226,8 +1172,6 @@ static void parse_packet_hevc(struct obs_qsv *obsqsv, struct encoder_packet *pac
 #endif
 	*received_packet = true;
 	pBS->DataLength = 0;
-
-	g_bFirst = false;
 }
 
 static void roi_cb(void *param, struct obs_encoder_roi *roi)

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -1062,15 +1062,15 @@ static void parse_packet(struct obs_qsv *obsqsv, struct encoder_packet *packet, 
 
 	/* ------------------------------------ */
 
-	//bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
-	//bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
-	//bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
-	//int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
-	//int64_t interval = obsqsv->params.nbFrames + 1;
-
 	packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
 
 #if 0
+	bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
+	bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
+	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
+	int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
+	//int64_t interval = obsqsv->params.nbFrames + 1;
+
 	info("parse packet:\n"
 		"\tFrameType: %d\n"
 		"\tpts:       %d\n"
@@ -1154,13 +1154,13 @@ static void parse_packet_hevc(struct obs_qsv *obsqsv, struct encoder_packet *pac
 
 	/* ------------------------------------ */
 
-	//bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
-	//bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
-	//bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
-
 	packet->dts = ts_mfx_to_obs(pBS->DecodeTimeStamp, voi);
 
 #if 0
+	bool iFrame = pBS->FrameType & MFX_FRAMETYPE_I;
+	bool bFrame = pBS->FrameType & MFX_FRAMETYPE_B;
+	bool pFrame = pBS->FrameType & MFX_FRAMETYPE_P;
+
 	int iType = iFrame ? 0 : (bFrame ? 1 : (pFrame ? 2 : -1));
 	int64_t interval = obsqsv->params.nbFrames + 1;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The old MSDK 1.6 code paths were for older devices which we no longer support. Typically, version 1.0 is reported when QSV fails to initialize. The lowest version that should be supported is 1.35, so we should not need code that covers versions 1.0 to 1.6.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want dead code.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 with an Arc A770M.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
