### PR TITLE
game-capture: reset hook_stop signal

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -1210,6 +1210,7 @@ static inline bool init_events(struct game_capture *gc)
 			warn("init_events: failed to get hook_stop event: %lu", GetLastError());
 			return false;
 		}
+		ResetEvent(gc->hook_stop);
 	}
 
 	if (!gc->hook_init) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If the game process is hooked successfully, but the game process does not call rendering. The capture_should_stop->capture_stopped of graphics-hook.dll will not be called.
The game plugin will fall into a loop:
![1732765128](https://github.com/user-attachments/assets/28edb02d-fa53-44d8-ba69-bd8109dc75a0)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Add a game capture source
- Capture an application that does not render
- Switch to another mode to stop capturing the application
- Recapture the application

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
