### PR TITLE
frontend: Transitions (dock) separation part 1

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -95,12 +95,12 @@ void OBSStudioAPI::obs_frontend_set_current_transition(obs_source_t *transition)
 
 int OBSStudioAPI::obs_frontend_get_transition_duration()
 {
-	return main->ui->transitionDuration->value();
+	return main->GetTransitionDuration();
 }
 
 void OBSStudioAPI::obs_frontend_set_transition_duration(int duration)
 {
-	QMetaObject::invokeMethod(main->ui->transitionDuration, "setValue", Q_ARG(int, duration));
+	QMetaObject::invokeMethod(main, "SetTransitionDuration", Q_ARG(int, duration));
 }
 
 void OBSStudioAPI::obs_frontend_release_tbar()

--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -74,14 +74,11 @@ void OBSStudioAPI::obs_frontend_set_current_scene(obs_source_t *scene)
 
 void OBSStudioAPI::obs_frontend_get_transitions(struct obs_frontend_source_list *sources)
 {
-	for (int i = 0; i < main->ui->transitions->count(); i++) {
-		OBSSource tr = main->ui->transitions->itemData(i).value<OBSSource>();
+	for (const auto &[uuid, transition] : main->transitions) {
+		obs_source_t *source = transition;
 
-		if (!tr)
-			continue;
-
-		if (obs_source_get_ref(tr) != nullptr)
-			da_push_back(sources->sources, &tr);
+		if (obs_source_get_ref(source) != nullptr)
+			da_push_back(sources->sources, &source);
 	}
 }
 

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -313,6 +313,14 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	connect(ui->transitions, &QComboBox::currentIndexChanged, this,
 		[this]() { SetCurrentTransition(ui->transitions->currentData().toString()); });
 
+	connect(this, &OBSBasic::TransitionDurationChanged, this, [this](int duration) {
+		QSignalBlocker sb(ui->transitionDuration);
+		ui->transitionDuration->setValue(duration);
+	});
+
+	connect(ui->transitionDuration, &QSpinBox::valueChanged, this,
+		[this](int value) { SetTransitionDuration(value); });
+
 	startingDockLayout = saveState();
 
 	statsDock = new OBSDock();

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -287,6 +287,32 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 
 	connect(controls, &OBSBasicControls::SettingsButtonClicked, this, &OBSBasic::on_action_Settings_triggered);
 
+	/* Set up transitions combobox connections */
+	connect(this, &OBSBasic::TransitionAdded, this, [this](const QString &name, const QString &uuid) {
+		QSignalBlocker sb(ui->transitions);
+		ui->transitions->addItem(name, uuid);
+	});
+	connect(this, &OBSBasic::TransitionRenamed, this, [this](const QString &uuid, const QString &newName) {
+		QSignalBlocker sb(ui->transitions);
+		ui->transitions->setItemText(ui->transitions->findData(uuid), newName);
+	});
+	connect(this, &OBSBasic::TransitionRemoved, this, [this](const QString &uuid) {
+		QSignalBlocker sb(ui->transitions);
+		ui->transitions->removeItem(ui->transitions->findData(uuid));
+	});
+	connect(this, &OBSBasic::TransitionsCleared, this, [this]() {
+		QSignalBlocker sb(ui->transitions);
+		ui->transitions->clear();
+	});
+
+	connect(this, &OBSBasic::CurrentTransitionChanged, this, [this](const QString &uuid) {
+		QSignalBlocker sb(ui->transitions);
+		ui->transitions->setCurrentIndex(ui->transitions->findData(uuid));
+	});
+
+	connect(ui->transitions, &QComboBox::currentIndexChanged, this,
+		[this]() { SetCurrentTransition(ui->transitions->currentData().toString()); });
+
 	startingDockLayout = saveState();
 
 	statsDock = new OBSDock();
@@ -967,7 +993,7 @@ void OBSBasic::OBSInit()
 	}
 
 	/* Modules can access frontend information (i.e. profile and scene collection data) during their initialization, and some modules (e.g. obs-websockets) are known to use the filesystem location of the current profile in their own code.
-     
+
      Thus the profile and scene collection discovery needs to happen before any access to that information (but after intializing global settings) to ensure legacy code gets valid path information.
      */
 	RefreshSceneCollections(true);

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1472,6 +1472,7 @@ private:
 	std::vector<std::string> transitionUuids;
 	// FIXME: Replace usages of a name to identify a transition
 	std::unordered_map<std::string, std::string> transitionNameToUuids;
