### PR TITLE
frontend: Fix crashes caused by scene collections with empty internal name

### DIFF
--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -83,6 +83,10 @@ void cleanBackupCollision(const OBSSceneCollection &collection)
 
 void OBSBasic::SetupNewSceneCollection(const std::string &collectionName)
 {
+	if (collectionName.empty()) {
+		throw std::logic_error("Cannot create new scene collection with empty collection name");
+	}
+
 	const OBSSceneCollection &newCollection = CreateSceneCollection(collectionName);
 
 	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGING);

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -394,12 +394,12 @@ void OBSBasic::RefreshSceneCollectionCache()
 			obs_data_create_from_json_file_safe(entry.path().u8string().c_str(), "bak");
 
 		std::string candidateName;
-		const char *collectionName = obs_data_get_string(collectionData, "name");
+		std::string collectionName = obs_data_get_string(collectionData, "name");
 
-		if (!collectionName) {
-			candidateName = entry.path().filename().u8string();
+		if (collectionName.empty()) {
+			candidateName = entry.path().stem().u8string();
 		} else {
-			candidateName = collectionName;
+			candidateName = std::move(collectionName);
 		}
 
 		foundCollections.try_emplace(candidateName,


### PR DESCRIPTION
### Description
Prevents API clients against creating scene collections without a name, while also handling the possible case of a malformed scene collection gracefully.

### Motivation and Context
OBS Studio itself does not allow users to create scene collections without a name, but the checks were not added to the internal API as well. Thus API clients were able to limbo right underneath that requirement.

This PR adds two changes:

1. Adds a check against providing an empty name for a new scene collection.
2. Adds a fallback to use the scene collection's filename stem as a collection name _if_ a malformed collection is present in the file system.

This should prevent new malformed scene collections to be created by API clients but also protect users against having their OBS Studio instance crash over such malformed collections.

> [!NOTE]
> A malformed scene collection will automatically be converted into a well-formed one once OBS Studio saves the current scene collection, as the fallback name will be written _into_ the collection.

> [!TIP]
> ## C++ Moment
> Because `collectionName` is a glvalue, the code uses `std::move` to allow C++ to pilfer the contents of it when initialising `candidateName` (turning `collectionName` into an xvalue), as it will not be used by anything else within the loop body after that assignment.
>
> That's also the reason why `collectionName` is _not_ marked as `const`, because pilfering requires the ability to modify the contents of it (setting its internal string pointer to `nullptr`). If it _were_ `const`, C++ would be forced to make a copy.

Fixes #11609 

### How Has This Been Tested?
Tested with a scene collection that has an empty name and another collection that has no `name` key in its collection.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
