### PR TITLE
libobs: Fix setting non-0 order on only scene item

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -2621,7 +2621,6 @@ void obs_sceneitem_set_order_position(obs_sceneitem_t *item, int position)
 		return;
 
 	struct obs_scene *scene = obs_scene_get_ref(item->parent);
-	struct obs_scene_item *next;
 
 	if (!scene)
 		return;
@@ -2629,11 +2628,12 @@ void obs_sceneitem_set_order_position(obs_sceneitem_t *item, int position)
 	full_lock(scene);
 
 	detach_sceneitem(item);
-	next = scene->first_item;
 
-	if (position == 0) {
+	if (!scene->first_item || position == 0) {
 		attach_sceneitem(scene, item, NULL);
 	} else {
+		struct obs_scene_item *next = scene->first_item;
+
 		for (int i = position; i > 1; --i) {
 			if (next->next == NULL)
 				break;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When trying to set non-zero `position` on a scene item with `obs_sceneitem_set_order_position`, an edge case kicks in, causing a crash due to `scene->first_item` being `NULL` after `detach_sceneitem(item)` is executed.

### Motivation and Context
`libobs` standard behaviour is to silently fix invalid input. This change respects this behaviour by silently fixing the edge case described above.

### How Has This Been Tested?
Manual testing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
