### PR TITLE
libobs-opengl: Avoid trying to allocate 0 byte on Linux

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -297,26 +297,28 @@ static inline bool is_implicit_dmabuf_modifiers_supported(void)
 static inline bool query_dmabuf_formats(EGLDisplay egl_display, EGLint **formats, EGLint *num_formats)
 {
 	EGLint max_formats = 0;
-	EGLint *format_list = NULL;
 
 	if (!glad_eglQueryDmaBufFormatsEXT(egl_display, 0, NULL, &max_formats)) {
 		blog(LOG_ERROR, "Cannot query the number of formats: %s", gl_egl_error_to_string(eglGetError()));
 		return false;
 	}
 
-	format_list = bzalloc(max_formats * sizeof(EGLint));
-	if (!format_list) {
-		blog(LOG_ERROR, "Unable to allocate memory");
-		return false;
+	if (max_formats != 0) {
+		EGLint *format_list = bzalloc(max_formats * sizeof(EGLint));
+		if (!format_list) {
+			blog(LOG_ERROR, "Unable to allocate memory");
+			return false;
+		}
+
+		if (!glad_eglQueryDmaBufFormatsEXT(egl_display, max_formats, format_list, &max_formats)) {
+			blog(LOG_ERROR, "Cannot query a list of formats: %s", gl_egl_error_to_string(eglGetError()));
+			bfree(format_list);
+			return false;
+		}
+
+		*formats = format_list;
 	}
 
-	if (!glad_eglQueryDmaBufFormatsEXT(egl_display, max_formats, format_list, &max_formats)) {
-		blog(LOG_ERROR, "Cannot query a list of formats: %s", gl_egl_error_to_string(eglGetError()));
-		bfree(format_list);
-		return false;
-	}
-
-	*formats = format_list;
 	*num_formats = max_formats;
 	return true;
 }
@@ -353,21 +355,24 @@ static inline bool query_dmabuf_modifiers(EGLDisplay egl_display, EGLint drm_for
 		return false;
 	}
 
-	EGLuint64KHR *modifier_list = bzalloc(max_modifiers * sizeof(EGLuint64KHR));
-	EGLBoolean *external_only = NULL;
-	if (!modifier_list) {
-		blog(LOG_ERROR, "Unable to allocate memory");
-		return false;
+	if (max_modifiers != 0) {
+		EGLuint64KHR *modifier_list = bzalloc(max_modifiers * sizeof(EGLuint64KHR));
+		EGLBoolean *external_only = NULL;
+		if (!modifier_list) {
+			blog(LOG_ERROR, "Unable to allocate memory");
+			return false;
+		}
+
+		if (!glad_eglQueryDmaBufModifiersEXT(egl_display, drm_format, max_modifiers, modifier_list,
+						     external_only, &max_modifiers)) {
+			blog(LOG_ERROR, "Cannot query a list of modifiers: %s", gl_egl_error_to_string(eglGetError()));
+			bfree(modifier_list);
+			return false;
+		}
+
+		*modifiers = modifier_list;
 	}
 
-	if (!glad_eglQueryDmaBufModifiersEXT(egl_display, drm_format, max_modifiers, modifier_list, external_only,
-					     &max_modifiers)) {
-		blog(LOG_ERROR, "Cannot query a list of modifiers: %s", gl_egl_error_to_string(eglGetError()));
-		bfree(modifier_list);
-		return false;
-	}
-
-	*modifiers = modifier_list;
 	*n_modifiers = (EGLuint64KHR)max_modifiers;
 	return true;
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #11617

If `query_dmabuf_modifiers` will return 0 modifiers, it will try to allocate 0 byte. (Same for `query_dmabuf_formats`)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fix it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Not tested, but https://github.com/KhronosGroup/EGL-Registry/blob/main/extensions/EXT/EGL_EXT_image_dma_buf_import_modifiers.txt does document that "<max_modifiers>" can be zero. (Same for "<max_formats>")

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
