### PR TITLE
rtmp-services: Update Castr.io ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 266,
+    "version": 267,
     "files": [
         {
             "name": "services.json",
-            "version": 266
+            "version": 267
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -708,16 +708,56 @@
                     "url": "rtmp://qc.castr.io/static"
                 },
                 {
-                    "name": "SA (Sao Paulo, BR)",
+                    "name": "Mexico",
+                    "url": "rtmp://mexico.castr.io/static"
+                },
+                {
+                    "name": "Sao Paulo, BR",
                     "url": "rtmp://br.castr.io/static"
+                },
+                {
+                    "name": "Colombia",
+                    "url": "rtmp://bogota.castr.io/static"
+                },
+                {
+                    "name": "Santiago, Chile",
+                    "url": "rtmp://santiago.castr.io/static"
+                },
+                {
+                    "name": "Istanbul, TR",
+                    "url": "rtmp://istanbul.castr.io/static"
+                },
+                {
+                    "name": "Tel Aviv, IL",
+                    "url": "rtmp://telaviv.castr.io/static"
                 },
                 {
                     "name": "EU-West (London, UK)",
                     "url": "rtmp://uk.castr.io/static"
                 },
                 {
+                    "name": "EU-West (Paris, FR)",
+                    "url": "rtmp://paris.castr.io/static"
+                },
+                {
+                    "name": "EU-West (Madrid, ES)",
+                    "url": "rtmp://madrid.castr.io/static"
+                },
+                {
                     "name": "EU-Central (Frankfurt, DE)",
                     "url": "rtmp://fr.castr.io/static"
+                },
+                {
+                    "name": "EU-Central (Milan, IT)",
+                    "url": "rtmp://milan.castr.io/static"
+                },
+                {
+                    "name": "EU-North (Stockholm, SE)",
+                    "url": "rtmp://stockholm.castr.io/static"
+                },
+                {
+                    "name": "EU-North (Copenhagen, DK)",
+                    "url": "rtmp://copenhagen.castr.io/static"
                 },
                 {
                     "name": "Russia (Moscow)",
@@ -728,12 +768,28 @@
                     "url": "rtmp://sg.castr.io/static"
                 },
                 {
+                    "name": "Asia (Hong Kong, HK)",
+                    "url": "rtmp://hongkong.castr.io/static"
+                },
+                {
                     "name": "Asia (India)",
                     "url": "rtmp://in.castr.io/static"
                 },
                 {
                     "name": "Australia (Sydney)",
                     "url": "rtmp://au.castr.io/static"
+                },
+                {
+                    "name": "UAE (Dubai)",
+                    "url": "rtmp://dubai.castr.io/static"
+                },
+                {
+                    "name": "Africa (Johannesburg, ZA)",
+                    "url": "rtmp://southafrica.castr.io/static"
+                },
+                {
+                    "name": "Africa (Lagos, NG)",
+                    "url": "rtmp://lagos.castr.io/static"
                 },
                 {
                     "name": "US Central",


### PR DESCRIPTION
### Description
This Pull Request updates the list of RTMP servers for Castr.io in the `services.json` file used by OBS Studio. The new server configurations are now included to support streaming functionality for users of Castr.io. The servers have been updated to reflect the latest changes from Castr.io.

### Motivation and Context
This update is required to ensure that OBS users who stream to Castr.io have the correct server configurations available in the RTMP services list. The previous list may not have included the latest server configurations, which could cause issues for users.

### How Has This Been Tested?
I have tested this update by adding the new RTMP server configurations to the `services.json` file and verifying that they appear correctly in the OBS Studio stream settings. I also ensured that users can successfully stream to Castr.io using the updated servers.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.