### PR TITLE
libobs: Remove relative scene item APIs

### DIFF
--- a/docs/sphinx/reference-scenes.rst
+++ b/docs/sphinx/reference-scenes.rst
@@ -365,18 +365,6 @@ Scene Item Functions
 
 ---------------------
 
-.. function:: void obs_sceneitem_set_relative_pos(obs_sceneitem_t *item, const struct vec2 *pos)
-              void obs_sceneitem_get_relative_pos(const obs_sceneitem_t *item, struct vec2 *pos)
-
-   Sets/gets the position of a scene item in relative coordinates.
-   In this system `(0.0, 0.0)` is the center of the screen, `(0, -1.0)` the bottom and `(0, 1.0)` the top.
-   The visible range of the horizontal axis depends on aspect ratio, for example, with 16:9 (1.7777...) this is `[-1.777.., -1.777..]`.
-   Positions are rounded to the nearest half-pixel when converting from relative to absolute pixel values to maintain backwards compaibility.
-
-   .. versionadded:: 31.0
-
----------------------
-
 .. function:: void obs_sceneitem_set_rot(obs_sceneitem_t *item, float rot_deg)
               float obs_sceneitem_get_rot(const obs_sceneitem_t *item)
 
@@ -469,16 +457,6 @@ Scene Item Functions
 
 ---------------------
 
-.. function:: void obs_sceneitem_set_relative_bounds(obs_sceneitem_t *item, const struct vec2 *bounds)
-              void obs_sceneitem_get_relative_bounds(const obs_sceneitem_t *item, struct vec2 *bounds)
-
-   Sets/gets the bounding box width/height of the scene item in relative sizes.
-   See :c:func:`obs_sceneitem_get_relative_pos()`/:c:func:`obs_sceneitem_set_relative_pos()` for details on the relative coordinate system.
-   
-   .. versionadded:: 31.0
-
----------------------
-
 .. function:: void obs_sceneitem_set_info(obs_sceneitem_t *item, const struct obs_transform_info *info)
               void obs_sceneitem_get_info(const obs_sceneitem_t *item, struct obs_transform_info *info)
 
@@ -493,16 +471,6 @@ Scene Item Functions
    This version of the function also sets the `crop_to_bounds` member of `obs_transform_info`.
 
    .. versionadded:: 30.1
-
----------------------
-
-.. function:: void obs_sceneitem_set_info3(obs_sceneitem_t *item, const struct obs_transform_info *info)
-              void obs_sceneitem_get_info3(const obs_sceneitem_t *item, struct obs_transform_info *info)
-
-   Sets/gets the transform information of the scene item.
-   This version uses relative coordinates, see :c:func:`obs_sceneitem_get_relative_pos()`/:c:func:`obs_sceneitem_set_relative_pos()` for details.
-
-   .. versionadded:: 31.0
 
 ---------------------
 

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2740,18 +2740,6 @@ void obs_sceneitem_set_pos(obs_sceneitem_t *item, const struct vec2 *pos)
 	}
 }
 
-void obs_sceneitem_set_relative_pos(obs_sceneitem_t *item, const struct vec2 *pos)
-{
-	if (item) {
-		if (!item->absolute_coordinates)
-			vec2_copy(&item->pos, pos);
-		else
-			pos_to_absolute(&item->pos, pos, item);
-
-		do_update_transform(item);
-	}
-}
-
 void obs_sceneitem_set_rot(obs_sceneitem_t *item, float rot)
 {
 	if (item) {
@@ -2937,18 +2925,6 @@ void obs_sceneitem_set_bounds(obs_sceneitem_t *item, const struct vec2 *bounds)
 	}
 }
 
