### PR TITLE
frontend: Use vector for filters dialog signals

### DIFF
--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -44,16 +44,16 @@ OBSBasicFilters::OBSBasicFilters(QWidget *parent, OBSSource source_)
 	: QDialog(parent),
 	  ui(new Ui::OBSBasicFilters),
 	  source(source_),
-	  addSignal(obs_source_get_signal_handler(source), "filter_add", OBSBasicFilters::OBSSourceFilterAdded, this),
-	  removeSignal(obs_source_get_signal_handler(source), "filter_remove", OBSBasicFilters::OBSSourceFilterRemoved,
-		       this),
-	  reorderSignal(obs_source_get_signal_handler(source), "reorder_filters", OBSBasicFilters::OBSSourceReordered,
-			this),
-	  removeSourceSignal(obs_source_get_signal_handler(source), "remove", OBSBasicFilters::SourceRemoved, this),
-	  renameSourceSignal(obs_source_get_signal_handler(source), "rename", OBSBasicFilters::SourceRenamed, this),
 	  noPreviewMargin(13)
 {
 	main = OBSBasic::Get();
+
+	signal_handler_t *handler = obs_source_get_signal_handler(source);
+	obsSignals.emplace_back(handler, "filter_add", OBSBasicFilters::OBSSourceFilterAdded, this);
+	obsSignals.emplace_back(handler, "filter_remove", OBSBasicFilters::OBSSourceFilterRemoved, this);
+	obsSignals.emplace_back(handler, "reorder_filters", OBSBasicFilters::OBSSourceReordered, this);
+	obsSignals.emplace_back(handler, "remove", OBSBasicFilters::SourceRemoved, this);
+	obsSignals.emplace_back(handler, "rename", OBSBasicFilters::SourceRenamed, this);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 

--- a/frontend/dialogs/OBSBasicFilters.hpp
+++ b/frontend/dialogs/OBSBasicFilters.hpp
@@ -34,12 +34,7 @@ private:
 	OBSSource source;
 	OBSPropertiesView *view = nullptr;
 
-	OBSSignal addSignal;
-	OBSSignal removeSignal;
-	OBSSignal reorderSignal;
-
-	OBSSignal removeSourceSignal;
-	OBSSignal renameSourceSignal;
+	std::vector<OBSSignal> obsSignals;
 	OBSSignal updatePropertiesSignal;
 
 	inline OBSSource GetFilter(int row, bool async);


### PR DESCRIPTION
### Description
This adds a vector for most signals in the filters dialog.

### Motivation and Context
Reduces code.

### How Has This Been Tested?
Used filters to make sure nothing broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
