### PR TITLE
libobs: Fix race when disconnecting raw video callbacks

### DIFF
--- a/docs/sphinx/reference-libobs-media-io.rst
+++ b/docs/sphinx/reference-libobs-media-io.rst
@@ -178,6 +178,17 @@ Video Handler
 
 ---------------------
 
+.. function:: bool video_output_disconnect2(video_t *video, void (*callback)(void *param, struct video_data *frame), void *param)
+
+   Disconnects a raw video callback from the video output handler.
+
+   :param video:    Video output handler object
+   :param callback: Callback
+   :param param:    Private data
+   :return:         *true* if callback was removed, *false* otherwise (e.g., already removed)
+
+---------------------
+
 .. function:: const struct video_output_info *video_output_get_info(const video_t *video)
 
    Gets the full video information of the video output handler.

--- a/libobs/media-io/video-io.c
+++ b/libobs/media-io/video-io.c
@@ -464,8 +464,13 @@ static void log_skipped(video_t *video)
 
 void video_output_disconnect(video_t *video, void (*callback)(void *param, struct video_data *frame), void *param)
 {
+	video_output_disconnect2(video, callback, param);
+}
+
+bool video_output_disconnect2(video_t *video, void (*callback)(void *param, struct video_data *frame), void *param)
+{
 	if (!video || !callback)
-		return;
+		return false;
 
 	video = get_root(video);
 
@@ -485,6 +490,8 @@ void video_output_disconnect(video_t *video, void (*callback)(void *param, struc
 	}
 
 	pthread_mutex_unlock(&video->input_mutex);
+
+	return idx != DARRAY_INVALID;
 }
 
 bool video_output_active(const video_t *video)

--- a/libobs/media-io/video-io.h
+++ b/libobs/media-io/video-io.h
@@ -305,6 +305,8 @@ EXPORT bool video_output_connect2(video_t *video, const struct video_scale_info 
 				  void *param);
 EXPORT void video_output_disconnect(video_t *video, void (*callback)(void *param, struct video_data *frame),
 				    void *param);
+EXPORT bool video_output_disconnect2(video_t *video, void (*callback)(void *param, struct video_data *frame),
+				     void *param);
 
 EXPORT bool video_output_active(const video_t *video);
 

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2929,17 +2929,19 @@ void start_raw_video(video_t *v, const struct video_scale_info *conversion, uint
 		     void (*callback)(void *param, struct video_data *frame), void *param)
 {
 	struct obs_core_video_mix *video = get_mix_for_video(v);
-	if (video)
+	if (!video)
+		return;
+	if (video_output_connect2(v, conversion, frame_rate_divisor, callback, param))
 		os_atomic_inc_long(&video->raw_active);
-	video_output_connect2(v, conversion, frame_rate_divisor, callback, param);
 }
 
 void stop_raw_video(video_t *v, void (*callback)(void *param, struct video_data *frame), void *param)
 {
 	struct obs_core_video_mix *video = get_mix_for_video(v);
-	if (video)
+	if (!video)
+		return;
+	if (video_output_disconnect2(v, callback, param))
 		os_atomic_dec_long(&video->raw_active);
-	video_output_disconnect(v, callback, param);
 }
 
 void obs_add_raw_video_callback(const struct video_scale_info *conversion,


### PR DESCRIPTION
### Description

Ensures `raw_active` counter is only incremented/decremented if a callback was actually added/removed.

### Motivation and Context

Fixes #11329

There is a race condition here where the encoder stopping due to failure will call `remove_connection()` from `full_stop()` and the output itself stopping will also call it from `end_data_capture_thread()`. This can  result in the `raw_active` counter being decremented twice to `-1`, so that the next time an output is started the counter will be incremented to `0` (instead of `1`), which is treated as inactive.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
