### PR TITLE
libobs/util: Fix tv_nsec becoming 1000000000 in os_event_timedwait

### DIFF
--- a/libobs/util/threading-posix.c
+++ b/libobs/util/threading-posix.c
@@ -97,7 +97,7 @@ static inline void add_ms_to_ts(struct timespec *ts, unsigned long milliseconds)
 {
 	ts->tv_sec += milliseconds / 1000;
 	ts->tv_nsec += (milliseconds % 1000) * 1000000;
-	if (ts->tv_nsec > 1000000000) {
+	if (ts->tv_nsec >= 1000000000) {
 		ts->tv_sec += 1;
 		ts->tv_nsec -= 1000000000;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix the carry condition of `tv_nsec` in the static function `add_ms_to_ts`, which add specified time in millisecond to an absolute time in `struct timespec`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The static function `add_ms_to_ts` calculate the absolute time that will passed to `pthread_cond_timedwait` in the function `os_event_timedwait`.

When `tv_nsec` is 1000000000, some implementation of `pthread_cond_timedwait`, such as glibc on Linux, immediately return with an error code `EINVAL`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 39

Tested with a modification as below to accelerate the failure condition.
```patch
 static inline void add_ms_to_ts(struct timespec *ts, unsigned long milliseconds)
 {
         ts->tv_sec += milliseconds / 1000;
         ts->tv_nsec += (milliseconds % 1000) * 1000000;
+
+        if (ts->tv_nsec > 999000000) {
+                blog(LOG_INFO, "setting tv_nsec = 1000000000");
+                ts->tv_nsec = 1000000000;
+        }
+
         if (ts->tv_nsec > 1000000000) {
                 ts->tv_sec += 1;
                 ts->tv_nsec -= 1000000000;
         }
 }
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
