### PR TITLE
frontend: Fix manifest commit hash comparison

### DIFF
--- a/frontend/utility/AutoUpdateThread.cpp
+++ b/frontend/utility/AutoUpdateThread.cpp
@@ -84,7 +84,7 @@ try {
 		/* Test or nightly builds may not have a (valid) version number,
 		 * so compare commit hashes instead. */
 		updateVer = manifest.commit.substr(0, 8);
-		*updatesAvailable = !currentVersion || !manifest.commit.compare(0, strlen(OBS_COMMIT), OBS_COMMIT);
+		*updatesAvailable = !currentVersion || manifest.commit.compare(0, strlen(OBS_COMMIT), OBS_COMMIT) != 0;
 	}
 
 	return true;


### PR DESCRIPTION
### Description

Fixes the comparison for the manifest commit hash.

### Motivation and Context

The intention here was to allow updates for builds that don't have distinct version numbers, e.g. on feature test branches. We never used this upstream but at Twitch we used it for our beta builds and I found the problem there.

### How Has This Been Tested?

Twitch closed beta OBS builds.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
