### PR TITLE
cmake: Fix regexp to detect installed FFmpeg version

### DIFF
--- a/cmake/finders/FindFFmpeg.cmake
+++ b/cmake/finders/FindFFmpeg.cmake
@@ -295,7 +295,7 @@ if(EXISTS "${FFmpeg_avutil_INCLUDE_DIR}/libavutil/ffversion.h")
     STRINGS
     "${FFmpeg_avutil_INCLUDE_DIR}/libavutil/ffversion.h"
     _version_string
-    REGEX "^.*FFMPEG_VERSION[ \t]+\"n?[0-9a-z\\~.-]+\"[ \t]*$"
+    REGEX "^.*FFMPEG_VERSION[ \t]+\"n?[0-9a-z\\~+.-]+\"[ \t]*$"
   )
   string(REGEX REPLACE ".*FFMPEG_VERSION[ \t]+\"n?([0-9]+\\.[0-9]).*\".*" "\\1" FFmpeg_VERSION "${_version_string}")
 endif()


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This adds a ``+`` in the regexp which is used to detect the version of FFmpeg on the system.

### Motivation and Context
Compiling was failing on my system (Ubuntu 24.04) with cmake complaining about FFmpeg's version. My system version is ``6.1.1-3ubuntu5+esm2``, which was detected as an empty string because the regexp does not match.

Fixes #11827

### How Has This Been Tested?
I successfully compiled OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch. *I do not understand what that means.*
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [N/A] I have included updates to all appropriate documentation.
