### PR TITLE
frontend: Adjust scene collection importer

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1440,7 +1440,7 @@ ResizeOutputSizeOfSource.Continue="Do you want to continue?"
 PreviewTransition="Preview Transition"
 
 # Import Dialog
-Importer="Scene Collection Importer"
+Importer="Import Scene Collection"
 Importer.SelectCollection="Select a Scene Collection"
 Importer.Collection="Scene Collection"
 Importer.HelpText="Add files to this window to import collections from OBS or other supported programs."
@@ -1448,6 +1448,7 @@ Importer.Path="Collection Path"
 Importer.Program="Detected Application"
 Importer.AutomaticCollectionPrompt="Automatically Search for Scene Collections"
 Importer.AutomaticCollectionText="OBS can automatically find importable scene collections from supported third-party programs. Would you like OBS to automatically find collections for you?\n\nYou can change this later in Settings > General > Importers."
+Importer.SelectFile="Browse..."
 
 # Importers
 OBSStudio="OBS Studio"

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -1536,7 +1536,8 @@ OBSBasicSettings {
 /* Checkboxes */
 
 QCheckBox::indicator,
-QGroupBox::indicator {
+QGroupBox::indicator,
+QTableView::indicator {
     width: var(--icon_base);
     height: var(--icon_base);
 }
@@ -1546,33 +1547,39 @@ QGroupBox::indicator {
 }
 
 QCheckBox::indicator:unchecked,
-QGroupBox::indicator:unchecked {
+QGroupBox::indicator:unchecked,
+QTableView::indicator:unchecked {
     image: url(theme:Yami/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
-QGroupBox::indicator:unchecked:hover {
+QGroupBox::indicator:unchecked:hover,
+QTableView::indicator:unchecked:hover {
     border: none;
     image: url(theme:Yami/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
-QGroupBox::indicator:checked {
+QGroupBox::indicator:checked,
+QTableView::indicator:checked {
     image: url(theme:Yami/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
-QGroupBox::indicator:checked:hover {
+QGroupBox::indicator:checked:hover,
+QTableView::indicator:checked:hover {
     image: url(theme:Yami/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
-QGroupBox::indicator:checked:disabled {
+QGroupBox::indicator:checked:disabled,
+QTableView::indicator:checked:disabled {
     image: url(theme:Yami/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
-QGroupBox::indicator:unchecked:disabled {
+QGroupBox::indicator:unchecked:disabled,
+QTableView::indicator:unchecked:disabled {
     image: url(theme:Yami/checkbox_unchecked_disabled.svg);
 }
 

--- a/frontend/data/themes/Yami_Light.ovt
+++ b/frontend/data/themes/Yami_Light.ovt
@@ -157,32 +157,38 @@ OBSBasicSettings {
 }
 
 QCheckBox::indicator:unchecked,
-QGroupBox::indicator:unchecked {
+QGroupBox::indicator:unchecked,
+QTableView::indicator:unchecked {
     image: url(theme:Light/checkbox_unchecked.svg);
 }
 
 QCheckBox::indicator:unchecked:hover,
-QGroupBox::indicator:unchecked:hover {
+QGroupBox::indicator:unchecked:hover,
+QTableView::indicator:unchecked:hover {
     image: url(theme:Light/checkbox_unchecked_focus.svg);
 }
 
 QCheckBox::indicator:checked,
-QGroupBox::indicator:checked {
+QGroupBox::indicator:checked,
+QTableView::indicator:checked {
     image: url(theme:Light/checkbox_checked.svg);
 }
 
 QCheckBox::indicator:checked:hover,
-QGroupBox::indicator:checked:hover {
+QGroupBox::indicator:checked:hover,
+QTableView::indicator:checked:hover {
     image: url(theme:Light/checkbox_checked_focus.svg);
 }
 
 QCheckBox::indicator:checked:disabled,
-QGroupBox::indicator:checked:disabled {
+QGroupBox::indicator:checked:disabled,
+QTableView::indicator:checked:disabled {
     image: url(theme:Light/checkbox_checked_disabled.svg);
 }
 
 QCheckBox::indicator:unchecked:disabled,
-QGroupBox::indicator:unchecked:disabled {
+QGroupBox::indicator:unchecked:disabled,
+QTableView::indicator:unchecked:disabled {
     image: url(theme:Light/checkbox_unchecked_disabled.svg);
 }
 

--- a/frontend/forms/OBSImporter.ui
+++ b/frontend/forms/OBSImporter.ui
@@ -17,26 +17,33 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Importer.HelpText</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <property name="spacing">
       <number>6</number>
      </property>
      <item>
+      <widget class="QPushButton" name="importerSelectFiles">
+       <property name="text">
+        <string>Importer.SelectFile</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QDialogButtonBox" name="buttonBox">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Close|QDialogButtonBox::Ok|QDialogButtonBox::Open</set>
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Importer.HelpText</string>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <widget class="QTableView" name="tableView">

--- a/frontend/importer/ImporterModel.cpp
+++ b/frontend/importer/ImporterModel.cpp
@@ -138,6 +138,8 @@ bool ImporterModel::setData(const QModelIndex &index, const QVariant &value, int
 				for (QString path : list) {
 					ImporterEntry entry;
 					entry.path = path;
+					entry.selected = true;
+					entry.empty = true;
 
 					options.insert(row, entry);
 

--- a/frontend/importer/OBSImporter.cpp
+++ b/frontend/importer/OBSImporter.cpp
@@ -42,6 +42,7 @@ OBSImporter::OBSImporter(QWidget *parent) : QDialog(parent), optionsModel(new Im
 	ui->tableView->setModel(optionsModel);
 	ui->tableView->setItemDelegateForColumn(ImporterColumn::Path, new ImporterEntryPathItemDelegate());
 	ui->tableView->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeMode::ResizeToContents);
+	ui->tableView->horizontalHeader()->setSectionResizeMode(ImporterColumn::Name, QHeaderView::ResizeMode::Stretch);
 	ui->tableView->horizontalHeader()->setSectionResizeMode(ImporterColumn::Path, QHeaderView::ResizeMode::Stretch);
 
 	connect(optionsModel, &ImporterModel::dataChanged, this, &OBSImporter::dataChanged);
@@ -49,12 +50,11 @@ OBSImporter::OBSImporter(QWidget *parent) : QDialog(parent), optionsModel(new Im
 	ui->tableView->setEditTriggers(QAbstractItemView::EditTrigger::CurrentChanged);
 
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setText(QTStr("Import"));
-	ui->buttonBox->button(QDialogButtonBox::Open)->setText(QTStr("Add"));
 
 	connect(ui->buttonBox->button(QDialogButtonBox::Ok), &QPushButton::clicked, this,
 		&OBSImporter::importCollections);
-	connect(ui->buttonBox->button(QDialogButtonBox::Open), &QPushButton::clicked, this, &OBSImporter::browseImport);
-	connect(ui->buttonBox->button(QDialogButtonBox::Close), &QPushButton::clicked, this, &OBSImporter::close);
+	connect(ui->importerSelectFiles, &QPushButton::clicked, this, &OBSImporter::browseImport);
+	connect(ui->buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &OBSImporter::close);
 
 	ImportersInit();
 
@@ -229,4 +229,16 @@ void OBSImporter::importCollections()
 void OBSImporter::dataChanged()
 {
 	ui->tableView->resizeColumnToContents(ImporterColumn::Name);
+
+	bool enableImportButton = false;
+
+	for (int i = 0; i < optionsModel->rowCount() - 1; i++) {
+		int selected = optionsModel->index(i, ImporterColumn::Selected).data(Qt::CheckStateRole).value<int>();
+		if (selected == Qt::Checked) {
+			enableImportButton = true;
+			break;
+		}
+	}
+
+	ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(enableImportButton);
 }


### PR DESCRIPTION
### Description
A few minor adjustments to the Scene Collection importer:
- Separate Browse and Import buttons physically in the bottom bar
  - Adjust text on these buttons to be more clear
- Disable Import button when no collections are checked
- Adjust window title
- Update QTableView checkboxes to use theme icons

![image](https://github.com/user-attachments/assets/ec164302-5a61-468e-8568-08f0f6239d6a)

### Motivation and Context
Hated how the old buttons were labeled "Import" and "Add" and the leftmost one was the one that actually added/imported the selected collections

### How Has This Been Tested?
Interacted with dialog, imported a collection.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
