### PR TITLE
Canvases - Part Deux (Loading/Saving + Frontend API)

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -689,6 +689,26 @@ void OBSStudioAPI::obs_frontend_add_undo_redo_action(const char *name, const und
 		[redo](const std::string &data) { redo(data.c_str()); }, undo_data, redo_data, repeatable);
 }
 
+void OBSStudioAPI::obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_list)
+{
+	for (const auto &canvas : main->canvases) {
+		obs_canvas_t *ref = obs_canvas_get_ref(canvas);
+		if (ref)
+			da_push_back(canvas_list->canvases, &ref);
+	}
+}
+
+obs_canvas_t *OBSStudioAPI::obs_frontend_add_canvas(const char *name, obs_video_info *ovi, int flags)
+{
+	auto &canvas = main->AddCanvas(std::string(name), ovi, flags);
+	return obs_canvas_get_ref(canvas);
+}
+
+bool OBSStudioAPI::obs_frontend_remove_canvas(obs_canvas_t *canvas)
+{
+	return main->RemoveCanvas(canvas);
+}
+
 void OBSStudioAPI::on_load(obs_data_t *settings)
 {
 	for (size_t i = saveCallbacks.size(); i > 0; i--) {

--- a/frontend/OBSStudioAPI.hpp
+++ b/frontend/OBSStudioAPI.hpp
@@ -224,6 +224,12 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					       const char *undo_data, const char *redo_data, bool repeatable) override;
 
+	void obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_list) override;
+
+	obs_canvas_t *obs_frontend_add_canvas(const char *name, obs_video_info *ovi, int flags) override;
+
+	bool obs_frontend_remove_canvas(obs_canvas_t *canvas) override;
+
 	void on_load(obs_data_t *settings) override;
 
 	void on_preload(obs_data_t *settings) override;

--- a/frontend/api/obs-frontend-api.cpp
+++ b/frontend/api/obs-frontend-api.cpp
@@ -597,3 +597,19 @@ void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo
 	if (callbacks_valid())
 		c->obs_frontend_add_undo_redo_action(name, undo, redo, undo_data, redo_data, repeatable);
 }
+
+void obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_list)
+{
+	if (callbacks_valid())
+		c->obs_frontend_get_canvases(canvas_list);
+}
+
+obs_canvas_t *obs_frontend_add_canvas(const char *name, obs_video_info *ovi, int flags)
+{
+	return !!callbacks_valid() ? c->obs_frontend_add_canvas(name, ovi, flags) : nullptr;
+}
+
+bool obs_frontend_remove_canvas(obs_canvas_t *canvas)
+{
+	return !!callbacks_valid() ? c->obs_frontend_remove_canvas(canvas) : false;
+}

--- a/frontend/api/obs-frontend-api.h
+++ b/frontend/api/obs-frontend-api.h
@@ -62,6 +62,9 @@ enum obs_frontend_event {
 	OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED,
 	OBS_FRONTEND_EVENT_THEME_CHANGED,
 	OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN,
+
+	OBS_FRONTEND_EVENT_CANVAS_ADDED,
+	OBS_FRONTEND_EVENT_CANVAS_REMOVED,
 };
 
 /* ------------------------------------------------------------------------- */
@@ -78,6 +81,19 @@ static inline void obs_frontend_source_list_free(struct obs_frontend_source_list
 	for (size_t i = 0; i < num; i++)
 		obs_source_release(source_list->sources.array[i]);
 	da_free(source_list->sources);
+}
+
+struct obs_frontend_canvas_list {
+	DARRAY(obs_canvas_t *) canvases;
+};
+
+static inline void obs_frontend_canvas_list_free(struct obs_frontend_canvas_list *canvas_list)
+{
+	size_t num = canvas_list->canvases.num;
+	for (size_t i = 0; i < num; i++)
+		obs_canvas_release(canvas_list->canvases.array[i]);
+
+	da_free(canvas_list->canvases);
 }
 
 #endif //!SWIG
@@ -237,6 +253,10 @@ EXPORT char *obs_frontend_get_last_replay(void);
 typedef void (*undo_redo_cb)(const char *data);
 EXPORT void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo, const undo_redo_cb redo,
 					      const char *undo_data, const char *redo_data, bool repeatable);
+
+EXPORT void obs_frontend_get_canvases(struct obs_frontend_canvas_list *canvas_list);
+EXPORT obs_canvas_t *obs_frontend_add_canvas(const char *name, struct obs_video_info *ovi, int flags);
+EXPORT bool obs_frontend_remove_canvas(obs_canvas_t *canvas);
 
 /* ------------------------------------------------------------------------- */
 

