### PR TITLE
frontend: Use static_cast when casting from void pointers

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -324,7 +324,7 @@ void OBSStudioAPI::obs_frontend_add_tools_menu_item(const char *name, obs_fronte
 
 void *OBSStudioAPI::obs_frontend_add_dock(void *dock)
 {
-	QDockWidget *d = reinterpret_cast<QDockWidget *>(dock);
+	QDockWidget *d = static_cast<QDockWidget *>(dock);
 
 	QString name = d->objectName();
 	if (name.isEmpty() || main->IsDockObjectNameUsed(name)) {
@@ -380,7 +380,7 @@ bool OBSStudioAPI::obs_frontend_add_custom_qdock(const char *id, void *dock)
 		return false;
 	}
 
-	QDockWidget *d = reinterpret_cast<QDockWidget *>(dock);
+	QDockWidget *d = static_cast<QDockWidget *>(dock);
 	d->setObjectName(QT_UTF8(id));
 
 	main->AddCustomDockWidget(d);

--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -257,62 +257,57 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 
 void OBSAdvAudioCtrl::OBSSourceActivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, true));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, true));
 }
 
 void OBSAdvAudioCtrl::OBSSourceDeactivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged",
-				  Q_ARG(bool, false));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, false));
 }
 
 void OBSAdvAudioCtrl::OBSSourceFlagsChanged(void *param, calldata_t *calldata)
 {
 	uint32_t flags = (uint32_t)calldata_int(calldata, "flags");
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceFlagsChanged",
-				  Q_ARG(uint32_t, flags));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceFlagsChanged", Q_ARG(uint32_t, flags));
 }
 
 void OBSAdvAudioCtrl::OBSSourceVolumeChanged(void *param, calldata_t *calldata)
 {
 	float volume = (float)calldata_float(calldata, "volume");
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceVolumeChanged",
-				  Q_ARG(float, volume));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceVolumeChanged", Q_ARG(float, volume));
 }
 
 void OBSAdvAudioCtrl::OBSSourceSyncChanged(void *param, calldata_t *calldata)
 {
 	int64_t offset = calldata_int(calldata, "offset");
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceSyncChanged",
-				  Q_ARG(int64_t, offset));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceSyncChanged", Q_ARG(int64_t, offset));
 }
 
 void OBSAdvAudioCtrl::OBSSourceMonitoringTypeChanged(void *param, calldata_t *calldata)
 {
 	int type = calldata_int(calldata, "type");
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceMonitoringTypeChanged",
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMonitoringTypeChanged",
 				  Q_ARG(int, type));
 }
 
 void OBSAdvAudioCtrl::OBSSourceMixersChanged(void *param, calldata_t *calldata)
 {
 	uint32_t mixers = (uint32_t)calldata_int(calldata, "mixers");
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceMixersChanged",
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMixersChanged",
 				  Q_ARG(uint32_t, mixers));
 }
 
 void OBSAdvAudioCtrl::OBSSourceBalanceChanged(void *param, calldata_t *calldata)
 {
 	int balance = (float)calldata_float(calldata, "balance") * 100.0f;
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SourceBalanceChanged",
-				  Q_ARG(int, balance));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceBalanceChanged", Q_ARG(int, balance));
 }
 
 void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
 {
 	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
 
-	QMetaObject::invokeMethod(reinterpret_cast<OBSAdvAudioCtrl *>(param), "SetSourceName", Q_ARG(QString, newName));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SetSourceName", Q_ARG(QString, newName));
 }
 
 /* ------------------------------------------------------------------------- */

--- a/frontend/components/SourceTree.cpp
+++ b/frontend/components/SourceTree.cpp
@@ -313,7 +313,7 @@ void SourceTree::dropEvent(QDropEvent *event)
 	using insertCollapsed_t = decltype(insertCollapsed);
 
 	auto preInsertCollapsed = [](obs_scene_t *, obs_sceneitem_t *item, void *param) {
-		(*reinterpret_cast<insertCollapsed_t *>(param))(item);
+		(*static_cast<insertCollapsed_t *>(param))(item);
 		return true;
 	};
 
