### PR TITLE
win-dshow: Fix possible crash if frame width or height is zero

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -936,6 +936,12 @@ bool DShowInput::UpdateVideoConfig(obs_data_t *settings)
 		return false;
 	}
 
+	if (!videoConfig.cx || !videoConfig.cy_abs) {
+		blog(LOG_ERROR, "%s: Frame width or height are zero (%" PRIu32 "x%" PRIu32 ")",
+		     obs_source_get_name(source), videoConfig.cx, videoConfig.cy_abs);
+		return false;
+	}
+
 	DStr formatName = GetVideoFormatName(videoConfig.internalFormat);
 
 	double fps = 0.0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

If a frame has a width or height of zero, this value will make it into libobs/media-io/video-frame.c:video_frame_init and cause linesizes or heights to be zero, which will result in a bmalloc(0) call and OBS will crash.

Instead of letting the call stack get that far, check the frame width and height here at the source, log an error, and return early if the frame width or height are zero.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Alternative to:
* #11803

Fixes #11729
Fixes #11860

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally by forcing `videoConfig.cx` or `videoConfig.cy_abs` above this change to be zero and verifying that the error is logged and OBS does not crash.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
