### PR TITLE
frontend/widgets: Fix integer overflow

### DIFF
--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -419,8 +419,9 @@ static vec2 GetItemSize(obs_sceneitem_t *item)
 
 		obs_sceneitem_get_scale(item, &scale);
 		obs_sceneitem_get_crop(item, &crop);
-		size.x = float(obs_source_get_width(source) - crop.left - crop.right) * scale.x;
-		size.y = float(obs_source_get_height(source) - crop.top - crop.bottom) * scale.y;
+		size.x = fmaxf(float((int)obs_source_get_width(source) - crop.left - crop.right), 0.0f);
+		size.y = fmaxf(float((int)obs_source_get_height(source) - crop.top - crop.bottom), 0.0f);
+		vec2_mul(&size, &size, &scale);
 	}
 
 	return size;


### PR DESCRIPTION
### Description

If the crop values combined are larger than the width or height of the source, an integer overflow will occur.
This fix converts the width/height values to int, and then clamps any negative values to 0.

Fixes obsproject/obs-studio#11917

### Motivation and Context
This was one of the root causes behind the freeze reported in https://github.com/obsproject/obs-studio/issues/11917. Due to the integer overflow, it would essentially make the for loop in `DrawStripedLine()` in `OBSBasicPreview.cpp` repeat nearly endlessly, which caused certain mutexes to stall (especially the scene video/audio mutexes). Because of that near-infinite loop, both the main and audio threads would stall until that near-indefinitely-stalled loop completed.

### How Has This Been Tested?
Tested according to the reproduction steps in https://github.com/obsproject/obs-studio/issues/11917 and it no longer stalls.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
