### PR TITLE
Fixed deckLinkIterator extra ref

### DIFF
--- a/plugins/decklink/plugin-main.cpp
+++ b/plugins/decklink/plugin-main.cpp
@@ -20,7 +20,7 @@ bool log_sdk_version()
 	ComPtr<IDeckLinkAPIInformation> deckLinkAPIInformation;
 	HRESULT result;
 
-	deckLinkIterator = CreateDeckLinkIteratorInstance();
+	deckLinkIterator.Set(CreateDeckLinkIteratorInstance());
 	if (deckLinkIterator == NULL) {
 		blog(LOG_WARNING,
 		     "A DeckLink iterator could not be created.  The DeckLink drivers may not be installed");


### PR DESCRIPTION
<!--- Why is this change required? What problem does it solve? -->
Assigning a ComPtr from a Raw pointer will create an extra ref, and the CreateDeckLinkIteratorInstance already increments the refcount.
This should also be similar to the current usage of CreateDeckLinkDiscoveryInstance and CreateVideoConversionInstance:

https://github.com/obsproject/obs-studio/blob/master/plugins/decklink/decklink-device-discovery.cpp#L8
https://github.com/obsproject/obs-studio/blob/master/plugins/decklink/decklink-device-instance.cpp#L198

