### PR TITLE
rtmp-services: Update ingest URL for Niconico Live Streaming(ニコニコ生放送)

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 265,
+    "version": 266,
     "files": [
         {
             "name": "services.json",
-            "version": 265
+            "version": 266
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1628,11 +1628,17 @@
             ]
         },
         {
-            "name": "niconico, premium member (ニコニコ生放送 プレミアム会員)",
+            "name": "niconico(ニコニコ生放送)",
+            "more_info_link": "https://live.nicovideo.jp",
+            "stream_key_link": "https://qa.nicovideo.jp/faq/show/701",
+            "alt_names": [
+                "niconico, premium member (ニコニコ生放送 プレミアム会員)",
+                "niconico, free member (ニコニコ生放送 一般会員)"
+            ],
             "servers": [
                 {
                     "name": "Default",
-                    "url": "rtmp://aliveorigin.dmc.nico/named_input"
+                    "url": "rtmp://liveorigin.dlive.nicovideo.jp/live/input"
                 }
             ],
             "recommended": {
@@ -1640,25 +1646,6 @@
                 "profile": "high",
                 "max audio bitrate": 192,
                 "max video bitrate": 5808,
-                "x264opts": "tune=zerolatency"
-            },
-            "supported video codecs": [
-                "h264"
-            ]
-        },
-        {
-            "name": "niconico, free member (ニコニコ生放送 一般会員)",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://aliveorigin.dmc.nico/named_input"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "profile": "high",
-                "max audio bitrate": 96,
-                "max video bitrate": 904,
                 "x264opts": "tune=zerolatency"
             },
             "supported video codecs": [


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
#### Update: Consolidation of Niconico Service Entries
The distinction between free and premium members in the server selection list has been removed. The Niconico service entry has been consolidated into a single entry, as the latest settings no longer require a separation based on membership type.

This PR updates the ingest URL for Niconico Live Streaming in the `rtmp-services` configuration file. The previous ingest URL is no longer valid, and the service now requires an updated URL.

Additionally, this PR adds `more_info_link` and a link to a page that explains how to obtain the stream key (`stream_key_link`) to the Niconico service in `services.json`, providing users with direct access to relevant information.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change is necessary because Niconico Live Streaming has updated its ingest URL. Without this update, users will not be able to stream to Niconico properly.

Niconico officially announced this change in the following blog post (Japanese):  
🔗 [ニコニコ生放送の配信エンドポイント変更について (Niconico Live Streaming Ingest URL Update)](https://blog.nicovideo.jp/niconews/235926.html)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have tested this update by adding the new RTMP server configurations to the `services.json` file and verifying that they appear correctly in the OBS Studio stream settings. Additionally, I have successfully conducted a live stream to Niconico Live Streaming using the updated ingest URL to confirm that it works as expected.
For the newly added `more_info_link` and `stream_key_link`, I verified that they correctly open the corresponding pages when clicked within the OBS Studio interface.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
