### PR TITLE
frontend: Remove additional spacing hack in SourceTreeItem

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -98,10 +98,6 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 	boxLayout->addWidget(label);
 	boxLayout->addWidget(vis);
 	boxLayout->addWidget(lock);
-#ifdef __APPLE__
-	/* Hack: Fixes a bug where scrollbars would be above the lock icon */
-	boxLayout->addSpacing(16);
-#endif
 
 	Update(false);
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This removes a hack that added additional spacing as scrollbars would go over content due to a Qt bug. This bug appears to be fixed, as the described behavior is no longer observed. As such, the additional spacing is no longer needed (and only looks out of place).
Effectively reverts 4e97b1bb30fa79215f7162f36066336732b59f28.

Before/After:
<p>
<img width="224" alt="Screenshot 2025-03-24 at 13 25 16" src="https://github.com/user-attachments/assets/473c7f4f-e8b4-401e-847a-3c2b053aaa1f" />
<img width="220" alt="Screenshot 2025-03-24 at 13 27 14" src="https://github.com/user-attachments/assets/46669d77-23aa-4476-bd0e-c4547dadc8fc" />
</p>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed the out-of-place looking spacing, which seemed wrong. Doesn't look like it's still needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15.3
Everything I tried (adding, removing, resizing) seems fine, the scrollbar never went over the icons. Unfortunately it appears the Qt bug was never documented anywhere by us.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
