### PR TITLE
Improve DLL loading behavior on Windows

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -847,6 +847,14 @@ static bool vc_runtime_outdated()
 
 	return true;
 }
+
+static void set_process_mitigation_policies()
+{
+	// DLL planting protection - prefer system32 images
+	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {};
+	policy.PreferSystem32Images = 1;
+	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
+}
 #endif
 
 #if defined(__APPLE__) || defined(__linux__)
@@ -901,11 +909,17 @@ int main(int argc, char *argv[])
 	// Abort as early as possible if MSVC runtime is outdated
 	if (vc_runtime_outdated())
 		return 1;
+
 	// Try to keep this as early as possible
 	install_dll_blocklist_hook();
 
+	set_process_mitigation_policies();
+
 	obs_init_win32_crash_handler();
 	SetErrorMode(SEM_FAILCRITICALERRORS);
+	SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT);
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	SetDllDirectoryW(L"");
 	load_debug_privilege();
 	base_set_crash_handler(main_crash_handler, nullptr);
 	set_process_mitigations();

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -83,18 +83,20 @@ void *os_dlopen(const char *path)
 	 * dynamically loaded libraries on windows to search for dependent
 	 * libraries that are within the library's own directory */
 	wpath_slash = wcsrchr(wpath, L'/');
+
 	if (wpath_slash) {
-		*wpath_slash = 0;
-		SetDllDirectoryW(wpath);
-		*wpath_slash = L'/';
+		wchar_t fullpath[MAX_PATH];
+
+		/* FIXME: this should use the OBS install dir as a base and not rely on the current directory */
+		if (GetFullPathNameW(wpath, MAX_PATH, fullpath, NULL)) {
+			h_library = LoadLibraryExW(fullpath, NULL,
+						   LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		}
+	} else {
+		h_library = LoadLibraryExW(wpath, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 	}
 
-	h_library = LoadLibraryW(wpath);
-
 	bfree(wpath);
-
-	if (wpath_slash)
-		SetDllDirectoryW(NULL);
 
 	if (!h_library) {
 		DWORD error = GetLastError();

--- a/plugins/coreaudio-encoder/windows-imports.h
+++ b/plugins/coreaudio-encoder/windows-imports.h
@@ -386,12 +386,10 @@ static bool load_from_shell_path(REFKNOWNFOLDERID rfid, const wchar_t *subpath)
 	}
 
 	wchar_t path[MAX_PATH];
-	_snwprintf(path, MAX_PATH, L"%s\\%s", sh_path, subpath);
+	_snwprintf(path, MAX_PATH, L"%s\\%s\\CoreAudioToolbox.dll", sh_path, subpath);
 	CoTaskMemFree(sh_path);
 
-	SetDllDirectory(path);
-	audio_toolbox = LoadLibraryW(L"CoreAudioToolbox.dll");
-	SetDllDirectory(nullptr);
+	audio_toolbox = LoadLibraryExW(path, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 	return !!audio_toolbox;
 }
@@ -401,7 +399,7 @@ static bool load_lib(void)
 	/* -------------------------------------------- */
 	/* attempt to load from path                    */
 
-	audio_toolbox = LoadLibraryW(L"CoreAudioToolbox.dll");
+	audio_toolbox = LoadLibraryExW(L"CoreAudioToolbox.dll", NULL, LOAD_LIBRARY_SAFE_CURRENT_DIRS);
 	if (!!audio_toolbox)
 		return true;
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -1152,6 +1152,13 @@ int main(int argc, char *argv[])
 	char **argv;
 
 	SetErrorMode(SEM_FAILCRITICALERRORS);
+	SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT);
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	SetDllDirectoryW(L"");
+
+	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
+	policy.PreferSystem32Images = 1;
+	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
 
 	argv = malloc(argc * sizeof(char *));
 	for (int i = 0; i < argc; i++) {

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
@@ -17,6 +17,13 @@ int main(int argc, char *argv[])
 	wc.lpszClassName = DUMMY_WNDCLASS;
 
 	SetErrorMode(SEM_FAILCRITICALERRORS);
+	SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT);
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	SetDllDirectoryW(L"");
+
+	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
+	policy.PreferSystem32Images = 1;
+	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
 
 	if (!RegisterClassA(&wc)) {
 		printf("failed to register '%s'\n", DUMMY_WNDCLASS);

--- a/plugins/win-capture/inject-helper/inject-helper.c
+++ b/plugins/win-capture/inject-helper/inject-helper.c
@@ -97,6 +97,14 @@ int main(void)
 	int ret = INJECT_ERROR_INVALID_PARAMS;
 
 	SetErrorMode(SEM_FAILCRITICALERRORS);
+	SetSearchPathMode(BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT);
+	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	SetDllDirectoryW(L"");
+
+	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
+	policy.PreferSystem32Images = 1;
+	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
+
 	load_debug_privilege();
 
 	pCommandLineW = GetCommandLineW();


### PR DESCRIPTION
### Description
Improves how we load various DLLs by preferring system32 DLLs, removing global `SetDllDirectory` changes, enabling safe path search mode and reducing risk of loading potentially wrong DLLs from the current directory.

### Motivation and Context
Annoyed by various bug reports that suggest OBS is vulnerable to DLL planting attacks. While this PR doesn't aim to solve that issue directly, it implements best practices to help reduce the risk. We still rely on the current directory for relative path generation which isn't ideal, but that's for another PR.

### How Has This Been Tested?
Tested loading OBS with default set of plugins. More testing with 3rd party plugins with complex dependency chains might be needed, though `LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR` should match the old behavior.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
