### PR TITLE
obs-frontend-api: Add event for video reset

### DIFF
--- a/UI/obs-frontend-api/obs-frontend-api.h
+++ b/UI/obs-frontend-api/obs-frontend-api.h
@@ -62,6 +62,7 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED,
 	OBS_FRONTEND_EVENT_THEME_CHANGED,
 	OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN,
+	OBS_FRONTEND_EVENT_VIDEO_RESET,
 };
 
 /* ------------------------------------------------------------------------- */

--- a/UI/window-basic-main.cpp
+++ b/UI/window-basic-main.cpp
@@ -4516,6 +4516,8 @@ int OBSBasic::ResetVideo()
 							       migrationBaseResolution->second != ovi.base_height));
 		ui->actionRemigrateSceneCollection->setEnabled(canMigrate);
 
+		OnEvent(OBS_FRONTEND_EVENT_VIDEO_RESET);
+
 		emit CanvasResized(ovi.base_width, ovi.base_height);
 		emit OutputResized(ovi.output_width, ovi.output_height);
 	}

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -30,6 +30,12 @@ static THREAD_LOCAL bool is_ui_thread = false;
 extern void add_default_module_paths(void);
 extern char *find_libobs_data_file(const char *file);
 
+static inline void obs_video_dosignal(const char *signal_obs)
+{
+	struct calldata params = {0};
+	signal_handler_signal(obs->signals, signal_obs, &params);
+}
+
 static inline void make_video_info(struct video_output_info *vi, struct obs_video_info *ovi)
 {
 	vi->name = "video";
@@ -695,6 +701,7 @@ static int obs_init_video(struct obs_video_info *ovi)
 
 	video->thread_initialized = true;
 
+	obs_video_dosignal("core_video_ready");
 	return OBS_VIDEO_SUCCESS;
 }
 
@@ -820,6 +827,8 @@ static void obs_free_video(void)
 	pthread_mutex_destroy(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	deque_free(&obs->video.tasks);
+
+	obs_video_dosignal("core_video_released");
 }
 
 static void obs_free_graphics(void)
@@ -1052,6 +1061,9 @@ static const char *obs_signals[] = {
 	"void hotkey_register(ptr hotkey)",
 	"void hotkey_unregister(ptr hotkey)",
 	"void hotkey_bindings_changed(ptr hotkey)",
+
+	"void core_video_ready()",
+	"void core_video_released()",
 
 	NULL,
 };


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
If obs_reset_video is called in OBS, for 3rd plugins, they should re-create the obs_output or video_output hold in their code. Otherwise, 3rd plugins will easily crash since their video_output and obs_output::video_t have been deleted in obs_reset_video.

### Motivation and Context
if a 3rd plugin hold their obs_output or video_output, crash will easily happen after below operation:
> install ndi plugin
> open settings of OBS, to video page
> modify resolution
> click OK
> Tool menu of OBS, select NDI, start its output, crash
the reason can be found in https://github.com/DistroAV/DistroAV/issues/1096

Except NDI plugin, I also found this kind of crash on other plugin, such as vertical-canvas, source-record.
If OBS provide this new front event, 3rd plugin has the chance to reset their obs_output or video_output.

### How Has This Been Tested?
settings -> video -> modify resolution -> click OK -> check if this event can be sent

### Types of changes
New feature (non-breaking change which adds functionality) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
