### PR TITLE
obs-outputs: Allow enabling BPM for Hybrid MP4 output

### DIFF
--- a/plugins/obs-outputs/CMakeLists.txt
+++ b/plugins/obs-outputs/CMakeLists.txt
@@ -13,6 +13,10 @@ if(NOT TARGET OBS::opts-parser)
   add_subdirectory("${CMAKE_SOURCE_DIR}/shared/opts-parser" "${CMAKE_BINARY_DIR}/shared/opts-parser")
 endif()
 
+if(NOT TARGET OBS::bpm)
+  add_subdirectory("${CMAKE_SOURCE_DIR}/shared/bpm" bpm)
+endif()
+
 add_library(obs-outputs MODULE)
 add_library(OBS::outputs ALIAS obs-outputs)
 
@@ -73,6 +77,7 @@ target_link_libraries(
     OBS::libobs
     OBS::happy-eyeballs
     OBS::opts-parser
+    OBS::bpm
     MbedTLS::mbedtls
     ZLIB::ZLIB
     $<$<PLATFORM_ID:Windows>:OBS::w32-pthreads>

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -24,6 +24,7 @@
 #include <util/dstr.h>
 #include <util/threading.h>
 #include <util/buffered-file-serializer.h>
+#include <bpm.h>
 
 #include <opts-parser.h>
 
@@ -46,6 +47,8 @@ struct mp4_output {
 	size_t buffer_size;
 	size_t chunk_size;
 	struct serializer serializer;
+
+	bool enable_bpm;
 
 	volatile bool active;
 	volatile bool stopping;
@@ -236,6 +239,8 @@ static void parse_custom_options(struct mp4_output *out, const char *opts_str)
 			out->buffer_size = strtoull(opt.value, 0, 10) * 1048576ULL;
 		} else if (strcmp(opt.name, "chunk_size") == 0) {
 			out->chunk_size = strtoull(opt.value, 0, 10) * 1048576ULL;
+		} else if (strcmp(opt.name, "bpm") == 0) {
+			out->enable_bpm = !!atoi(opt.value);
 		} else {
 			blog(LOG_WARNING, "Unknown muxer option: %s = %s", opt.name, opt.value);
 		}
@@ -280,6 +285,11 @@ static bool mp4_output_start(void *data)
 	parse_custom_options(out, muxer_settings);
 
 	obs_data_release(settings);
+
+	if (out->enable_bpm) {
+		info("Enabling BPM");
+		obs_output_add_packet_callback(out->output, bpm_inject, NULL);
+	}
 
 	if (!buffered_file_serializer_init(&out->serializer, out->path.array, out->buffer_size, out->chunk_size)) {
 		warn("Unable to open MP4 file '%s'", out->path.array);
@@ -450,6 +460,11 @@ static void mp4_output_actual_stop(struct mp4_output *out, int code)
 	}
 
 	mp4_mux_finalise(out->muxer);
+
+	if (out->enable_bpm) {
+		obs_output_remove_packet_callback(out->output, bpm_inject, NULL);
+		bpm_destroy(out->output);
+	}
 
 	if (code) {
 		obs_output_signal_stop(out->output, code);


### PR DESCRIPTION
### Description

Adds an option to enable BPM (Broadcast Performance Metrics) for the Hybrid MP4 output.

### Motivation and Context

BPM is quite useful to track performance over time, having it in a local file is a nice debugging option.

### How Has This Been Tested?

Enabled it and checked BPM data is in output file.

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