@@ -373,7 +373,7 @@ void SourceTree::dropEvent(QDropEvent *event)
 	using updateScene_t = decltype(updateScene);
 
 	auto preUpdateScene = [](void *data, obs_scene_t *) {
-		(*reinterpret_cast<updateScene_t *>(data))();
+		(*static_cast<updateScene_t *>(data))();
 	};
 
 	ignoreReorder = true;

--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -176,7 +176,7 @@ void SourceTreeItem::ReconnectSignals()
 	/* --------------------------------------------------------- */
 
 	auto removeItem = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 		obs_scene_t *curScene = (obs_scene_t *)calldata_ptr(cd, "scene");
 
@@ -190,7 +190,7 @@ void SourceTreeItem::ReconnectSignals()
 	};
 
 	auto itemVisible = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 		bool visible = calldata_bool(cd, "visible");
 
@@ -199,7 +199,7 @@ void SourceTreeItem::ReconnectSignals()
 	};
 
 	auto itemLocked = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 		bool locked = calldata_bool(cd, "locked");
 
@@ -208,7 +208,7 @@ void SourceTreeItem::ReconnectSignals()
 	};
 
 	auto itemSelect = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
@@ -216,7 +216,7 @@ void SourceTreeItem::ReconnectSignals()
 	};
 
 	auto itemDeselect = [](void *data, calldata_t *cd) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
@@ -224,7 +224,7 @@ void SourceTreeItem::ReconnectSignals()
 	};
 
 	auto reorderGroup = [](void *data, calldata_t *) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		QMetaObject::invokeMethod(this_->tree, "ReorderItems");
 	};
 
