### PR TITLE
obs-ffmpeg: Encoder timeout hybridmp4 dataloss

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -542,7 +542,13 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	obs_output_signal_stop(stream->output, code);
 
 	os_atomic_set_bool(&stream->capturing, false);
-    
+    os_atomic_set_bool(&stream->active, false);
+    os_atomic_set_bool(&stream->stopping, false);
+    os_atomic_set_bool(&stream->sent_headers, false);
+
+	obs_output_end_data_capture(stream->output);
+	replay_buffer_clear(stream);
+
 }
 
 static void find_best_filename(struct dstr *path, bool space)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -540,8 +540,14 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	}
 
 	obs_output_signal_stop(stream->output, code);
-	os_atomic_set_bool(&stream->capturing, false);
 
+	os_atomic_set_bool(&stream->capturing, false);
+    os_atomic_set_bool(&stream->active, false);
+    os_atomic_set_bool(&stream->stopping, false);
+    os_atomic_set_bool(&stream->sent_headers, false);
+
+	obs_output_end_data_capture(stream->output);
+	replay_buffer_clear(stream);
 
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -540,14 +540,8 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	}
 
 	obs_output_signal_stop(stream->output, code);
-
 	os_atomic_set_bool(&stream->capturing, false);
-    os_atomic_set_bool(&stream->active, false);
-    os_atomic_set_bool(&stream->stopping, false);
-    os_atomic_set_bool(&stream->sent_headers, false);
 
-	obs_output_end_data_capture(stream->output);
-	replay_buffer_clear(stream);
 
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -542,13 +542,12 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	obs_output_signal_stop(stream->output, code);
 
 	os_atomic_set_bool(&stream->capturing, false);
-    os_atomic_set_bool(&stream->active, false);
-    os_atomic_set_bool(&stream->stopping, false);
-    os_atomic_set_bool(&stream->sent_headers, false);
+	os_atomic_set_bool(&stream->active, false);
+	os_atomic_set_bool(&stream->stopping, false);
+	os_atomic_set_bool(&stream->sent_headers, false);
 
 	obs_output_end_data_capture(stream->output);
 	replay_buffer_clear(stream);
-
 }
 
 static void find_best_filename(struct dstr *path, bool space)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -542,13 +542,7 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	obs_output_signal_stop(stream->output, code);
 
 	os_atomic_set_bool(&stream->capturing, false);
-    os_atomic_set_bool(&stream->active, false);
-    os_atomic_set_bool(&stream->stopping, false);
-    os_atomic_set_bool(&stream->sent_headers, false);
-
-	obs_output_end_data_capture(stream->output);
-	replay_buffer_clear(stream);
-
+    
 }
 
 static void find_best_filename(struct dstr *path, bool space)

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -540,7 +540,15 @@ static void signal_failure(struct ffmpeg_muxer *stream)
 	}
 
 	obs_output_signal_stop(stream->output, code);
+
 	os_atomic_set_bool(&stream->capturing, false);
+    os_atomic_set_bool(&stream->active, false);
+    os_atomic_set_bool(&stream->stopping, false);
+    os_atomic_set_bool(&stream->sent_headers, false);
+
+	obs_output_end_data_capture(stream->output);
+	replay_buffer_clear(stream);
+
 }
 
 static void find_best_filename(struct dstr *path, bool space)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This pull request refines the error-handling logic in signal_failure() within obs-ffmpeg-mux.c. The updates ensure that after an encoder timeout or other muxing-related failures occur, the function now properly resets internal state variables and concludes the data capture session. This change addresses scenarios where subsequent recordings could fail silently after an encoder timeout, improving the overall reliability of hybrid MP4 muxing.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Previously, when an encoder timed out, certain state flags and resources within signal_failure() were not fully reset. As a result, starting a new recording session after a failure could lead to silent hangs and zero-byte files, forcing users to restart OBS. By fully cleaning up and ending the data capture process, these issues are prevented, ensuring that subsequent recordings can start without residual state causing problems. 
In response to following issue: https://github.com/obsproject/obs-studio/issues/11329

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Test PC:
OS: Windows 10 Pro 22H2
CPU: AMD Ryzen 7 5800x3d
GPU: NVIDIA GeForce RTX 4070 Super
RAM: 32 GB 3600 MHZ 

Steps taken:
1. Started a recording using the hybrid MP4 container and highly demanding encoder settings to induce a timeout.
2. Observed the “Recording error” dialog appearing due to the timeout.
3. Initiated a second recording session without restarting OBS.
4. Verified that the second session now functions correctly, records frames as intended, and cleanly stops.
5. Ran automated tests using ctest to ensure no regression or loss of functionality in the program.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
