### PR TITLE
rtmp-services: Add bump.live

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 264,
+    "version": 265,
     "files": [
         {
             "name": "services.json",
-            "version": 264
+            "version": 265
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3530,6 +3530,33 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "bump.live",
+            "more_info_link": "https://help.bump.live/en/articles/10364182-streaming-on-bump",
+            "stream_key_link": "https://bump.live/dashboard/stream",
+            "servers": [
+                {
+                    "name": "Global",
+                    "url": "rtmps://fa46d4725148.global-contribute.live-video.net/app"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720",
+                    "852x480",
+                    "640x360"
+                ],
+                "max fps": 60,
+                "max video bitrate": 8000,
+                "max audio bitrate": 160,
+                "x264opts": "scenecut=0"
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds bump.live to services.

Service entry added to `plugins/rtmp-services/data/services.json`
Incremented package version in `plugins/rtmp-services/data/package.json `

### Motivation and Context
To help new users easily and quickly configure the service for live streaming, it also provides direct access to our streaming help documentation.


### How Has This Been Tested?
- Built locally on Windows 11 23H2 build: 22635.4660
- Replaced the JSON files in the existing OBS install - v31.0.0
- Tested `bump.live` service entry from dropdown and was able to successfully broadcast after adding just a stream key

### Types of changes
- New feature (non-breaking change which adds functionality) 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