+	int transitionDuration;
 	std::string currentTransitionUuid;
 	obs_source_t *fadeTransition;
 	obs_source_t *cutTransition;
@@ -1539,6 +1540,8 @@ public slots:
 
 	void SetCurrentTransition(const QString &uuid);
 
+	void SetTransitionDuration(int duration);
+
 private slots:
 	void AddTransition(const char *id);
 	void RenameTransition(OBSSource transition);
@@ -1554,7 +1557,6 @@ private slots:
 	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
-	void on_transitionDuration_valueChanged();
 
 	void ShowTransitionProperties();
 	void HideTransitionProperties();
@@ -1566,6 +1568,8 @@ signals:
 	void TransitionsCleared();
 
 	void CurrentTransitionChanged(const QString &uuid);
+
+	void TransitionDurationChanged(const int &duration);
 
 public:
 	int GetTransitionDuration();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1466,6 +1466,13 @@ private:
 	std::vector<OBSDataAutoRelease> safeModeTransitions;
 	QPointer<QPushButton> transitionButton;
 	QPointer<QMenu> perSceneTransitionMenu;
+
+	std::unordered_map<std::string, OBSSource> transitions;
+	// TODO: Reduce usages of an index to identify a transition
+	std::vector<std::string> transitionUuids;
+	// FIXME: Replace usages of a name to identify a transition
+	std::unordered_map<std::string, std::string> transitionNameToUuids;
+	std::string currentTransitionUuid;
 	obs_source_t *fadeTransition;
 	obs_source_t *cutTransition;
 	std::vector<QuickTransition> quickTransitions;
@@ -1519,6 +1526,8 @@ private:
 
 	void PasteShowHideTransition(obs_sceneitem_t *item, bool show, obs_source_t *tr, int duration);
 
+	void UpdateCurrentTransition(const std::string &uuid, bool setTransition);
+
 public slots:
 	void SetCurrentScene(OBSSource scene, bool force = false);
 
@@ -1527,6 +1536,8 @@ public slots:
 	void TransitionToScene(OBSScene scene, bool force = false);
 	void TransitionToScene(OBSSource scene, bool force = false, bool quickTransition = false, int quickDuration = 0,
 			       bool black = false, bool manual = false);
+
+	void SetCurrentTransition(const QString &uuid);
 
 private slots:
 	void AddTransition(const char *id);
@@ -1540,7 +1551,6 @@ private slots:
 	void TBarChanged(int value);
 	void TBarReleased();
 
-	void on_transitions_currentIndexChanged(int index);
 	void on_transitionAdd_clicked();
 	void on_transitionRemove_clicked();
 	void on_transitionProps_clicked();
@@ -1548,6 +1558,14 @@ private slots:
 
 	void ShowTransitionProperties();
 	void HideTransitionProperties();
+
+signals:
+	void TransitionAdded(const QString &name, const QString &uuid);
+	void TransitionRenamed(const QString &uuid, const QString &newName);
+	void TransitionRemoved(const QString &uuid);
+	void TransitionsCleared();
+
+	void CurrentTransitionChanged(const QString &uuid);
 
 public:
 	int GetTransitionDuration();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1468,7 +1468,7 @@ private:
 	QPointer<QMenu> perSceneTransitionMenu;
 
 	std::unordered_map<std::string, OBSSource> transitions;
-	// TODO: Reduce usages of an index to identify a transition
+	// FIXME: Any code accessing this collection relies on order of insertion
 	std::vector<std::string> transitionUuids;
 	// FIXME: Replace usages of a name to identify a transition
 	std::unordered_map<std::string, std::string> transitionNameToUuids;

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -882,12 +882,12 @@ void OBSBasic::Save(SceneCollection &collection)
 		curProgramScene = obs_scene_get_source(scene);
 
 	OBSDataArrayAutoRelease sceneOrder = SaveSceneListOrder();
