### PR TITLE
image-source: Fix slideshow stopping on last file in random mode

### DIFF
--- a/plugins/image-source/obs-slideshow-mk2.c
+++ b/plugins/image-source/obs-slideshow-mk2.c
@@ -868,7 +868,7 @@ static void ss_video_tick(void *data, float seconds)
 	if (ssd->elapsed > ssd->slide_time) {
 		ssd->elapsed -= ssd->slide_time;
 
-		if (!ssd->loop && ssd->slides.cur.slide_idx == ssd->files.num - 1) {
+		if (!ssd->randomize && !ssd->loop && ssd->slides.cur.slide_idx == ssd->files.num - 1) {
 			if (ssd->hide)
 				do_transition(ss, true);
 			else


### PR DESCRIPTION
### Description

Don't stop slideshow in random mode.

### Motivation and Context

Fixes #11449

### How Has This Been Tested?

Hasn't.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
