### PR TITLE
Add mapping for non-numlocked numpad keys under Wayland

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -1032,7 +1032,24 @@ static obs_key_t obs_nix_wayland_key_from_virtual_key(int sym)
 		return OBS_KEY_NUM8;
 	case XKB_KEY_KP_9:
 		return OBS_KEY_NUM9;
-
+	case XKB_KEY_KP_Home:
+		return OBS_KEY_HOME;
+	case XKB_KEY_KP_Up:
+		return OBS_KEY_UP;
+	case XKB_KEY_KP_Prior:
+		return OBS_KEY_PAGEUP;
+	case XKB_KEY_KP_Left:
+		return OBS_KEY_LEFT;
+	case XKB_KEY_KP_Begin:
+		return OBS_KEY_CLEAR;
+	case XKB_KEY_KP_Right:
+		return OBS_KEY_RIGHT;
+	case XKB_KEY_KP_End:
+		return OBS_KEY_END;
+	case XKB_KEY_KP_Down:
+		return OBS_KEY_DOWN;
+	case XKB_KEY_KP_Next:
+		return OBS_KEY_PAGEDOWN;
 	case XKB_KEY_XF86AudioPlay:
 		return OBS_KEY_VK_MEDIA_PLAY_PAUSE;
 	case XKB_KEY_XF86AudioStop:

--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -24,14 +24,49 @@
 #include <xcb/xcb.h>
 #if defined(XCB_XINPUT_FOUND)
 #include <xcb/xinput.h>
-#include <xkbcommon/xkbcommon.h>
-#include <xkbcommon/xkbcommon-keysyms.h>
 #endif
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xlib-xcb.h>
 #include <X11/XF86keysym.h>
 #include <X11/Sunkeysym.h>
+#include <X11/keysymdef.h>
+
+#ifndef XKB_KEY_KP_Home
+#define XKB_KEY_KP_Home XK_KP_Home
+#endif
+
+#ifndef XKB_KEY_KP_Up
+#define XKB_KEY_KP_Up XK_KP_Up
+#endif
+
+#ifndef XKB_KEY_KP_Prior
+#define XKB_KEY_KP_Prior XK_KP_Prior
+#endif
+
+#ifndef XKB_KEY_KP_Left
+#define XKB_KEY_KP_Left XK_KP_Left
+#endif
+
+#ifndef XKB_KEY_KP_Begin
+#define XKB_KEY_KP_Begin XK_KP_Begin
+#endif
+
+#ifndef XKB_KEY_KP_Right
+#define XKB_KEY_KP_Right XK_KP_Right
+#endif
+
+#ifndef XKB_KEY_KP_End
+#define XKB_KEY_KP_End XK_KP_End
+#endif
+
+#ifndef XKB_KEY_KP_Down
+#define XKB_KEY_KP_Down XK_KP_Down
+#endif
+
+#ifndef XKB_KEY_KP_Next
+#define XKB_KEY_KP_Next XK_KP_Next
+#endif
 
 void obs_nix_x11_log_info(void)
 {

--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -24,6 +24,8 @@
 #include <xcb/xcb.h>
 #if defined(XCB_XINPUT_FOUND)
 #include <xcb/xinput.h>
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbcommon-keysyms.h>
 #endif
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>

--- a/libobs/obs-nix-x11.c
+++ b/libobs/obs-nix-x11.c
@@ -1254,7 +1254,28 @@ static obs_key_t obs_nix_x11_key_from_virtual_key(int sym)
 		}
 	}
 
-	return OBS_KEY_NONE;
+	switch (sym) {
+	case XKB_KEY_KP_Home:
+		return OBS_KEY_HOME;
+	case XKB_KEY_KP_Up:
+		return OBS_KEY_UP;
+	case XKB_KEY_KP_Prior:
+		return OBS_KEY_PAGEUP;
+	case XKB_KEY_KP_Left:
+		return OBS_KEY_LEFT;
+	case XKB_KEY_KP_Begin:
+		return OBS_KEY_CLEAR;
+	case XKB_KEY_KP_Right:
+		return OBS_KEY_RIGHT;
+	case XKB_KEY_KP_End:
+		return OBS_KEY_END;
+	case XKB_KEY_KP_Down:
+		return OBS_KEY_DOWN;
+	case XKB_KEY_KP_Next:
+		return OBS_KEY_PAGEDOWN;
+	default:
+		return OBS_KEY_NONE;
+	}
 }
 
 static int obs_nix_x11_key_to_virtual_key(obs_key_t key)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
This Pull Request adds mappings for non-numlocked numpad keys under Wayland.  Previously, keys such as KP_End, KP_Down, KP_Home, etc. were not assignable as hotkeys when Num Lock was turned off. Now, these keys are mapped to their corresponding navigation keys (End, Down, Home, Page Up/Down, etc.), allowing users to assign them as hotkeys as expected.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
This change is required because users on Wayland could not assign non-numlocked numpad keys as hotkeys in OBS. It fixes issue https://github.com/obsproject/obs-studio/issues/9244 .
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Turned off Num Lock, then opened Hotkeys settings in OBS.
Pressed Numpad 1 (which maps to KP_End), verified that it now registers as "End".
Repeated the test for other non-numlocked numpad keys (KP_Home, KP_Up, KP_Prior, etc.)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
