### PR TITLE
frontend: Replace completely QPlatformNativeInterface in Qt 6.9+

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -26,6 +26,9 @@
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 #include <obs-nix-platform.h>
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
+#include <qpa/qplatformnativeinterface.h>
+#endif
 #endif
 #include <qt-wrappers.hpp>
 
@@ -37,9 +40,6 @@
 #include <QSessionManager>
 #else
 #include <QSocketNotifier>
-#endif
-#if !defined(_WIN32) && !defined(__APPLE__)
-#include <qpa/qplatformnativeinterface.h>
 #endif
 
 #ifdef _WIN32
@@ -1026,20 +1026,36 @@ bool OBSApp::OBSInit()
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 	if (QApplication::platformName() == "xcb") {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+		auto native = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
+
+		obs_set_nix_platform_display(native->display());
+#endif
+
 		obs_set_nix_platform(OBS_NIX_PLATFORM_X11_EGL);
+
 		blog(LOG_INFO, "Using EGL/X11");
 	}
 
 #ifdef ENABLE_WAYLAND
 	if (QApplication::platformName().contains("wayland")) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+		auto native = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+
+		obs_set_nix_platform_display(native->display());
+#endif
+
 		obs_set_nix_platform(OBS_NIX_PLATFORM_WAYLAND);
 		setAttribute(Qt::AA_DontCreateNativeWidgetSiblings);
+
 		blog(LOG_INFO, "Platform: Wayland");
 	}
 #endif
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 5, 0)
 	QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
 	obs_set_nix_platform_display(native->nativeResourceForIntegration("display"));
+#endif
 #endif
 
 #ifdef __APPLE__

--- a/frontend/widgets/OBSQTDisplay.cpp
+++ b/frontend/widgets/OBSQTDisplay.cpp
@@ -10,7 +10,9 @@
 #include <QWindow>
 #ifdef ENABLE_WAYLAND
 #include <QApplication>
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
 #include <qpa/qplatformnativeinterface.h>
+#endif
 #endif
 
 #ifdef _WIN32
@@ -50,8 +52,12 @@ static bool QTToGSWindow(QWindow *window, gs_window &gswindow)
 		break;
 #ifdef ENABLE_WAYLAND
 	case OBS_NIX_PLATFORM_WAYLAND: {
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
 		QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
 		gswindow.display = native->nativeResourceForWindow("surface", window);
+#else
+		gswindow.display = (void *)window->winId();
+#endif
 		success = gswindow.display != nullptr;
 		break;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Using QNativeInterface allows us to move away from QPlatformNativeInterface and once all supported platforms are using Qt 6.5+.

~~Note that we still use private headers for the surface, private here stands for "unstable".~~

As of Qt 6.9 (https://github.com/qt/qtwayland/commit/32f9b4d0fc0bb749c63266ce36f8e4239b351f97), `QWidget::winId()` will provide the surface pointer as stable API.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

@RytoEX had a branch a while ago and I decided to rebase it and push it as PR.

This [blog post](https://blog.david-redondo.de/qt/kde/2022/12/09/wayland-native-interface.html) about QNativeInterface.

The former method with `QPlatformNativeInterface` is an unstable API and mainly relies on function that returns `void *`, where QNativeInterface use real types.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Ran on my machine with Qt ~~6.8~~ 6.9, no issue launching OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
