### PR TITLE
obs-qsv11: Remove old DX9 code and DX11 checks

### DIFF
--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -33,8 +33,6 @@ target_sources(
     QSV_Encoder_Internal.h
 )
 
-target_compile_definitions(obs-qsv11 PRIVATE $<$<PLATFORM_ID:Windows>:DX11_D3D>)
-
 target_compile_options(
   obs-qsv11
   PRIVATE

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -1,10 +1,5 @@
 #include "common_utils.h"
-
-// ATTENTION: If D3D surfaces are used, DX11_D3D must be set in project settings or hardcoded here
-
-#ifdef DX11_D3D
 #include "common_directx11.h"
-#endif
 
 #include <util/windows/device-enum.h>
 #include <util/config-file.h>
@@ -127,9 +122,7 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession, mfxFrameAllocator *pm
 
 void Release()
 {
-#if defined(DX11_D3D)
 	CleanupHWDevice();
-#endif
 }
 
 void ReleaseSessionData(void *) {}
@@ -239,15 +232,11 @@ fail:
 #if 0
 void ClearYUVSurfaceVMem(mfxMemId memId)
 {
-#if defined(DX11_D3D)
     ClearYUVSurfaceD3D(memId);
-#endif
 }
 
 void ClearRGBSurfaceVMem(mfxMemId memId)
 {
-#if defined(DX11_D3D)
     ClearRGBSurfaceD3D(memId);
-#endif
 }
 #endif

--- a/plugins/obs-qsv11/common_utils_windows.cpp
+++ b/plugins/obs-qsv11/common_utils_windows.cpp
@@ -1,10 +1,8 @@
 #include "common_utils.h"
 
-// ATTENTION: If D3D surfaces are used, DX9_D3D or DX11_D3D must be set in project settings or hardcoded here
+// ATTENTION: If D3D surfaces are used, DX11_D3D must be set in project settings or hardcoded here
 
-#ifdef DX9_D3D
-#include "common_directx.h"
-#elif DX11_D3D
+#ifdef DX11_D3D
 #include "common_directx11.h"
 #endif
 
@@ -129,7 +127,7 @@ mfxStatus Initialize(mfxVersion ver, mfxSession *pSession, mfxFrameAllocator *pm
 
 void Release()
 {
-#if defined(DX9_D3D) || defined(DX11_D3D)
+#if defined(DX11_D3D)
 	CleanupHWDevice();
 #endif
 }
@@ -241,14 +239,14 @@ fail:
 #if 0
 void ClearYUVSurfaceVMem(mfxMemId memId)
 {
-#if defined(DX9_D3D) || defined(DX11_D3D)
+#if defined(DX11_D3D)
     ClearYUVSurfaceD3D(memId);
 #endif
 }
 
 void ClearRGBSurfaceVMem(mfxMemId memId)
 {
-#if defined(DX9_D3D) || defined(DX11_D3D)
+#if defined(DX11_D3D)
     ClearRGBSurfaceD3D(memId);
 #endif
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR does two things:
1. Remove old DX9 code
2. Remove checks for DX11

The DX9_D3D ifdefs were left over from a previous cleanup. We currently only use DX11_D3D surfaces on Windows, so we can remove the ifdefs and references.

Since we currently only support DX11_D3D surfaces on Windows, we can remove the checks for the DX11_D3D and the flag itself.

There are currently two commits here just to be explicit about the changes in each, but they can be squashed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want unused or redundant checks.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on Windows 11 on an Arc A770M.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
