### PR TITLE
deps/json11: Fix compile error on GCC 15+

### DIFF
--- a/deps/json11/json11.cpp
+++ b/deps/json11/json11.cpp
@@ -22,6 +22,7 @@
 #include "json11.hpp"
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <limits>


### PR DESCRIPTION
### Description
Fixes a compile error in `json11` introduced in GCC 15.

The compiler already suggests this solution:
```
/builddir/build/BUILD/obs-studio-31.0.3-build/obs-studio/deps/json11/json11.cpp:25:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   24 | #include <cmath>
  +++ |+#include <cstdint>
   25 | #include <cstdlib>
```

* Fixes #11989 

### Motivation and Context
Ran across a compile error, don't like those.

### How Has This Been Tested?
Compiled with GCC 15 on Fedora 42.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
