### PR TITLE
UI: Fix remigrating scene collections from absolute to relative

### DIFF
--- a/UI/window-basic-main-scene-collections.cpp
+++ b/UI/window-basic-main-scene-collections.cpp
@@ -636,8 +636,6 @@ void OBSBasic::on_actionRemigrateSceneCollection_triggered()
 		return;
 	}
 
-	OBSDataAutoRelease priv = obs_get_private_data();
-
 	if (!usingAbsoluteCoordinates && !migrationBaseResolution) {
 		OBSMessageBox::warning(
 			this, QTStr("Basic.Main.RemigrateSceneCollection.Title"),
@@ -691,12 +689,12 @@ void OBSBasic::on_actionRemigrateSceneCollection_triggered()
 		ResetVideo();
 	}
 
-	ActivateSceneCollection(currentCollection);
+	ActivateSceneCollection(currentCollection, !usingAbsoluteCoordinates);
 }
 
 // MARK: - Scene Collection Management Helper Functions
 
-void OBSBasic::ActivateSceneCollection(const OBSSceneCollection &collection)
+void OBSBasic::ActivateSceneCollection(const OBSSceneCollection &collection, bool remigrate)
 {
 	const std::string currentCollectionName{config_get_string(App()->GetUserConfig(), "Basic", "SceneCollection")};
 
@@ -709,7 +707,7 @@ void OBSBasic::ActivateSceneCollection(const OBSSceneCollection &collection)
 	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollection", collection.name.c_str());
 	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollectionFile", collection.fileName.c_str());
 
-	Load(collection.collectionFile.u8string().c_str());
+	Load(collection.collectionFile.u8string().c_str(), remigrate);
 
 	RefreshSceneCollections();
 

--- a/UI/window-basic-main.hpp
+++ b/UI/window-basic-main.hpp
@@ -1345,7 +1345,7 @@ private:
 	void RefreshSceneCollectionCache();
 
 	void RefreshSceneCollections(bool refreshCache = false);
-	void ActivateSceneCollection(const OBSSceneCollection &collection);
+	void ActivateSceneCollection(const OBSSceneCollection &collection, bool remigrate = false);
 
 public:
 	inline const OBSSceneCollectionCache &GetSceneCollectionCache() const noexcept { return collections; };


### PR DESCRIPTION
### Description

Fixes resetting scene collection base resolution to work again.

### Motivation and Context

This was broken in #11055

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
