### PR TITLE
libobs: Do not lock sources mutex unnecessarily

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2254,7 +2254,6 @@ obs_source_t *obs_load_private_source(obs_data_t *source_data)
 
 void obs_load_sources(obs_data_array_t *array, obs_load_source_cb cb, void *private_data)
 {
-	struct obs_core_data *data = &obs->data;
 	DARRAY(obs_source_t *) sources;
 	size_t count;
 	size_t i;
@@ -2263,8 +2262,6 @@ void obs_load_sources(obs_data_array_t *array, obs_load_source_cb cb, void *priv
 
 	count = obs_data_array_count(array);
 	da_reserve(sources, count);
-
-	pthread_mutex_lock(&data->sources_mutex);
 
 	for (i = 0; i < count; i++) {
 		obs_data_t *source_data = obs_data_array_item(array, i);
@@ -2291,8 +2288,6 @@ void obs_load_sources(obs_data_array_t *array, obs_load_source_cb cb, void *priv
 
 	for (i = 0; i < sources.num; i++)
 		obs_source_release(sources.array[i]);
-
-	pthread_mutex_unlock(&data->sources_mutex);
 
 	da_free(sources);
 }


### PR DESCRIPTION
### Description

The sources mutex does not need to be manually locked when calling `obs_load_sources()`.

### Motivation and Context

Noticed that #11687 was opened due to the fact that the sources mutex was being locked here. #11687 will probably be unnecessary after merging this PR.  

### How Has This Been Tested?
Only lightly tested. Things seem okay but could use some extra testing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.