### PR TITLE
UI: Fix autoconfig saving signed stream key

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -427,17 +427,6 @@ bool AutoConfigStreamPage::validatePage()
 					multitrackVideoBitrate += bitrate;
 				}
 
-				// grab a streamkey from the go live config if we can
-				for (auto &endpoint : config.ingest_endpoints) {
-					const char *p = endpoint.protocol.c_str();
-					const char *auth = endpoint.authentication ? endpoint.authentication->c_str()
-										   : nullptr;
-					if (qstrnicmp("RTMP", p, 4) == 0 && auth && *auth) {
-						wiz->key = auth;
-						break;
-					}
-				}
-
 				if (multitrackVideoBitrate > 0) {
 					wiz->startingBitrate = multitrackVideoBitrate;
 					wiz->idealBitrate = multitrackVideoBitrate;


### PR DESCRIPTION
### Description

Fixes the auto config wizard saving the signed stream key when testing with multitrack video enabled.

Since we don't use the MT config anyway for the bandwidth test there's no reason to save or use the key returned by the API.

### Motivation and Context

Reported on TEB Discord by a Linux user (OAuth wasn't available in initial Flatpak builds).

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
