### PR TITLE
frontend: Make projectors somewhat work on Wayland

### DIFF
--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -13,14 +13,35 @@
 
 #include "moc_OBSProjector.cpp"
 
+#ifdef ENABLE_WAYLAND
+#include <obs-nix-platform.h>
+#endif
+
+#ifdef _WIN32
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN 1
+#include <Windows.h>
+#endif
+
 static QList<OBSProjector *> multiviewProjectors;
 
 static bool updatingMultiview = false, mouseSwitching, transitionOnDoubleClick;
 
+static bool IsWayland()
+{
+	return QApplication::platformName().contains("wayland");
+}
+
 OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, ProjectorType type_)
-	: OBSQTDisplay(widget, Qt::Window),
+	: QWidget(widget, Qt::Window),
+	  display(this),
 	  weakSource(OBSGetWeakRef(source_))
 {
+	QVBoxLayout *layout = new QVBoxLayout(this);
+	layout->addWidget(&display);
+	layout->setContentsMargins(0, 0, 0, 0);
+	setLayout(layout);
+
 	OBSSource source = GetSource();
 	if (source) {
 		sigs.emplace_back(obs_source_get_signal_handler(source), "rename", OBSSourceRenamed, this);
@@ -34,7 +55,7 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, 
 
 	// Mark the window as a projector so SetDisplayAffinity
 	// can skip it
-	windowHandle()->setProperty("isOBSProjectorWindow", true);
+	display.windowHandle()->setProperty("isOBSProjectorWindow", true);
 
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__DragonFly__)
 	// Prevents resizing of projector windows
@@ -72,11 +93,11 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, 
 
 	auto addDrawCallback = [this]() {
 		bool isMultiview = type == ProjectorType::Multiview;
-		obs_display_add_draw_callback(GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender, this);
-		obs_display_set_background_color(GetDisplay(), 0x000000);
+		obs_display_add_draw_callback(display.GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender, this);
+		obs_display_set_background_color(display.GetDisplay(), 0x000000);
 	};
 
-	connect(this, &OBSQTDisplay::DisplayCreated, addDrawCallback);
+	connect(&display, &OBSQTDisplay::DisplayCreated, addDrawCallback);
 	connect(App(), &QGuiApplication::screenRemoved, this, &OBSProjector::ScreenRemoved);
 
 	if (type == ProjectorType::Multiview) {
@@ -95,9 +116,6 @@ OBSProjector::OBSProjector(QWidget *widget, obs_source_t *source_, int monitor, 
 	ready = true;
 
 	show();
-
-	// We need it here to allow keyboard input in X11 to listen to Escape
-	activateWindow();
 }
 
 OBSProjector::~OBSProjector()
@@ -105,7 +123,7 @@ OBSProjector::~OBSProjector()
 	sigs.clear();
 
 	bool isMultiview = type == ProjectorType::Multiview;
-	obs_display_remove_draw_callback(GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender, this);
+	obs_display_remove_draw_callback(display.GetDisplay(), isMultiview ? OBSRenderMultiview : OBSRender, this);
 
 	OBSSource source = GetSource();
 	if (source)
@@ -224,7 +242,7 @@ void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)
 
 void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)
 {
-	OBSQTDisplay::mouseDoubleClickEvent(event);
+	QWidget::mouseDoubleClickEvent(event);
 
 	if (!mouseSwitching)
 		return;
@@ -253,29 +271,33 @@ void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)
 
 void OBSProjector::mousePressEvent(QMouseEvent *event)
 {
-	OBSQTDisplay::mousePressEvent(event);
+	QWidget::mousePressEvent(event);
+
+	QMenu popup(this);
 
 	if (event->button() == Qt::RightButton) {
-		QMenu *projectorMenu = new QMenu(QTStr("Fullscreen"));
-		OBSBasic::AddProjectorMenuMonitors(projectorMenu, this, &OBSProjector::OpenFullScreenProjector);
+		if (!IsWayland()) {
+			QMenu *projectorMenu = new QMenu(QTStr("Fullscreen"));
+			OBSBasic::AddProjectorMenuMonitors(projectorMenu, this, &OBSProjector::OpenFullScreenProjector);
 
-		QMenu popup(this);
-		popup.addMenu(projectorMenu);
+			popup.addMenu(projectorMenu);
 
-		if (GetMonitor() > -1) {
-			popup.addAction(QTStr("Windowed"), this, &OBSProjector::OpenWindowedProjector);
-
-		} else if (!this->isMaximized()) {
-			popup.addAction(QTStr("ResizeProjectorWindowToContent"), this, &OBSProjector::ResizeToContent);
+			if (GetMonitor() > -1)
+				popup.addAction(QTStr("Windowed"), this, &OBSProjector::OpenWindowedProjector);
 		}
 
-		QAction *alwaysOnTopButton = new QAction(QTStr("Basic.MainMenu.View.AlwaysOnTop"), this);
-		alwaysOnTopButton->setCheckable(true);
-		alwaysOnTopButton->setChecked(isAlwaysOnTop);
+		if (!isMaximized() && GetMonitor() == -1)
+			popup.addAction(QTStr("ResizeProjectorWindowToContent"), this, &OBSProjector::ResizeToContent);
 
-		connect(alwaysOnTopButton, &QAction::toggled, this, &OBSProjector::AlwaysOnTopToggled);
+		if (!IsWayland()) {
+			QAction *alwaysOnTopButton = new QAction(QTStr("Basic.MainMenu.AlwaysOnTop"), this);
+			alwaysOnTopButton->setCheckable(true);
+			alwaysOnTopButton->setChecked(isAlwaysOnTop);
 
-		popup.addAction(alwaysOnTopButton);
+			connect(alwaysOnTopButton, &QAction::toggled, this, &OBSProjector::AlwaysOnTopToggled);
+
+			popup.addAction(alwaysOnTopButton);
+		}
 
 		popup.addAction(QTStr("Close"), this, &OBSProjector::EscapeTriggered);
 		popup.exec(QCursor::pos());
@@ -415,7 +437,6 @@ void OBSProjector::OpenFullScreenProjector()
 
 void OBSProjector::OpenWindowedProjector()
 {
-	showFullScreen();
 	showNormal();
 	setCursor(Qt::ArrowCursor);
 
@@ -466,6 +487,24 @@ void OBSProjector::closeEvent(QCloseEvent *event)
 {
 	EscapeTriggered();
 	event->accept();
+}
+
+bool OBSProjector::nativeEvent(const QByteArray &, void *message, qintptr *)
+{
+#ifdef _WIN32
+	const MSG &msg = *static_cast<MSG *>(message);
+	switch (msg.message) {
+	case WM_MOVE:
+		display.OnMove();
+		break;
+	case WM_DISPLAYCHANGE:
+		display.OnDisplayChange();
+	}
+#else
+	UNUSED_PARAMETER(message);
+#endif
+
+	return false;
 }
 
 bool OBSProjector::IsAlwaysOnTop() const

--- a/frontend/widgets/OBSProjector.hpp
+++ b/frontend/widgets/OBSProjector.hpp
@@ -12,12 +12,15 @@ enum class ProjectorType {
 	Multiview,
 };
 
-class OBSProjector : public OBSQTDisplay {
+class QMouseEvent;
+
+class OBSProjector : public QWidget {
 	Q_OBJECT
 
 private:
 	OBSWeakSourceAutoRelease weakSource;
 	std::vector<OBSSignal> sigs;
+	OBSQTDisplay display;
 
 	static void OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy);
 	static void OBSRender(void *data, uint32_t cx, uint32_t cy);
@@ -27,6 +30,7 @@ private:
 	void mousePressEvent(QMouseEvent *event) override;
 	void mouseDoubleClickEvent(QMouseEvent *event) override;
 	void closeEvent(QCloseEvent *event) override;
+	virtual bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;
 
 	bool isAlwaysOnTop;
 	bool isAlwaysOnTopOverridden = false;


### PR DESCRIPTION
### Description
This makes the projectors work on Wayland. The ability to set a fullscreen projector windowed and vice-versa is disabled, as Wayland doesn't really support resizing windows from code.

### Motivation and Context
Original PR by @kkartaltepe #6357 

### How Has This Been Tested?
Make projectors usable on Wayland

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
