### PR TITLE
frontend: Focus text entry in NameDialog

### DIFF
--- a/frontend/dialogs/NameDialog.cpp
+++ b/frontend/dialogs/NameDialog.cpp
@@ -51,6 +51,9 @@ NameDialog::NameDialog(QWidget *parent) : QDialog(parent)
 	QDialogButtonBox *buttonbox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 	layout->addWidget(buttonbox);
 	buttonbox->setCenterButtons(true);
+
+	userText->setFocus();
+
 	connect(buttonbox, &QDialogButtonBox::accepted, this, &QDialog::accept);
 	connect(buttonbox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }


### PR DESCRIPTION
### Description
Sets the focused widget to the QLineEdit in NameDialog widgets.

### Motivation and Context
Want the text entry field to be focused when these dialogs are created.

I think this was already the case in past versions, unsure when the regression happened and if it was our fault or Qts.

### How Has This Been Tested?
Opened Profile and Scene Collection New/Rename/Duplicate dialogs

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
