### PR TITLE
CI: Add workflow_dispatch trigger to scheduled repository workflow

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -1,6 +1,7 @@
 name: Scheduled
 run-name: Scheduled Repository Actions ⏰
 on:
+  workflow_dispatch:
   schedule:
     - cron: 17 0 * * *
 permissions:


### PR DESCRIPTION
### Description
Adds the `workflow_dispatch` trigger to the scheduled repository workflow.

### Motivation and Context
By adding the workflow_dispatch trigger, the scheduled workflow can also be manually triggered if the scheduled run failed to run due to scheduling issues or because of an error that might have been fixed since then.

This gives back some manual control of the workflow runs to repository owners.

### How Has This Been Tested?
Was already implemented and tested on `obs-deps` in the same way.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
