### PR TITLE
libobs-opengl: Fix for formats with zero modifiers

### DIFF
--- a/libobs-opengl/gl-egl-common.c
+++ b/libobs-opengl/gl-egl-common.c
@@ -353,6 +353,10 @@ static inline bool query_dmabuf_modifiers(EGLDisplay egl_display, EGLint drm_for
 		return false;
 	}
 
+	if (max_modifiers == 0) {
+		return false;
+	}
+
 	EGLuint64KHR *modifier_list = bzalloc(max_modifiers * sizeof(EGLuint64KHR));
 	EGLBoolean *external_only = NULL;
 	if (!modifier_list) {
@@ -364,6 +368,10 @@ static inline bool query_dmabuf_modifiers(EGLDisplay egl_display, EGLint drm_for
 					     &max_modifiers)) {
 		blog(LOG_ERROR, "Cannot query a list of modifiers: %s", gl_egl_error_to_string(eglGetError()));
 		bfree(modifier_list);
+		return false;
+	}
+
+	if (max_modifiers == 0) {
 		return false;
 	}
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When compiled from the most recent commit on `master`, [`f03280c`](https://github.com/obsproject/obs-studio/commit/f03280c4fd449d1591363291fd2762ffca878e6a), OBS would crash in [`query_dmabuf_modifiers`](https://github.com/obsproject/obs-studio/blob/f03280c4fd449d1591363291fd2762ffca878e6a/libobs-opengl/gl-egl-common.c#L356). The cause of the crash is a zero-size allocation caused by `max_modifiers` being 0.

### Motivation and Context
OBS would crash on startup with no other information. This change allows it to properly handle this case.

### How Has This Been Tested?
OBS no longer crashes after applying the changes.
OS: EndeavourOS x86_64
Kernel: Linux 6.12.4-arch1-1
DE: KDE Plasma 6.2.4
CPU: Intel(R) Pentium(R) G4560 (4) @ 3.50 GHz
GPU 1: AMD Radeon RX 560 Series [Discrete]
GPU 2: Intel HD Graphics 610 @ 1.05 GHz [Integrated]

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
