### PR TITLE
libobs: plugins: Use MAD for sRGB functions

### DIFF
--- a/libobs/data/color.effect
+++ b/libobs/data/color.effect
@@ -10,7 +10,7 @@ float3 srgb_linear_to_nonlinear(float3 v)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)
@@ -148,7 +148,7 @@ float3 linear_to_hlg(float3 rgb, float Lw)
 
 	float Yd = dot(rgb, float3(0.2627, 0.678, 0.0593));
 
-	// pow(0., exponent) can lead to NaN, use smallest positive normal number
+	// avoid inf from pow(0., negative) by using smallest positive normal number
 	Yd = max(6.10352e-5, Yd);
 
 	rgb *= pow(Yd, -1. / 6.);

--- a/plugins/nv-filters/data/color.effect
+++ b/plugins/nv-filters/data/color.effect
@@ -10,7 +10,7 @@ float3 srgb_linear_to_nonlinear(float3 v)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)

--- a/plugins/obs-filters/data/color.effect
+++ b/plugins/obs-filters/data/color.effect
@@ -10,7 +10,7 @@ float3 srgb_linear_to_nonlinear(float3 v)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)

--- a/plugins/obs-transitions/data/fade_to_color_transition.effect
+++ b/plugins/obs-transitions/data/fade_to_color_transition.effect
@@ -24,7 +24,7 @@ VertData VSDefault(VertData v_in)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)

--- a/plugins/obs-transitions/data/fade_transition.effect
+++ b/plugins/obs-transitions/data/fade_transition.effect
@@ -28,7 +28,7 @@ VertData VSDefault(VertData v_in)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)

--- a/plugins/obs-transitions/data/stinger_matte_transition.effect
+++ b/plugins/obs-transitions/data/stinger_matte_transition.effect
@@ -25,7 +25,7 @@ VertData VSDefault(VertData v_in)
 
 float srgb_nonlinear_to_linear_channel(float u)
 {
-	return (u <= 0.04045) ? (u / 12.92) : pow((u + 0.055) / 1.055, 2.4);
+	return (u <= 0.04045) ? (u / 12.92) : pow(mad(u, 1. / 1.055, .055 / 1.055), 2.4);
 }
 
 float3 srgb_nonlinear_to_linear(float3 v)


### PR DESCRIPTION
### Description
MAD is faster than ADD then MUL. Also fix stray comment about pow behavior to be accurate.

### Motivation and Context
Speed increase is probably nothing to write home about, but I was working on another project in a similar area and figured I might as well address this.

### How Has This Been Tested?
- [x] Step through logic with RenderDoc for `libobs/data/color.effect`
- [x] Step through logic with RenderDoc for `plugins/obs-filters/data/color.effect`
- [x] Verify text diff for all other files is identical
- [x] Check Windows OpenGL still works

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.