### PR TITLE
libobs: Fix various comment typos

### DIFF
--- a/libobs/util/platform-nix-dbus.c
+++ b/libobs/util/platform-nix-dbus.c
@@ -25,7 +25,7 @@ enum service_type {
 	FREEDESKTOP_SS, /* freedesktop screensaver (KDE >= 4, GNOME >= 3.10) */
 	FREEDESKTOP_PM, /* freedesktop power management (KDE, gnome <= 2.26) */
 	MATE_SM,        /* MATE (>= 1.0) session manager */
-	GNOME_SM,       /* GNOME 2.26 - 3.4 sessopm mamager */
+	GNOME_SM,       /* GNOME 2.26 - 3.4 session manager */
 };
 
 struct service_info {

--- a/libobs/util/threading-windows.h
+++ b/libobs/util/threading-windows.h
@@ -108,7 +108,7 @@ static inline bool os_atomic_set_bool(volatile bool *ptr, bool val)
 	const char c = _InterlockedExchange8((volatile char *)ptr, (char)val);
 	bool b;
 
-	/* Avoid unnecesary char to bool conversion. Value known 0 or 1. */
+	/* Avoid unnecessary char to bool conversion. Value known 0 or 1. */
 	memcpy(&b, &c, sizeof(b));
 
 	return b;
@@ -135,7 +135,7 @@ static inline bool os_atomic_load_bool(const volatile bool *ptr)
 	_ReadWriteBarrier();
 #endif
 
-	/* Avoid unnecesary char to bool conversion. Value known 0 or 1. */
+	/* Avoid unnecessary char to bool conversion. Value known 0 or 1. */
 	memcpy(&b, &c, sizeof(b));
 
 	return b;


### PR DESCRIPTION
### Description

Found typos via `codespell -q 3 -S "*.ini,./AUTHORS,./UI/data/locale,./deps/w32-pthreads" -L abitrate,aci,addres,caf,currentry,datas,dur,iff,inout,lod,mot,mut,numer,ot,parm,ques,settinga,statics,trun,uint,vas,writen`

### Motivation and Context

Improving accuracy of source comment for quality, readability, and may be used to generate source docs  

### How Has This Been Tested?

n/a

### Types of changes

Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
