### PR TITLE
obs-nvenc: Fix lookahead depth value logging

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -393,7 +393,8 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings)
 	dstr_catf(&log, "\theight:       %d\n", enc->cy);
 	dstr_catf(&log, "\tb-frames:     %ld\n", enc->props.bf);
 	dstr_catf(&log, "\tb-ref-mode:   %ld\n", enc->props.bframe_ref_mode);
-	dstr_catf(&log, "\tlookahead:    %s (%d frames)\n", lookahead ? "true" : "false", rc_lookahead);
+	dstr_catf(&log, "\tlookahead:    %s (%d frames)\n", lookahead ? "true" : "false",
+		  config->rcParams.lookaheadDepth);
 	dstr_catf(&log, "\taq:           %s\n", enc->props.adaptive_quantization ? "true" : "false");
 
 	if (enc->props.split_encode) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Log the final `lookaheadDepth` value after all calculations, instead of an intermediate value. (For Nvenc.)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Without this change, a value gets logged based on an internal variable `rc_lookahead` that's not necessarily equal to the actual, final value that gets used for the encode. (e.g. It can get [bounded to a lower value](https://github.com/obsproject/obs-studio/blob/6f115df3afa6baa1cd12c5e7809a96ef6c4445e3/plugins/obs-nvenc/nvenc.c#L314-L318) afterward without updating this internal variable.)

Would like to show users the actual value of `lookaheadDepth` that's being used for their encode session, or at least show what's actually _set_ on the encode session. (It's a bit unclear which values the driver actually respects / meaningfully responds to.)

Thanks to @Penwy for pointing out this discrepancy.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- I set `lookaheadDepth=9999` in the "Custom Encoder Options" field of an "NVIDIA NVENC H.264" encoder in the Advanced Output tab. (This is a knowingly "too-high" value.)
- I then started a recording and **checked the logs** to see if the correct value was logged, knowing the `obs-nvenc` plugin's code internally bounds this value to within some reasonable limits.

Before:
```
lookahead:    true (9999 frames)
[ . . . ]
user opts:    lookaheadDepth=9999
```

After:
```
lookahead:    true (56 frames)
[ . . . ]
user opts:    lookaheadDepth=9999
```
Note the "true (**56** frames)" instead of "true (9999 frames)". This (56) is the actual value the plugin has limited/sanitized the `lookaheadDepth` value to. So, this change causes the correct (bounded) final value to be logged. Doing it this way should now survive any refactoring of the above "intermediate state"/input-sanitizing code as well.

Tested on Windows 10 on a 3070, Studio Driver 561.09, FWIW.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.