### PR TITLE
Allow sources to know when it is being previewed

### DIFF
--- a/frontend/widgets/OBSBasic_StudioMode.cpp
+++ b/frontend/widgets/OBSBasic_StudioMode.cpp
@@ -209,7 +209,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		if (curScene) {
 			obs_source_t *source = obs_scene_get_source(curScene);
-			obs_source_inc_showing(source);
+			obs_source_inc_preview(source);
 			lastScene = OBSGetWeakRef(source);
 			programScene = OBSGetWeakRef(source);
 		}

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -606,9 +606,9 @@ void OBSBasic::SetCurrentScene(OBSSource scene, bool force)
 		OBSSource actualLastScene = OBSGetStrongRef(lastScene);
 		if (actualLastScene != scene) {
 			if (scene)
-				obs_source_inc_showing(scene);
+				obs_source_inc_preview(scene);
 			if (actualLastScene)
-				obs_source_dec_showing(actualLastScene);
+				obs_source_dec_preview(actualLastScene);
 			lastScene = OBSGetWeakRef(scene);
 		}
 	}

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -711,6 +711,9 @@ struct obs_source {
 	/* ensures activate/deactivate are only called once */
 	volatile long activate_refs;
 
+	/* ensures preview/depreview are only called once */
+	volatile long preview_refs;
+
 	/* source is in the process of being destroyed */
 	volatile long destroying;
 
@@ -724,6 +727,7 @@ struct obs_source {
 
 	bool active;
 	bool showing;
+	bool preview;
 
 	/* used to temporarily disable sources if needed */
 	bool enabled;
@@ -906,10 +910,7 @@ extern obs_source_t *obs_source_create_set_last_ver(const char *id, const char *
 extern void obs_source_destroy(struct obs_source *source);
 extern void obs_source_addref(obs_source_t *source);
 
-enum view_type {
-	MAIN_VIEW,
-	AUX_VIEW,
-};
+enum view_type { MAIN_VIEW, AUX_VIEW, SHOW_VIEW };
 
 static inline void obs_source_dosignal(struct obs_source *source, const char *signal_obs, const char *signal_source)
 {

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -302,6 +302,12 @@ struct obs_source_info {
 	 */
 	void (*deactivate)(void *data);
 
+	/** Called when the source has been previewed */
+	void (*preview)(void *data);
+
+	/* Called when the source has been removed or hidden from preview */
+	void (*depreview)(void *data);
+
 	/** Called when the source is visible */
 	void (*show)(void *data);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1138,6 +1138,9 @@ EXPORT void obs_source_enum_full_tree(obs_source_t *source, obs_source_enum_proc
 /** Returns true if active, false if not */
 EXPORT bool obs_source_active(const obs_source_t *source);
 
+/** Returns true if being previewed, false if not */
+EXPORT bool obs_source_preview(const obs_source_t *source);
+
 /**
  * Returns true if currently displayed somewhere (active or not), false if not
  */
@@ -1203,6 +1206,20 @@ EXPORT void obs_source_dec_showing(obs_source_t *source);
  * used instead.
  */
 EXPORT void obs_source_dec_active(obs_source_t *source);
+
+/**
+ * Increments the preview reference counter to indicate that the source is
+ * in preview.  If the reference counter was 0, will call the preview
+ * callback.
+ */
+EXPORT void obs_source_inc_preview(obs_source_t *source);
+
+/**
+ * Decrements the preview reference counter to indicate that the source is no
+ * longer in preview. If the reference counter is set to 0, will call the
+ * depreview callback
+ */
+EXPORT void obs_source_dec_preview(obs_source_t *source);
 
 /** Enumerates filters assigned to the source */
 EXPORT void obs_source_enum_filters(obs_source_t *source, obs_source_enum_proc_t callback, void *param);

--- a/shared/obs-scripting/obs-scripting-lua-source.c
+++ b/shared/obs-scripting/obs-scripting-lua-source.c
@@ -131,6 +131,8 @@ struct obs_lua_source {
 	int func_update;
 	int func_activate;
 	int func_deactivate;
+	int func_preview;
+	int func_depreview;
 	int func_show;
 	int func_hide;
 	int func_video_tick;
@@ -392,6 +394,8 @@ fail:
 	}
 DEFINE_VOID_DATA_CALLBACK(activate)
 DEFINE_VOID_DATA_CALLBACK(deactivate)
+DEFINE_VOID_DATA_CALLBACK(preview)
+DEFINE_VOID_DATA_CALLBACK(depreview)
 DEFINE_VOID_DATA_CALLBACK(show)
 DEFINE_VOID_DATA_CALLBACK(hide)
 #undef DEFINE_VOID_DATA_CALLBACK
@@ -503,6 +507,8 @@ static void source_type_unload(struct obs_lua_source *ls)
 	unref(ls->func_update);
 	unref(ls->func_activate);
 	unref(ls->func_deactivate);
+	unref(ls->func_preview);
+	unref(ls->func_depreview);
 	unref(ls->func_show);
 	unref(ls->func_hide);
 	unref(ls->func_video_tick);
@@ -612,6 +618,8 @@ static int obs_lua_register_source(lua_State *script)
 	get_callback(update);
 	get_callback(activate);
 	get_callback(deactivate);
+	get_callback(preview);
+	get_callback(depreview);
 	get_callback(show);
 	get_callback(hide);
 	get_callback(video_tick);


### PR DESCRIPTION
### Description
A preview state is added to the OBS API to allow sources to determine if they are in the current preview scene or not. The new preview state APIs work similiar to the existing activate/deactivate/show/hide APIs where a callback is optionally provided to notify the source of changes in state. Building on this new preview state, toggling of visibility of a source in the preview scene will change the preview state and notify the source immediately.

The changes consist of three parts:
- Inc/dec new preview_refs counts and inc/dec activate_refs counts correctly
- C APIs for exposing preview state 
- Lua APIs for exposing preview state

This PR contains 5 commits:
```
obs-source: Add preview and depreview states to sources
    libobs/obs-source.c
    libobs/obs-internal.h
libobs: Add preview and depreview APIs 
    libobs/obs.h
    libobs/obs-source.h
obs-scene: Fix ref count bugs* 
    libobs/obs-scene.c
obs-scripting: Add preview and depreview callbacks to lua API
    shared/obs-scripting/obs-scripting-lua-source.c
frontend: Set preview state on scene changes
    frontend/widgets/OBSBasic_StudioMode.cpp
    frontend/widgets/OBSBasic_Transitions.cpp
```

* It should be noted that there were two problems with how active_ref counts were handled at the scene level. The first issue was that the active_refs was getting decreased while applying audio actions. The problem is they were never increased to begin with, or at least not in the current code base, so the active_refs count would go negative. The second issue is that repeatedly toggling the item visibility would increase the active_refs count as it was only being increased when turning on visibility. The fix was to decrease active_refs when visibility is turned off. 

The big part of this PR is seperating the show_refs count from the activate_refs. To do this a new SHOW_VIEW enum was added to the AUX_VIEW and MAIN_VIEW enums. This allows callers (specifically projectors or multiview) to only inc/dec show_refs and not change activate or preview ref counts.

### Motivation and Context
Currently a source can know when it is being shown and when it is active on the main "program" scene. In the case of studio mode, a source may be also be shown in the current preview scene. When a source is in the current program scene, it is considered 'shown' and 'active' by OBS. If it is only in preview scene, it is just 'shown'. Also, when a source is shown as part of a scene in Multiview or on a projector, the source will also have a state of 'shown'. This causes a problem when a source needs to implement a tally. A tally is traditionally a red (active) or green (preview) light on the camera to give the camera operator or video subject indication as to if the camera is live/on program (red) or being previewed (green), or not being used (no light). This means the condition: shown AND not active is not indicative of being in the current preview scene.

So the basic issue is that show state is used for projection/multiview and when a source is in the current program scene. This PR fixes this problem by introducing a preview state.

This issue has been documented by a DistroAV (formerly obs-ndi) user, complaining that his tally light on his NDI camera flashes red/green/red/green/... when it is in the current program scene and not in preview. https://github.com/DistroAV/DistroAV/issues/687

The issue can also be witnessed in NDI Studio Monitor when viewing the source when it is in the current program scene in OBS, but not in the current preview scene. A red and a green bar appears at the top of the video. Also, a green bar appears when the NDI source is being projected or in multiview, and not in the current preview scene.

There is also a OBS API feature request for this here: 
https://ideas.obsproject.com/posts/1271/add-obs_source_inpreview-to-sdk

Finally a long time problem of the Multi-view causing all NDI sources to show as in 
preview, is here: https://github.com/DistroAV/DistroAV/issues/318


### Type of change
- New feature (non-breaking change which adds functionality)

### API considerations
Since the show/hide API is used by sources to know if OBS is using the source in any way, we cannot change the meaning of show/hide, without breaking the API. With this change, new APIs were added so the source can simply and accurately determine if a source is being previewed and immediately react to changes the user makes to the source state.

Exactly mirroring the activate/deactivate APIs, this PR adds the following APIs:

```
bool obs_source_preview(const obs_source_t *source);
void obs_source_inc_preview(obs_source_t *source);
void obs_source_dec_preview(obs_source_t *source);

struct obs_source_info {...
	void (*preview)(void *data);
	void (*depreview)(void *data);
}
```
### Testing
To test, I modified DistroAV to use the new preview APIs. I then created 3 Test Pattern sources in NDI Tools. I then opened Studio Monitor on each Test Pattern Source, and turned on Tally display. I created a collection of 3 scenes as shown in the table below, along with results of the testing.

![Screenshot 2025-02-23 173234](https://github.com/user-attachments/assets/a241373d-cae8-4533-b893-87c13e4ecf1d)

The table shows the tally after each step for each source. Sometimes the tally is red and green. 

To aid in testing by reviewers of this PR, I created a Lua script that creates an OBS source called "Tally Test". The script will log when any of the 6 callbacks are called: activate, deactivate, preview, depreview, show and hide. Pleae find the Lua script here: 

[testtally.txt](https://github.com/user-attachments/files/18973471/testtally.txt)

Finally, the tests were done in Normal (non Studio) mode with no Preview scene and all callbacks were called correctly.

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