@@ -249,7 +249,7 @@ void SourceTreeItem::ReconnectSignals()
 	/* --------------------------------------------------------- */
 
 	auto removeSource = [](void *data, calldata_t *) {
-		SourceTreeItem *this_ = reinterpret_cast<SourceTreeItem *>(data);
+		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
 		QMetaObject::invokeMethod(this_->tree, "RefreshItems");

--- a/frontend/components/SourceTreeModel.cpp
+++ b/frontend/components/SourceTreeModel.cpp
@@ -14,7 +14,7 @@ static inline OBSScene GetCurrentScene()
 
 void SourceTreeModel::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 {
-	SourceTreeModel *stm = reinterpret_cast<SourceTreeModel *>(ptr);
+	SourceTreeModel *stm = static_cast<SourceTreeModel *>(ptr);
 
 	switch (event) {
 	case OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED:
@@ -43,7 +43,7 @@ void SourceTreeModel::Clear()
 
 static bool enumItem(obs_scene_t *, obs_sceneitem_t *item, void *ptr)
 {
-	QVector<OBSSceneItem> &items = *reinterpret_cast<QVector<OBSSceneItem> *>(ptr);
+	QVector<OBSSceneItem> &items = *static_cast<QVector<OBSSceneItem> *>(ptr);
 
 	obs_source_t *src = obs_sceneitem_get_source(item);
 	if (obs_source_removed(src)) {

--- a/frontend/components/UIValidation.cpp
+++ b/frontend/components/UIValidation.cpp
@@ -16,7 +16,7 @@ static int CountVideoSources()
 
 		uint32_t flags = obs_source_get_output_flags(source);
 		if ((flags & OBS_SOURCE_VIDEO) != 0)
-			(*reinterpret_cast<int *>(param))++;
+			(*static_cast<int *>(param))++;
 
 		return true;
 	};

--- a/frontend/components/VisibilityItemWidget.cpp
+++ b/frontend/components/VisibilityItemWidget.cpp
@@ -33,7 +33,7 @@ VisibilityItemWidget::VisibilityItemWidget(obs_source_t *source_)
 
 void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)
 {
-	VisibilityItemWidget *window = reinterpret_cast<VisibilityItemWidget *>(param);
+	VisibilityItemWidget *window = static_cast<VisibilityItemWidget *>(param);
 	bool enabled = calldata_bool(data, "enabled");
 
 	QMetaObject::invokeMethod(window, "SourceEnabled", Q_ARG(bool, enabled));

--- a/frontend/dialogs/OBSBasicAdvAudio.cpp
+++ b/frontend/dialogs/OBSBasicAdvAudio.cpp
@@ -43,7 +43,7 @@ OBSBasicAdvAudio::~OBSBasicAdvAudio()
 
 bool OBSBasicAdvAudio::EnumSources(void *param, obs_source_t *source)
 {
-	OBSBasicAdvAudio *dialog = reinterpret_cast<OBSBasicAdvAudio *>(param);
+	OBSBasicAdvAudio *dialog = static_cast<OBSBasicAdvAudio *>(param);
 	uint32_t flags = obs_source_get_output_flags(source);
 
 	if ((flags & OBS_SOURCE_AUDIO) != 0 &&
@@ -57,15 +57,14 @@ void OBSBasicAdvAudio::OBSSourceAdded(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(reinterpret_cast<OBSBasicAdvAudio *>(param), "SourceAdded", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded", Q_ARG(OBSSource, source));
 }
 
 void OBSBasicAdvAudio::OBSSourceRemoved(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(reinterpret_cast<OBSBasicAdvAudio *>(param), "SourceRemoved",
-				  Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceRemoved", Q_ARG(OBSSource, source));
 }
 
 void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
@@ -73,7 +72,7 @@ void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
 	if (obs_source_audio_active(source))
-		QMetaObject::invokeMethod(reinterpret_cast<OBSBasicAdvAudio *>(param), "SourceAdded",
+		QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded",
 					  Q_ARG(OBSSource, source));
 }
 

--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -174,7 +174,7 @@ inline OBSSource OBSBasicFilters::GetFilter(int row, bool async)
 
 void FilterChangeUndoRedo(void *vp, obs_data_t *nd_old_settings, obs_data_t *new_settings)
 {
-	obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
+	obs_source_t *source = static_cast<obs_source_t *>(vp);
 	const char *source_uuid = obs_source_get_uuid(source);
 	const char *name = obs_source_get_name(source);
 	OBSBasic *main = OBSBasic::Get();
@@ -250,7 +250,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 	auto disabled_undo = [](void *vp, obs_data_t *settings) {
 		OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 		main->undo_s.disable();
-		obs_source_t *source = reinterpret_cast<obs_source_t *>(vp);
+		obs_source_t *source = static_cast<obs_source_t *>(vp);
 		obs_source_update(source, settings);
 	};
 
@@ -363,7 +363,7 @@ void OBSBasicFilters::ReorderFilters()
 	obs_source_enum_filters(
 		source,
 		[](obs_source_t *, obs_source_t *filter, void *p) {
-			FilterOrderInfo *info = reinterpret_cast<FilterOrderInfo *>(p);
+			FilterOrderInfo *info = static_cast<FilterOrderInfo *>(p);
 			uint32_t flags;
 			bool async;
 
@@ -390,7 +390,7 @@ void OBSBasicFilters::UpdateFilters()
 	obs_source_enum_filters(
 		source,
 		[](obs_source_t *, obs_source_t *filter, void *p) {
-			OBSBasicFilters *window = reinterpret_cast<OBSBasicFilters *>(p);
+			OBSBasicFilters *window = static_cast<OBSBasicFilters *>(p);
 
 			window->AddFilter(filter, false);
 		},
@@ -619,7 +619,7 @@ bool OBSBasicFilters::nativeEvent(const QByteArray &, void *message, qintptr *)
 
 void OBSBasicFilters::OBSSourceFilterAdded(void *param, calldata_t *data)
 {
-	OBSBasicFilters *window = reinterpret_cast<OBSBasicFilters *>(param);
+	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
 	QMetaObject::invokeMethod(window, "AddFilter", Q_ARG(OBSSource, OBSSource(filter)));
@@ -627,7 +627,7 @@ void OBSBasicFilters::OBSSourceFilterAdded(void *param, calldata_t *data)
 
 void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
 {
-	OBSBasicFilters *window = reinterpret_cast<OBSBasicFilters *>(param);
+	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
 	QMetaObject::invokeMethod(window, "RemoveFilter", Q_ARG(OBSSource, OBSSource(filter)));
@@ -635,7 +635,7 @@ void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
 
 void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(reinterpret_cast<OBSBasicFilters *>(param), "ReorderFilters");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "ReorderFilters");
 }
 
 void OBSBasicFilters::SourceRemoved(void *param, calldata_t *)

--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -256,7 +256,7 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 			obs_scene_t *scene = obs_get_scene_by_name(scene_name);
 			OBSSceneItem item;
 			auto cb = [](obs_scene_t *, obs_sceneitem_t *sceneitem, void *data) {
-				OBSSceneItem &last = *reinterpret_cast<OBSSceneItem *>(data);
+				OBSSceneItem &last = *static_cast<OBSSceneItem *>(data);
 				last = sceneitem;
 				return true;
 			};

--- a/frontend/dialogs/OBSBasicTransform.cpp
+++ b/frontend/dialogs/OBSBasicTransform.cpp
@@ -6,7 +6,7 @@
 
 static bool find_sel(obs_scene_t *, obs_sceneitem_t *item, void *param)
 {
-	OBSSceneItem &dst = *reinterpret_cast<OBSSceneItem *>(param);
+	OBSSceneItem &dst = *static_cast<OBSSceneItem *>(param);
 
 	if (obs_sceneitem_selected(item)) {
 		dst = item;
@@ -138,7 +138,7 @@ void OBSBasicTransform::SetItemQt(OBSSceneItem newItem)
 
 void OBSBasicTransform::OBSChannelChanged(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	uint32_t channel = (uint32_t)calldata_int(data, "channel");
 	OBSSource source = (obs_source_t *)calldata_ptr(data, "source");
 
@@ -155,7 +155,7 @@ void OBSBasicTransform::OBSChannelChanged(void *param, calldata_t *data)
 
 void OBSBasicTransform::OBSSceneItemTransform(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item == window->item && !window->ignoreTransformSignal)
@@ -164,7 +164,7 @@ void OBSBasicTransform::OBSSceneItemTransform(void *param, calldata_t *data)
 
 void OBSBasicTransform::OBSSceneItemRemoved(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(data, "scene");
 	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
@@ -174,7 +174,7 @@ void OBSBasicTransform::OBSSceneItemRemoved(void *param, calldata_t *data)
 
 void OBSBasicTransform::OBSSceneItemSelect(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item != window->item)
@@ -183,7 +183,7 @@ void OBSBasicTransform::OBSSceneItemSelect(void *param, calldata_t *data)
 
 void OBSBasicTransform::OBSSceneItemDeselect(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(data, "scene");
 	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
@@ -195,7 +195,7 @@ void OBSBasicTransform::OBSSceneItemDeselect(void *param, calldata_t *data)
 
 void OBSBasicTransform::OBSSceneItemLocked(void *param, calldata_t *data)
 {
-	OBSBasicTransform *window = reinterpret_cast<OBSBasicTransform *>(param);
+	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	bool locked = calldata_bool(data, "locked");
 
 	QMetaObject::invokeMethod(window, "SetEnabled", Q_ARG(bool, !locked));

--- a/frontend/utility/QuickTransition.cpp
+++ b/frontend/utility/QuickTransition.cpp
@@ -37,7 +37,7 @@ static inline QString MakeQuickTransitionText(QuickTransition *qt)
 
 void QuickTransition::SourceRenamed(void *param, calldata_t *)
 {
-	QuickTransition *qt = reinterpret_cast<QuickTransition *>(param);
+	QuickTransition *qt = static_cast<QuickTransition *>(param);
 
 	QString hotkeyName = QTStr("QuickTransitions.HotkeyName").arg(MakeQuickTransitionText(qt));
 

--- a/frontend/utility/ScreenshotObj.cpp
+++ b/frontend/utility/ScreenshotObj.cpp
@@ -286,7 +286,7 @@ void ScreenshotObj::MuxAndFinish()
 
 static void ScreenshotTick(void *param, float)
 {
-	ScreenshotObj *data = reinterpret_cast<ScreenshotObj *>(param);
+	ScreenshotObj *data = static_cast<ScreenshotObj *>(param);
 
 	if (data->stage == STAGE_FINISH) {
 		return;

--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -107,7 +107,7 @@ static bool CloseFloat(float a, float b, float epsilon = 0.01)
 
 static bool FindItemAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	SceneFindData *data = reinterpret_cast<SceneFindData *>(param);
+	SceneFindData *data = static_cast<SceneFindData *>(param);
 	matrix4 transform;
 	matrix4 invTransform;
 	vec3 transformedPos;
@@ -224,7 +224,7 @@ OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos, bool selectBelow)
 
 static bool CheckItemSelected(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	SceneFindData *data = reinterpret_cast<SceneFindData *>(param);
+	SceneFindData *data = static_cast<SceneFindData *>(param);
 	matrix4 transform;
 	vec3 transformedPos;
 	vec3 pos3;
@@ -316,7 +316,7 @@ struct HandleFindData {
 
 static bool FindHandleAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	HandleFindData &data = *reinterpret_cast<HandleFindData *>(param);
+	HandleFindData &data = *static_cast<HandleFindData *>(param);
 
 	if (!obs_sceneitem_selected(item)) {
 		if (obs_sceneitem_is_group(item)) {
@@ -667,7 +667,7 @@ void OBSBasicPreview::UpdateCursor(uint32_t &flags)
 
 static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	obs_sceneitem_t *selectedItem = reinterpret_cast<obs_sceneitem_t *>(param);
+	obs_sceneitem_t *selectedItem = static_cast<obs_sceneitem_t *>(param);
 	if (obs_sceneitem_is_group(item))
 		obs_sceneitem_group_enum_items(item, select_one, param);
 
@@ -799,7 +799,7 @@ struct SelectedItemBounds {
 
 static bool AddItemBounds(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	SelectedItemBounds *data = reinterpret_cast<SelectedItemBounds *>(param);
+	SelectedItemBounds *data = static_cast<SelectedItemBounds *>(param);
 	vec3 t[4];
 
 	auto add_bounds = [data, &t]() {
@@ -856,7 +856,7 @@ struct OffsetData {
 
 static bool GetSourceSnapOffset(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	OffsetData *data = reinterpret_cast<OffsetData *>(param);
+	OffsetData *data = static_cast<OffsetData *>(param);
 
 	if (obs_sceneitem_selected(item))
 		return true;
@@ -951,7 +951,7 @@ static bool move_items(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *p
 		return true;
 
 	bool selected = obs_sceneitem_selected(item);
-	vec2 *offset = reinterpret_cast<vec2 *>(param);
+	vec2 *offset = static_cast<vec2 *>(param);
 
 	if (obs_sceneitem_is_group(item) && !selected) {
 		matrix4 transform;
@@ -1052,7 +1052,7 @@ static bool IntersectBox(matrix4 transform, float x1, float x2, float y1, float 
 
 bool OBSBasicPreview::FindSelected(obs_scene_t *, obs_sceneitem_t *item, void *param)
 {
-	SceneFindBoxData *data = reinterpret_cast<SceneFindBoxData *>(param);
+	SceneFindBoxData *data = static_cast<SceneFindBoxData *>(param);
 
 	if (obs_sceneitem_selected(item))
 		data->sceneItems.push_back(item);
@@ -1062,7 +1062,7 @@ bool OBSBasicPreview::FindSelected(obs_scene_t *, obs_sceneitem_t *item, void *p
 
 static bool FindItemsInBox(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	SceneFindBoxData *data = reinterpret_cast<SceneFindBoxData *>(param);
+	SceneFindBoxData *data = static_cast<SceneFindBoxData *>(param);
 	matrix4 transform;
 	matrix4 invTransform;
 	vec3 transformedPos;
@@ -1785,7 +1785,7 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *, obs_sceneitem_t *item,
 	if (!SceneItemHasVideo(item))
 		return true;
 
-	OBSBasicPreview *prev = reinterpret_cast<OBSBasicPreview *>(param);
+	OBSBasicPreview *prev = static_cast<OBSBasicPreview *>(param);
 
 	if (!prev->GetOverflowSelectionHidden() && !obs_sceneitem_visible(item))
 		return true;
@@ -1865,7 +1865,7 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 	if (!SceneItemHasVideo(item))
 		return true;
 
-	OBSBasicPreview *prev = reinterpret_cast<OBSBasicPreview *>(param);
+	OBSBasicPreview *prev = static_cast<OBSBasicPreview *>(param);
 
 	if (obs_sceneitem_is_group(item)) {
 		matrix4 mat;

--- a/frontend/widgets/OBSBasicStats.cpp
+++ b/frontend/widgets/OBSBasicStats.cpp
@@ -17,7 +17,7 @@
 
 void OBSBasicStats::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 {
-	OBSBasicStats *stats = reinterpret_cast<OBSBasicStats *>(ptr);
+	OBSBasicStats *stats = static_cast<OBSBasicStats *>(ptr);
 
 	switch (event) {
 	case OBS_FRONTEND_EVENT_RECORDING_STARTED:

--- a/frontend/widgets/OBSBasicStatusBar.cpp
+++ b/frontend/widgets/OBSBasicStatusBar.cpp
@@ -365,7 +365,7 @@ void OBSBasicStatusBar::UpdateDroppedFrames()
 
 void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 {
-	OBSBasicStatusBar *statusBar = reinterpret_cast<OBSBasicStatusBar *>(data);
+	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
 	int seconds = (int)calldata_int(params, "timeout_sec");
 	QMetaObject::invokeMethod(statusBar, "Reconnect", Q_ARG(int, seconds));
@@ -373,7 +373,7 @@ void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 
 void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data, calldata_t *)
 {
-	OBSBasicStatusBar *statusBar = reinterpret_cast<OBSBasicStatusBar *>(data);
+	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
 	QMetaObject::invokeMethod(statusBar, "ReconnectSuccess");
 }

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -294,7 +294,7 @@ static bool nudge_callback(obs_scene_t *, obs_sceneitem_t *item, void *param)
 	if (obs_sceneitem_locked(item))
 		return true;
 
-	struct vec2 &offset = *reinterpret_cast<struct vec2 *>(param);
+	struct vec2 &offset = *static_cast<struct vec2 *>(param);
 	struct vec2 pos;
 
 	if (!obs_sceneitem_selected(item)) {

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -844,7 +844,7 @@ void OBSBasic::on_actionAddSource_triggered()
 
 static bool remove_items(obs_scene_t *, obs_sceneitem_t *item, void *param)
 {
-	vector<OBSSceneItem> &items = *reinterpret_cast<vector<OBSSceneItem> *>(param);
+	vector<OBSSceneItem> &items = *static_cast<vector<OBSSceneItem> *>(param);
 
 	if (obs_sceneitem_selected(item)) {
 		items.emplace_back(item);
@@ -1084,7 +1084,7 @@ static bool RotateSelectedSources(obs_scene_t * /* scene */, obs_sceneitem_t *it
 	if (obs_sceneitem_locked(item))
 		return true;
 
-	float rot = *reinterpret_cast<float *>(param);
+	float rot = *static_cast<float *>(param);
 
 	vec3 tl = GetItemTL(item);
 
@@ -1146,7 +1146,7 @@ void OBSBasic::on_actionRotate180_triggered()
 
 static bool MultiplySelectedItemScale(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	vec2 &mul = *reinterpret_cast<vec2 *>(param);
+	vec2 &mul = *static_cast<vec2 *>(param);
 
 	if (obs_sceneitem_is_group(item))
 		obs_sceneitem_group_enum_items(item, MultiplySelectedItemScale, param);
@@ -1201,7 +1201,7 @@ void OBSBasic::on_actionFlipVertical_triggered()
 
 static bool CenterAlignSelectedItems(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	obs_bounds_type boundsType = *reinterpret_cast<obs_bounds_type *>(param);
+	obs_bounds_type boundsType = *static_cast<obs_bounds_type *>(param);
 
 	if (obs_sceneitem_is_group(item))
 		obs_sceneitem_group_enum_items(item, CenterAlignSelectedItems, param);

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -133,7 +133,7 @@ void OBSBasic::AddScene(OBSSource source)
 		scene,
 		[](obs_scene_t *, obs_sceneitem_t *item, void *param) {
 			addSceneItem_t *func;
-			func = reinterpret_cast<addSceneItem_t *>(param);
+			func = static_cast<addSceneItem_t *>(param);
 			(*func)(item);
 			return true;
 		},
@@ -187,7 +187,7 @@ void OBSBasic::RemoveScene(OBSSource source)
 
 static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
 {
-	obs_sceneitem_t *selectedItem = reinterpret_cast<obs_sceneitem_t *>(param);
+	obs_sceneitem_t *selectedItem = static_cast<obs_sceneitem_t *>(param);
 	if (obs_sceneitem_is_group(item))
 		obs_sceneitem_group_enum_items(item, select_one, param);
 

--- a/frontend/widgets/OBSBasic_VolControl.cpp
+++ b/frontend/widgets/OBSBasic_VolControl.cpp
@@ -99,7 +99,7 @@ void OBSBasic::UnhideAllAudioControls()
 
 	auto PreEnum = [](void *data, obs_source_t *source) -> bool /* -- */
 	{
-		return (*reinterpret_cast<UnhideAudioMixer_t *>(data))(source);
+		return (*static_cast<UnhideAudioMixer_t *>(data))(source);
 	};
 
 	obs_enum_sources(PreEnum, &UnhideAudioMixer);

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -155,7 +155,7 @@ void OBSProjector::OBSRenderMultiview(void *data, uint32_t cx, uint32_t cy)
 
 void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 {
-	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
+	OBSProjector *window = static_cast<OBSProjector *>(data);
 
 	if (!window->ready)
 		return;
@@ -209,7 +209,7 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 
 void OBSProjector::OBSSourceRenamed(void *data, calldata_t *params)
 {
-	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
+	OBSProjector *window = static_cast<OBSProjector *>(data);
 	QString oldName = calldata_string(params, "prev_name");
 	QString newName = calldata_string(params, "new_name");
 
@@ -218,7 +218,7 @@ void OBSProjector::OBSSourceRenamed(void *data, calldata_t *params)
 
 void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)
 {
-	OBSProjector *window = reinterpret_cast<OBSProjector *>(data);
+	OBSProjector *window = static_cast<OBSProjector *>(data);
 	QMetaObject::invokeMethod(window, "EscapeTriggered");
 }
 

--- a/frontend/wizards/AutoConfigTestPage.cpp
+++ b/frontend/wizards/AutoConfigTestPage.cpp
@@ -295,12 +295,12 @@ void AutoConfigTestPage::TestBandwidthThread()
 	using on_stopped_t = decltype(on_stopped);
 
 	auto pre_on_started = [](void *data, calldata_t *) {
-		on_started_t &on_started = *reinterpret_cast<on_started_t *>(data);
+		on_started_t &on_started = *static_cast<on_started_t *>(data);
 		on_started();
 	};
 
 	auto pre_on_stopped = [](void *data, calldata_t *) {
-		on_stopped_t &on_stopped = *reinterpret_cast<on_stopped_t *>(data);
+		on_stopped_t &on_stopped = *static_cast<on_stopped_t *>(data);
 		on_stopped();
 	};
 
@@ -529,7 +529,7 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 	using on_stopped_t = decltype(on_stopped);
 
 	auto pre_on_stopped = [](void *data, calldata_t *) {
-		on_stopped_t &on_stopped = *reinterpret_cast<on_stopped_t *>(data);
+		on_stopped_t &on_stopped = *static_cast<on_stopped_t *>(data);
 		on_stopped();
 	};
 


### PR DESCRIPTION
### Description
Using static_cast is preferred here, as it is safer to use than reinterpret_cast.

### Motivation and Context
I've been reading about different types of casts, and I keep reading that you should never use reinterpret_cast unless you absolutely have to, as there is no guarantee that the casting will work unlike with static_cast.

### How Has This Been Tested?
Compiled and ran OBS to made sure nothing broke.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
