### PR TITLE
obs-qsv11: Remove non-functional CQM-related code

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -347,17 +347,6 @@ static bool rate_control_modified(obs_properties_t *ppts, obs_property_t *p, obs
 	return true;
 }
 
-static bool profile_modified(obs_properties_t *ppts, obs_property_t *p, obs_data_t *settings)
-{
-	const char *profile = obs_data_get_string(settings, "profile");
-	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
-	bool bVisible = ((astrcmpi(profile, "high") == 0) &&
-			 (plat >= QSV_CPU_PLATFORM_ICL || plat == QSV_CPU_PLATFORM_UNKNOWN));
-	p = obs_properties_get(ppts, "CQM");
-	obs_property_set_visible(p, bVisible);
-	return true;
-}
-
 static inline void add_rate_controls(obs_property_t *list, const struct qsv_rate_control_info *rc)
 {
 	enum qsv_cpu_platform plat = qsv_get_cpu_platform();
@@ -409,8 +398,6 @@ static obs_properties_t *obs_qsv_props(enum qsv_codec codec, void *unused, int v
 		add_strings(prop, qsv_profile_names_av1);
 	else if (codec == QSV_CODEC_HEVC)
 		add_strings(prop, qsv_profile_names_hevc);
-
-	obs_property_set_modified_callback(prop, profile_modified);
 
 	prop = obs_properties_add_int(props, "keyint_sec", TEXT_KEYINT_SEC, 0, 20, 1);
 	obs_property_int_set_suffix(prop, " s");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Remove a function that, due to other, previous code removals, doesn't do anything anymore.

This `profile_modified` callback function exists simply to toggle visibility of a "CQM" encoder option in the settings UI; however, said option has been removed from the plugin years ago. There is no option to toggle anymore, so this code effectively does nothing now. This PR removes the non-functioning function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Cleaning up a "fancy no-op with extra steps" function I saw when stepping through this plugin in the Visual Studio debugger.

(It used to do something, but the stuff it did has been removed from the codebase some time ago.)

History of this code: This callback function and the "CQM" setting it _used to_ toggle were added in https://github.com/obsproject/obs-studio/pull/2077. Then the standalone "CQM" setting was phased out and rolled into a combined "Subjective Video Enhancements" setting in https://github.com/obsproject/obs-studio/pull/3035. That PR migrated existing users' settings from "CQM" to "Subjective Video Enhancements." (At that point this callback could have been removed, as it didn't do anything anymore.) And lastly, all "Subjective Video Enhancements" and "CQM"-related code but this callback function were removed by https://github.com/obsproject/obs-studio/pull/10388.

So, in summary, there is nothing left of CQM in obs-qsv11 besides this one last check/toggle that doesn't accomplish anything anymore.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

`obs-qsv11` encoder plugin still works with the dead code removed (identically as it did before). Tested on self-compiled OBS with this change, on Windows 10, with a UHD770 iGPU (12700K).

Recordings succeeded and played back fine. Switching the encoder profile from High to Baseline etc. and back works fine. Everything looks normal when stepping through with the debugger.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
