### PR TITLE
libobs: Fix duplicating scene with custom size

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1990,6 +1990,14 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name, enum obs_
 	new_scene = make_private ? create_private_id(scene->source->info.id, name)
 				 : create_id(scene->source->info.id, name);
 
+	new_scene->is_group = scene->is_group;
+	new_scene->custom_size = scene->custom_size;
+	new_scene->cx = scene->cx;
+	new_scene->cy = scene->cy;
+	new_scene->absolute_coordinates = scene->absolute_coordinates;
+	new_scene->last_width = scene->last_width;
+	new_scene->last_height = scene->last_height;
+
 	obs_source_copy_filters(new_scene->source, scene->source);
 
 	obs_data_apply(new_scene->source->private_settings, scene->source->private_settings);


### PR DESCRIPTION
### Description
Fix duplicating scene with custom size

### Motivation and Context
When duplicating a scene with a custom size all scene items would be resized based on the base size of the main mix.
When a scene is loaded the `scene_load` function would set the size, but that is not done when duplicating a scene, so the `obs_scene_duplicate` function has to copy the custom size

### How Has This Been Tested?
With Aitum Vertical plugin duplicating a vertical scene

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
