### PR TITLE
cmake: Fix build directory exclusion for real

### DIFF
--- a/cmake/linux/cpackconfig.cmake
+++ b/cmake/linux/cpackconfig.cmake
@@ -16,7 +16,7 @@ endif()
 
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "obs-studio-${CPACK_PACKAGE_VERSION}-sources")
 set(CPACK_SOURCE_GENERATOR "TGZ")
-set(CPACK_SOURCE_IGNORE_FILES "/.git" "/build_${CMAKE_SYSTEM_PROCESSOR}" "/.ccache" "/.deps")
+set(CPACK_SOURCE_IGNORE_FILES "/.git" "${CMAKE_BINARY_DIR}" "/.ccache" "/.deps")
 set(CPACK_ARCHIVE_THREADS 0)
 
 if(OS_LINUX)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Upon further review, the build directory is never set to build_$arch. Currently, our CMake Presets on Ubuntu only use build_ubuntu. However, we can attempt to be flexible here and simply exclude the build directory configured in CMake.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Want this to really be fixed. Follow-up to #11501.

Discovered after tagging 31.0.0-rc1 that the build directory was not excluded from the source package. Dug a bit deeper and realized that the build directory on CI is always `build_ubuntu` and never `build_$arch`/`/build_${CMAKE_SYSTEM_PROCESSOR}`.

We could also simply say "we only support our provided presets" and hardcode this to "build_ubuntu" as we do in `CMakePresets.json`, but this _should_ use that same value.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested locally on WSL.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
