### PR TITLE
cmake: Turn off camera reaction by default on macOS 14.4 and later

### DIFF
--- a/UI/cmake/macos/Info.plist.in
+++ b/UI/cmake/macos/Info.plist.in
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraReactionEffectGesturesEnabledDefault</key>
+	<false/>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>LSAppNapIsDisabled</key>


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds an Info.plist flag available since macOS 14.4 that turns off the reaction effects by default (which Apple turned on by default for all apps for some reason).
Amazingly, this is only documented in `@discussion` part the `AVCaptureDevice.h` header in the macOS SDK (line 2335ff on the 15.2 SDK), not in the same part of the [official documentation](https://developer.apple.com/documentation/avfoundation/avcapturedevice/reactionEffectGesturesEnabled?language=objc). (See also FB16132155)

In fact, I only know that it is even possible to disable it because I saw Zoom do it (the macOS UI very much encourages the user to turn it on, see the screenshot below) and then went digging as to how it was done.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The reaction effects that macOS adds by default are confusing to users as they're turned on by default and users don't know where they come from or where to turn them off. Setting this flag in the apps Info.plist prevents them from being turned on by default. The macOS UI makes it very obvious to the user where they can turn them on should they wish to do so.

This comes up often enough in support that I would consider it to be a bug fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Changed the bundle identifier of OBS (which the reaction setting appears to be tied to).
After adding a camera source on first launch, got this notification:

<img width="353" alt="Bildschirmfoto 2024-12-20 um 20 40 31" src="https://github.com/user-attachments/assets/735873f4-8d25-4c4c-b685-b12f528692a1" />


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