-	OBSDataArrayAutoRelease transitions = SaveTransitions();
+	OBSDataArrayAutoRelease transitionsData = SaveTransitions();
 	OBSDataArrayAutoRelease quickTrData = SaveQuickTransitions();
 	OBSDataArrayAutoRelease savedProjectorList = SaveProjectors();
 	OBSDataArrayAutoRelease savedCanvases = OBS::Canvas::SaveCanvases(canvases);
 	OBSDataAutoRelease saveData = GenerateSaveData(sceneOrder, quickTrData, ui->transitionDuration->value(),
-						       transitions, scene, curProgramScene, savedProjectorList,
+						       transitionsData, scene, curProgramScene, savedProjectorList,
 						       savedCanvases);
 
 	obs_data_set_bool(saveData, "preview_locked", ui->preview->Locked());
@@ -1172,7 +1172,7 @@ void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
 	OBSDataArrayAutoRelease sceneOrder = obs_data_get_array(data, "scene_order");
 	OBSDataArrayAutoRelease sources = obs_data_get_array(data, "sources");
 	OBSDataArrayAutoRelease groups = obs_data_get_array(data, "groups");
-	OBSDataArrayAutoRelease transitions = obs_data_get_array(data, "transitions");
+	OBSDataArrayAutoRelease transitionsData = obs_data_get_array(data, "transitions");
 	OBSDataArrayAutoRelease collection_canvases = obs_data_get_array(data, "canvases");
 	const char *sceneName = obs_data_get_string(data, "current_scene");
 	const char *programSceneName = obs_data_get_string(data, "current_program_scene");
@@ -1295,8 +1295,8 @@ void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
 
 	if (resetVideo)
 		ResetVideo();
-	if (transitions)
-		LoadTransitions(transitions, AddMissingFiles, files);
+	if (transitionsData)
+		LoadTransitions(transitionsData, AddMissingFiles, files);
 	if (sceneOrder)
 		LoadSceneListOrder(sceneOrder);
 

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1499,7 +1499,12 @@ void OBSBasic::ClearSceneData()
 	ClearListItems(ui->scenes);
 	ui->sources->Clear();
 	ClearQuickTransitions();
-	ui->transitions->clear();
+
+	currentTransitionUuid.clear();
+	transitions.clear();
+	transitionNameToUuids.clear();
+	transitionUuids.clear();
+	emit TransitionsCleared();
 
 	ClearProjectors();
 

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -886,9 +886,8 @@ void OBSBasic::Save(SceneCollection &collection)
 	OBSDataArrayAutoRelease quickTrData = SaveQuickTransitions();
 	OBSDataArrayAutoRelease savedProjectorList = SaveProjectors();
 	OBSDataArrayAutoRelease savedCanvases = OBS::Canvas::SaveCanvases(canvases);
-	OBSDataAutoRelease saveData = GenerateSaveData(sceneOrder, quickTrData, ui->transitionDuration->value(),
-						       transitionsData, scene, curProgramScene, savedProjectorList,
-						       savedCanvases);
+	OBSDataAutoRelease saveData = GenerateSaveData(sceneOrder, quickTrData, transitionDuration, transitionsData,
+						       scene, curProgramScene, savedProjectorList, savedCanvases);
 
 	obs_data_set_bool(saveData, "preview_locked", ui->preview->Locked());
 	obs_data_set_bool(saveData, "scaling_enabled", ui->preview->IsFixedScaling());
@@ -1004,7 +1003,7 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	ClearSceneData();
 	InitDefaultTransitions();
 	CreateDefaultQuickTransitions();
-	ui->transitionDuration->setValue(300);
+	transitionDuration = 300;
 	SetTransition(fadeTransition);
 
 	updateRemigrationMenuItem(SceneCoordinateMode::Relative, ui->actionRemigrateSceneCollection);
@@ -1304,7 +1303,7 @@ void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
 	if (!curTransition)
 		curTransition = fadeTransition;
 
-	ui->transitionDuration->setValue(newDuration);
+	transitionDuration = newDuration;
 	SetTransition(curTransition);
 
 retryScene:

--- a/frontend/widgets/OBSBasic_StudioMode.cpp
+++ b/frontend/widgets/OBSBasic_StudioMode.cpp
@@ -76,8 +76,8 @@ void OBSBasic::CreateProgramOptions()
 	transitionButton = new QPushButton(QTStr("Transition"));
 	transitionButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-	QHBoxLayout *quickTransitions = new QHBoxLayout();
-	quickTransitions->setSpacing(2);
+	QHBoxLayout *quickTransitionsLayout = new QHBoxLayout();
+	quickTransitionsLayout->setSpacing(2);
 
 	QPushButton *addQuickTransition = new QPushButton();
 	addQuickTransition->setProperty("class", "icon-plus");
