### PR TITLE
rtmp-services: Add HEVC (h265) to the list of supported video codecs for Bilibili RTMP streaming

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 268,
+    "version": 269,
     "files": [
         {
             "name": "services.json",
-            "version": 268
+            "version": 269
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -2134,7 +2134,8 @@
                 }
             ],
             "supported video codecs": [
-                "h264"
+                "h264",
+                "hevc"
             ]
         },
         {


### PR DESCRIPTION
Description
Added HEVC (h265) to the list of supported video codecs in services.json for Bilibili RTMP streaming.

Motivation and Context
Bilibili now supports HEVC encoding for RTMP streaming, but OBS’s services.json previously only listed h264. This change ensures that OBS correctly reflects HEVC as a supported codec for Bilibili.

How Has This Been Tested?
Tested on OBS version 31.0.2, using HEVC encoding to stream to the Bilibili RTMP server, and confirmed the video plays correctly.

Types of Changes
 - New feature (non-breaking change which adds functionality) 

Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.