### PR TITLE
obs-nvenc: Correct max target quality for AV1

### DIFF
--- a/plugins/obs-nvenc/nvenc-properties.c
+++ b/plugins/obs-nvenc/nvenc-properties.c
@@ -126,7 +126,8 @@ obs_properties_t *nvenc_properties_internal(enum codec_type codec)
 	p = obs_properties_add_int(props, "bitrate", obs_module_text("Bitrate"), 50, UINT32_MAX / 1000, 50);
 	obs_property_int_set_suffix(p, " Kbps");
 
-	obs_properties_add_int(props, "target_quality", obs_module_text("TargetQuality"), 1, 51, 1);
+	obs_properties_add_int(props, "target_quality", obs_module_text("TargetQuality"), 1,
+			       codec == CODEC_AV1 ? 63 : 51, 1);
 
 	p = obs_properties_add_int(props, "max_bitrate", obs_module_text("MaxBitrate"), 0, UINT32_MAX / 1000, 50);
 	obs_property_int_set_suffix(p, " Kbps");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

AV1 has a max CQ of `63`. Before it was set to `51` for all codecs but this is only the max for H264 and HEVC.

### Motivation and Context

Show correct settings for the encoder

### How Has This Been Tested?

Set target quality to new maximum and started a local recording. Verified that bitrate and visual quality are lower compared to old max value.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
