### PR TITLE
frontend: Allow 5 multitrack reconnect attempts before re-running GCC

### DIFF
--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -26,6 +26,9 @@ static const char *hevc_main = "Main";
 static const char *hevc_main10 = "Main 10";
 static const char *av1_main = "Main";
 
+// Maximum reconnect attempts with an invalid key error before giving up (roughly 30 seconds with default start value)
+static constexpr uint8_t MAX_RECONNECT_ATTEMPTS = 5;
+
 Qt::ConnectionType BlockingConnectionTypeFor(QObject *object)
 {
 	return object->thread() == QThread::currentThread() ? Qt::DirectConnection : Qt::BlockingQueuedConnection;
@@ -454,10 +457,11 @@ void MultitrackVideoOutput::PrepareStreaming(QWidget *parent, const char *servic
 	obs_output_add_packet_callback(output, bpm_inject, NULL);
 
 	// Set callback to prevent reconnection attempts once the stream key has become invalid
-	static auto reconnect_cb = [](void *, obs_output_t *, int code) -> bool {
-		return code != OBS_OUTPUT_INVALID_STREAM;
+	static auto reconnect_cb = [](void *param, obs_output_t *, int code) -> bool {
+		auto _this = static_cast<MultitrackVideoOutput *>(param);
+		return code != OBS_OUTPUT_INVALID_STREAM || (_this->reconnect_attempts++ < MAX_RECONNECT_ATTEMPTS);
 	};
-	obs_output_set_reconnect_callback(output, reconnect_cb, nullptr);
+	obs_output_set_reconnect_callback(output, reconnect_cb, this);
 
 	OBSSignal start_streaming;
 	OBSSignal stop_streaming;
@@ -869,6 +873,7 @@ void StreamStartHandler(void *arg, calldata_t *)
 {
 	auto self = static_cast<MultitrackVideoOutput *>(arg);
 	self->restart_on_error = true;
+	self->reconnect_attempts = 0;
 }
 
 void StreamStopHandler(void *arg, calldata_t *data)

--- a/frontend/utility/MultitrackVideoOutput.hpp
+++ b/frontend/utility/MultitrackVideoOutput.hpp
@@ -63,6 +63,7 @@ private:
 	std::optional<OBSOutputObjects> current_stream_dump;
 
 	bool restart_on_error = false;
+	uint8_t reconnect_attempts = 0;
 
 	friend void StreamStartHandler(void *arg, calldata_t *data);
 	friend void StreamStopHandler(void *arg, calldata_t *data);


### PR DESCRIPTION
### Description

Adds a counter to allow up to 5 reconnect failures with the "invalid key" status code before actually giving up.

### Motivation and Context

Rather than fully resetting the output, we should try a few more times to wait out any server-side timeouts. If the stream key is still unavailable after 5 attempts (~50 seconds) this will fall back to re-running the full API flow to obtain a new stream key, and possibly different configuration.

### How Has This Been Tested?

Locally. Ideally could use a 48 hour test still.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
