### PR TITLE
linux-v4l2: Fix virtual camera start failure

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -15,6 +15,7 @@ struct virtualcam_data {
 	obs_output_t *output;
 	int device;
 	uint32_t frame_size;
+	bool use_caps_workaround;
 };
 
 static const char *virtualcam_name(void *unused)
@@ -110,11 +111,54 @@ static void *virtualcam_create(obs_data_t *settings, obs_output_t *output)
 	return vcam;
 }
 
+bool try_reset_output_caps(const char *device)
+{
+	struct v4l2_capability capability;
+	struct v4l2_format format;
+	int fd;
+
+	blog(LOG_INFO, "Attempting to reset output capability of '%s'", device);
+
+	fd = open(device, O_RDWR);
+	if (fd < 0)
+		return false;
+
+	format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+	if (ioctl(fd, VIDIOC_G_FMT, &format) < 0)
+		goto fail_close_reset_caps_fd;
+
+	if (ioctl(fd, VIDIOC_S_FMT, &format) < 0)
+		goto fail_close_reset_caps_fd;
+
+	if (ioctl(fd, VIDIOC_STREAMON, &format.type) < 0)
+		goto fail_close_reset_caps_fd;
+
+	if (ioctl(fd, VIDIOC_STREAMOFF, &format.type) < 0)
+		goto fail_close_reset_caps_fd;
+
+	close(fd);
+
+	fd = open(device, O_RDWR);
+	if (fd < 0)
+		return false;
+
+	if (ioctl(fd, VIDIOC_QUERYCAP, &capability) < 0)
+		goto fail_close_reset_caps_fd;
+
+	close(fd);
+	return (capability.device_caps & V4L2_CAP_VIDEO_OUTPUT) != 0;
+
+fail_close_reset_caps_fd:
+	close(fd);
+	return false;
+}
+
 static bool try_connect(void *data, const char *device)
 {
+	static bool use_caps_workaround = false;
 	struct virtualcam_data *vcam = (struct virtualcam_data *)data;
-	struct v4l2_format format;
 	struct v4l2_capability capability;
+	struct v4l2_format format;
 	struct v4l2_streamparm parm;
 
 	uint32_t width = obs_output_get_width(vcam->output);
@@ -129,6 +173,14 @@ static bool try_connect(void *data, const char *device)
 
 	if (ioctl(vcam->device, VIDIOC_QUERYCAP, &capability) < 0)
 		goto fail_close_device;
+
+	if (!use_caps_workaround && !(capability.device_caps & V4L2_CAP_VIDEO_OUTPUT)) {
+		if (!try_reset_output_caps(device))
+			goto fail_close_device;
+
+		use_caps_workaround = true;
+	}
+	vcam->use_caps_workaround = use_caps_workaround;
 
 	format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
@@ -165,7 +217,7 @@ static bool try_connect(void *data, const char *device)
 	memset(&parm, 0, sizeof(parm));
 	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_STREAMON, &parm) < 0) {
+	if (vcam->use_caps_workaround && ioctl(vcam->device, VIDIOC_STREAMON, &format.type) < 0) {
 		blog(LOG_ERROR, "Failed to start streaming on '%s' (%s)", device, strerror(errno));
 		goto fail_close_device;
 	}
@@ -238,10 +290,9 @@ static void virtualcam_stop(void *data, uint64_t ts)
 	struct virtualcam_data *vcam = (struct virtualcam_data *)data;
 	obs_output_end_data_capture(vcam->output);
 
-	struct v4l2_streamparm parm = {0};
-	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+	uint32_t buf_type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
-	if (ioctl(vcam->device, VIDIOC_STREAMOFF, &parm) < 0) {
+	if (vcam->use_caps_workaround && ioctl(vcam->device, VIDIOC_STREAMOFF, buf_type) < 0) {
 		blog(LOG_WARNING, "Failed to stop streaming on video device %d (%s)", vcam->device, strerror(errno));
 	}
 


### PR DESCRIPTION
Skip the 'non-compliant' usage of STREAMON ioctl for V4L2 compliant _v4l2loopback_ module


### Description

When starting the virtual camera:

-   Check the OUTPUT capability is reported for the device.
    -   If has OUTPUT: use compliant calls only (do not use STREAMON/OFF workaround).
    -   If no OUTPUT capability: _attempt_ to reset using the STREAMON/OFF workaround for _loopback_ 0.12.5-0.12.7, then continue to use workaround each time opened.


### Motivation and Context

Fixes #11891

_v4l2loopback_ was recently updated to have stronger compliance with V4L2 UAPI; thus, the invocation of STREAMON by _OBS_ when no streaming I/O buffers have been negotiated (e.g. via REQBUFS) results in an error.

This is also a revision of the fix for #4808 - where it was identified that the STREAMON call would trigger the reset of the OUTPUT capability when the loopback node was closed (thus allowing the camera to be restarted).


### How Has This Been Tested?

Built on Ubuntu 24.04, x64 machine, with _v4l2loopback_:

1.  @ 0.12.5-0.12.7 - confirm no regression for #4808;
2.  @ 0.13.0-0.13.2 - confirm no longer use workaround as _loopback_ was already patched, and;
3.  @ 0.14.0 - confirm fix #11891

Starting, stopping, and re-starting the virtual camera succeeded in all versions tested.


### Types of changes

- Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
