### PR TITLE
libobs/media-io: Avoid allocating frame memory if size is zero

### DIFF
--- a/libobs/media-io/video-frame.c
+++ b/libobs/media-io/video-frame.c
@@ -219,6 +219,10 @@ void video_frame_init(struct video_frame *frame, enum video_format format, uint3
 		offsets[i] = size;
 	}
 
+	/* return early if size is zero */
+	if (!size)
+		return;
+
 	/* allocate memory */
 	frame->data[0] = bmalloc(size);
 	frame->linesize[0] = linesizes[0];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

It is possible that size can still be zero after the preceding loop. If that happens, and bmalloc is called with 0 as its argument, OBS will crash as intended with OBS Studio 31. Avoid crashing by not allocating memory for a frame with a size of zero.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

See the crash in:
* #11729

If there's a better place to do this check, I'm open to alternatives.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran locally on Windows 11 with a Video Capture Device added.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