-void obs_sceneitem_set_relative_bounds(obs_sceneitem_t *item, const struct vec2 *bounds)
-{
-	if (item) {
-		if (!item->absolute_coordinates)
-			vec2_copy(&item->bounds, bounds);
-		else
-			size_to_absolute(&item->bounds, bounds, item);
-
-		do_update_transform(item);
-	}
-}
-
 void obs_sceneitem_get_pos(const obs_sceneitem_t *item, struct vec2 *pos)
 {
 	if (!item)
@@ -2958,17 +2934,6 @@ void obs_sceneitem_get_pos(const obs_sceneitem_t *item, struct vec2 *pos)
 		pos_to_absolute(pos, &item->pos, item);
 	else
 		vec2_copy(pos, &item->pos);
-}
-
-void obs_sceneitem_get_relative_pos(const obs_sceneitem_t *item, struct vec2 *pos)
-{
-	if (!item)
-		return;
-
-	if (!item->absolute_coordinates)
-		vec2_copy(pos, &item->pos);
-	else
-		pos_from_absolute(pos, &item->pos, item);
 }
 
 float obs_sceneitem_get_rot(const obs_sceneitem_t *item)
@@ -3018,17 +2983,6 @@ void obs_sceneitem_get_bounds(const obs_sceneitem_t *item, struct vec2 *bounds)
 		vec2_copy(bounds, &item->bounds);
 }
 
