### PR TITLE
cmake: Fix some Qt DLLs not being copied due to filename patterns

### DIFF
--- a/cmake/windows/helpers.cmake
+++ b/cmake/windows/helpers.cmake
@@ -470,6 +470,7 @@ function(_bundle_dependencies target)
     COMPONENT Runtime
   )
 
+  set(debug_dll_exceptions qdirect2d qcertonlybackend qopensslbackend qschannelbackend)
   list(REMOVE_DUPLICATES plugins_list)
   foreach(plugin IN LISTS plugins_list)
     message(TRACE "Adding Qt plugin ${plugin}...")
@@ -479,12 +480,13 @@ function(_bundle_dependencies target)
 
     list(APPEND plugin_stems ${plugin_stem})
 
-    if(plugin MATCHES ".+d\\.dll$")
+    if(plugin MATCHES "(.+d)\\.dll$" AND CMAKE_MATCH_COUNT EQUAL 1 AND NOT CMAKE_MATCH_1 IN_LIST debug_dll_exceptions)
       list(APPEND plugin_${plugin_stem}_debug ${plugin})
     else()
       list(APPEND plugin_${plugin_stem} ${plugin})
     endif()
   endforeach()
+  unset(debug_exceptions)
 
   list(REMOVE_DUPLICATES plugin_stems)
   foreach(stem IN LISTS plugin_stems)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Qt has some Release DLLs that end with the letter d:
* qdirect2d.dll
* qcertonlybackend.dll
* qopensslbackend.dll
* qschannelbackend.dll

As a result, they get caught by our simple check for if a DLL is a Debug DLL which just checks if the DLL ends with the letter d.

Extend that check to exclude these specific DLLs from being marked as Debug DLLs.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Noticed these files weren't being copied.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally some time last year.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
