### PR TITLE
nv-filters: Update for new SDK

### DIFF
--- a/plugins/nv-filters/nv_sdk_versions.h
+++ b/plugins/nv-filters/nv_sdk_versions.h
@@ -1,2 +1,2 @@
-#define MIN_VFX_SDK_VERSION (0 << 24 | 7 << 16 | 2 << 8 | 0 << 0)
-#define MIN_AFX_SDK_VERSION (1 << 24 | 3 << 16 | 0 << 0)
+#define MIN_VFX_SDK_VERSION (0 << 24 | 7 << 16 | 6 << 8 | 0 << 0)
+#define MIN_AFX_SDK_VERSION (1 << 24 | 6 << 16 | 1 << 8 | 2 << 0)

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -1189,14 +1189,6 @@ bool load_nvidia_vfx(void)
 	LOAD_SYM(NvCVImage_FromD3DColorSpace);
 #undef LOAD_SYM
 
-#define LOAD_SYM(sym) LOAD_SYM_FROM_LIB(sym, nv_cudart, "cudart64_110.dll")
-	LOAD_SYM(cudaMalloc);
-	LOAD_SYM(cudaStreamSynchronize);
-	LOAD_SYM(cudaFree);
-	LOAD_SYM(cudaMemcpy);
-	LOAD_SYM(cudaMemsetAsync);
-#undef LOAD_SYM
-
 #define LOAD_SYM(sym) LOAD_SYM_FROM_LIB2(sym, nv_videofx, "NVVideoEffects.dll")
 	LOAD_SYM(NvVFX_SetStateObjectHandleArray);
 	LOAD_SYM(NvVFX_AllocateState);

--- a/plugins/nv-filters/nvvfx-load.h
+++ b/plugins/nv-filters/nvvfx-load.h
@@ -670,15 +670,6 @@ static inline void release_nv_vfx()
 		FreeLibrary(nv_cvimage);
 		nv_cvimage = NULL;
 	}
-	cudaMalloc = NULL;
-	cudaStreamSynchronize = NULL;
-	cudaFree = NULL;
-	cudaMemcpy = NULL;
-	cudaMemsetAsync = NULL;
-	if (nv_cudart) {
-		FreeLibrary(nv_cudart);
-		nv_cudart = NULL;
-	}
 }
 
 static inline void nvvfx_get_sdk_path(char *buffer, const size_t len)
@@ -702,9 +693,8 @@ static inline bool load_nv_vfx_libs()
 
 	nv_videofx = LoadLibrary(L"NVVideoEffects.dll");
 	nv_cvimage = LoadLibrary(L"NVCVImage.dll");
-	nv_cudart = LoadLibrary(L"cudart64_110.dll");
 	SetDllDirectoryA(NULL);
-	return !!nv_videofx && !!nv_cvimage && !!nv_cudart;
+	return !!nv_videofx && !!nv_cvimage;
 }
 
 static unsigned int get_lib_version(void)


### PR DESCRIPTION
### Description
This PR does two things:
- updates the checks against the new redistributables of NVIDIA AUDIO & VIDEO effects to:

   - 0.7.6. for Video Effects;
   - 1.6.1.2 for Audio Effects.

- cleans up the code related with cuda RT functions, which is not used anymore.

### Motivation and Context
Allow nv-filters to work with newer SDK.

Fixes #11813

### How Has This Been Tested?
The video & audio effects load fine on windows 11 PRO 24H2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
- Code cleanup (non-breaking change which makes code smaller or more readable)
### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
