### PR TITLE
frontend: Only emit frontend events for existing scene collection

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1035,14 +1035,14 @@ void OBSBasic::OBSInit()
 			disableSaving++;
 		}
 
-		disableSaving--;
 		if (foundCollection || configuredCollection) {
+			disableSaving--;
 			OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
 			OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
+			OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
+			OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
+			disableSaving++;
 		}
-		OnEvent(OBS_FRONTEND_EVENT_SCENE_CHANGED);
-		OnEvent(OBS_FRONTEND_EVENT_PREVIEW_SCENE_CHANGED);
-		disableSaving++;
 	}
 
 	loaded = true;


### PR DESCRIPTION
### Description
Change emission of frontend events for scene collection and scene changes during startup only for existing scenes.

### Motivation and Context
To emit frontend events early during OBS' initialisation, the `disableSaving` state variable needs to be "falsy" (as events will not be emitted otherwise).

The code path taken for generating a new fallback scene collection has `disableSaving` decremented to "enable" saving (and thus frontend events) already, so it's just the code paths for existing collections that need this workaround.

Emitting the "scene changed" and "preview scene changed" events when a fallback scene collection has been created has side-effects when OBS Studio is set to studio mode and can lead to potential crashes, as the studio mode is still in an invalid state at this point.

### How Has This Been Tested?
Tested by launching OBS with studio mode active but without the configured scene collection available. 

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
