### PR TITLE
libobs: Reset reconnecting state when can_reconnect is false

### DIFF
--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -2897,6 +2897,8 @@ void obs_output_signal_stop(obs_output_t *output, int code)
 	} else {
 		if (delay_active(output))
 			os_atomic_set_bool(&output->delay_active, false);
+		if (reconnecting(output))
+			os_atomic_set_bool(&output->reconnecting, false);
 		obs_output_end_data_capture(output);
 	}
 }


### PR DESCRIPTION
### Description

Ensures `reconnecting` is false if reconnection attempts are aborted.

### Motivation and Context

Fixes an issue where an output remains "active" after a failed reconnection attempt due to `reconnecting` never being reset to `false`.

### How Has This Been Tested?

Tested with Twitch and two OBS instances:
- Instance A streaming with the regular stream key
- Instance B starting a few seconds later with `?priority=2` appended to the stream key

This will lead to instance B taking over the stream and instance A being disconnected by the streaming platform. Without this change OBS will perpetually be stuck in a semi-active state where the output cannot be restarted as `obs_output_active()` remains `true`.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
