### PR TITLE
Fix random capture freeze on Wayland

### DIFF
--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -57,6 +57,9 @@ struct screencast_portal_capture {
 
 	obs_pipewire *obs_pw;
 	obs_pipewire_stream *obs_pw_stream;
+
+	// P4694
+	bool capture_freeze_detected;
 };
 
 /* ------------------------------------------------- */


### PR DESCRIPTION
Fixes #11818

Address random capture freeze issue on Wayland when using 'Screen Capture (PipeWire)'.

* **pipewire.c**
  - Add `capture_freeze_detected` flag to `obs_pipewire_stream` structure.
  - Detect capture freeze in `on_state_changed_cb` and set `capture_freeze_detected` flag.
  - Handle capture freeze in `on_process_cb` by logging the freeze and attempting to recover by renegotiating the format.

* **screencast-portal.c**
  - Add `capture_freeze_detected` flag to `screencast_context` structure.

