### PR TITLE
Solve Issue #9244

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -995,8 +995,8 @@ static obs_key_t obs_nix_wayland_key_from_virtual_key(int sym)
 	case XKB_KEY_Page_Down:
 		return OBS_KEY_PAGEDOWN;
 
-	case XKB_KEY_KP_Equal:
-		return OBS_KEY_NUMEQUAL;
+	case XKB_KEY_KP_End:
+		return OBS_KEY_NUMEND;
 	case XKB_KEY_KP_Multiply:
 		return OBS_KEY_NUMASTERISK;
 	case XKB_KEY_KP_Add:


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Change in
	case XKB_KEY_KP_Equal:
		return OBS_KEY_NUMEQUAL;
         to
	case XKB_KEY_KP_End:
		return OBS_KEY_NUMEND; 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