@@ -85,8 +85,8 @@ void OBSBasic::CreateProgramOptions()
 	QLabel *quickTransitionsLabel = new QLabel(QTStr("QuickTransitions"));
 	quickTransitionsLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
-	quickTransitions->addWidget(quickTransitionsLabel);
-	quickTransitions->addWidget(addQuickTransition);
+	quickTransitionsLayout->addWidget(quickTransitionsLabel);
+	quickTransitionsLayout->addWidget(addQuickTransition);
 
 	mainButtonLayout->addWidget(transitionButton);
 	mainButtonLayout->addWidget(configTransitions);
@@ -102,7 +102,7 @@ void OBSBasic::CreateProgramOptions()
 
 	layout->addStretch(0);
 	layout->addLayout(mainButtonLayout);
-	layout->addLayout(quickTransitions);
+	layout->addLayout(quickTransitionsLayout);
 	layout->addWidget(tBar);
 	layout->addStretch(0);
 

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -17,6 +17,8 @@
 
 #include "OBSBasic.hpp"
 
+#include <algorithm>
+
 #include <components/MenuButton.hpp>
 #include <dialogs/NameDialog.hpp>
 #include <utility/display-helpers.hpp>
@@ -69,8 +71,16 @@ void OBSBasic::InitDefaultTransitions()
 	}
 
 	for (OBSSource &tr : defaultTransitions) {
-		ui->transitions->addItem(QT_UTF8(obs_source_get_name(tr)), QVariant::fromValue(OBSSource(tr)));
+		std::string uuid = obs_source_get_uuid(tr);
+
+		transitions.insert({uuid, OBSSource(tr)});
+		transitionNameToUuids.insert({obs_source_get_name(tr), uuid});
+		transitionUuids.push_back(uuid);
+
+		emit TransitionAdded(QT_UTF8(obs_source_get_name(tr)), QString::fromStdString(uuid));
 	}
+
+	UpdateCurrentTransition(transitionUuids.back(), true);
 }
 
 void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
