### PR TITLE
Improve preview primitive performance

### DIFF
--- a/docs/sphinx/graphics.rst
+++ b/docs/sphinx/graphics.rst
@@ -85,7 +85,7 @@ effects:  **ViewProj**, and **image**.  The **ViewProj** parameter
 combination.  The **image** parameter (which is a texture2d) is a
 commonly used parameter for the main texture; this parameter will be
 used with the functions :c:func:`obs_source_draw()`,
-:c:func:`gs_draw_sprite()`, and
+:c:func:`gs_draw_sprite()`, :c:func:`gs_draw_quadf()`, and
 :c:func:`obs_source_process_filter_end()`.
 
 Here is an example of effect parameters:

--- a/docs/sphinx/reference-libobs-graphics-graphics.rst
+++ b/docs/sphinx/reference-libobs-graphics-graphics.rst
@@ -420,13 +420,33 @@ Draw Functions
 .. function:: void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t height)
 
    Draws a 2D sprite.  Sets the "image" parameter of the current effect
-   to the texture and renders a quad.
+   to the texture and renders a quad. Can be omitted if drawing without
+   a texture.
 
    If width or height is 0, the width or height of the texture will be
    used.  The flip value specifies whether the texture should be flipped
    on the U or V axis with GS_FLIP_U and GS_FLIP_V.
 
-   :param tex:    Texture to draw
+   :param tex:    Texture to draw (can be NULL if drawing without a
+                  texture)
+   :param flip:   Can be 0 or a bitwise-OR combination of one of the
+                  following values:
+
+                  - GS_FLIP_U - Flips the texture horizontally
+                  - GS_FLIP_V - Flips the texture vertically
+
+   :param width:  Width
+   :param height: Height
+
+---------------------
+
+.. function:: void gs_draw_quadf(gs_texture_t *tex, uint32_t flip, float width, float height)
+
+   Same as :c:func:`gs_draw_sprite()`, but with floating point width/height
+   values instead of integer width/height values.
+
+   :param tex:    Texture to draw (can be NULL if drawing without a
+                  texture)
    :param flip:   Can be 0 or a bitwise-OR combination of one of the
                   following values:
 

--- a/frontend/data/striped_line.effect
+++ b/frontend/data/striped_line.effect
@@ -1,0 +1,38 @@
+uniform float4x4 ViewProj;
+uniform float4 color = {1.0, 1.0, 1.0, 1.0};
+uniform float2 size;
+uniform float2 count_inv;
+
+struct VertInOut {
+	float4 pos : POSITION;
+	float2 uv : TEXCOORD0;
+};
+
+VertInOut VSStripedLine(VertInOut vert_in)
+{
+	VertInOut vert_out;
+	vert_out.pos = mul(float4(vert_in.pos.xyz, 1.0), ViewProj);
+	vert_out.uv = vert_in.uv;
+	return vert_out;
+}
+
+float4 PSStripedLine(VertInOut vert_in) : TARGET
+{
+	float2 multiplier = floor(fmod(vert_in.uv * size * count_inv, float2(2.0, 2.0)));
+	if (size.x == 0.0) {
+		multiplier.x = 1.0;
+	} else {
+		multiplier.y = 1.0;
+	}
+
+	return color * multiplier.xxxx * multiplier.yyyy;
+}
+
+technique StripedLine
+{
+	pass
+	{
+		vertex_shader = VSStripedLine(vert_in);
+		pixel_shader = PSStripedLine(vert_in);
+	}
+}

--- a/frontend/widgets/OBSBasicPreview.hpp
+++ b/frontend/widgets/OBSBasicPreview.hpp
@@ -55,6 +55,8 @@ private:
 	gs_texture_t *overflow = nullptr;
 	gs_vertbuffer_t *rectFill = nullptr;
 	gs_vertbuffer_t *circleFill = nullptr;
+	gs_effect_t *solidEffect = nullptr;
+	gs_effect_t *stripedLineEffect = nullptr;
 
 	vec2 startPos;
 	vec2 mousePos;
@@ -112,6 +114,8 @@ private:
 	void BoxItems(const vec2 &startPos, const vec2 &pos);
 
 	void ProcessClick(const vec2 &pos);
+
+	void DrawStripedLine(float x1, float y1, float x2, float y2, float thickness, vec2 scale);
 
 	OBSDataAutoRelease wrapper = nullptr;
 	bool changed;

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -23,6 +23,10 @@
 #include "matrix3.h"
 #include "matrix4.h"
 
