### PR TITLE
docs: Fix various typos

### DIFF
--- a/docs/sphinx/graphics.rst
+++ b/docs/sphinx/graphics.rst
@@ -198,7 +198,7 @@ Vertex components can have the following semantics:
 - **POSITION**       - Position value (*float4*).
 - **NORMAL**         - Normal value (*float4*).
 - **TANGENT**        - Tangent value (*float4*).
-- **TEXCOORD[0..7]** - Texture cooordinate value (*float2*, *float3*, or
+- **TEXCOORD[0..7]** - Texture coordinate value (*float2*, *float3*, or
   *float4*).
 
 Here is an example of a vertex semantic structure:

--- a/docs/sphinx/reference-libobs-util-source-profiler.rst
+++ b/docs/sphinx/reference-libobs-util-source-profiler.rst
@@ -86,6 +86,6 @@ Source Profiler Functions
    
    This function exists to avoid having to allocate new memory each time a profiling result is queried.
 
-   :param source: Source to get profiling informatio for
+   :param source: Source to get profiling information for
    :param result: Result object to fill
    :return:       *true* if data for the source exists, *false* otherwise

--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -157,7 +157,7 @@ Property Object Functions
                           - **OBS_TEXT_PASSWORD** - Single line of text (passworded)
                           - **OBS_TEXT_MULTILINE** - Multi-line text
                           - **OBS_TEXT_INFO** - Read-only informative text, behaves differently
-                            depending on wether description, string value and long description
+                            depending on whether description, string value and long description
                             are set
 
    :return:               The property


### PR DESCRIPTION
### Description

Found typos via `codespell -q 3 -S "*.ini,./AUTHORS,./UI/data/locale,./deps/w32-pthreads" -L abitrate,aci,addres,caf,currentry,datas,dur,iff,inout,lod,mot,mut,numer,ot,parm,ques,settinga,statics,trun,uint,vas,writen`

### Motivation and Context

Improving accuracy of documentation

### How Has This Been Tested?

n/a

### Types of changes

Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
