### PR TITLE
frontend: Increase MAX_CRASH_REPORT_SIZE to 200 KB

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -733,7 +733,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	return ret;
 }
 
-#define MAX_CRASH_REPORT_SIZE (150 * 1024)
+#define MAX_CRASH_REPORT_SIZE (200 * 1024)
 
 #ifdef _WIN32
 


### PR DESCRIPTION
### Description

With CEF and NDI, logs can exceed 150KB, cutting off symbol addresses. Bump up the maximum crash report size to make that less likely.

### Motivation and Context

One method of fixing #11842. Could raise it higher, but there's a reason why the limit exists.

### How Has This Been Tested?

Make OBS crash on Windows.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
