### PR TITLE
cmake: Don't copy legacy, unused Chromium file

### DIFF
--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -174,9 +174,8 @@ function(set_target_properties_obs target)
             COMMAND
               "${CMAKE_COMMAND}" -E copy_if_different "${imported_location}" "${cef_location}/chrome-sandbox"
               "${cef_location}/libEGL.so" "${cef_location}/libGLESv2.so" "${cef_location}/libvk_swiftshader.so"
-              "${cef_location}/libvulkan.so.1" "${cef_location}/snapshot_blob.bin"
-              "${cef_location}/v8_context_snapshot.bin" "${cef_location}/vk_swiftshader_icd.json"
-              "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_PLUGIN_DESTINATION}/"
+              "${cef_location}/libvulkan.so.1" "${cef_location}/v8_context_snapshot.bin"
+              "${cef_location}/vk_swiftshader_icd.json" "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_PLUGIN_DESTINATION}/"
             COMMAND
               "${CMAKE_COMMAND}" -E copy_if_different "${cef_root_location}/Resources/chrome_100_percent.pak"
               "${cef_root_location}/Resources/chrome_200_percent.pak" "${cef_root_location}/Resources/icudtl.dat"
@@ -195,7 +194,6 @@ function(set_target_properties_obs target)
               "${cef_location}/libGLESv2.so"
               "${cef_location}/libvk_swiftshader.so"
               "${cef_location}/libvulkan.so.1"
-              "${cef_location}/snapshot_blob.bin"
               "${cef_location}/v8_context_snapshot.bin"
               "${cef_location}/vk_swiftshader_icd.json"
               "${cef_root_location}/Resources/chrome_100_percent.pak"

--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -109,8 +109,8 @@ function(set_target_properties_obs target)
             COMMAND "${CMAKE_COMMAND}" -E make_directory "${OBS_OUTPUT_DIR}/$<CONFIG>/${target_destination}"
             COMMAND
               "${CMAKE_COMMAND}" -E copy_if_different "${imported_location}" "${cef_location}/chrome_elf.dll"
-              "${cef_location}/libEGL.dll" "${cef_location}/libGLESv2.dll" "${cef_location}/snapshot_blob.bin"
-              "${cef_location}/v8_context_snapshot.bin" "${OBS_OUTPUT_DIR}/$<CONFIG>/${target_destination}"
+              "${cef_location}/libEGL.dll" "${cef_location}/libGLESv2.dll" "${cef_location}/v8_context_snapshot.bin"
+              "${OBS_OUTPUT_DIR}/$<CONFIG>/${target_destination}"
             COMMAND
               "${CMAKE_COMMAND}" -E copy_if_different "${cef_root_location}/Resources/chrome_100_percent.pak"
               "${cef_root_location}/Resources/chrome_200_percent.pak" "${cef_root_location}/Resources/icudtl.dat"
@@ -127,7 +127,6 @@ function(set_target_properties_obs target)
               "${cef_location}/chrome_elf.dll"
               "${cef_location}/libEGL.dll"
               "${cef_location}/libGLESv2.dll"
-              "${cef_location}/snapshot_blob.bin"
               "${cef_location}/v8_context_snapshot.bin"
               "${cef_root_location}/Resources/chrome_100_percent.pak"
               "${cef_root_location}/Resources/chrome_200_percent.pak"


### PR DESCRIPTION
> [!IMPORTANT]  
> The updater will need to be informed that this file is deleted.

### Description

While attempting to test a fix for https://github.com/obsproject/obs-browser/issues/468 I was unable to build obs-browser with Chromium 133 (CEF 6943) because our CMake was attempting to copy a file that no longer existed. After some digging, I found the below commit, which states

> Shipping both snapshot_blob.bin and v8_context_snapshot.bin is unnecessary, and v8_context_snapshot.bin is available on all supported platforms. Chrome stopped shipping snapshot_blob.bin in https://crrev.com/b550792f0f (~M66).

https://bitbucket.org/chromiumembedded/cef/commits/719f423e7030540f9b334d12e2ef9f82fc759a36

### Motivation and Context

While CEF continues to ship & read this up to and including in CEF 6834, it hasn't actually been used since Chromium 66, so we can safely remove it without causing regressions in 5060 or 6533. No point in making our download size larger when it's not used.

### How Has This Been Tested?

* Build OBS with any recent or future version of CEF
* Launch OBS and ensure all browser functionality continues to work correctly

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
