### PR TITLE
obs-ffmpeg: Fix throughput checks for older AMD driver

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -422,6 +422,7 @@ static inline void check_preset_compatibility(amf_base *enc, const char *&preset
 	 * encoder properties. If the throughput is lower than the max
 	 * throughput, switch to a lower preset. */
 
+	refresh_throughput_caps(enc, preset);
 	if (astrcmpi(preset, "highQuality") == 0) {
 		if (!enc->max_throughput) {
 			preset = "quality";
@@ -447,9 +448,14 @@ static inline void check_preset_compatibility(amf_base *enc, const char *&preset
 	}
 
 	if (astrcmpi(preset, "balanced") == 0) {
-		if (enc->max_throughput && enc->max_throughput - enc->requested_throughput < enc->throughput) {
+		if (!enc->max_throughput) {
 			preset = "speed";
-			refresh_throughput_caps(enc, preset);
+			set_opt(QUALITY_PRESET, get_preset(enc, preset));
+		} else {
+			if (enc->max_throughput - enc->requested_throughput < enc->throughput) {
+				preset = "speed";
+				refresh_throughput_caps(enc, preset);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This PR fixes the case where OBS does not refresh the throughput caps with the user's setting so stale throughput values are used to check preset compatibility as well as the case where `..._CAP_MAX_THROUGHPUT` does not work as expected -> returns 0 -> and fails to fall back to the lowest preset.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This is a bug fix.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Tested on multiple Windows machines

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
