### PR TITLE
frontend: Fix crash drawing extreme long striped line

### DIFF
--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -1710,6 +1710,12 @@ static void DrawStripedLine(float x1, float y1, float x2, float y2, float thickn
 	float xSide = (x1 == x2) ? (x1 < 0.5f ? 1.0f : -1.0f) : 0.0f;
 
 	float dist = sqrt(pow((x1 - x2) * scale.x, 2) + pow((y1 - y2) * scale.y, 2));
+	if (dist > 1000000.0f) {
+		// too many stripes to draw, draw it as a line as fallback
+		DrawLine(x1, y1, x2, y2, thickness, scale);
+		return;
+	}
+
 	float offX = (x2 - x1) / dist;
 	float offY = (y2 - y1) / dist;
 


### PR DESCRIPTION
### Description
Fix crash drawing extreme long striped line

### Motivation and Context
In case a selected source has an extreme large size and is cropped OBS hangs on drawing all the stripes.
As fallback I made it draw a line instead.
The cause of the extreme large source is fixed in #11919

### How Has This Been Tested?
On windows 11 using the steps in #11917

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
