### PR TITLE
flatpak: Bump KDE runtime to 6.7

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -249,7 +249,7 @@ jobs:
     env:
       FLATPAK_BUILD_SHARE_PATH: flatpak_app/files/share
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.6
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.7
       options: --privileged
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
       YOUTUBE_SECRET: ${{ secrets.YOUTUBE_SECRET }}
       YOUTUBE_SECRET_HASH: ${{ secrets.YOUTUBE_SECRET_HASH }}
     container:
-      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.6
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-6.7
       options: --privileged
     strategy:
       matrix:

--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -1,7 +1,7 @@
 {
     "id": "com.obsproject.Studio",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.6",
+    "runtime-version": "6.7",
     "sdk": "org.kde.Sdk",
     "command": "obs",
     "finish-args": [


### PR DESCRIPTION
The 6.6 runtime is now EOL:
>Info: (pinned) runtime org.kde.Platform branch 6.6 is end-of-life, with reason:
>   We strongly recommend moving to the latest stable version of the Platform and SDK

Note: I tried going to 6.8  but there were C++ build errors that will need sorting out eventually but I'll leave that to someone else. The 6.7 runtime is still supported and works as-is.