### PR TITLE
feat: implement flags for config locations

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -66,6 +66,9 @@ extern bool opt_disable_updater;
 extern bool opt_disable_missing_files_check;
 extern string opt_starting_collection;
 extern string opt_starting_profile;
+extern string opt_user_config_location;
+extern string opt_user_scenes_location;
+extern string opt_user_profiles_location;
 
 extern QPointer<OBSLogViewer> obsLogViewer;
 
@@ -458,6 +461,18 @@ bool OBSApp::InitGlobalConfig()
 		userScenesLocation =
 			std::filesystem::u8path(config_get_string(appConfig, "Locations", "SceneCollections"));
 		userProfilesLocation = std::filesystem::u8path(config_get_string(appConfig, "Locations", "Profiles"));
+	}
+
+	if (!opt_user_config_location.empty()) {
+		userConfigLocation = opt_user_config_location;
+	}
+
+	if (!opt_user_scenes_location.empty()) {
+		userScenesLocation = opt_user_scenes_location;
+	}
+
+	if (!opt_user_profiles_location.empty()) {
+		userProfilesLocation = opt_user_profiles_location;
 	}
 
 	bool userConfigResult = InitUserConfig(userConfigLocation, lastVersion);

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -77,6 +77,9 @@ bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
+string opt_user_config_location;
+string opt_user_scenes_location;
+string opt_user_profiles_location;
 
 bool restart = false;
 bool restart_safe = false;
@@ -1033,6 +1036,18 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--steam", nullptr)) {
 			steam = true;
 
+		} else if (arg_is(argv[i], "--user-config-location", nullptr)) {
+			if (++i < argc)
+				opt_user_config_location = argv[i];
+
+		} else if (arg_is(argv[i], "--user-scenes-location", nullptr)) {
+			if (++i < argc)
+				opt_user_scenes_location = argv[i];
+
+		} else if (arg_is(argv[i], "--user-profiles-location", nullptr)) {
+			if (++i < argc)
+				opt_user_profiles_location = argv[i];
+
 		} else if (arg_is(argv[i], "--help", "-h")) {
 			std::string help =
 				"--help, -h: Get list of available commands.\n\n"
@@ -1053,6 +1068,9 @@ int main(int argc, char *argv[])
 				"--safe-mode: Run in Safe Mode (disables third-party plugins, scripting, and WebSockets).\n"
 				"--only-bundled-plugins: Only load included (first-party) plugins\n"
 				"--disable-shutdown-check: Disable unclean shutdown detection.\n"
+				"--user-config-location: Set the location of the user configuration.\n"
+				"--user-scenes-location: Set the location of the user scenes.\n"
+				"--user-profiles-location: Set the location of the user profiles.\n"
 				"--verbose: Make log more verbose.\n"
 				"--always-on-top: Start in 'always on top' mode.\n\n"
 				"--unfiltered_log: Make log unfiltered.\n\n"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Issues

This change actually puts the files in the set location + "/obs-studio", which isn't great in my opinion. However, fixing this would require a lot of changes. What do you think is the best option here?

### Description

Adds 3 flags for configurable locations:
- `--user-config-location`
- `--user-scenes-location`
- `--user-profiles-location`

Related: #10048

### Motivation and Context

The default mode doesn't allow for flexible configurable paths except on linux with `XDG_CONFIG_HOME`. The portable mode only works for Windows and required one to copy the entire folder, with executables and everything.

Users might want to run multiple instances of OBS on all operating systems, and having configurable locations is thus quite useful.

### How Has This Been Tested?

Just setting the flags and checking if the files were populated and used accordingly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
