### PR TITLE
cmake: Adjust macOS SDK detection

### DIFF
--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -21,22 +21,48 @@ endif()
 set_property(CACHE CMAKE_OSX_ARCHITECTURES PROPERTY STRINGS arm64 x86_64)
 
 # Ensure recent enough Xcode and platform SDK
-set(_obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
-set(_obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
-message(DEBUG "macOS SDK Path: ${CMAKE_OSX_SYSROOT}")
-string(REGEX MATCH ".+/MacOSX.platform/Developer/SDKs/MacOSX([0-9]+\\.[0-9])+\\.sdk$" _ ${CMAKE_OSX_SYSROOT})
-set(_obs_macos_current_sdk ${CMAKE_MATCH_1})
-message(DEBUG "macOS SDK version: ${_obs_macos_current_sdk}")
-if(_obs_macos_current_sdk VERSION_LESS _obs_macos_minimum_sdk)
-  message(
-    FATAL_ERROR
-    "Your macOS SDK version (${_obs_macos_current_sdk}) is too low. "
-    "The macOS ${_obs_macos_minimum_sdk} SDK (Xcode ${_obs_macos_minimum_xcode}) is required to build OBS."
+function(check_sdk_requirements)
+  set(obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
+  set(obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
+  execute_process(
+    COMMAND xcrun --sdk macosx --show-sdk-platform-version
+    OUTPUT_VARIABLE obs_macos_current_sdk
+    RESULT_VARIABLE result
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
-endif()
-unset(_obs_macos_current_sdk)
-unset(_obs_macos_minimum_sdk)
-unset(_obs_macos_minimum_xcode)
+  if(NOT result EQUAL 0)
+    message(
+      FATAL_ERROR
+      "Failed to fetch macOS SDK version. "
+      "Ensure that the macOS SDK is installed and that xcode-select points at the Xcode developer directory."
+    )
+  endif()
+  message(DEBUG "macOS SDK version: ${obs_macos_current_sdk}")
+  if(obs_macos_current_sdk VERSION_LESS obs_macos_minimum_sdk)
+    message(
+      FATAL_ERROR
+      "Your macOS SDK version (${obs_macos_current_sdk}) is too low. "
+      "The macOS ${obs_macos_minimum_sdk} SDK (Xcode ${obs_macos_minimum_xcode}) is required to build OBS."
+    )
+  endif()
+  execute_process(COMMAND xcrun --find xcodebuild OUTPUT_VARIABLE obs_macos_xcodebuild RESULT_VARIABLE result)
+  if(NOT result EQUAL 0)
+    message(
+      FATAL_ERROR
+      "Xcode was not found. "
+      "Ensure you have installed Xcode and that xcode-select points at the Xcode developer directory."
+    )
+  endif()
+  message(DEBUG "Path to xcodebuild binary: ${obs_macos_xcodebuild}")
+  if(XCODE_VERSION VERSION_LESS obs_macos_minimum_xcode)
+    message(
+      FATAL_ERROR
+      "Your Xcode version (${XCODE_VERSION}) is too low. Xcode ${obs_macos_minimum_xcode} is required to build OBS."
+    )
+  endif()
+endfunction()
+
+check_sdk_requirements()
 
 # Enable dSYM generator for release builds
 string(APPEND CMAKE_C_FLAGS_RELEASE " -g")


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adjust the macOS CMake initialization logic to use `xcrun` to derive our SDK version information, rather than relying on the presence of `${CMAKE_OSX_SYSROOT}`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
CMake 4.0.0 (currently in the release candidate phase) breaks OBS configuration/generation on macOS. This is because CMake 4.0.0 no longer defines `CMAKE_OSX_SYSROOT` by default for macOS builds, which we currently rely on to make sure the user has an SDK supported by OBS.

This CMake change was apparently made because specifying `CMAKE_OSX_SYSROOT` seems to translate under the hood to passing `-isysroot` to the compiler, which apparently had some undesired impacts in some situations (further context [here](https://gitlab.kitware.com/cmake/cmake/-/commit/7b195312919cbf69497af2514b91b55bd9a6da71) and [here](https://gitlab.kitware.com/cmake/cmake/-/issues/19180)). Letting the compiler wrapper figure out its sysroot on its own seems to now be the preferred pattern.

As we would still like to check what SDK version the user has installed, we can just derive it ourselves using `xcrun` to populate a variable with the user's environment's currently configured SDK path. This way we can make sure that the user has an SDK version we support, while still letting CMake not define a sysroot.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Installed [CMake 4.0.0 rc1](https://cmake.org/download/) and configured/generated/built OBS successfully; also made sure configuration/generation/building proceeded successfully on CMake 3.31.4.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
