### PR TITLE
frontend: Move media control dynamic properties to ui file

### DIFF
--- a/frontend/components/MediaControls.cpp
+++ b/frontend/components/MediaControls.cpp
@@ -46,10 +46,6 @@ void MediaControls::OBSMediaPrevious(void *data, calldata_t *)
 MediaControls::MediaControls(QWidget *parent) : QWidget(parent), ui(new Ui::MediaControls)
 {
 	ui->setupUi(this);
-	ui->playPauseButton->setProperty("class", "icon-media-play");
-	ui->previousButton->setProperty("class", "icon-media-prev");
-	ui->nextButton->setProperty("class", "icon-media-next");
-	ui->stopButton->setProperty("class", "icon-media-stop");
 	setFocusPolicy(Qt::StrongFocus);
 
 	connect(&mediaTimer, &QTimer::timeout, this, &MediaControls::SetSliderPosition);

--- a/frontend/forms/source-toolbar/media-controls.ui
+++ b/frontend/forms/source-toolbar/media-controls.ui
@@ -74,6 +74,9 @@
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="class" stdset="0">
+      <string>icon-media-play</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -111,6 +114,9 @@
      </property>
      <property name="flat">
       <bool>true</bool>
+     </property>
+     <property name="class" stdset="0">
+      <string>icon-media-prev</string>
      </property>
     </widget>
    </item>
@@ -150,6 +156,9 @@
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="class" stdset="0">
+      <string>icon-media-stop</string>
+     </property>
     </widget>
    </item>
    <item>
@@ -187,6 +196,9 @@
      </property>
      <property name="flat">
       <bool>true</bool>
+     </property>
+     <property name="class" stdset="0">
+      <string>icon-media-next</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
### Description
This moves the dynamic properties for the media control buttons from the cpp file to the ui file.

### Motivation and Context
Nicer code

### How Has This Been Tested?
Opened OBS and made sure media buttons still looked correct

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
