### PR TITLE
UI: Make list widgets look consistent

### DIFF
--- a/UI/data/themes/Yami.obt
+++ b/UI/data/themes/Yami.obt
@@ -510,9 +510,16 @@ SourceTree {
 }
 
 QListWidget::item,
+SourceTree::item,
+SceneTree::item {
+    height: 32px;
+}
+
+QListWidget::item,
 SourceTreeItem,
 SceneTree::item {
-    padding: var(--padding_large) var(--padding_large);
+    padding-left: var(--padding_large);
+    padding-right: var(--padding_large);
 }
 
 QMenu::item {
@@ -524,15 +531,15 @@ QMenu::item {
 }
 
 QListWidget::item,
-SourceTreeItem,
+SourceTree::item,
 QMenu::item,
 SceneTree::item {
     border-radius: var(--border_radius);
     color: var(--text);
-    border: 1px solid transparent;
+    margin-bottom: var(--spacing_base);
 }
 
-SourceTree::item {
+SourceTreeItem {
     border-radius: var(--border_radius);
     color: var(--text);
 }
@@ -593,18 +600,7 @@ SourceTree QLineEdit:focus {
     border: 1px solid var(--grey1);
 }
 
-/* Settings QList */
-
-OBSBasicSettings QListWidget {
-    border-radius: var(--border_radius);
-    padding: var(--spacing_base);
-}
-
-OBSBasicSettings QListWidget::item {
-    border-radius: var(--border_radius);
-    padding: var(--padding_large);
-}
-
+/* Settings scrollbar */
 OBSBasicSettings QScrollBar:vertical {
     width: var(--settings_scrollbar_size);
     margin-left: 9px;

--- a/UI/data/themes/Yami_Classic.ovt
+++ b/UI/data/themes/Yami_Classic.ovt
@@ -118,9 +118,35 @@ QDockWidget > QWidget {
     padding: var(--padding_xlarge);
 }
 
-SceneTree::item,
-SourceTreeItem {
-    border-width: 0px;
+QListWidget,
+SourceTree,
+SceneTree,
+SourceTree {
+    padding: 0;
+}
+
+SceneTree,
+SourceTree {
+    padding-top: 1px;
+}
+
+QListWidget::item,
+SourceTree::item,
+SceneTree::item {
+    height: 24px;
+    margin: 0;
+}
+
+QListWidget::item,
+SourceTreeItem,
+SceneTree::item {
+    padding-left: 4px;
+    padding-right: 4px;
+    border-radius: 0;
+}
+
+SourceTree::item {
+    border-radius: 0;
 }
 
 QMenu::item {
@@ -207,10 +233,6 @@ QDoubleSpinBox::down-button:off {
 
 OBSBasicSettings #PropertiesContainer {
     background-color: var(--bg_window);
-}
-
-OBSBasicSettings QListWidget::item {
-    padding: 4px;
 }
 
 QPushButton:checked {

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -54,9 +54,6 @@
          <height>16</height>
         </size>
        </property>
-       <property name="spacing">
-        <number>1</number>
-       </property>
        <property name="currentRow">
         <number>0</number>
        </property>

--- a/UI/source-tree.cpp
+++ b/UI/source-tree.cpp
@@ -997,8 +997,6 @@ SourceTree::SourceTree(QWidget *parent_) : QListView(parent_)
 	UpdateNoSourcesMessage();
 	connect(App(), &OBSApp::StyleChanged, this, &SourceTree::UpdateNoSourcesMessage);
 	connect(App(), &OBSApp::StyleChanged, this, &SourceTree::UpdateIcons);
-
-	setItemDelegate(new SourceTreeDelegate(this));
 }
 
 void SourceTree::UpdateIcons()
@@ -1597,17 +1595,4 @@ void SourceTree::paintEvent(QPaintEvent *event)
 	} else {
 		QListView::paintEvent(event);
 	}
-}
-
-SourceTreeDelegate::SourceTreeDelegate(QObject *parent) : QStyledItemDelegate(parent) {}
-
-QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const
-{
-	SourceTree *tree = qobject_cast<SourceTree *>(parent());
-	QWidget *item = tree->indexWidget(index);
-
-	if (!item)
-		return (QSize(0, 0));
-
-	return (QSize(option.widget->minimumWidth(), item->height()));
 }

--- a/UI/source-tree.hpp
+++ b/UI/source-tree.hpp
@@ -8,7 +8,6 @@
 #include <QStaticText>
 #include <QSvgRenderer>
 #include <QAbstractListModel>
-#include <QStyledItemDelegate>
 #include <obs.hpp>
 #include <obs-frontend-api.h>
 
@@ -191,12 +190,4 @@ protected:
 	virtual void paintEvent(QPaintEvent *event) override;
 
 	virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-};
-
-class SourceTreeDelegate : public QStyledItemDelegate {
-	Q_OBJECT
-
-public:
-	SourceTreeDelegate(QObject *parent);
-	virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };


### PR DESCRIPTION
### Description
The scene and source list widget items were different heights. This sets a height in the themes instead of padding. The source tree delegate is also removed in this code.

Before:
![Screenshot from 2024-11-12 19-25-09](https://github.com/user-attachments/assets/cca4f3db-2a40-4a8f-89d4-9266085d36c2)

After:
![Screenshot from 2024-11-12 21-28-30](https://github.com/user-attachments/assets/b3185427-9d8c-49b2-a97c-48e0b0bc4301)

### Motivation and Context
Make UI look better

### How Has This Been Tested?
Looked at each list widget to make sure they looked good

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
