### PR TITLE
frontend: Enforce Qt to have a DE-agnostic behavior on Linux

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -526,12 +526,15 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #endif
 
 #if !defined(_WIN32) && !defined(__APPLE__)
-	/* NOTE: Users blindly set this, but this theme is incompatble with Qt6 and
-	 * crashes loading saved geometry. Just turn off this theme and let users complain OBS
-	 * looks ugly instead of crashing. */
-	const char *platform_theme = getenv("QT_QPA_PLATFORMTHEME");
-	if (platform_theme && strcmp(platform_theme, "qt5ct") == 0)
-		unsetenv("QT_QPA_PLATFORMTHEME");
+	/* NOTE: This will prevent users and Qt itself to pick a platform theme that might enforce some undesired
+	 * choice on the behavior of Qt.
+	 * "xdgdesktopportal" is also the default when Qt is built without GTK 3 support.*/
+	qputenv("QT_QPA_PLATFORMTHEME", "xdgdesktopportal");
+
+	/* NOTE: "bradient" is the default decoration provided by Qt.
+	 * But since Qt 6.8, GNOME-like decoration were added to allow Qt apps to "fit" on GNOME.
+	 * The same look on all DE is preferred */
+	qputenv("QT_WAYLAND_DECORATION", "bradient");
 #endif
 
 	/* NOTE: This disables an optimisation in Qt that attempts to determine if


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Enforce Qt to have a DE-agnostic behavior on Linux

Before (with Qt 6.8 on GNOME):

![Screenshot From 2025-02-01 16-58-58](https://github.com/user-attachments/assets/75f0043f-866d-4dec-b952-0a08ce632421)

After:

![Screenshot From 2025-02-01 16-59-12](https://github.com/user-attachments/assets/5788c5fc-3eb7-4bc8-a324-371284010155)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

If the platform theme is not enforced, Plasma Wayland will enforce SSD decoration (that also lead to some menu issues depending on the distro defaults).

If the wayland decoration is not enforced, under GNOME, Qt (since 6.8) will try to enforce a GNOME-like decoration.

There is also third-party Qt plugins (e.g. qt5ct, qgnome) that caused their share of issues in the past, removing them from the list of potential culprit still can be useful.

I think this is not controversial to expect OBS Studio to look the same under any desktop environment.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Ran locally OBS (outside of a Flatpak) and no issue were met using file chooser and the window decoration is Bradient.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
