### PR TITLE
obs-nvenc: Fix incorrect CUDA array size allocation

### DIFF
--- a/plugins/obs-nvenc/nvenc-cuda.c
+++ b/plugins/obs-nvenc/nvenc-cuda.c
@@ -118,9 +118,8 @@ static bool cuda_surface_init(struct nvenc_data *enc, struct nv_cuda_surface *nv
 			desc.Height += enc->cy / 2;
 			break;
 		case NV_ENC_BUFFER_FORMAT_YUV420_10BIT:
-			desc.Format = CU_AD_FORMAT_UNSIGNED_INT16;
+			desc.Format = CU_AD_FORMAT_UNSIGNED_INT16; // 2 bytes per element
 			desc.Height += enc->cy / 2;
-			desc.NumChannels = 2; // number of bytes per element
 			break;
 		case NV_ENC_BUFFER_FORMAT_YUV444:
 			desc.Format = CU_AD_FORMAT_UNSIGNED_INT8;


### PR DESCRIPTION
### Description

Fix incorrect CUDA array size allocation.

### Motivation and Context

The obs-nvenc module was using a double-sized CUDA array as a shared texture with the P010 format.

The original code snippet:

```cpp
desc.Format = CU_AD_FORMAT_UNSIGNED_INT16;
desc.Height += enc->cy / 2;
desc.NumChannels = 2; // number of bytes per element
```

According to the [cuArray3DCreate](https://developer.download.nvidia.cn/compute/DevZone/docs/html/C/doc/html/group__CUDA__MEM_gc2322c70b38c2984536c90ed118bb1d7.html) documentation,
the previous descriptor requested **4 bytes** per element, which was incorrect.

### How Has This Been Tested?

The changes were tested on Ubuntu 24.10 with an RTX 3060 Ti GPU.

To force obs-nvenc to use shared textures as if it were running on a different GPU,
in the `hevc_nvenc_create` function within nvenc.c, `nvenc_create_base` was called with texture=false.

The frontend configuration used the P010 color format with the NVENC HEVC encoder.

The following recording scenarios were tested:

1. CU_AD_FORMAT_UNSIGNED_INT16 with channels=2 (original): Everything OK
2. CU_AD_FORMAT_UNSIGNED_INT16 with channels=1: Everything OK
3. CU_AD_FORMAT_UNSIGNED_INT8 with channels=2: Everything OK
4. CU_AD_FORMAT_UNSIGNED_INT8 with channels=1: Error occurred.

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
