### PR TITLE
frontend: Remove Exit button

### DIFF
--- a/frontend/forms/OBSBasicControls.ui
+++ b/frontend/forms/OBSBasicControls.ui
@@ -353,25 +353,6 @@
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="exitButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Exit</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <spacer name="expVSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -284,8 +284,6 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 
 	connect(controls, &OBSBasicControls::SettingsButtonClicked, this, &OBSBasic::on_action_Settings_triggered);
 
-	connect(controls, &OBSBasicControls::ExitButtonClicked, this, &QMainWindow::close);
-
 	startingDockLayout = saveState();
 
 	statsDock = new OBSDock();

--- a/frontend/widgets/OBSBasicControls.cpp
+++ b/frontend/widgets/OBSBasicControls.cpp
@@ -44,9 +44,6 @@ OBSBasicControls::OBSBasicControls(OBSBasic *main) : QFrame(nullptr), ui(new Ui:
 	connect(
 		ui->settingsButton, &QPushButton::clicked, this, [this]() { emit this->SettingsButtonClicked(); },
 		Qt::DirectConnection);
-	connect(
-		ui->exitButton, &QPushButton::clicked, this, [this]() { emit this->ExitButtonClicked(); },
-		Qt::DirectConnection);
 
 	/* Transfer menu actions signals as OBSBasicControls signals */
 	connect(

--- a/frontend/widgets/OBSBasicControls.hpp
+++ b/frontend/widgets/OBSBasicControls.hpp
@@ -64,7 +64,6 @@ signals:
 	void VirtualCamConfigButtonClicked();
 	void StudioModeButtonClicked();
 	void SettingsButtonClicked();
-	void ExitButtonClicked();
 
 	void StartStreamMenuActionClicked();
 	void StopStreamMenuActionClicked();


### PR DESCRIPTION
### Description
Remove the Exit button from the Controls dock

![image](https://github.com/user-attachments/assets/fce9298d-4154-4d6a-9280-8989a46a7a27)

### Motivation and Context
I don't know a single other application that has an exit button in the main UI.

The Controls dock is something I'd like to fully replace one day but in the meantime this helps remove some clutter from it.

### How Has This Been Tested?
Compiled

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
