### PR TITLE
CI: Update macOS workflows to macOS 15 runners with Xcode 16.1

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -41,7 +41,7 @@ jobs:
 
   macos:
     name: macOS 🍏 (clang-analyze)
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
@@ -50,6 +50,26 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+
+      - name: Set Up Environment 🔧
+        id: setup
+        run: |
+          : Set Up Environment 🔧
+          if (( ${+RUNNER_DEBUG} )) setopt XTRACE
+
+          print '::group::Enable Xcode 16.1'
+          sudo xcode-select --switch /Applications/Xcode_16.1.0.app/Contents/Developer
+          print '::endgroup::'
+
+          print '::group::Clean Homebrew Environment'
+          local -a unwanted_formulas=()
+          local -a remove_formulas=()
+          for formula (${unwanted_formulas}) {
+            if [[ -d ${HOMEBREW_PREFIX}/Cellar/${formula} ]] remove_formulas+=(${formula})
+          }
+
+          if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
+          print '::endgroup::'
 
       - name: Set Up Code Signing 🔑
         uses: ./.github/actions/setup-macos-codesigning
@@ -89,6 +109,7 @@ jobs:
 
           git fetch origin --no-tags --no-recurse-submodules -q
           .github/scripts/build-macos ${build_args}
+
       - name: Compile Analytics Data 📊
         run: |
           : Compile Analytics Data 📊

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -59,7 +59,7 @@ jobs:
 
   macos-build:
     name: macOS 🍏
-    runs-on: macos-14
+    runs-on: macos-15
     needs: check-event
     strategy:
       fail-fast: false
@@ -80,18 +80,18 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 15.4'
-          sudo xcode-select --switch /Applications/Xcode_15.4.app/Contents/Developer
+          print '::group::Enable Xcode 16.1'
+          sudo xcode-select --switch /Applications/Xcode_16.1.0.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'
-          local -a to_remove=()
-
-          for formula (curl) {
-            if [[ -d ${HOMEBREW_PREFIX}/opt/${formula} ]] to_remove+=(${formula})
+          local -a unwanted_formulas=()
+          local -a remove_formulas=()
+          for formula (${unwanted_formulas}) {
+            if [[ -d ${HOMEBREW_PREFIX}/Cellar/${formula} ]] remove_formulas+=(${formula})
           }
 
-          if (( #to_remove )) brew uninstall --ignore-dependencies ${to_remove}
+          if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
           print '::endgroup::'
 
           local -A arch_names=(x86_64 intel arm64 apple)

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -15,7 +15,7 @@ jobs:
           failCondition: error
 
   swift-format:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -39,7 +39,7 @@ jobs:
   services-validation:
     name: Validate Services 🕵️
     if: github.repository_owner == 'obsproject' && inputs.job == 'services'
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       checks: write
       contents: write
@@ -73,7 +73,7 @@ jobs:
   steam-upload:
     name: Upload Steam Builds 🚂
     if: github.repository_owner == 'obsproject' && inputs.job == 'steam'
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/steam-upload

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -139,7 +139,7 @@ jobs:
   create-appcast:
     name: Create Sparkle Appcast 🎙️
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
-    runs-on: macos-14
+    runs-on: macos-15
     needs: build-project
     strategy:
       fail-fast: false

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
   services-availability:
     name: Check Service Availability 🛜
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-14
+    runs-on: macos-15
     permissions:
       checks: write
       contents: write
@@ -49,7 +49,7 @@ jobs:
           # each item in the array with the 'actions_caches' key.
           # First it only selects objects whose 'ref' element has the value
           # 'refs/heads/master', of those objects only those whose 'key'
-          # value matches the specifies expression, before finally only
+          # value matches the specified expression, before finally only
           # selecting the 'id' and 'key' elements for a new object.
           # The final 'join' command combines both elements with a semicolon
           # into a raw string which can then be parsed directly.
@@ -124,7 +124,7 @@ jobs:
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
           # This 'gh' command retrieves the last 2 runs of the workflow defined
-          # by 'scheduled.yaml' and retrieve only the 'headSha' value of the
+          # by 'scheduled.yaml' and retrieves just the 'headSha' value of the
           # JSON response payload.
           #
           # As this job runs in context of the same workflow, the first element
@@ -162,7 +162,7 @@ jobs:
     name: Upload Steam Builds 🚂
     needs: [build-project]
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-14
+    runs-on: macos-15
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
@@ -178,7 +178,7 @@ jobs:
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
           # This 'gh' command retrieves the last 2 runs of the workflow defined
-          # by 'scheduled.yaml' and retrieve only the 'headSha' value of the
+          # by 'scheduled.yaml' and retrieves just the 'headSha' value of the
           # JSON response payload.
           #
           # As this job runs in context of the same workflow, the first element

--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -21,8 +21,8 @@ endif()
 set_property(CACHE CMAKE_OSX_ARCHITECTURES PROPERTY STRINGS arm64 x86_64)
 
 # Ensure recent enough Xcode and platform SDK
-set(_obs_macos_minimum_sdk 14.2) # Keep in sync with Xcode
-set(_obs_macos_minimum_xcode 15.1) # Keep in sync with SDK
+set(_obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
+set(_obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
 message(DEBUG "macOS SDK Path: ${CMAKE_OSX_SYSROOT}")
 string(REGEX MATCH ".+/MacOSX.platform/Developer/SDKs/MacOSX([0-9]+\\.[0-9])+\\.sdk$" _ ${CMAKE_OSX_SYSROOT})
 set(_obs_macos_current_sdk ${CMAKE_MATCH_1})


### PR DESCRIPTION
### Description
Updates macOS-based jobs to use macOS 15 runners and switch to Xcode 16.1 as development environment.

### Motivation and Context
Using any feature introduced in macOS 15 requires compiling OBS Studio with Xcode 16+, which is only available on macOS 15 runners. Otherwise new features of the content sharing picker or audio sinks cannot be compiled on CI.

### How Has This Been Tested?
Requires test runs on CI itself.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
