### PR TITLE
CI: Fix Flatpak build caching issues

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -297,8 +297,8 @@ jobs:
           build-bundle: ${{ fromJSON(needs.check-event.outputs.package) }}
           bundle: obs-studio-flatpak-${{ needs.check-event.outputs.commitHash }}.flatpak
           manifest-path: ${{ github.workspace }}/build-aux/com.obsproject.Studio.json
-          cache: ${{ fromJSON(steps.setup.outputs.cacheHit) || (github.event_name == 'push' && github.ref_name == 'master')}}
-          restore-cache: ${{ fromJSON(steps.setup.outputs.cacheHit) }}
+          cache: ${{ fromJSON(steps.setup.outputs.cacheHit) || ((github.event_name == 'push' || github.event_name == 'scheduled') && github.ref_name == 'master')}}
+          restore-cache: ${{ fromJSON(steps.setup.outputs.cacheHit) && github.event_name != 'scheduled' }}
           cache-key: ${{ steps.setup.outputs.cacheKey }}
           mirror-screenshots-url: https://dl.flathub.org/media
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
At some point on or around February 13, Flatpak builds started to always take the full build time of roughly 45+ minutes. There are no CI changes to point to why this happened. Best guess is that the Flatpak cache was deleted from GitHub Actions, which caused the cache parameter to be set to false on all builds. This meant that scheduled nightly builds could not produce fresh caches, so all builds continued to take the full build time.

Expand the cache condition to include scheduled runs so that cache creation is enabled. Restrict the restore-cache condition to exclude scheduled runs so that they always produce a fresh cache.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Noticed Flatpak builds were taking longer than usual.

Push to master on Feb 11, 22m05s: <https://github.com/obsproject/obs-studio/actions/runs/13272141500>
Push to master on Feb 14, 48m01s: <https://github.com/obsproject/obs-studio/actions/runs/13337690503>
Scheduled on Feb 12, 22m29s: <https://github.com/obsproject/obs-studio/actions/runs/13297743566>
Scheduled on Feb 13, 45m19s: <https://github.com/obsproject/obs-studio/actions/runs/13319880583>

We explicitly set the `cache` and `restore-cache` values for the flatpak-builder action here: https://github.com/obsproject/obs-studio/blob/7f94906d5f76d01e0f599f724462edb7bcae0824/.github/workflows/build-project.yaml#L300-L302

My only guess is that there was a valid cache that got deleted around that time, and then the scheduled run stopped producing new caches as a result of the combination of no cacheHit and scheduled runs not being a "push to master" (`false || false`).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
