### PR TITLE
bpm: Fix potential null-pointer dereference

### DIFF
--- a/shared/bpm/bpm.c
+++ b/shared/bpm/bpm.c
@@ -16,7 +16,12 @@ static void render_metrics_time(struct metrics_time *m_time)
 static bool update_metrics(obs_output_t *output, const struct encoder_packet *pkt,
 			   const struct encoder_packet_time *ept, struct metrics_data *m_track)
 {
-	if (!output || !pkt || !ept || !m_track) {
+	if (!pkt) {
+		blog(LOG_DEBUG, "%s: Null encoder_packet pointer", __FUNCTION__);
+		return false;
+	}
+
+	if (!output || !ept || !m_track) {
 		blog(LOG_DEBUG, "%s: Null arguments for track %lu", __FUNCTION__, pkt->track_idx);
 		return false;
 	}


### PR DESCRIPTION
### Description
`update_metrics()` in `bpm.c` is checking for null pointer arguments, and there was a very minor chance of de-referencing a null-pointer in the logged message. Correct the logic to prevent this from happening.

### How Has This Been Tested?
Tested with a local build with live streams to Twitch with Enhanced Broadcasting.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
