### PR TITLE
obs-filters: Maintain order of migrated NVAFX filters

### DIFF
--- a/plugins/obs-filters/noise-suppress-filter.c
+++ b/plugins/obs-filters/noise-suppress-filter.c
@@ -449,7 +449,9 @@ static void noise_suppress_nvafx_migrate_task(void *param)
 {
 	struct noise_suppress_data *ng = param;
 	obs_source_t *parent = obs_filter_get_parent(ng->context);
+	int index = obs_source_filter_get_index(parent, ng->context);
 	obs_source_filter_add(parent, ng->migrated_filter);
+	obs_source_filter_set_index(parent, ng->migrated_filter, index);
 	obs_source_set_enabled(ng->migrated_filter, obs_source_enabled(ng->context));
 	obs_source_filter_remove(parent, ng->context);
 }


### PR DESCRIPTION
### Description
This fixes a bug where the NVIDIA NVAFX filters are migrated but not kept in their original order, with respect to other filters.

### Motivation and Context
Fixes a bug.
The bug was noticed by @Penwy whom I thank for the info.

### How Has This Been Tested?
Tested on windows 11 pro 24H2, with an RTX 4090 GPU.
The filter order is kept during migration of NVIDIA audio FX.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
