### PR TITLE
libobs: Fix deadlock on macOS input method change

### DIFF
--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -563,6 +563,8 @@ static void InputMethodChangedProc(CFNotificationCenterRef center __unused, void
 
     CFRetain(platform->layout_data);
     platform->layout = (UCKeyboardLayout *) CFDataGetBytePtr(platform->layout_data);
+
+    pthread_mutex_unlock(&hotkeys->mutex);
 }
 
 // MARK: macOS Hotkey API Implementation


### PR DESCRIPTION
### Description
Fixed a deadlock in macOS input method change handler.

### Motivation and Context
In the existing code for handling macOS input method changes, if keyboard layout information is correctly obtained, it will result in the mutex of hotkeys never being released.

This will cause a deadlock on hotkeys and freeze OBS when exit. See #11650.

### How Has This Been Tested?
Tested on macOS Sequoia 15.2, seems fixed the issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
