### PR TITLE
UI: Fix repeated log entries

### DIFF
--- a/UI/obs-app.cpp
+++ b/UI/obs-app.cpp
@@ -342,9 +342,11 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 	static mutex log_mutex;
 	static const char *last_msg_ptr = nullptr;
 	static int last_char_sum = 0;
+	static size_t last_len = 0;
 	static int rep_count = 0;
 
 	int new_sum = sum_chars(output_str);
+	size_t new_len = strlen(output_str);
 
 	lock_guard<mutex> guard(log_mutex);
 
@@ -357,6 +359,8 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 		if (diff < MAX_CHAR_VARIATION) {
 			return (rep_count++ >= MAX_REPEATED_LINES);
 		}
+	} else if (last_len == new_len && new_sum == last_char_sum) {
+		return (rep_count++ >= MAX_REPEATED_LINES);
 	}
 
 	if (rep_count > MAX_REPEATED_LINES) {
@@ -366,6 +370,7 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 
 	last_msg_ptr = msg;
 	last_char_sum = new_sum;
+	last_len = new_len;
 	rep_count = 0;
 
 	return false;

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -162,9 +162,11 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 	static mutex log_mutex;
 	static const char *last_msg_ptr = nullptr;
 	static int last_char_sum = 0;
+	static size_t last_len = 0;
 	static int rep_count = 0;
 
 	int new_sum = sum_chars(output_str);
+	size_t new_len = strlen(output_str);
 
 	lock_guard<mutex> guard(log_mutex);
 
@@ -177,6 +179,8 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 		if (diff < MAX_CHAR_VARIATION) {
 			return (rep_count++ >= MAX_REPEATED_LINES);
 		}
+	} else if (last_len == new_len && new_sum == last_char_sum) {
+		return (rep_count++ >= MAX_REPEATED_LINES);
 	}
 
 	if (rep_count > MAX_REPEATED_LINES) {
@@ -186,6 +190,7 @@ static inline bool too_many_repeated_entries(fstream &logFile, const char *msg, 
 
 	last_msg_ptr = msg;
 	last_char_sum = new_sum;
+	last_len = new_len;
 	rep_count = 0;
 
 	return false;


### PR DESCRIPTION
### Description
`too_many_repeated_entries` did only detect repeated entries when the format pointer stayed the same.
With this change it also detects repeat entries when the format pointer is not the same, but the contents has the same length and the same sum.

### Motivation and Context
[`ffmpeg_log`](https://github.com/obsproject/obs-studio/blob/48dad45ed5b778ddaf80d282b3c7cd66581c999c/plugins/win-dshow/win-dshow.cpp#L108l) uses a `DStr` internal for the format of `blogva`, because of that the pointer is different every call and `too_many_repeated_entries` would never detect any repeats.

### How Has This Been Tested?
On windows 11 by having a plugin blog multiple the same messages with different format pointers

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