-void obs_sceneitem_get_relative_bounds(const obs_sceneitem_t *item, struct vec2 *bounds)
-{
-	if (!item)
-		return;
-
-	if (!item->absolute_coordinates)
-		vec2_copy(bounds, &item->bounds);
-	else
-		size_from_absolute(bounds, &item->bounds, item);
-}
-
 static inline void scene_item_get_info_internal(const obs_sceneitem_t *item, struct obs_transform_info *info)
 {
 	if (!item->absolute_coordinates) {
@@ -3057,26 +3011,6 @@ void obs_sceneitem_get_info2(const obs_sceneitem_t *item, struct obs_transform_i
 {
 	if (item && info) {
 		scene_item_get_info_internal(item, info);
-		info->crop_to_bounds = item->crop_to_bounds;
-	}
-}
-
-void obs_sceneitem_get_info3(const obs_sceneitem_t *item, struct obs_transform_info *info)
-{
-	if (item && info) {
-		if (!item->absolute_coordinates) {
-			info->pos = item->pos;
-			item_canvas_scale(&info->scale, item);
-			info->bounds = item->bounds;
-		} else {
-			pos_from_absolute(&info->pos, &item->pos, item);
-			item_relative_scale(&info->scale, &item->scale, item);
-			size_from_absolute(&info->bounds, &item->bounds, item);
-		}
-		info->rot = item->rot;
-		info->alignment = item->align;
-		info->bounds_type = item->bounds_type;
-		info->bounds_alignment = item->bounds_align;
 		info->crop_to_bounds = item->crop_to_bounds;
 	}
 }
@@ -3115,32 +3049,6 @@ void obs_sceneitem_set_info2(obs_sceneitem_t *item, const struct obs_transform_i
 {
 	if (item && info) {
 		scene_item_set_info_internal(item, info);
-		item->crop_to_bounds = info->crop_to_bounds;
-		do_update_transform(item);
-	}
-}
-
-void obs_sceneitem_set_info3(obs_sceneitem_t *item, const struct obs_transform_info *info)
-{
-	if (item && info) {
-		if (!item->absolute_coordinates) {
-			item->pos = info->pos;
-			item->bounds = info->bounds;
-			if (isfinite(info->scale.x) && isfinite(info->scale.y)) {
-				item_relative_scale(&item->scale, &info->scale, item);
-			}
-		} else {
-			pos_to_absolute(&item->pos, &info->pos, item);
-			size_to_absolute(&item->bounds, &info->bounds, item);
-			if (isfinite(info->scale.x) && isfinite(info->scale.y)) {
-				item_canvas_scale(&item->scale, item);
-			}
-		}
-
-		item->rot = info->rot;
-		item->align = info->alignment;
-		item->bounds_type = info->bounds_type;
-		item->bounds_align = info->bounds_alignment;
 		item->crop_to_bounds = info->crop_to_bounds;
 		do_update_transform(item);
 	}

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1672,7 +1672,6 @@ EXPORT bool obs_sceneitem_set_locked(obs_sceneitem_t *item, bool lock);
 
 /* Functions for getting/setting specific orientation of a scene item */
 EXPORT void obs_sceneitem_set_pos(obs_sceneitem_t *item, const struct vec2 *pos);
-EXPORT void obs_sceneitem_set_relative_pos(obs_sceneitem_t *item, const struct vec2 *pos);
 EXPORT void obs_sceneitem_set_rot(obs_sceneitem_t *item, float rot_deg);
 EXPORT void obs_sceneitem_set_scale(obs_sceneitem_t *item, const struct vec2 *scale);
 EXPORT void obs_sceneitem_set_alignment(obs_sceneitem_t *item, uint32_t alignment);
@@ -1682,12 +1681,10 @@ EXPORT void obs_sceneitem_set_bounds_type(obs_sceneitem_t *item, enum obs_bounds
 EXPORT void obs_sceneitem_set_bounds_alignment(obs_sceneitem_t *item, uint32_t alignment);
 EXPORT void obs_sceneitem_set_bounds_crop(obs_sceneitem_t *item, bool crop);
 EXPORT void obs_sceneitem_set_bounds(obs_sceneitem_t *item, const struct vec2 *bounds);
-EXPORT void obs_sceneitem_set_relative_bounds(obs_sceneitem_t *item, const struct vec2 *bounds);
 
 EXPORT int64_t obs_sceneitem_get_id(const obs_sceneitem_t *item);
 
 EXPORT void obs_sceneitem_get_pos(const obs_sceneitem_t *item, struct vec2 *pos);
-EXPORT void obs_sceneitem_get_relative_pos(const obs_sceneitem_t *item, struct vec2 *pos);
 EXPORT float obs_sceneitem_get_rot(const obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_get_scale(const obs_sceneitem_t *item, struct vec2 *scale);
 EXPORT uint32_t obs_sceneitem_get_alignment(const obs_sceneitem_t *item);
@@ -1696,14 +1693,11 @@ EXPORT enum obs_bounds_type obs_sceneitem_get_bounds_type(const obs_sceneitem_t 
 EXPORT uint32_t obs_sceneitem_get_bounds_alignment(const obs_sceneitem_t *item);
 EXPORT bool obs_sceneitem_get_bounds_crop(const obs_sceneitem_t *item);
 EXPORT void obs_sceneitem_get_bounds(const obs_sceneitem_t *item, struct vec2 *bounds);
-EXPORT void obs_sceneitem_get_relative_bounds(const obs_sceneitem_t *item, struct vec2 *bounds);
 
 OBS_DEPRECATED EXPORT void obs_sceneitem_get_info(const obs_sceneitem_t *item, struct obs_transform_info *info);
 OBS_DEPRECATED EXPORT void obs_sceneitem_set_info(obs_sceneitem_t *item, const struct obs_transform_info *info);
 EXPORT void obs_sceneitem_get_info2(const obs_sceneitem_t *item, struct obs_transform_info *info);
 EXPORT void obs_sceneitem_set_info2(obs_sceneitem_t *item, const struct obs_transform_info *info);
-EXPORT void obs_sceneitem_get_info3(const obs_sceneitem_t *item, struct obs_transform_info *info);
-EXPORT void obs_sceneitem_set_info3(obs_sceneitem_t *item, const struct obs_transform_info *info);
 
 EXPORT void obs_sceneitem_get_draw_transform(const obs_sceneitem_t *item, struct matrix4 *transform);
 EXPORT void obs_sceneitem_get_box_transform(const obs_sceneitem_t *item, struct matrix4 *transform);


### PR DESCRIPTION
### Description

Removes APIs and their documentation introduced in #9910.

### Motivation and Context

Based on discussions we had in private the implementation details of how this works are a bit too messy right now and thus the API a bit too counter-intuitive to make sense to be exposed to users.

We will revise it later, but for now just remove it to avoid having it in a stable release which would then require us to maintain the current behaviour for a while before we can remove it.

### How Has This Been Tested?

Compiles.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
