### PR TITLE
image-source: Set minimal size for color source to 1 pixel

### DIFF
--- a/plugins/image-source/color-source.c
+++ b/plugins/image-source/color-source.c
@@ -25,8 +25,8 @@ static void color_source_update(void *data, obs_data_t *settings)
 
 	vec4_from_rgba(&context->color, color);
 	vec4_from_rgba_srgb(&context->color_srgb, color);
-	context->width = width;
-	context->height = height;
+	context->width = width > 0 ? width : 1;
+	context->height = height > 0 ? height : 1;
 }
 
 static void *color_source_create(obs_data_t *settings, obs_source_t *source)
@@ -52,9 +52,9 @@ static obs_properties_t *color_source_properties(void *unused)
 
 	obs_properties_add_color_alpha(props, "color", obs_module_text("ColorSource.Color"));
 
-	obs_properties_add_int(props, "width", obs_module_text("ColorSource.Width"), 0, 4096, 1);
+	obs_properties_add_int(props, "width", obs_module_text("ColorSource.Width"), 1, 4096, 1);
 
-	obs_properties_add_int(props, "height", obs_module_text("ColorSource.Height"), 0, 4096, 1);
+	obs_properties_add_int(props, "height", obs_module_text("ColorSource.Height"), 1, 4096, 1);
 
 	return props;
 }


### PR DESCRIPTION
### Description
 Set minimal size for color source to 1 pixel

### Motivation and Context
OBS can't create draw a sprite without a width/height and will complain about it in the OBS log file.

### How Has This Been Tested?
On windows 11 by checking the OBS log file

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
