### PR TITLE
libobs: Fix scale calculation when applying new group transform

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3567,6 +3567,9 @@ static void apply_group_transform(obs_sceneitem_t *item, obs_sceneitem_t *group)
 	vec4_set(&mat.t, 0.0f, 0.0f, 0.0f, 1.0f);
 	matrix4_mul(&mat, &mat, &transform);
 
+	scale_abs.x = vec4_len(&mat.x) * (scale_abs.x > 0.0f ? 1.0f : -1.0f);
+	scale_abs.y = vec4_len(&mat.y) * (scale_abs.y > 0.0f ? 1.0f : -1.0f);
+
 	if (item->absolute_coordinates) {
 		vec2_copy(&item->scale, &scale_abs);
 		vec2_copy(&item->pos, &pos_abs);


### PR DESCRIPTION
### Description

Adds the erroneously removed scale calculation back to `apply_group_transform()`.

### Motivation and Context

Fixes #11488

### How Has This Been Tested?

Using reproduction steps in https://github.com/obsproject/obs-studio/issues/11488#issuecomment-2487083369

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