--- a/frontend/api/obs-frontend-internal.hpp
+++ b/frontend/api/obs-frontend-internal.hpp
@@ -137,6 +137,10 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_add_undo_redo_action(const char *name, const undo_redo_cb undo,
 						       const undo_redo_cb redo, const char *undo_data,
 						       const char *redo_data, bool repeatable) = 0;
+
+	virtual obs_canvas_t *obs_frontend_add_canvas(const char *name, obs_video_info *ovi, int flags) = 0;
+	virtual bool obs_frontend_remove_canvas(obs_canvas_t *canvas) = 0;
+	virtual void obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_list) = 0;
 };
 
 EXPORT void obs_frontend_set_callbacks_internal(obs_frontend_callbacks *callbacks);

--- a/frontend/cmake/ui-utility.cmake
+++ b/frontend/cmake/ui-utility.cmake
@@ -33,6 +33,8 @@ target_sources(
     utility/MultitrackVideoOutput.hpp
     utility/obf.c
     utility/obf.h
+    utility/OBSCanvas.cpp
+    utility/OBSCanvas.hpp
     utility/OBSEventFilter.hpp
     utility/OBSProxyStyle.cpp
     utility/OBSProxyStyle.hpp

--- a/frontend/cmake/ui-widgets.cmake
+++ b/frontend/cmake/ui-widgets.cmake
@@ -15,6 +15,7 @@ target_sources(
     widgets/OBSBasic.cpp
     widgets/OBSBasic.hpp
     widgets/OBSBasic_Browser.cpp
+    widgets/OBSBasic_Canvases.cpp
     widgets/OBSBasic_Clipboard.cpp
     widgets/OBSBasic_ContextToolbar.cpp
     widgets/OBSBasic_Docks.cpp

--- a/frontend/utility/OBSCanvas.cpp
+++ b/frontend/utility/OBSCanvas.cpp
@@ -1,0 +1,100 @@
+/******************************************************************************
+    Copyright (C) 2025 by Dennis Sädtler <saedtler@twitch.tv>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "OBSCanvas.hpp"
+
+#include <utility>
+
+namespace OBS {
+
+Canvas::Canvas(obs_canvas_t *canvas) : canvas(canvas) {}
+
+Canvas::Canvas(Canvas &&other) noexcept
+{
+	canvas = std::exchange(other.canvas, nullptr);
+}
+
+Canvas::~Canvas() noexcept
+{
+	if (!canvas)
+		return;
+
+	obs_canvas_remove(canvas);
+	obs_canvas_release(canvas);
+	canvas = nullptr;
+}
+
+Canvas &Canvas::operator=(Canvas &&other) noexcept
+{
+	canvas = std::exchange(other.canvas, canvas);
+
+	return *this;
+}
+
+std::optional<OBSDataAutoRelease> Canvas::Save() const
+{
+	if (!canvas)
+		return std::nullopt;
+	if (obs_data_t *saved = obs_save_canvas(canvas))
+		return saved;
+
+	return std::nullopt;
+}
+
+std::optional<Canvas> Canvas::Load(obs_data_t *data)
+{
+	if (OBSDataAutoRelease canvas_data = obs_data_get_obj(data, "info")) {
+		if (obs_canvas_t *canvas = obs_load_canvas(canvas_data)) {
+			return canvas;
+		}
+	}
+
+	return std::nullopt;
+}
+
+std::vector<Canvas> Canvas::LoadCanvases(obs_data_array_t *canvases)
+{
+	auto cb = [](obs_data_t *data, void *param) -> void {
+		auto vec = static_cast<std::vector<Canvas> *>(param);
+		if (auto canvas = Canvas::Load(data))
+			vec->emplace_back(std::move(*canvas));
+	};
+
+	std::vector<Canvas> ret;
+	obs_data_array_enum(canvases, cb, &ret);
+
+	return ret;
+}
+
+OBSDataArrayAutoRelease Canvas::SaveCanvases(const std::vector<Canvas> &canvases)
+{
+	OBSDataArrayAutoRelease savedCanvases = obs_data_array_create();
+
+	for (auto &canvas : canvases) {
+		auto canvas_data = canvas.Save();
+		if (!canvas_data)
+			continue;
+
+		OBSDataAutoRelease data = obs_data_create();
+		obs_data_set_obj(data, "info", *canvas_data);
+		obs_data_array_push_back(savedCanvases, data);
+	}
+
+	return savedCanvases;
+}
+
+} // namespace OBS

--- a/frontend/utility/OBSCanvas.hpp
+++ b/frontend/utility/OBSCanvas.hpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+    Copyright (C) 2025 by Dennis Sädtler <saedtler@twitch.tv>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "obs.h"
+#include "obs.hpp"
+
+namespace OBS {
+class Canvas {
+
+public:
+	Canvas(obs_canvas_t *canvas);
+	Canvas(Canvas &&other) noexcept;
+
+	~Canvas() noexcept;
+
+	// No default or copy/move constructors
+	Canvas() = delete;
+	Canvas(Canvas &other) = delete;
+
+	Canvas &operator=(Canvas &&other) noexcept;
+
+	operator obs_canvas_t *() const { return canvas; }
+
+	[[nodiscard]] std::optional<OBSDataAutoRelease> Save() const;
+	static std::optional<Canvas> Load(obs_data_t *data);
+	static std::vector<Canvas> LoadCanvases(obs_data_array_t *canvases);
+	static OBSDataArrayAutoRelease SaveCanvases(const std::vector<Canvas> &canvases);
+
+private:
+	obs_canvas_t *canvas = nullptr;
+};
+} // namespace OBS

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -842,7 +842,7 @@ void OBSBasic::InitOBSCallbacks()
 {
 	ProfileScope("OBSBasic::InitOBSCallbacks");
 
-	signalHandlers.reserve(signalHandlers.size() + 9);
+	signalHandlers.reserve(signalHandlers.size() + 10);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_create", OBSBasic::SourceCreated, this);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_remove", OBSBasic::SourceRemoved, this);
 	signalHandlers.emplace_back(obs_get_signal_handler(), "source_activate", OBSBasic::SourceActivated, this);
@@ -866,6 +866,7 @@ void OBSBasic::InitOBSCallbacks()
 						  Qt::QueuedConnection);
 		},
 		this);
+	signalHandlers.emplace_back(obs_get_signal_handler(), "canvas_remove", OBSBasic::CanvasRemoved, this);
 }
 
 #define STARTUP_SEPARATOR "==== Startup complete ==============================================="

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -23,6 +23,7 @@
 #include <OBSApp.hpp>
 #include <oauth/Auth.hpp>
 #include <utility/BasicOutputHandler.hpp>
+#include <utility/OBSCanvas.hpp>
 #include <utility/VCamConfig.hpp>
 #include <utility/platform.hpp>
 #include <utility/undo_stack.hpp>
@@ -1107,6 +1108,23 @@ public:
 
 	std::optional<SceneCollection> GetSceneCollectionByName(const std::string &collectionName) const;
 	std::optional<SceneCollection> GetSceneCollectionByFileName(const std::string &fileName) const;
+
+	/* -------------------------------------
+	 * MARK: - OBSBasic_Canvases
+	 * -------------------------------------
+	 */
+private:
+	std::vector<OBS::Canvas> canvases;
+
+	static void CanvasRemoved(void *data, calldata_t *params);
+
+public:
+	const std::vector<OBS::Canvas> &GetCanvases() const noexcept { return canvases; }
+
+	const OBS::Canvas &AddCanvas(const std::string &name, obs_video_info *ovi = nullptr, int flags = 0);
+
+public slots:
+	bool RemoveCanvas(obs_canvas_t *canvas);
 
 	/* -------------------------------------
 	 * MARK: - OBSBasic_SceneItems

--- a/frontend/widgets/OBSBasic_Canvases.cpp
+++ b/frontend/widgets/OBSBasic_Canvases.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+    Copyright (C) 2025 by Dennis Sädtler <saedtler@twitch.tv>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "OBSBasic.hpp"
+
+void OBSBasic::CanvasRemoved(void *data, calldata_t *params)
+{
+	obs_canvas_t *canvas = static_cast<obs_canvas_t *>(calldata_ptr(params, "canvas"));
+	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveCanvas", Q_ARG(OBSCanvas, OBSCanvas(canvas)));
+}
+
+const OBS::Canvas &OBSBasic::AddCanvas(const std::string &name, obs_video_info *ovi, int flags)
+{
+	OBSCanvas canvas = obs_canvas_create(name.c_str(), ovi, flags);
+	auto &it = canvases.emplace_back(canvas);
+	OnEvent(OBS_FRONTEND_EVENT_CANVAS_ADDED);
+	return it;
+}
+
+bool OBSBasic::RemoveCanvas(obs_canvas_t *canvas)
+{
+	if (!canvas)
+		return false;
+
+	auto canvas_it = std::find(std::begin(canvases), std::end(canvases), canvas);
+	if (canvas_it != std::end(canvases)) {
+		canvases.erase(canvas_it);
+		OnEvent(OBS_FRONTEND_EVENT_CANVAS_REMOVED);
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
### Description

Adds saving and loading for frontend-owned canvases as well as a frontend API to create/remove/enumerate them.

### Motivation and Context

In order to persist additional canvases and their scenes/sources in a way that is reasonably straightforward for API users we want the frontend to own/manage additional canvases that it may interface with.

In the future I'd also like to make transitions and the main canvas part of this abstraction.

### How Has This Been Tested?

This was tested with this fork of the vertical canvas plugin that makes use of the new APIs: https://github.com/dsaedtler/obs-vertical-canvas

### Types of changes

- New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
