### PR TITLE
frontend: Allow Stream Delay with multitrack video

### DIFF
--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -689,7 +689,7 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 	bool enableDynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
 	if (multitrackVideo && multitrackVideoActive &&
-	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, useDelay, enableNewSocketLoop,
+	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableNewSocketLoop,
 							 enableDynBitrate)) {
 		multitrackVideoActive = false;
 		return false;

--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -486,8 +486,7 @@ void MultitrackVideoOutput::StopStreaming()
 }
 
 bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t *config, obs_service_t *service,
-						       bool &useDelay, bool &enableNewSocketLoop,
-						       bool &enableDynBitrate)
+						       bool &enableNewSocketLoop, bool &enableDynBitrate)
 {
 	QString incompatible_settings;
 	QString where_to_disable;
@@ -512,7 +511,6 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 		num += 1;
 	};
 
-	check_setting(useDelay, "Basic.Settings.Advanced.StreamDelay", "Basic.Settings.Advanced.StreamDelay");
 #ifdef _WIN32
 	check_setting(enableNewSocketLoop, "Basic.Settings.Advanced.Network.EnableNewSocketLoop",
 		      "Basic.Settings.Advanced.Network");
@@ -552,12 +550,10 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 	     incompatible_settings_list.toUtf8().constData(), action);
 
 	if (mb.clickedButton() == this_stream || mb.clickedButton() == all_streams) {
-		useDelay = false;
 		enableNewSocketLoop = false;
 		enableDynBitrate = false;
 
 		if (mb.clickedButton() == all_streams) {
-			config_set_bool(config, "Output", "DelayEnable", false);
 #ifdef _WIN32
 			config_set_bool(config, "Output", "NewSocketLoopEnable", false);
 #endif

--- a/frontend/utility/MultitrackVideoOutput.hpp
+++ b/frontend/utility/MultitrackVideoOutput.hpp
@@ -31,7 +31,7 @@ public:
 	signal_handler_t *StreamingSignalHandler();
 	void StartedStreaming();
 	void StopStreaming();
-	bool HandleIncompatibleSettings(QWidget *parent, config_t *config, obs_service_t *service, bool &useDelay,
+	bool HandleIncompatibleSettings(QWidget *parent, config_t *config, obs_service_t *service,
 					bool &enableNewSocketLoop, bool &enableDynBitrate);
 
 	OBSOutputAutoRelease StreamingOutput()

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -680,7 +680,7 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 	bool enableDynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
 	if (multitrackVideo && multitrackVideoActive &&
-	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, useDelay, enableNewSocketLoop,
+	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableNewSocketLoop,
 							 enableDynBitrate)) {
 		multitrackVideoActive = false;
 		return false;


### PR DESCRIPTION
### Description
Remove Stream Delay from the incompatible settings list for multitrack video as it works properly now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stream Delay was incompatible with Enhanced Broadcasting during early development, along with some other standard OBS features, which led to the creation of a `MultitrackVideoOutput::HandleIncompatibleSettings()` function to notify users and block the stream attempt. Stream Delay compatibility with Enhanced Broadcasting has been tested within the TEB beta and has been working reliably for several months. As a result, we can safely remove Stream Delay from the incompatible function.

### How Has This Been Tested?
Tested in the TEB beta for several months, and also local testing on Linux and Windows.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
