### PR TITLE
obs-transitions: Fix stinger showing count for update during transition

### DIFF
--- a/plugins/obs-transitions/transition-stinger.c
+++ b/plugins/obs-transitions/transition-stinger.c
@@ -79,6 +79,9 @@ static void stinger_update(void *data, obs_data_t *settings)
 	obs_data_set_bool(media_settings, "is_stinger", true);
 	obs_data_set_bool(media_settings, "is_track_matte", s->track_matte_enabled);
 
+	if (s->media_source && s->transitioning)
+		obs_source_remove_active_child(s->source, s->media_source);
+
 	obs_source_release(s->media_source);
 	struct dstr name;
 	dstr_init_copy(&name, obs_source_get_name(s->source));
@@ -86,6 +89,9 @@ static void stinger_update(void *data, obs_data_t *settings)
 	s->media_source = obs_source_create_private("ffmpeg_source", name.array, media_settings);
 	dstr_free(&name);
 	obs_data_release(media_settings);
+
+	if (s->media_source && s->transitioning)
+		obs_source_add_active_child(s->source, s->media_source);
 
 	int64_t point = obs_data_get_int(settings, "transition_point");
 
@@ -107,6 +113,9 @@ static void stinger_update(void *data, obs_data_t *settings)
 	s->do_texrender = s->track_matte_enabled && s->matte_layout < MATTE_LAYOUT_SEPARATE_FILE;
 
 	if (s->matte_source) {
+		if (s->transitioning)
+			obs_source_remove_active_child(s->source, s->matte_source);
+
 		obs_source_release(s->matte_source);
 		s->matte_source = NULL;
 	}
@@ -120,6 +129,8 @@ static void stinger_update(void *data, obs_data_t *settings)
 
 		s->matte_source = obs_source_create_private("ffmpeg_source", NULL, tm_media_settings);
 		obs_data_release(tm_media_settings);
+		if (s->matte_source && s->transitioning)
+			obs_source_add_active_child(s->source, s->matte_source);
 
 		// no need to output sound from the matte video
 		obs_source_set_muted(s->matte_source, true);
@@ -476,7 +487,7 @@ static bool stinger_audio_render(void *data, uint64_t *ts_out, struct obs_source
 		return false;
 	}
 
-	if (!obs_source_audio_pending(s->media_source)) {
+	if (s->media_source && !obs_source_audio_pending(s->media_source)) {
 		ts = obs_source_get_audio_timestamp(s->media_source);
 		if (!ts)
 			return false;


### PR DESCRIPTION
### Description
Fix stinger showing count for update during transition

### Motivation and Context
When a transition is updated while a transition is running the `obs_source_remove_active_child` was called on an other source than `obs_source_add_active_child`
the `show_refs` counter gets to -1, because `obs_source_deactivate` does only check if it is above 0 for the source it is called on, not for the tree items in `hide_tree`

### How Has This Been Tested?
On windows 11 in combination with move transition having matched items doing a stinger transition

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
