### PR TITLE
obs-scripting: Fix macOS Homebrew Python loading

### DIFF
--- a/shared/obs-scripting/obs-scripting-python-import.c
+++ b/shared/obs-scripting/obs-scripting-python-import.c
@@ -35,7 +35,7 @@
 #define PATH_MAX MAX_PATH
 #elif __APPLE__
 #define VERSION_PATTERN "%d.%d"
-#define FILE_PATTERN "Python.framework/Versions/Current/lib/libpython%s.dylib"
+#define FILE_PATTERN "Python.framework/Versions/%s/lib/libpython%s.dylib"
 #endif
 
 #define PY_MAJOR_VERSION_MAX 3
@@ -71,7 +71,7 @@ bool import_python(const char *python_path, python_version_t *python_version)
 
 	struct dstr temp;
 	dstr_init(&temp);
-	dstr_printf(&temp, FILE_PATTERN, cur_version);
+	dstr_printf(&temp, FILE_PATTERN, cur_version, cur_version);
 
 	int minor_version = PY_MINOR_VERSION_MAX;
 	do {

--- a/shared/obs-scripting/obs-scripting-python.c
+++ b/shared/obs-scripting/obs-scripting-python.c
@@ -1607,7 +1607,8 @@ bool obs_scripting_load_python(const char *python_path)
 	if (python_path && *python_path) {
 #ifdef __APPLE__
 		char temp[PATH_MAX];
-		snprintf(temp, sizeof(temp), "%s/Python.framework/Versions/Current", python_path);
+		snprintf(temp, sizeof(temp), "%s/Python.framework/Versions/%i.%i", python_path, python_version.major,
+			 python_version.minor);
 		os_utf8_to_wcs(temp, 0, home_path, PATH_MAX);
 		Py_SetPythonHome(home_path);
 #else


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use the explicit version number for the directory when dynamically loading Python inside a Framework bundle on macOS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
If using Homebrew to manage Python versions (as is commonly done on macOS), no versions of Python supported by OBS seem to currently be loadable on macOS. When currently installed via Homebrew as of December 6th, 2024, supported Python versions (3.10 through 3.12 tested) do not contain a "Current" symlink inside their "Versions" folder, which is what OBS looks for when loading the dynamic library within the framework bundle.

Python 3.13 *does* contains a "Current" symlink. It also seems clear that at some point, past versions of Python also had this "Current" symlink. I do not know why Homebrew Python is packaged in this way where the "Current" symlink will sometimes be there and other times not. Regardless, the Versions directory does seem to always contain the`<major>.<minor>` directory that "Current" symlinks to, so it seems safe to just load Python using this path, since we already have the version information explicitly available.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15.1.1, Apple Silicon; Python now loads with current installs of supported Python versions via Homebrew.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
