### PR TITLE
frontend: Use Q_OBJECT macro for BrowserDock

### DIFF
--- a/frontend/docks/BrowserDock.cpp
+++ b/frontend/docks/BrowserDock.cpp
@@ -1,6 +1,7 @@
 #include "BrowserDock.hpp"
 
 #include <QCloseEvent>
+#include "moc_BrowserDock.cpp"
 
 void BrowserDock::closeEvent(QCloseEvent *event)
 {

--- a/frontend/docks/BrowserDock.hpp
+++ b/frontend/docks/BrowserDock.hpp
@@ -8,6 +8,8 @@ extern QCef *cef;
 extern QCefCookieManager *panel_cookies;
 
 class BrowserDock : public OBSDock {
+	Q_OBJECT
+
 private:
 	QString title;
 


### PR DESCRIPTION
### Description
This is needed as the BrowserDock is a QObject.

### Motivation and Context
Without this, #11784 fails to compile

### How Has This Been Tested?
Compiled and ran OBS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
