### PR TITLE
frontend: Make list spacing consistent

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -529,7 +529,6 @@ QMenu::item,
 SceneTree::item {
     border-radius: var(--border_radius);
     color: var(--text);
-    border: 1px solid transparent;
 }
 
 SourceTree::item {

--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -920,7 +920,7 @@
            <enum>Qt::TargetMoveAction</enum>
           </property>
           <property name="spacing">
-           <number>0</number>
+           <number>1</number>
           </property>
           <addaction name="actionRemoveScene"/>
          </widget>
@@ -1042,7 +1042,7 @@
            <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
           <property name="spacing">
-           <number>0</number>
+           <number>1</number>
           </property>
           <addaction name="actionRemoveSource"/>
          </widget>


### PR DESCRIPTION
### Description
Not all list widgets were using this consistently, and these should be set in the themes instead.

### Motivation and Context
Makes things consistent

### How Has This Been Tested?
Looked at each list widget to make sure there was no extra spacing besides margins set in themes.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
