### PR TITLE
frontend-tools: Correctly pass settings to modified cb on reload

### DIFF
--- a/UI/frontend-plugins/frontend-tools/scripts.cpp
+++ b/UI/frontend-plugins/frontend-tools/scripts.cpp
@@ -245,7 +245,7 @@ void ScriptsTool::ReloadScript(const char *path)
 		if (strcmp(script_path, path) == 0) {
 			obs_script_reload(script);
 
-			OBSDataAutoRelease settings = obs_data_create();
+			OBSDataAutoRelease settings = obs_script_get_settings(script);
 
 			obs_properties_t *prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
@@ -349,7 +349,7 @@ void ScriptsTool::on_addScripts_clicked()
 			item->setData(Qt::UserRole, QString(file));
 			ui->scripts->addItem(item);
 
-			OBSDataAutoRelease settings = obs_data_create();
+			OBSDataAutoRelease settings = obs_script_get_settings(script);
 
 			obs_properties_t *prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
86ce0e965253f5470ccd0fb3e093ecfe136135d7 set properties modified callbacks to be called on load/reload of the script.
However it passed them an empty data settings object instead of the actual data settings of the script.
This changes to instead correctly pass the data settings object of the script to those callbacks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The callbacks are made to expect the script's data settings object, they should recieve it in any instance where they are called.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
[This script](https://github.com/user-attachments/files/17686591/modified_cb.zip) allows checking the whole state of the data settings object passed to a modified callback.
Using this (on ubuntu 24.04, python 12), checked the correct data settings object was passed, and no crash or memory leak was observed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
