### PR TITLE
obs-webrtc: Add "bframes" key override for mac VT encoder

### DIFF
--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -29,6 +29,8 @@ void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 	// For now, ensure maximum compatibility with webrtc peers
 	if (video_settings) {
 		obs_data_set_int(video_settings, "bf", 0);
+		// VideoToolbox encoder uses "bframes" as a config key
+		obs_data_set_int(video_settings, "bframes", 0);
 		obs_data_set_bool(video_settings, "repeat_headers", true);
 	}
 }


### PR DESCRIPTION
Most of the encoders use "bf" as a key to store the number of bframes but VT and QSV use "bframes". QSV already has code to work around this issue.


*NOTE* There is another way to accomplish this, similar to the QSV encoder:
```	
if (obs_data_has_user_value(settings, "bf"))
		bFrames = (int)obs_data_get_int(settings, "bf");
```

This seemed a bit "hidden behavior..y", but happy to do either way! Certainly would make it most consistent to override bframes in the future if everyone didn't need to reason about both bframes and bf.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adds "bframes" override in addition to "bf" to convert VT encoders.

### Motivation and Context
The WHIP service overrides bframes using "bf" but the VT encoder uses "bframes" as the key. As a result, the encoder ends up sending bframes if they are configured in the output settings.

### How Has This Been Tested?
Tested on Mac with and without keyframes specified in the output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
