### PR TITLE
nv-filters: Various bugfixes

### DIFF
--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -834,7 +834,7 @@ static void draw_greenscreen_blur(struct nvvfx_data *filter, bool has_blur)
 			gs_effect_set_texture_srgb(filter->blur_param, filter->blur_texture);
 		} else {
 			gs_effect_set_texture(filter->mask_param, filter->alpha_texture);
-			gs_effect_set_float(filter->threshold_param, filter->threshold);
+			gs_effect_set_float(filter->threshold_param, min(filter->threshold, 0.95f));
 		}
 		gs_effect_set_texture_srgb(filter->image_param, gs_texrender_get_texture(filter->render));
 

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -407,7 +407,9 @@ static void nvvfx_filter_reset(void *data, calldata_t *calldata)
 		vfxErr = NvVFX_Load(filter->handle);
 		if (NVCV_SUCCESS != vfxErr)
 			error("Error loading NVIDIA Video FX %i", vfxErr);
-		vfxErr = NvVFX_ResetState(filter->handle, filter->stateObjectHandle);
+		// reallocate state object
+		vfxErr = NvVFX_AllocateState(filter->handle, &filter->stateObjectHandle);
+		vfxErr = NvVFX_SetStateObjectHandleArray(filter->handle, NVVFX_STATE, &filter->stateObjectHandle);
 	}
 	if (filter->filter_id != S_FX_AIGS) {
 		vfxErr = NvVFX_SetF32(filter->handle_blur, NVVFX_STRENGTH, filter->strength);

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -183,10 +183,6 @@ static void nvvfx_filter_actual_destroy(void *data)
 			NvCVImage_Destroy(filter->blur_dst_img);
 		}
 	}
-	if (filter->stream)
-		NvVFX_CudaStreamDestroy(filter->stream);
-	if (filter->stream_blur)
-		NvVFX_CudaStreamDestroy(filter->stream_blur);
 
 	if (filter->handle) {
 		if (filter->stateObjectHandle) {
@@ -197,6 +193,10 @@ static void nvvfx_filter_actual_destroy(void *data)
 	if (filter->handle_blur) {
 		NvVFX_DestroyEffect(filter->handle_blur);
 	}
+	if (filter->stream)
+		NvVFX_CudaStreamDestroy(filter->stream);
+	if (filter->stream_blur)
+		NvVFX_CudaStreamDestroy(filter->stream_blur);
 
 	if (filter->effect) {
 		obs_enter_graphics();
@@ -378,12 +378,6 @@ static void nvvfx_filter_reset(void *data, calldata_t *calldata)
 
 	os_atomic_set_bool(&filter->processing_stop, true);
 	// [A] first destroy
-	if (filter->stream) {
-		NvVFX_CudaStreamDestroy(filter->stream);
-	}
-	if (filter->stream_blur) {
-		NvVFX_CudaStreamDestroy(filter->stream_blur);
-	}
 	if (filter->handle) {
 		if (filter->stateObjectHandle) {
 			NvVFX_DeallocateState(filter->handle, filter->stateObjectHandle);
@@ -392,6 +386,12 @@ static void nvvfx_filter_reset(void *data, calldata_t *calldata)
 	}
 	if (filter->handle_blur) {
 		NvVFX_DestroyEffect(filter->handle_blur);
+	}
+	if (filter->stream) {
+		NvVFX_CudaStreamDestroy(filter->stream);
+	}
+	if (filter->stream_blur) {
+		NvVFX_CudaStreamDestroy(filter->stream_blur);
 	}
 	// [B] recreate
 	/* 1. Create FX */

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -634,7 +634,7 @@ static bool process_texture(struct nvvfx_data *filter)
 	}
 
 	/* 2. Convert to BGR. */
-	vfxErr = NvCVImage_Transfer(filter->src_img, filter->BGR_src_img, 1.0f, filter->stream_blur, filter->stage);
+	vfxErr = NvCVImage_Transfer(filter->src_img, filter->BGR_src_img, 1.0f, process_stream, filter->stage);
 	if (vfxErr != NVCV_SUCCESS) {
 		const char *errString = NvCV_GetErrorStringFromCode(vfxErr);
 		error("Error converting src to BGR img; error %i: %s", vfxErr, errString);

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -144,10 +144,8 @@ static void nvvfx_filter_update(void *data, obs_data_t *settings)
 		if (filter->strength != strength) {
 			filter->strength = strength;
 			vfxErr = NvVFX_SetF32(filter->handle_blur, NVVFX_STRENGTH, filter->strength);
+			vfxErr = NvVFX_Load(filter->handle_blur);
 		}
-		vfxErr = NvVFX_Load(filter->handle_blur);
-		if (NVCV_SUCCESS != vfxErr)
-			error("Error loading blur FX %i", vfxErr);
 	}
 }
 

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -55,7 +55,6 @@ struct nvvfx_data {
 	bool processed_frame;
 	bool target_valid;
 	bool got_new_frame;
-	signal_handler_t *handler;
 
 	/* RTX SDK vars */
 	NvVFX_Handle handle;
@@ -295,7 +294,6 @@ static void *nvvfx_filter_create(obs_data_t *settings, obs_source_t *context, en
 	filter->height = 0;
 	filter->initial_render = false;
 	os_atomic_set_bool(&filter->processing_stop, false);
-	filter->handler = NULL;
 	filter->processing_interval = 1;
 	filter->processing_counter = 0;
 	// set nvvfx_fx_id
@@ -874,11 +872,6 @@ static void nvvfx_filter_render(void *data, gs_effect_t *effect, bool has_blur)
 	if (filter->processed_frame) {
 		draw_greenscreen_blur(filter, has_blur);
 		return;
-	}
-
-	if (parent && !filter->handler) {
-		filter->handler = obs_source_get_signal_handler(parent);
-		signal_handler_connect(filter->handler, "update", nvvfx_filter_reset, filter);
 	}
 
 	/* 1. Render to retrieve texture. */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This is a split of https://github.com/obsproject/obs-studio/pull/11899 which now only carries new features and improvements.
The current PR focuses on bug fixes.
Fixes bug #11383 
Fixes also a bug with a third-party plugin which requires Background Removal to set bulk foreground to alpha = 1. [1]
This fixes also several unreported bugs:
- when resetting Background Removal, the temporal state variable has to be recreated and not just reset.
- the cuda stream used for the operations of mapping, transfer and unmapping of resources must be the same; there was an error with Blur effect.
- the reset signal is removed because it recreates the effect and can cause bugs (crashes); we now leave the SDK deal on its own with parent source updates.
- the SDK reports an error on initial load; we silence the associated log report because it is a false positive on initial load.

[1] https://github.com/FiniteSingularity/obs-stroke-glow-shadow/issues/61


### Motivation and Context
Fixes bugs.

Fixes #11383

### How Has This Been Tested?
Listed bugs are gone.
Tested on win 11, RTX 4090.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
