### PR TITLE
UI: Fix wrong order for requesting mutex

### DIFF
--- a/UI/window-basic-preview.cpp
+++ b/UI/window-basic-preview.cpp
@@ -2488,9 +2488,20 @@ void OBSBasicPreview::DrawSpacingHelpers()
 	vec3 start, end;
 
 	float pixelRatio = main->GetDevicePixelRatio();
-	for (int i = 0; i < 4; i++) {
-		if (!spacerLabel[i])
-			spacerLabel[i] = CreateLabel(pixelRatio, i);
+	if (!labelCreated) {
+		QMetaObject::invokeMethod(this, [this, pixelRatio]() {
+			if (labelCreated)
+				return;
+
+			for (int i = 0; i < 4; i++) {
+				if (!spacerLabel[i])
+					spacerLabel[i] = CreateLabel(pixelRatio, i);
+			}
+
+			labelCreated = true;
+		});
+
+		return; // wait label source to be created
 	}
 
 	vec3_set(&start, top.x, 0.0f, 1.0f);

--- a/UI/window-basic-preview.hpp
+++ b/UI/window-basic-preview.hpp
@@ -188,6 +188,7 @@ public:
 	static inline void operator delete(void *ptr) { bfree(ptr); }
 
 	OBSSourceAutoRelease spacerLabel[4];
+	bool labelCreated = false;
 	int spacerPx[4] = {0};
 
 	void DrawSpacingHelpers();


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Below callstack is from graphic thread where gs_enter has been gotten. As this, the order of requesting mutex is as gs->sources_mutex. That is conflicting with basic logic in libobs. About basic request order, sources_mutex should be requested before gs.

[callstask]
render_displays
(1)request gs enter
DrawSpacingHelpers()
CreateLabel
obs_source_create_private
(2)request obs->data.sources_mutex


### Motivation and Context
keep the righ order for requesting mutex. otherwise there will be a nested logic which will cause block.
But what I must declare is that this block is not easily happen

### How Has This Been Tested?
run obs and select any video source, 
ensure pixel label in preview window can be displayed normally

### Types of changes
Bug fix (non-breaking change which fixes an issue) -

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
