### PR TITLE
frontend: Allow network optimizations with multitrack video

### DIFF
--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -683,14 +683,11 @@ bool AdvancedOutput::StartStreaming(obs_service_t *service)
 #ifdef _WIN32
 	bool enableNewSocketLoop = config_get_bool(main->Config(), "Output", "NewSocketLoopEnable");
 	bool enableLowLatencyMode = config_get_bool(main->Config(), "Output", "LowLatencyEnable");
-#else
-	bool enableNewSocketLoop = false;
 #endif
 	bool enableDynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
 	if (multitrackVideo && multitrackVideoActive &&
-	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableNewSocketLoop,
-							 enableDynBitrate)) {
+	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableDynBitrate)) {
 		multitrackVideoActive = false;
 		return false;
 	}

--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -545,7 +545,7 @@ void MultitrackVideoOutput::StopStreaming()
 }
 
 bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t *config, obs_service_t *service,
-						       bool &enableNewSocketLoop, bool &enableDynBitrate)
+						       bool &enableDynBitrate)
 {
 	QString incompatible_settings;
 	QString where_to_disable;
@@ -570,10 +570,6 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 		num += 1;
 	};
 
-#ifdef _WIN32
-	check_setting(enableNewSocketLoop, "Basic.Settings.Advanced.Network.EnableNewSocketLoop",
-		      "Basic.Settings.Advanced.Network");
-#endif
 	check_setting(enableDynBitrate, "Basic.Settings.Output.DynamicBitrate.Beta", "Basic.Settings.Advanced.Network");
 
 	if (incompatible_settings.isEmpty())
@@ -609,13 +605,9 @@ bool MultitrackVideoOutput::HandleIncompatibleSettings(QWidget *parent, config_t
 	     incompatible_settings_list.toUtf8().constData(), action);
 
 	if (mb.clickedButton() == this_stream || mb.clickedButton() == all_streams) {
-		enableNewSocketLoop = false;
 		enableDynBitrate = false;
 
 		if (mb.clickedButton() == all_streams) {
-#ifdef _WIN32
-			config_set_bool(config, "Output", "NewSocketLoopEnable", false);
-#endif
 			config_set_bool(config, "Output", "DynamicBitrate", false);
 		}
 

--- a/frontend/utility/MultitrackVideoOutput.hpp
+++ b/frontend/utility/MultitrackVideoOutput.hpp
@@ -32,7 +32,7 @@ public:
 	void StartedStreaming();
 	void StopStreaming();
 	bool HandleIncompatibleSettings(QWidget *parent, config_t *config, obs_service_t *service,
-					bool &enableNewSocketLoop, bool &enableDynBitrate);
+					bool &enableDynBitrate);
 
 	OBSOutputAutoRelease StreamingOutput()
 	{

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -674,14 +674,11 @@ bool SimpleOutput::StartStreaming(obs_service_t *service)
 #ifdef _WIN32
 	bool enableNewSocketLoop = config_get_bool(main->Config(), "Output", "NewSocketLoopEnable");
 	bool enableLowLatencyMode = config_get_bool(main->Config(), "Output", "LowLatencyEnable");
-#else
-	bool enableNewSocketLoop = false;
 #endif
 	bool enableDynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 
 	if (multitrackVideo && multitrackVideoActive &&
-	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableNewSocketLoop,
-							 enableDynBitrate)) {
+	    !multitrackVideo->HandleIncompatibleSettings(main, main->Config(), service, enableDynBitrate)) {
 		multitrackVideoActive = false;
 		return false;
 	}

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -1033,8 +1033,11 @@ static int init_send(struct rtmp_stream *stream)
 			}
 		}
 
-		obs_encoder_t *aencoder = obs_output_get_audio_encoder(context, 0);
-		if (aencoder) {
+		for (size_t i = 0; i < MAX_OUTPUT_AUDIO_ENCODERS; i++) {
+			obs_encoder_t *aencoder = obs_output_get_audio_encoder(context, 0);
+			if (!aencoder)
+				continue;
+
 			obs_data_t *params = obs_encoder_get_settings(aencoder);
 			if (params) {
 				int bitrate = obs_data_get_int(params, "bitrate");


### PR DESCRIPTION
### Description

This PR depends on https://github.com/obsproject/obs-studio/pull/12003 being merged first, to avoid merge conflicts. 

Remove network optimizations (aka New Socket Loop) from the incompatible settings list for multitrack video as it works properly now. Network optimizations are controlled in Settings -> Advanced and have 2 elements:

![image](https://github.com/user-attachments/assets/eaf6dac2-9c0e-451a-9e82-4d7c8ff35bfb)

This PR enables both options (network optimizations and TCP pacing) to be used with multitrack video.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Network optimizations were incompatible with Enhanced Broadcasting during early development, along with some other standard OBS features, which led to the creation of a `MultitrackVideoOutput::HandleIncompatibleSettings()` function to notify users and block the stream attempt. The features have been tested within the TEB beta and have been working reliably for several months. As a result, we can safely remove them from the incompatible function.

### How Has This Been Tested?
Tested in the TEB beta for several months, and also local testing on Windows.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
