### PR TITLE
libobs: Use limited range for R10l output

### DIFF
--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -51,7 +51,7 @@ float4 PSDrawAlphaDivideR10L(VertInOut vert_in) : TARGET
 	rgba.rgb *= (rgba.a > 0.) ? (multiplier / rgba.a) : 0.;
 	rgba.rgb = rec709_to_rec2020(rgba.rgb);
 	rgba.rgb = linear_to_st2084(rgba.rgb);
-	uint3 rgb1023 = uint3(mad(rgba.rgb, 1023., .5));
+	uint3 rgb1023 = uint3(mad(rgba.rgb, 876., 64.5));
 	uint b = (rgb1023.b & 0x3Fu) << 2;
 	uint g = ((rgb1023.b & 0x3C0u) >> 6) | ((rgb1023.g & 0xFu) << 4);
 	uint r = ((rgb1023.g & 0x3F0u) >> 4) | ((rgb1023.r & 0x3u) << 6);


### PR DESCRIPTION
### Description
DeckLink hardware seems to want the values in video range.

### Motivation and Context
The scopes on my fancy display were showing bad values were being sent over the wire.

Values being between 64 and 940 for bmdFormat10BitRGBXLE don't seem to be in the DeckLink SDK PDF, but they are in code comments of Mac/Linux DeckLinkAPIModes.h and Windows DeckLinkAPIModes.idl.

### How Has This Been Tested?
Scopes on my display show proper values are being sent over the wire.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.