### PR TITLE
libobs/frontend: Add callback for reconnection decision

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -772,6 +772,28 @@ General Output Functions
 
    .. versionadded:: 31.0
 
+---------------------
+
+.. function:: void obs_output_set_reconnect_callback(obs_output_t *output, bool (*reconnect_cb)(void *data, obs_output_t *output, int code), void *param)
+
+   Sets a callback that can be used to decide whether or not to attempt reconnecting.
+   Can also be used to reconfigure the output within the callback before continuing the reconnection attempts,
+   e.g., to update the stream key after the previous one has expired.
+   
+   Passing in a `NULL` pointer removes the callback.
+
+   :param output:        The output to register the reconnect_cb() function against
+   :param reconnect_cb:  Function pointer to the callback function
+   :param param:         Data passed to the callback
+
+   reconnect_cb() arguments:
+   :param data:    Data passed to the callback
+   :param output:  The output associated with the invoked callback function
+   :param code:    Error code the output was stopped with
+   :return:        Whether or not to continue attempting to reconnect
+
+   .. versionadded:: 31.1
+
 Functions used by outputs
 -------------------------
 

--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -394,6 +394,12 @@ void MultitrackVideoOutput::PrepareStreaming(QWidget *parent, const char *servic
 	// Register the BPM (Broadcast Performance Metrics) callback
 	obs_output_add_packet_callback(output, bpm_inject, NULL);
 
+	// Set callback to prevent reconnection attempts once the stream key has become invalid
+	static auto reconnect_cb = [](void *, obs_output_t *, int code) -> bool {
+		return code != OBS_OUTPUT_INVALID_STREAM;
+	};
+	obs_output_set_reconnect_callback(output, reconnect_cb, nullptr);
+
 	OBSSignal start_streaming;
 	OBSSignal stop_streaming;
 	SetupSignalHandlers(false, this, output, start_streaming, stop_streaming);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -78,6 +78,11 @@ struct packet_callback {
 	void *param;
 };
 
+struct reconnect_callback {
+	bool (*reconnect_cb)(void *data, obs_output_t *output, int code);
+	void *param;
+};
+
 /* ------------------------------------------------------------------------- */
 /* validity checks */
 
@@ -1149,6 +1154,8 @@ struct obs_output {
 	/* Packet callbacks */
 	pthread_mutex_t pkt_callbacks_mutex;
 	DARRAY(struct packet_callback) pkt_callbacks;
+
+	struct reconnect_callback reconnect_callback;
 
 	bool valid;
 

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2874,9 +2874,20 @@ static void output_reconnect(struct obs_output *output)
 	}
 }
 
-static inline bool can_reconnect(const obs_output_t *output, int code)
+static inline bool check_reconnect_cb(obs_output_t *output, int code)
+{
+	if (!output->reconnect_callback.reconnect_cb)
+		return true;
+
+	return output->reconnect_callback.reconnect_cb(output->reconnect_callback.param, output, code);
+}
+
+static inline bool can_reconnect(obs_output_t *output, int code)
 {
 	bool reconnect_active = output->reconnect_retry_max != 0;
+
+	if (reconnect_active && !check_reconnect_cb(output, code))
+		return false;
 
 	return (reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||
 	       (reconnect_active && code == OBS_OUTPUT_DISCONNECTED);
@@ -3189,4 +3200,16 @@ void obs_output_remove_packet_callback(obs_output_t *output,
 	pthread_mutex_lock(&output->pkt_callbacks_mutex);
 	da_erase_item(output->pkt_callbacks, &data);
 	pthread_mutex_unlock(&output->pkt_callbacks_mutex);
+}
+
+void obs_output_set_reconnect_callback(obs_output_t *output,
+				       bool (*reconnect_cb)(void *data, obs_output_t *output, int code), void *param)
+{
+	if (!reconnect_cb) {
+		output->reconnect_callback.reconnect_cb = NULL;
+		output->reconnect_callback.param = NULL;
+	} else {
+		output->reconnect_callback.reconnect_cb = reconnect_cb;
+		output->reconnect_callback.param = param;
+	}
 }

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2878,8 +2878,8 @@ static inline bool can_reconnect(const obs_output_t *output, int code)
 {
 	bool reconnect_active = output->reconnect_retry_max != 0;
 
-	return code != OBS_OUTPUT_INVALID_STREAM && ((reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||
-						     (reconnect_active && code == OBS_OUTPUT_DISCONNECTED));
+	return (reconnecting(output) && code != OBS_OUTPUT_SUCCESS) ||
+	       (reconnect_active && code == OBS_OUTPUT_DISCONNECTED);
 }
 
 void obs_output_signal_stop(obs_output_t *output, int code)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2074,6 +2074,12 @@ EXPORT void obs_output_remove_packet_callback(obs_output_t *output,
 								struct encoder_packet_time *pkt_time, void *param),
 					      void *param);
 
+/* Sets a callback to be called when the output checks if it should attempt to reconnect.
+ * If the callback returns false, the output will not attempt to reconnect. */
+EXPORT void obs_output_set_reconnect_callback(obs_output_t *output,
+					      bool (*reconnect_cb)(void *data, obs_output_t *output, int code),
+					      void *param);
+
 /* ------------------------------------------------------------------------- */
 /* Functions used by outputs */
 


### PR DESCRIPTION
### Description

Adds a callback for making reconnection decision.

Also reverts #11304

### Motivation and Context

#11304 was necessary for #11452, but negatively impacted regular users as some servers would not accept a reconnection attempt after the default retry time (2 seconds), which resulted in some users seeing a warning message instead of automatic reconnection.

To restore the old behaviour, we instead add a new callback that makes it a decision by the output's creator on whether or not they want to allow a reconnect attempt.

In addition to a simple yes/no decision this also allows reconfiguring the output in the callback, allowing for a futrue rework of #11452 that does not rely on the somewhat ugly UI changes to hijack the regular disconnect logic and instead updates the output in-place before returning.

### How Has This Been Tested?

Verified regular output still works fine. Will need more testing.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