@@ -198,14 +208,15 @@ obs_data_array_t *OBSBasic::SaveQuickTransitions()
 
 obs_source_t *OBSBasic::FindTransition(const char *name)
 {
-	for (int i = 0; i < ui->transitions->count(); i++) {
-		OBSSource tr = ui->transitions->itemData(i).value<OBSSource>();
-		if (!tr)
-			continue;
+	auto nameToUuid = transitionNameToUuids.find(name);
 
-		const char *trName = obs_source_get_name(tr);
-		if (strcmp(trName, name) == 0)
-			return tr;
+	if (nameToUuid != transitionNameToUuids.end()) {
+		auto transition = transitions.find(nameToUuid->second);
+
+		if (transition == transitions.end())
+			return nullptr;
+
+		return transition->second;
 	}
 
 	return nullptr;
@@ -377,9 +388,10 @@ void OBSBasic::SetTransition(OBSSource transition)
 	OBSSourceAutoRelease oldTransition = obs_get_output_source(0);
 
 	if (oldTransition && transition) {
+		std::string uuid = obs_source_get_uuid(transition);
 		obs_transition_swap_begin(transition, oldTransition);
-		if (transition != GetCurrentTransition())
-			SetComboTransition(ui->transitions, transition);
+		if (currentTransitionUuid != uuid)
+			UpdateCurrentTransition(uuid, false);
 		obs_set_output_source(0, transition);
 		obs_transition_swap_end(transition, oldTransition);
 	} else {
@@ -399,13 +411,12 @@ void OBSBasic::SetTransition(OBSSource transition)
 
 OBSSource OBSBasic::GetCurrentTransition()
 {
-	return ui->transitions->currentData().value<OBSSource>();
-}
+	auto transition = transitions.find(currentTransitionUuid);
 
-void OBSBasic::on_transitions_currentIndexChanged(int)
-{
-	OBSSource transition = GetCurrentTransition();
-	SetTransition(transition);
+	if (transition == transitions.end())
+		return nullptr;
+
+	return transition->second;
 }
 
 void OBSBasic::AddTransition(const char *id)
@@ -424,6 +435,8 @@ void OBSBasic::AddTransition(const char *id)
 					       name, placeHolderText);
 
 	if (accepted) {
+		std::string uuid;
+
 		if (name.empty()) {
 			OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
 			AddTransition(id);
@@ -440,8 +453,16 @@ void OBSBasic::AddTransition(const char *id)
 
 		source = obs_source_create_private(id, name.c_str(), NULL);
 		InitTransition(source);
-		ui->transitions->addItem(QT_UTF8(name.c_str()), QVariant::fromValue(OBSSource(source)));
-		ui->transitions->setCurrentIndex(ui->transitions->count() - 1);
+
+		uuid = obs_source_get_uuid(source);
+		transitions.insert({uuid, source});
+		transitionNameToUuids.insert({name, uuid});
+		transitionUuids.push_back(uuid);
+
+		emit TransitionAdded(QString::fromStdString(name), QString::fromStdString(uuid));
+
+		UpdateCurrentTransition(uuid, true);
+
 		CreatePropertiesWindow(source);
 		obs_source_release(source);
 
@@ -477,13 +498,16 @@ void OBSBasic::on_transitionAdd_clicked()
 
 void OBSBasic::on_transitionRemove_clicked()
 {
-	OBSSource tr = GetCurrentTransition();
+	auto transitionIterator = transitions.find(currentTransitionUuid);
+	OBSSource tr;
+	const char *name;
 
-	if (!tr || !obs_source_configurable(tr) || !QueryRemoveSource(tr))
+	if (transitionIterator == transitions.end())
 		return;
 
-	int idx = ui->transitions->findData(QVariant::fromValue<OBSSource>(tr));
-	if (idx == -1)
+	tr = transitionIterator->second;
+
+	if (!tr || !obs_source_configurable(tr) || !QueryRemoveSource(tr))
 		return;
 
 	for (size_t i = quickTransitions.size(); i > 0; i--) {
@@ -496,7 +520,15 @@ void OBSBasic::on_transitionRemove_clicked()
 		}
 	}
 
-	ui->transitions->removeItem(idx);
+	name = obs_source_get_name(tr);
+	if (name)
+		transitionNameToUuids.erase(std::string(name));
+
+	transitionUuids.erase(std::find(transitionUuids.begin(), transitionUuids.end(), currentTransitionUuid));
+	transitions.erase(currentTransitionUuid);
+	emit TransitionRemoved(QString::fromStdString(currentTransitionUuid));
+
+	UpdateCurrentTransition(transitionUuids.back(), true);
 
 	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
 
@@ -506,8 +538,10 @@ void OBSBasic::on_transitionRemove_clicked()
 
 void OBSBasic::RenameTransition(OBSSource transition)
 {
-	string name;
-	QString placeHolderText = QT_UTF8(obs_source_get_name(transition));
+	std::string name;
+	std::string oldName = obs_source_get_name(transition);
+	std::string uuid = obs_source_get_uuid(transition);
+	QString placeHolderText = QString::fromStdString(oldName);
 	obs_source_t *source = nullptr;
 
 	bool accepted = NameDialog::AskForName(this, QTStr("TransitionNameDlg.Title"), QTStr("TransitionNameDlg.Text"),
@@ -530,15 +564,19 @@ void OBSBasic::RenameTransition(OBSSource transition)
 	}
 
 	obs_source_set_name(transition, name.c_str());
-	int idx = ui->transitions->findData(QVariant::fromValue(transition));
-	if (idx != -1) {
-		ui->transitions->setItemText(idx, QT_UTF8(name.c_str()));
 
-		OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
+	if (transitionNameToUuids.find(oldName) == transitionNameToUuids.end())
+		return;
 
-		ClearQuickTransitionWidgets();
-		RefreshQuickTransitions();
-	}
+	transitionNameToUuids.erase(oldName);
+	transitionNameToUuids.insert({name, uuid});
+
+	emit TransitionRenamed(QString::fromStdString(uuid), QString::fromStdString(name));
+
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);
+
+	ClearQuickTransitionWidgets();
+	RefreshQuickTransitions();
 }
 
 void OBSBasic::on_transitionProps_clicked()
@@ -763,13 +801,17 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 		int idx = action->property("transition_index").toInt();
 		OBSSource scene = GetCurrentSceneSource();
 		OBSDataAutoRelease data = obs_source_get_private_settings(scene);
+		auto transitionIter = transitions.find(transitionUuids[idx]);
 
 		if (idx == -1) {
 			obs_data_set_string(data, "transition", "");
 			return;
 		}
 
-		OBSSource tr = GetTransitionComboItem(ui->transitions, idx);
+		if (transitionIter == transitions.end())
+			return;
+
+		OBSSource tr = transitionIter->second;
 
 		if (tr) {
 			const char *name = obs_source_get_name(tr);
@@ -786,12 +828,17 @@ QMenu *OBSBasic::CreatePerSceneTransitionMenu()
 
 	connect(duration, (void(QSpinBox::*)(int)) & QSpinBox::valueChanged, setDuration);
 
-	for (int i = -1; i < ui->transitions->count(); i++) {
+	for (int i = -1; i < (int)transitionUuids.size(); i++) {
 		const char *name = "";
 
 		if (i >= 0) {
+			auto transitionIter = transitions.find(transitionUuids[i]);
 			OBSSource tr;
-			tr = GetTransitionComboItem(ui->transitions, i);
+
+			if (transitionIter == transitions.end())
+				continue;
+
+			tr = transitionIter->second;
 			if (!tr)
 				continue;
 			name = obs_source_get_name(tr);
@@ -1051,8 +1098,13 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 		connect(action, &QAction::triggered, this, &OBSBasic::AddQuickTransition);
 	}
 
-	for (int i = 0; i < ui->transitions->count(); i++) {
-		tr = GetTransitionComboItem(ui->transitions, i);
+	for (int i = 0; i < (int)transitionUuids.size(); i++) {
+		auto transitionIter = transitions.find(transitionUuids[i]);
+
+		if (transitionIter == transitions.end())
+			continue;
+
+		tr = transitionIter->second;
 
 		if (!tr)
 			continue;
@@ -1121,7 +1173,13 @@ void OBSBasic::AddQuickTransition()
 	int trIdx = sender()->property("transition_index").toInt();
 	QSpinBox *duration = sender()->property("duration").value<QSpinBox *>();
 	bool fadeToBlack = sender()->property("fadeToBlack").value<bool>();
-	OBSSource transition = fadeToBlack ? OBSSource(fadeTransition) : GetTransitionComboItem(ui->transitions, trIdx);
+	auto transitionIter = transitions.find(transitionUuids[trIdx]);
+	OBSSource transition;
+
+	if (!fadeToBlack && (transitionIter == transitions.end()))
+		return;
+
+	transition = fadeToBlack ? OBSSource(fadeTransition) : transitionIter->second;
 
 	if (!transition)
 		return;
@@ -1177,7 +1235,14 @@ void OBSBasic::QuickTransitionChange()
 	QuickTransition *qt = GetQuickTransition(id);
 
 	if (qt) {
-		OBSSource tr = fadeToBlack ? OBSSource(fadeTransition) : GetTransitionComboItem(ui->transitions, trIdx);
+		auto transitionIter = transitions.find(transitionUuids[trIdx]);
+		OBSSource tr;
+
+		if (!fadeToBlack && (transitionIter == transitions.end()))
+			return;
+
+		tr = fadeToBlack ? OBSSource(fadeTransition) : transitionIter->second;
+
 		if (tr) {
 			qt->source = tr;
 			qt->fadeToBlack = fadeToBlack;
@@ -1282,16 +1347,15 @@ obs_data_array_t *OBSBasic::SaveTransitions()
 {
 	obs_data_array_t *transitionsData = obs_data_array_create();
 
-	for (int i = 0; i < ui->transitions->count(); i++) {
-		OBSSource tr = ui->transitions->itemData(i).value<OBSSource>();
-		if (!tr || !obs_source_configurable(tr))
+	for (const auto &[uuid, transition] : transitions) {
+		if (!transition || !obs_source_configurable(transition.Get()))
 			continue;
 
 		OBSDataAutoRelease sourceData = obs_data_create();
-		OBSDataAutoRelease settings = obs_source_get_settings(tr);
+		OBSDataAutoRelease settings = obs_source_get_settings(transition.Get());
 
-		obs_data_set_string(sourceData, "name", obs_source_get_name(tr));
-		obs_data_set_string(sourceData, "id", obs_obj_get_id(tr));
+		obs_data_set_string(sourceData, "name", obs_source_get_name(transition.Get()));
+		obs_data_set_string(sourceData, "id", obs_obj_get_id(transition.Get()));
 		obs_data_set_obj(sourceData, "settings", settings);
 
 		obs_data_array_push_back(transitionsData, sourceData);
@@ -1317,16 +1381,23 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitionsData, obs_load_sourc
 
 		OBSSourceAutoRelease source = obs_source_create_private(id, name, settings);
 		if (!obs_obj_invalid(source)) {
+			std::string uuid = obs_source_get_uuid(source);
 			InitTransition(source);
 
-			ui->transitions->addItem(QT_UTF8(name), QVariant::fromValue(OBSSource(source)));
-			ui->transitions->setCurrentIndex(ui->transitions->count() - 1);
+			transitions.insert({uuid, OBSSource(source)});
+			transitionNameToUuids.insert({name, uuid});
+			transitionUuids.push_back(uuid);
+
+			emit TransitionAdded(QT_UTF8(name), QString::fromStdString(uuid));
+
 			if (cb)
 				cb(private_data, source);
 		} else if (safe_mode || disable_3p_plugins) {
 			safeModeTransitions.push_back(std::move(item));
 		}
 	}
+
+	UpdateCurrentTransition(transitionUuids.back(), true);
 }
 
 OBSSource OBSBasic::GetOverrideTransition(OBSSource source)
@@ -1360,4 +1431,32 @@ int OBSBasic::GetOverrideTransitionDuration(OBSSource source)
 int OBSBasic::GetTransitionDuration()
 {
 	return ui->transitionDuration->value();
+}
+
+void OBSBasic::UpdateCurrentTransition(const std::string &uuid, bool setTransition)
+{
+	auto transitionIter = transitions.find(uuid);
+
+	if (currentTransitionUuid == uuid || transitionIter == transitions.end())
+		return;
+
+	currentTransitionUuid = uuid;
+
+	if (setTransition)
+		SetTransition(transitionIter->second);
+
+	emit CurrentTransitionChanged(QString::fromStdString(uuid));
+}
+
+void OBSBasic::SetCurrentTransition(const QString &uuid)
+{
+	auto transitionIter = transitions.find(uuid.toStdString());
+
+	if (currentTransitionUuid == uuid.toStdString() || transitionIter == transitions.end())
+		return;
+
+	currentTransitionUuid = uuid.toStdString();
+	SetTransition(transitionIter->second);
+
+	emit CurrentTransitionChanged(uuid);
 }

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -333,7 +333,7 @@ void OBSBasic::TransitionToScene(OBSSource source, bool force, bool quickTransit
 		obs_transition_set(transition, source);
 		OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
 	} else {
-		int duration = ui->transitionDuration->value();
+		int duration = GetTransitionDuration();
 
 		/* check for scene override */
 		OBSSource trOverride = GetOverrideTransition(source);
@@ -601,11 +601,6 @@ void OBSBasic::on_transitionProps_clicked()
 	menu.addAction(action);
 
 	menu.exec(QCursor::pos());
-}
-
-void OBSBasic::on_transitionDuration_valueChanged()
-{
-	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
 }
 
 QuickTransition *OBSBasic::GetQuickTransition(int id)
@@ -1420,7 +1415,7 @@ int OBSBasic::GetOverrideTransitionDuration(OBSSource source)
 
 int OBSBasic::GetTransitionDuration()
 {
-	return ui->transitionDuration->value();
+	return transitionDuration;
 }
 
 void OBSBasic::UpdateCurrentTransition(const std::string &uuid, bool setTransition)
@@ -1449,4 +1444,19 @@ void OBSBasic::SetCurrentTransition(const QString &uuid)
 	SetTransition(transitionIter->second);
 
 	emit CurrentTransitionChanged(uuid);
+}
+
+void OBSBasic::SetTransitionDuration(int duration)
+{
+	duration = std::max(duration, 50);
+	duration = std::min(duration, 20000);
+
+	if (duration == transitionDuration)
+		return;
+
+	transitionDuration = duration;
+
+	emit TransitionDurationChanged(transitionDuration);
+
+	OnEvent(OBS_FRONTEND_EVENT_TRANSITION_DURATION_CHANGED);
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Began to split transitions and transition duration storage from the UI.
Also makes the frontend code rely more on transitions UUID even if those are not preserved between sessions for now.

While this PR remove any kind of reliance on *index* of a transition, it does **not** overhaul things to rely only on UUID so there is still reliance on the transition name as an identifier. Same for retaining which transition was inserted last.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

After multiple tries, I finally managed to separated the transitions data from this combobox, now it needs reviews and testings…

The awaited sequel of #7278, but it's the prequel of the expected sequel.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Please tests

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
