### PR TITLE
obs-nvenc: Fix translation string for 4:4:4 unsupported error

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -738,7 +738,7 @@ static bool init_encoder(struct nvenc_data *enc, enum codec_type codec, obs_data
 	enc->in_format = get_preferred_format(pref_format);
 
 	if (enc->in_format == VIDEO_FORMAT_I444 && !support_444) {
-		NV_FAIL(obs_module_text("NVENC.444Unsupported"));
+		NV_FAIL(obs_module_text("444Unsupported"));
 		return false;
 	}
 


### PR DESCRIPTION
### Description

Fix string

### Motivation and Context

Fix string

### How Has This Been Tested?

Fix string

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
