### PR TITLE
obs-outputs: Make MP4 output buffer/chunk size configurable

### DIFF
--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -42,6 +42,9 @@ struct mp4_output {
 	obs_output_t *output;
 	struct dstr path;
 
+	/* File serializer buffer configuration */
+	size_t buffer_size;
+	size_t chunk_size;
 	struct serializer serializer;
 
 	volatile bool active;
@@ -212,7 +215,7 @@ static inline void apply_flag(int *flags, const char *value, int flag_value)
 		*flags &= ~flag_value;
 }
 
-static int parse_custom_options(const char *opts_str)
+static void parse_custom_options(struct mp4_output *out, const char *opts_str)
 {
 	int flags = MP4_USE_NEGATIVE_CTS;
 
@@ -229,6 +232,10 @@ static int parse_custom_options(const char *opts_str)
 			apply_flag(&flags, opt.value, MP4_USE_MDTA_KEY_VALUE);
 		} else if (strcmp(opt.name, "use_negative_cts") == 0) {
 			apply_flag(&flags, opt.value, MP4_USE_NEGATIVE_CTS);
+		} else if (strcmp(opt.name, "buffer_size") == 0) {
+			out->buffer_size = strtoull(opt.value, 0, 10) * 1048576ULL;
+		} else if (strcmp(opt.name, "chunk_size") == 0) {
+			out->chunk_size = strtoull(opt.value, 0, 10) * 1048576ULL;
 		} else {
 			blog(LOG_WARNING, "Unknown muxer option: %s = %s", opt.name, opt.value);
 		}
@@ -236,7 +243,7 @@ static int parse_custom_options(const char *opts_str)
 
 	obs_free_options(opts);
 
-	return flags;
+	out->flags = flags;
 }
 
 static bool mp4_output_start(void *data)
@@ -263,11 +270,11 @@ static bool mp4_output_start(void *data)
 
 	/* Allow skipping the remux step for debugging purposes. */
 	const char *muxer_settings = obs_data_get_string(settings, "muxer_settings");
-	out->flags = parse_custom_options(muxer_settings);
+	parse_custom_options(out, muxer_settings);
 
 	obs_data_release(settings);
 
-	if (!buffered_file_serializer_init_defaults(&out->serializer, out->path.array)) {
+	if (!buffered_file_serializer_init(&out->serializer, out->path.array, out->buffer_size, out->chunk_size)) {
 		warn("Unable to open MP4 file '%s'", out->path.array);
 		return false;
 	}
@@ -391,7 +398,7 @@ static bool change_file(struct mp4_output *out, struct encoder_packet *pkt)
 	generate_filename(out, &out->path, out->allow_overwrite);
 	info("Changing output file to '%s'", out->path.array);
 
-	if (!buffered_file_serializer_init_defaults(&out->serializer, out->path.array)) {
+	if (!buffered_file_serializer_init(&out->serializer, out->path.array, out->buffer_size, out->chunk_size)) {
 		warn("Unable to open MP4 file '%s'", out->path.array);
 		return false;
 	}


### PR DESCRIPTION
### Description

Adds `buffer_size`/`chunk_size` options to configure the buffered file writers buffer size.

### Motivation and Context

In some cases, e.g. high bitrate with high latency storage (NAS, SMR HDD) the default buffer size can be insufficient, and increasing it is relatively painless but not something we probably want to do by default.

### How Has This Been Tested?

Compiles and still works.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
