### PR TITLE
UI: Fix handling of Amazon IVS auto URLs when using multitrack video output

### DIFF
--- a/UI/multitrack-video-output.hpp
+++ b/UI/multitrack-video-output.hpp
@@ -30,7 +30,7 @@ public:
 			      const char *audio_encoder_id, std::optional<uint32_t> maximum_aggregate_bitrate,
 			      std::optional<uint32_t> maximum_video_tracks, std::optional<std::string> custom_config,
 			      obs_data_t *dump_stream_to_file_config, size_t main_audio_mixer,
-			      std::optional<size_t> vod_track_mixer);
+			      std::optional<size_t> vod_track_mixer, std::optional<bool> use_rtmps);
 	signal_handler_t *StreamingSignalHandler();
 	void StartedStreaming();
 	void StopStreaming();

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2426,7 +2426,7 @@ std::shared_future<void> BasicOutputHandler::SetupMultitrackVideo(obs_service_t 
 
 	std::optional<std::string> custom_rtmp_url;
 	auto server = obs_data_get_string(settings, "server");
-	if (strcmp(server, "auto") != 0) {
+	if (strncmp(server, "auto", 4) != 0) {
 		custom_rtmp_url = server;
 	}
 

--- a/UI/window-basic-main-outputs.cpp
+++ b/UI/window-basic-main-outputs.cpp
@@ -2425,9 +2425,13 @@ std::shared_future<void> BasicOutputHandler::SetupMultitrackVideo(obs_service_t 
 	}
 
 	std::optional<std::string> custom_rtmp_url;
+	std::optional<bool> use_rtmps;
 	auto server = obs_data_get_string(settings, "server");
 	if (strncmp(server, "auto", 4) != 0) {
 		custom_rtmp_url = server;
+	} else {
+		QString server_ = server;
+		use_rtmps = server_.contains("rtmps", Qt::CaseInsensitive);
 	}
 
 	auto service_custom_server = obs_data_get_bool(settings, "using_custom_server");
@@ -2485,7 +2489,7 @@ std::shared_future<void> BasicOutputHandler::SetupMultitrackVideo(obs_service_t 
 			multitrackVideo->PrepareStreaming(main, service_name.c_str(), service, custom_rtmp_url, key,
 							  audio_encoder_id.c_str(), maximum_aggregate_bitrate,
 							  maximum_video_tracks, custom_config, stream_dump_config,
-							  main_audio_mixer, vod_track_mixer);
+							  main_audio_mixer, vod_track_mixer, use_rtmps);
 		} catch (const MultitrackVideoError &error_) {
 			error.emplace(error_);
 		}


### PR DESCRIPTION
### Description
Allow multitrack video to work with Amazon IVS `Auto (RTMPS)` and `Auto (RTMP)` server entries selected

### Motivation and Context
Amazon IVS uses two `auto` entries:
- `auto-rtmp` for rtmp URLs
- `auto-rtmps` for rtmps URLs

since channels by default only allow RTMPS, not RTMP (RTMP is a separate toggle when creating/modifying the channel).

With multitrack video, the effective server for "auto" entries is selected by the GetClientConfiguration call, where the response both RTMPS and RTMP entries generally; which of these should be used depends on whether RTMPS or RTMP is selected, hence the preference of using RTMP or RTMPS needs to be visible to the multitrack video output.

### How Has This Been Tested?
Streamed up to an Amazon IVS channel with "Auto (RTMP)" and "Auto (RTMPS)" selected, and checked the log for the correct protocol

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