+/* ========================================================================= *
+ * Exports                                                                   *
+ * ========================================================================= */
+
 struct gs_exports {
 	const char *(*device_get_name)(void);
 	const char *(*gpu_get_driver_version)(void);
@@ -279,6 +283,10 @@ struct gs_exports {
 	bool (*device_sync_wait)(gs_device_t *device, gs_sync_t *sync);
 #endif
 };
+
+/* ========================================================================= *
+ * Graphics Subsystem Data                                                   *
+ * ========================================================================= */
 
 struct blend_state {
 	bool enabled;

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -311,6 +311,8 @@ struct graphics_subsystem {
 	struct gs_effect *cur_effect;
 
 	gs_vertbuffer_t *sprite_buffer;
+	gs_vertbuffer_t *flipped_sprite_buffer;
+	gs_vertbuffer_t *subregion_buffer;
 
 	bool using_immediate;
 	struct gs_vb_data *vbd;

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1004,7 +1004,7 @@ static inline void build_sprite_rect(struct gs_vb_data *data, gs_texture_t *tex,
 	build_sprite(data, fcx, fcy, start_u, end_u, start_v, end_v);
 }
 
-void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t height)
+void gs_draw_quadf(gs_texture_t *tex, uint32_t flip, float width, float height)
 {
 	graphics_t *graphics = thread_graphics;
 	float fcx, fcy;
@@ -1016,15 +1016,15 @@ void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t h
 			return;
 		}
 	} else {
-		if (!width || !height) {
+		if (width == 0.0f || height == 0.0f) {
 			blog(LOG_ERROR, "A sprite cannot be drawn without "
 					"a width/height");
 			return;
 		}
 	}
 
-	fcx = width ? (float)width : (float)gs_texture_get_width(tex);
-	fcy = height ? (float)height : (float)gs_texture_get_height(tex);
+	fcx = width != 0.0f ? width : (float)gs_texture_get_width(tex);
+	fcy = height != 0.0f ? height : (float)gs_texture_get_height(tex);
 
 	gs_matrix_push();
 	gs_matrix_scale3f(fcx, fcy, 1.0f);
@@ -1043,6 +1043,11 @@ void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t h
 	}
 
 	gs_matrix_pop();
+}
+
+void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t height)
+{
+	gs_draw_quadf(tex, flip, (float)width, (float)height);
 }
 
 void gs_draw_sprite_subregion(gs_texture_t *tex, uint32_t flip, uint32_t sub_x, uint32_t sub_y, uint32_t sub_cx,

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -651,10 +651,6 @@ gs_vertbuffer_t *gs_render_save(void)
 void gs_vertex2f(float x, float y)
 {
 	struct vec3 v3;
-
-	if (!gs_valid("gs_verte"))
-		return;
-
 	vec3_set(&v3, x, y, 0.0f);
 	gs_vertex3v(&v3);
 }
@@ -662,10 +658,6 @@ void gs_vertex2f(float x, float y)
 void gs_vertex3f(float x, float y, float z)
 {
 	struct vec3 v3;
-
-	if (!gs_valid("gs_vertex3f"))
-		return;
-
 	vec3_set(&v3, x, y, z);
 	gs_vertex3v(&v3);
 }
@@ -673,10 +665,6 @@ void gs_vertex3f(float x, float y, float z)
 void gs_normal3f(float x, float y, float z)
 {
 	struct vec3 v3;
-
-	if (!gs_valid("gs_normal3f"))
-		return;
-
 	vec3_set(&v3, x, y, z);
 	gs_normal3v(&v3);
 }
@@ -709,10 +697,6 @@ void gs_color(uint32_t color)
 void gs_texcoord(float x, float y, int unit)
 {
 	struct vec2 v2;
-
-	if (!gs_valid("gs_texcoord"))
-		return;
-
 	vec2_set(&v2, x, y);
 	gs_texcoord2v(&v2, unit);
 }
@@ -720,10 +704,6 @@ void gs_texcoord(float x, float y, int unit)
 void gs_vertex2v(const struct vec2 *v)
 {
 	struct vec3 v3;
-
-	if (!gs_valid("gs_vertex2v"))
-		return;
-
 	vec3_set(&v3, v->x, v->y, 0.0f);
 	gs_vertex3v(&v3);
 }

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -581,6 +581,7 @@ EXPORT uint8_t *gs_create_texture_file_data3(const char *file, enum gs_image_alp
  * axis with GS_FLIP_U and GS_FLIP_V.
  */
 EXPORT void gs_draw_sprite(gs_texture_t *tex, uint32_t flip, uint32_t width, uint32_t height);
+EXPORT void gs_draw_quadf(gs_texture_t *tex, uint32_t flip, float width, float height);
 
 EXPORT void gs_draw_sprite_subregion(gs_texture_t *tex, uint32_t flip, uint32_t x, uint32_t y, uint32_t cx,
 				     uint32_t cy);

--- a/libobs/graphics/matrix4.c
+++ b/libobs/graphics/matrix4.c
@@ -59,20 +59,57 @@ void matrix4_from_axisang(struct matrix4 *dst, const struct axisang *aa)
 
 void matrix4_mul(struct matrix4 *dst, const struct matrix4 *m1, const struct matrix4 *m2)
 {
-	const struct vec4 *m1v = (const struct vec4 *)m1;
-	const float *m2f = (const float *)m2;
-	struct vec4 out[4];
-	int i, j;
+	struct matrix4 transposed;
+	struct matrix4 out;
 
-	for (i = 0; i < 4; i++) {
-		for (j = 0; j < 4; j++) {
-			struct vec4 temp;
-			vec4_set(&temp, m2f[j], m2f[j + 4], m2f[j + 8], m2f[j + 12]);
-			out[i].ptr[j] = vec4_dot(&m1v[i], &temp);
-		}
-	}
+	matrix4_transpose(&transposed, m2);
 
-	matrix4_copy(dst, (struct matrix4 *)out);
+	out.x.x = vec4_dot(&m1->x, &transposed.x);
+	out.x.y = vec4_dot(&m1->x, &transposed.y);
+	out.x.z = vec4_dot(&m1->x, &transposed.z);
+	out.x.w = vec4_dot(&m1->x, &transposed.t);
+	out.y.x = vec4_dot(&m1->y, &transposed.x);
+	out.y.y = vec4_dot(&m1->y, &transposed.y);
+	out.y.z = vec4_dot(&m1->y, &transposed.z);
+	out.y.w = vec4_dot(&m1->y, &transposed.t);
+	out.z.x = vec4_dot(&m1->z, &transposed.x);
+	out.z.y = vec4_dot(&m1->z, &transposed.y);
+	out.z.z = vec4_dot(&m1->z, &transposed.z);
+	out.z.w = vec4_dot(&m1->z, &transposed.t);
+	out.t.x = vec4_dot(&m1->t, &transposed.x);
+	out.t.y = vec4_dot(&m1->t, &transposed.y);
+	out.t.z = vec4_dot(&m1->t, &transposed.z);
+	out.t.w = vec4_dot(&m1->t, &transposed.t);
+
+	matrix4_copy(dst, &out);
+}
+
+void matrix4_mul_4x3_only(struct matrix4 *dst, const struct matrix4 *m1, const struct matrix4 *m2)
+{
+	struct matrix4 transposed;
+	struct vec4 x;
+	struct vec4 y;
+	struct vec4 z;
+
+	matrix4_transpose(&transposed, m2);
+
+	x.x = vec4_dot(&m1->x, &transposed.x);
+	x.y = vec4_dot(&m1->x, &transposed.y);
+	x.z = vec4_dot(&m1->x, &transposed.z);
+	x.w = vec4_dot(&m1->x, &transposed.t);
+	y.x = vec4_dot(&m1->y, &transposed.x);
+	y.y = vec4_dot(&m1->y, &transposed.y);
+	y.z = vec4_dot(&m1->y, &transposed.z);
+	y.w = vec4_dot(&m1->y, &transposed.t);
+	z.x = vec4_dot(&m1->z, &transposed.x);
+	z.y = vec4_dot(&m1->z, &transposed.y);
+	z.z = vec4_dot(&m1->z, &transposed.z);
+	z.w = vec4_dot(&m1->z, &transposed.t);
+
+	vec4_copy(&dst->x, &x);
+	vec4_copy(&dst->y, &y);
+	vec4_copy(&dst->z, &z);
+	vec4_copy(&dst->t, &m2->t);
 }
 
 static inline void get_3x3_submatrix(float *dst, const struct matrix4 *m, int i, int j)
@@ -172,38 +209,50 @@ void matrix4_scale(struct matrix4 *dst, const struct matrix4 *m, const struct ve
 
 void matrix4_translate3v_i(struct matrix4 *dst, const struct vec3 *v, const struct matrix4 *m)
 {
-	struct matrix4 temp;
-	vec4_set(&temp.x, 1.0f, 0.0f, 0.0f, 0.0f);
-	vec4_set(&temp.y, 0.0f, 1.0f, 0.0f, 0.0f);
-	vec4_set(&temp.z, 0.0f, 0.0f, 1.0f, 0.0f);
-	vec4_from_vec3(&temp.t, v);
+	struct matrix4 transposed;
+	struct vec4 v4;
+	struct vec4 t;
 
-	matrix4_mul(dst, &temp, m);
+	vec4_from_vec3(&v4, v);
+	matrix4_transpose(&transposed, m);
+	t.x = vec4_dot(&v4, &transposed.x);
+	t.y = vec4_dot(&v4, &transposed.y);
+	t.z = vec4_dot(&v4, &transposed.z);
+	t.w = vec4_dot(&v4, &transposed.t);
+	vec4_copy(&dst->x, &m->x);
+	vec4_copy(&dst->y, &m->y);
+	vec4_copy(&dst->z, &m->z);
+	vec4_copy(&dst->t, &t);
 }
 
 void matrix4_translate4v_i(struct matrix4 *dst, const struct vec4 *v, const struct matrix4 *m)
 {
-	struct matrix4 temp;
-	vec4_set(&temp.x, 1.0f, 0.0f, 0.0f, 0.0f);
-	vec4_set(&temp.y, 0.0f, 1.0f, 0.0f, 0.0f);
-	vec4_set(&temp.z, 0.0f, 0.0f, 1.0f, 0.0f);
-	vec4_copy(&temp.t, v);
+	struct matrix4 transposed;
+	struct vec4 t;
 
-	matrix4_mul(dst, &temp, m);
+	matrix4_transpose(&transposed, m);
+	t.x = vec4_dot(v, &transposed.x);
+	t.y = vec4_dot(v, &transposed.y);
+	t.z = vec4_dot(v, &transposed.z);
+	t.w = vec4_dot(v, &transposed.t);
+	vec4_copy(&dst->x, &m->x);
+	vec4_copy(&dst->y, &m->y);
+	vec4_copy(&dst->z, &m->z);
+	vec4_copy(&dst->t, &t);
 }
 
 void matrix4_rotate_i(struct matrix4 *dst, const struct quat *q, const struct matrix4 *m)
 {
 	struct matrix4 temp;
 	matrix4_from_quat(&temp, q);
-	matrix4_mul(dst, &temp, m);
+	matrix4_mul_4x3_only(dst, &temp, m);
 }
 
 void matrix4_rotate_aa_i(struct matrix4 *dst, const struct axisang *aa, const struct matrix4 *m)
 {
 	struct matrix4 temp;
 	matrix4_from_axisang(&temp, aa);
-	matrix4_mul(dst, &temp, m);
+	matrix4_mul_4x3_only(dst, &temp, m);
 }
 
 void matrix4_scale_i(struct matrix4 *dst, const struct vec3 *v, const struct matrix4 *m)
@@ -213,7 +262,7 @@ void matrix4_scale_i(struct matrix4 *dst, const struct vec3 *v, const struct mat
 	vec4_set(&temp.y, 0.0f, v->y, 0.0f, 0.0f);
 	vec4_set(&temp.z, 0.0f, 0.0f, v->z, 0.0f);
 	vec4_set(&temp.t, 0.0f, 0.0f, 0.0f, 1.0f);
-	matrix4_mul(dst, &temp, m);
+	matrix4_mul_4x3_only(dst, &temp, m);
 }
 
 bool matrix4_inv(struct matrix4 *dst, const struct matrix4 *m)


### PR DESCRIPTION
### Description
Minorly improves performance by reusing vertex buffers for sprite drawing, for the preview primitives, and also improves performance by optimizing a few commonly-used matrix transformation functions and reducing the amount of math needed every time a matrix translate/rotate/scale occurs.

### Motivation and Context
Due to obsproject/obs-studio#11917,  I realized that the preview was recreating vertex buffers for every draw call, which is very unnecessary. I just decided to improve the code for all of it because once I saw it I couldn't help but feel the need to fix this unnecessarily perf hit, and in turn that led me down other minor perf-related rabbit holes which I decided to fix up as I noticed them.

### How Has This Been Tested?
This affects all drawing so if there was something wrong it would probably affect everything if there were an issue, but it's because it affects everything that I'd like it tested as thoroughly as possible.

Note that I'm also not entirely sure how best to test this for perf improvement considering most of the impact is on the GPU. It'd be nice to know though.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
