### PR TITLE
mac-avcapture: Clear memory when creating frame struct

### DIFF
--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -20,8 +20,8 @@ static void *av_capture_create(obs_data_t *settings, obs_source_t *source)
     capture_data->isFastPath = false;
     capture_data->settings = settings;
     capture_data->source = source;
-    capture_data->videoFrame = bmalloc(sizeof(OBSAVCaptureVideoFrame));
-    capture_data->audioFrame = bmalloc(sizeof(OBSAVCaptureAudioFrame));
+    capture_data->videoFrame = bzalloc(sizeof(OBSAVCaptureVideoFrame));
+    capture_data->audioFrame = bzalloc(sizeof(OBSAVCaptureAudioFrame));
 
     OBSAVCapture *capture = [[OBSAVCapture alloc] initWithCaptureInfo:capture_data];
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When creating the `obs_source_frame` for a Video Capture Device source, use `bzalloc` instead of `bmalloc` to ensure the memory inside the struct is fully cleared before use.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
macOS users have been noticing that, occasionally, Video Capture Device sources are flipped upside down inexplicably. It turns out that this was due to uncleared memory inside the `obs_source_frame` struct having the `flip` property evaluating to a truth-ish value.

While `malloc` on macOS seems like it should possibly [zero on allocations by itself](https://github.com/apple-oss-distributions/libmalloc/blob/bdc20d994577999401fb11f1db855e05707ae599/src/malloc.c#L1625) (since we target 11.0; though I'm not sure exactly what the program_sdk value represents in our case), one way or another we were getting uncleared memory back from `bmalloc` that contained junk data where `flip` resides. This was verified by checking the memory in a debugger immediately after the call to `bmalloc` for the struct.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
The bug only occurred occasionally and under particular circumstances, but it was reproduced several times without the fix, and I am thus far unable to reproduce the bug with the fix (testing performed on Apple Silicon, macOS 15.3.1).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
