### PR TITLE
CI: Update clang-format scripts and actions to version 19.1.1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -81,6 +81,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
+SkipMacroDefinitionBody: true
 SortIncludes: false
 SortUsingDeclarations: false
 SpaceAfterCStyleCast: false

--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -35,7 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@17/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,11 +50,11 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
         
-        print ::group::Install clang-format-17
-        brew install --quiet obsproject/tools/clang-format@17
+        print ::group::Install clang-format-19
+        brew install --quiet obsproject/tools/clang-format@19
         print ::endgroup::
 
-        print ::group::Run clang-format-17
+        print ::group::Run clang-format-19
         local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
         ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
         print ::endgroup::

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -33,24 +33,24 @@ invoke_formatter() {
 
   case ${formatter} {
     clang)
-      if (( ${+commands[clang-format-17]} )) {
-        local formatter=clang-format-17
+      if (( ${+commands[clang-format-19]} )) {
+        local formatter=clang-format-19
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
       } else {
-        log_error "No viable clang-format version found (required 17.0.3)"
+        log_error "No viable clang-format version found (required 19.1.1)"
         exit 2
       }
 
       local -a formatter_version=($(${formatter} --version))
 
-      if ! is-at-least 17.0.3 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 17.0.3 or above (found ${formatter_version[-1]}."
+      if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
+        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
         exit 2
       fi
 
-      if ! is-at-least ${formatter_version[-1]} 17.0.3; then
-        log_error "clang-format is more recent than version 17.0.3 (found ${formatter_version[-1]})."
+      if ! is-at-least ${formatter_version[-1]} 19.1.1; then
+        log_error "clang-format is more recent than version 19.1.1 (found ${formatter_version[-1]})."
         exit 2
       fi
 

--- a/frontend/settings/OBSHotkeyWidget.cpp
+++ b/frontend/settings/OBSHotkeyWidget.cpp
@@ -117,9 +117,8 @@ void OBSHotkeyWidget::AddEdit(obs_key_combination combo, int idx)
 		return std::distance(begin(removeButtons), res);
 	};
 
-	QObject::connect(add, &QPushButton::clicked, [&, CurrentIndex] {
-		AddEdit({0, OBS_KEY_NONE}, CurrentIndex() + 1);
-	});
+	QObject::connect(add, &QPushButton::clicked,
+			 [&, CurrentIndex] { AddEdit({0, OBS_KEY_NONE}, CurrentIndex() + 1); });
 
 	QObject::connect(remove, &QPushButton::clicked, [&, CurrentIndex] { RemoveEdit(CurrentIndex()); });
 

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -65,7 +65,7 @@ struct BasicOutputHandler {
 
 	BasicOutputHandler(OBSBasic *main_);
 
-	virtual ~BasicOutputHandler(){};
+	virtual ~BasicOutputHandler() {};
 
 	virtual std::shared_future<void> SetupStreaming(obs_service_t *service,
 							SetupStreamingContinuation_t continuation) = 0;

--- a/frontend/utility/RemuxWorker.hpp
+++ b/frontend/utility/RemuxWorker.hpp
@@ -31,7 +31,7 @@ class RemuxWorker : public QObject {
 	void UpdateProgress(float percent);
 
 	explicit RemuxWorker() : isWorking(false) {}
-	virtual ~RemuxWorker(){};
+	virtual ~RemuxWorker() {};
 
 private slots:
 	void remux(const QString &source, const QString &target);

--- a/libobs/util/threading-windows.c
+++ b/libobs/util/threading-windows.c
@@ -185,7 +185,8 @@ void os_set_thread_name(const char *name)
 		RaiseException(VC_EXCEPTION, 0, THREADNAME_INFO_SIZE, (ULONG_PTR *)&info);
 #ifdef NO_SEH_MINGW
 	}
-	__except1{
+	__except1
+	{
 #else
 	} __except (EXCEPTION_EXECUTE_HANDLER) {
 #endif

--- a/plugins/coreaudio-encoder/encoder.cpp
+++ b/plugins/coreaudio-encoder/encoder.cpp
@@ -1263,7 +1263,7 @@ bool obs_module_load(void)
 	CA_LOG(LOG_INFO, "Adding CoreAudio AAC encoder");
 #endif
 
-	struct obs_encoder_info aac_info {};
+	struct obs_encoder_info aac_info{};
 	aac_info.id = "CoreAudio_AAC";
 	aac_info.type = OBS_ENCODER_AUDIO;
 	aac_info.codec = "aac";

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -600,10 +600,10 @@ static obs_properties_t *display_capture_properties(void *unused)
                                                      BOOL *_Nonnull stop __unused) {
         char dimension_buffer[4][12];
         char name_buffer[256];
-        snprintf(dimension_buffer[0], sizeof(dimension_buffer[0]), "%u", (uint32_t)[screen frame].size.width);
-        snprintf(dimension_buffer[1], sizeof(dimension_buffer[0]), "%u", (uint32_t)[screen frame].size.height);
-        snprintf(dimension_buffer[2], sizeof(dimension_buffer[0]), "%d", (int32_t)[screen frame].origin.x);
-        snprintf(dimension_buffer[3], sizeof(dimension_buffer[0]), "%d", (int32_t)[screen frame].origin.y);
+        snprintf(dimension_buffer[0], sizeof(dimension_buffer[0]), "%u", (uint32_t) [screen frame].size.width);
+        snprintf(dimension_buffer[1], sizeof(dimension_buffer[0]), "%u", (uint32_t) [screen frame].size.height);
+        snprintf(dimension_buffer[2], sizeof(dimension_buffer[0]), "%d", (int32_t) [screen frame].origin.x);
+        snprintf(dimension_buffer[3], sizeof(dimension_buffer[0]), "%d", (int32_t) [screen frame].origin.y);
 
         snprintf(name_buffer, sizeof(name_buffer), "%.200s: %.12sx%.12s @ %.12s,%.12s",
                  [[screen localizedName] UTF8String], dimension_buffer[0], dimension_buffer[1], dimension_buffer[2],

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -243,7 +243,7 @@ static bool nvvfx_filter_create_internal(struct nvvfx_data *filter)
 	}
 	if (NVCV_SUCCESS != vfxErr)
 		log_nverror_destroy(filter, vfxErr);
-		/* debug */
+	/* debug */
 #ifdef _DEBUG
 	const char *info;
 	vfxErr = NvVFX_GetString(filter->handle_blur, NVVFX_INFO, &info);

--- a/plugins/nv-filters/nvvfx-load.h
+++ b/plugins/nv-filters/nvvfx-load.h
@@ -252,7 +252,7 @@ typedef struct
 #ifdef _MSC_VER
 	__declspec(dllexport)
 #endif // _MSC_VER
-		NvCVImage {
+	NvCVImage {
 	unsigned int width;                    //!< The number of pixels horizontally in the image.
 	unsigned int height;                   //!< The number of pixels  vertically  in the image.
 	signed int pitch;                      //!< The byte stride between pixels vertically.

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -682,7 +682,7 @@ void register_whip_output()
 		return obs_properties_create();
 	};
 	info.get_total_bytes = [](void *priv_data) -> uint64_t {
-		return (uint64_t) static_cast<WHIPOutput *>(priv_data)->GetTotalBytes();
+		return (uint64_t)static_cast<WHIPOutput *>(priv_data)->GetTotalBytes();
 	};
 	info.get_connect_time_ms = [](void *priv_data) -> int {
 		return static_cast<WHIPOutput *>(priv_data)->GetConnectTime();

--- a/shared/obs-scripting/obs-scripting-python.c
+++ b/shared/obs-scripting/obs-scripting-python.c
@@ -1599,7 +1599,7 @@ bool obs_scripting_load_python(const char *python_path)
 	if (python_loaded)
 		return true;
 
-		/* Use external python on windows and mac */
+	/* Use external python on windows and mac */
 #if RUNTIME_LINK
 	if (!import_python(python_path, &python_version))
 		return false;

--- a/shared/obs-scripting/obs-scripting.c
+++ b/shared/obs-scripting/obs-scripting.c
@@ -161,7 +161,7 @@ void obs_scripting_unload(void)
 	if (!scripting_loaded)
 		return;
 
-		/* ---------------------- */
+	/* ---------------------- */
 
 #if defined(LUAJIT_FOUND)
 	obs_lua_unload();


### PR DESCRIPTION
### Description
Updates source code formatting script and CI actions to use `clang-format` v19.1.1.

Enables the `SkipMacroDefinitionBody` for `clang-format` to avoid reformatting of multi-line macro definitions.

Also includes updated formatting of all source code files with the updated version.

### Motivation and Context
Microsoft Visual Studio started shipping version 19.1.1 of `clang-format`, thus any developer using that IDE will see their source code files automatically formatted using that version.

To minimise friction for these developers, updating to the same version on CI (and thus updating the project to that version) will reduce the potential for CI build failures.

Homebrew's current `clang-format` version is v20.1.0, so macOS is still "ahead" of Visual Studio, so a custom Formula is provided to easily install v19.1.1 on macOS and Ubuntu CI runners.

### How Has This Been Tested?
Installed `clang-format` 19.1.1 using the custom formula and formatted source code with the updated formatting script.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
