### PR TITLE
Add SOOP Global RTMP service

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3531,5 +3531,80 @@
                 "h264"
             ]
         }
+        {
+            "name": "SOOP Global",
+            "alt_names": [
+                "SOOP Global RTMP",
+                "sooplive.com"
+            ]
+            "common": false, 
+            "stream_key_link": "https://www.sooplive.com/dashboard",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://global-stream.sooplive.com/app"
+                }
+            ],
+            "protocol": "RTMP",
+            "recommended": {
+                "profile": "main",
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "960x540",
+                    "640x360"
+                ],
+                "bitrate matrix": [
+                    {
+                        "res": "640x360",
+                        "fps": 30,
+                        "max bitrate": 500
+                    },
+                    {
+                        "res": "640x360",
+                        "fps": 60,
+                        "max bitrate": 1000
+                    },
+                    {
+                        "res": "960x540",
+                        "fps": 30,
+                        "max bitrate": 2000
+                    },
+                    {
+                        "res": "960x540",
+                        "fps": 60,
+                        "max bitrate": 2000
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 30,
+                        "max bitrate": 4000
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 60,
+                        "max bitrate": 4000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 30,
+                        "max bitrate": 8000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 60,
+                        "max bitrate": 8000
+                    }
+                ],
+                "keyint": 1,
+                "max fps": 60,
+                "max video bitrate": 8000,
+                "max audio bitrate": 192,
+                "bframes": 0
+            },
+            "supported video codecs": [
+                "h264"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Added 'SOOP Global' to stream service options.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
SOOP Global is a global platform created by the same company as SOOP Korea (formerly AfreecaTV).
It launched in beta on May 30, 2024, and is set for its official launch on November 22, 2024.
To provide more options for streamers on SOOP Global, the platform is introducing an RTMP service.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Locally tested and is working properly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
