### PR TITLE
Adding dynamic stream delay to OBS

### DIFF
--- a/frontend/plugins/frontend-tools/data/scripts/stream-delay.lua
+++ b/frontend/plugins/frontend-tools/data/scripts/stream-delay.lua
@@ -1,0 +1,49 @@
+obs = obslua
+
+function get_output()
+	local output = obs.obs_get_output_by_name("rtmp multitrack video")
+	return output
+end
+
+-- Function to get the current delay and add 1 second
+function increment_stream_delay()
+    -- Get the output (stream or recording)
+    local output = get_output()
+    local current_delay = obs.obs_output_get_delay(output)
+
+    -- Add 1 second to the current delay
+    local new_delay = current_delay + 1
+    
+    obs.obs_output_set_delay(output, new_delay, 0)
+
+    -- Log the new delay
+    obs.script_log(obs.LOG_INFO, "Increased stream delay from " .. current_delay .. " to " .. new_delay .. " seconds.")
+end
+
+function decrement_stream_delay()
+    -- Get the output (stream or recording)
+    local output = get_output()
+    local current_delay = obs.obs_output_get_delay(output)
+
+    -- Add 1 second to the current delay
+    local new_delay = current_delay - 1
+    
+    obs.obs_output_set_delay(output, new_delay, 0)
+
+    -- Log the new delay
+    obs.script_log(obs.LOG_INFO, "Decreased stream delay from " .. current_delay .. " to " .. new_delay .. " seconds.")
+end
+
+-- Register the function as a hotkey
+hotkey_id = obs.obs_hotkey_register_frontend("increment_stream_delay", "Increase Stream Delay by 1s", increment_stream_delay)
+hotkey_id = obs.obs_hotkey_register_frontend("decrement_stream_delay", "Descrease Stream Delay by 1s", decrement_stream_delay)
+-- Script description (appears in the script UI in OBS)
+function script_description()
+    return "This script increases the stream delay by 1 second every time the hotkey is pressed."
+end
+
+-- Called when the script is unloaded
+function script_unload()
+    -- obs.obs_hotkey_unregister(hotkey_id)
+end
+

--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -507,7 +507,6 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 		num += 1;
 	};
 
-	check_setting(useDelay, "Basic.Settings.Advanced.StreamDelay", "Basic.Settings.Advanced.StreamDelay");
 #ifdef _WIN32
 	check_setting(enableNewSocketLoop, "Basic.Settings.Advanced.Network.EnableNewSocketLoop",
 		      "Basic.Settings.Advanced.Network");


### PR DESCRIPTION
### Title: Question Regarding Experimental Blank Frame Generation in OBS Delay Mode

Hi OBS Community,

I'm working on a feature for OBS Studio that generates blank audio and video frames during delay mode to ensure seamless playback when live data is unavailable. The code is still untested and experimental, and I'd appreciate some guidance or insights from the community to ensure stability and compatibility with OBS's architecture.


Here’s a brief overview of what I’m attempting:

1. **Blank Video Frames**:

   - Zero-filled data to represent a black frame.
   - Dynamically sized based on the video output's resolution.

2. **Silent Audio Packets**:
   - Filled with zeroes to create silence.
   - Supports multiple sample rates and channel configurations.

3. **Integration**:
   - These blank frames are pushed into the delay queue when gaps are detected to maintain consistency.

### My Questions:
1. This approach does not fully work, so I have commented out the filling of the blank frames, as it crashes during the interleave packets discarding audio frames due to idx being 0. I didn't spent a lot of time debugging as I would hope someone would be able to assist with this feature or point me in the right direction.
1. Does this approach align with OBS's internal data flow for audio and video processing?
1. Are there any best practices for memory allocation and lifecycle management of the generated packets?
1. Could this cause unintended side effects when pushed into the delay queue, particularly with encoders or filters?
1. What additional tests should I run to validate this implementation?


Any feedback or suggestions would be greatly appreciated! Since this is my first attempt at contributing to OBS, I’m eager to learn and refine this feature based on your expertise.

Thanks in advance! 😊