### PR TITLE
frontend: Remove channel change signal handler from transform dialog

### DIFF
--- a/frontend/dialogs/OBSBasicTransform.cpp
+++ b/frontend/dialogs/OBSBasicTransform.cpp
@@ -77,8 +77,6 @@ OBSBasicTransform::OBSBasicTransform(OBSSceneItem item, OBSBasic *parent)
 
 	OBSDataAutoRelease wrapper = obs_scene_save_transform_states(main->GetCurrentScene(), false);
 	undo_data = std::string(obs_data_get_json(wrapper));
-
-	channelChangedSignal.Connect(obs_get_signal_handler(), "channel_change", OBSChannelChanged, this);
 }
 
 OBSBasicTransform::~OBSBasicTransform()
@@ -134,23 +132,6 @@ void OBSBasicTransform::SetItemQt(OBSSceneItem newItem)
 
 	bool enable = !!item && !obs_sceneitem_locked(item);
 	SetEnabled(enable);
-}
-
-void OBSBasicTransform::OBSChannelChanged(void *param, calldata_t *data)
-{
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
-	uint32_t channel = (uint32_t)calldata_int(data, "channel");
-	OBSSource source = (obs_source_t *)calldata_ptr(data, "source");
-
-	if (channel == 0) {
-		OBSScene scene = obs_scene_from_source(source);
-		window->SetScene(scene);
-
-		if (!scene)
-			window->SetItem(nullptr);
-		else
-			window->SetItem(FindASelectedItem(scene));
-	}
 }
 
 void OBSBasicTransform::OBSSceneItemTransform(void *param, calldata_t *data)

--- a/frontend/dialogs/OBSBasicTransform.hpp
+++ b/frontend/dialogs/OBSBasicTransform.hpp
@@ -17,7 +17,6 @@ private:
 
 	OBSBasic *main;
 	OBSSceneItem item;
-	OBSSignal channelChangedSignal;
 	std::vector<OBSSignal> sigs;
 
 	std::string undo_data;
@@ -34,8 +33,6 @@ private:
 
 	void SetScene(OBSScene scene);
 	void SetItem(OBSSceneItem newItem);
-
-	static void OBSChannelChanged(void *param, calldata_t *data);
 
 	static void OBSSceneItemTransform(void *param, calldata_t *data);
 	static void OBSSceneItemRemoved(void *param, calldata_t *data);


### PR DESCRIPTION
### Description

Remove `OBSChannelChanged` from `OBSBasicTransform`.

### Motivation and Context

This doesn't work. The primary channel is a transtiion, not a scene. This actually breaks the transform dialog if it's open while the transition is being changed.

### How Has This Been Tested?

Compiled, still works.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
