### PR TITLE
frontend: Adjust styling for Sources list

### DIFF
--- a/frontend/components/SourceTreeDelegate.cpp
+++ b/frontend/components/SourceTreeDelegate.cpp
@@ -10,7 +10,7 @@ QSize SourceTreeDelegate::sizeHint(const QStyleOptionViewItem &option, const QMo
 	QWidget *item = tree->indexWidget(index);
 
 	if (!item)
-		return (QSize(0, 0));
+		return QStyledItemDelegate::sizeHint(option, index);
 
-	return (QSize(option.widget->minimumWidth(), item->height()));
+	return (QSize(item->sizeHint()));
 }

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -434,9 +434,8 @@ QDoubleSpinBox {
     margin-bottom: var(--spacing_input);
 }
 
-QListWidget QWidget,
-SceneTree QWidget,
-SourceTree QWidget {
+QListView QWidget,
+QListWidget QWidget {
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -502,16 +501,14 @@ QListWidget::item {
     color: var(--text);
 }
 
+QListView,
 QListWidget,
-QMenu,
-SceneTree,
-SourceTree {
+QMenu {
     padding: var(--spacing_base);
 }
 
 QListWidget::item,
-SourceTreeItem,
-SceneTree::item {
+SourceTreeItem {
     padding: var(--padding_large) var(--padding_large);
 }
 
@@ -523,63 +520,54 @@ QMenu::item {
     padding-right: 20px;
 }
 
+QListView::item,
 QListWidget::item,
-SourceTreeItem,
-QMenu::item,
-SceneTree::item {
+QMenu::item {
     border-radius: var(--border_radius);
     color: var(--text);
     border: 1px solid transparent;
 }
 
-SourceTree::item {
+SourceTreeItem {
     border-radius: var(--border_radius);
     color: var(--text);
 }
 
 QMenu::item:selected,
-QListWidget::item:selected,
-SceneTree::item:selected,
-SourceTree::item:selected {
+QListView::item:selected,
+QListWidget::item:selected {
     background-color: var(--primary);
 }
 
 QMenu::item:hover,
+QListView::item:hover,
 QListWidget::item:hover,
-SceneTree::item:hover,
-SourceTree::item:hover,
 QMenu::item:selected:hover,
-QListWidget::item:selected:hover,
-SceneTree::item:selected:hover,
-SourceTree::item:selected:hover {
+QListView::item:selected:hover,
+QListWidget::item:selected:hover {
     background-color: var(--primary_light);
     color: var(--text);
 }
 
 QMenu::item:focus,
+QListView::item:focus,
 QListWidget::item:focus,
-SceneTree::item:focus,
-SourceTree::item:focus,
 QMenu::item:selected:focus,
-QListWidget::item:selected:focus,
-SceneTree::item:selected:focus,
-SourceTree::item:selected:focus {
+QListView::item:selected:focus,
+QListWidget::item:selected:focus {
     border: 1px solid var(--border_highlight);
 }
 
+QListView::item:disabled,
+QListView::item:disabled:hover,
 QListWidget::item:disabled,
-QListWidget::item:disabled:hover,
-SourceTree::item:disabled,
-SourceTree::item:disabled:hover,
-SceneTree::item:disabled,
-SceneTree::item:disabled:hover {
+QListWidget::item:disabled:hover {
     background: transparent;
     color: var(--text_disabled);
 }
 
-QListWidget QLineEdit,
-SceneTree QLineEdit,
-SourceTree QLineEdit {
+QListView QLineEdit,
+QListWidget QLineEdit {
     padding: 0;
     padding-bottom: 1px;
     margin: 0;
@@ -587,23 +575,12 @@ SourceTree QLineEdit {
     border-radius: var(--border_radius);
 }
 
-QListWidget QLineEdit:focus,
-SceneTree QLineEdit:focus,
-SourceTree QLineEdit:focus {
+QListView QLineEdit:focus,
+QListWidget QLineEdit:focus {
     border: 1px solid var(--grey1);
 }
 
 /* Settings QList */
-
-OBSBasicSettings QListWidget {
-    border-radius: var(--border_radius);
-    padding: var(--spacing_base);
-}
-
-OBSBasicSettings QListWidget::item {
-    border-radius: var(--border_radius);
-    padding: var(--padding_large);
-}
 
 OBSBasicSettings QScrollBar:vertical {
     width: var(--settings_scrollbar_size);
@@ -1485,16 +1462,6 @@ OBSQTDisplay {
 }
 
 /* Filters Window */
-
-OBSBasicFilters QListWidget {
-    border-radius: var(--border_radius_large);
-    padding: var(--spacing_base);
-}
-
-OBSBasicFilters QListWidget::item {
-    border-radius: var(--border_radius);
-    padding: var(--padding_base) var(--padding_large);
-}
 
 OBSBasicFilters #widget,
 OBSBasicFilters #widget_2 {


### PR DESCRIPTION
### Description
Minor adjustment to the SourceTreeItem sizeHint calculation and styling rule cleanup.

This also fixes the items in the Sources list being different sizes than the Scene list, which is a bug.

Before:
![image](https://github.com/user-attachments/assets/7453f949-b55c-403f-9f13-25d90e44a9e6)

After:
![image](https://github.com/user-attachments/assets/1bd4b3fe-2474-4af1-a77f-c35b5aa0f20a)


### Motivation and Context
There are a few confusing SourceTree specific style rules to account for the fact it uses a QListView with custom widgets instead of a QListWidget. This PR tidies that up a little bit and also removes some unnecessary rules targeting the SceneTree widget.

### How Has This Been Tested?
Compiled and checked visual changes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
