### PR TITLE
frontend: Fix scaling scene items without a size

### DIFF
--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -1533,12 +1533,14 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 		baseSize.x -= float(crop.left + crop.right);
 		baseSize.y -= float(crop.top + crop.bottom);
 
-		if (!shiftDown) {
-			ClampAspect(tl, br, size, baseSize);
-		}
+		if (baseSize.x > 0.0 && baseSize.y > 0.0) {
+			if (!shiftDown) {
+				ClampAspect(tl, br, size, baseSize);
+			}
 
-		vec2_div(&size, &size, &baseSize);
-		obs_sceneitem_set_scale(stretchItem, &size);
+			vec2_div(&size, &size, &baseSize);
+			obs_sceneitem_set_scale(stretchItem, &size);
+		}
 	}
 
 	pos3 = CalculateStretchPos(tl, br);


### PR DESCRIPTION
### Description
Fix scaling scene items without a size

### Motivation and Context
Scene items that don't have a size and not using bounding box should not be scaled as it it can create infinite large sources.
Fixing #11917

### How Has This Been Tested?
On windows 11 with the steps of #11917

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
