### PR TITLE
frontend: Add dedicated translation of remaining time

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -266,6 +266,7 @@ Basic.Stats.DroppedFrames="Dropped Frames (Network)"
 Basic.Stats.MegabytesSent="Total Data Output"
 Basic.Stats.Bitrate="Bitrate"
 Basic.Stats.DiskFullIn="Disk full in (approx.)"
+Basic.Stats.DiskFullIn.Text="%1 Hours, %2 Minutes"
 Basic.Stats.ResetStats="Reset Stats"
 
 ResetUIWarning.Title="Are you sure you want to reset the UI?"

--- a/frontend/widgets/OBSBasicStats.cpp
+++ b/frontend/widgets/OBSBasicStats.cpp
@@ -39,7 +39,7 @@ void OBSBasicStats::OBSFrontendEvent(enum obs_frontend_event event, void *ptr)
 
 static QString MakeTimeLeftText(int hours, int minutes)
 {
-	return QString::asprintf("%d %s, %d %s", hours, Str("Hours"), minutes, Str("Minutes"));
+	return QTStr("Basic.Stats.DiskFullIn.Text").arg(QString::number(hours), QString::number(minutes));
 }
 
 static QString MakeMissedFramesText(uint32_t total_lagged, uint32_t total_rendered, long double num)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR adds a dedicated translation for the remaining time of the disk space in the stats window.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I want to remove `, ` from the remaining time when the locale is Japanese.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

| | English | Japanese |
| --- | --- | --- |
| master | ![screenshot-master-en_US](https://github.com/user-attachments/assets/1102632a-107f-4bd1-ade7-a39c5ef7d073) | ![screenshot-master-ja_JP](https://github.com/user-attachments/assets/56859f4b-db3a-44dd-bf2d-5850c28608e4) |
| this PR | ![screenshot-mod-en_US](https://github.com/user-attachments/assets/4e5c7416-c109-4278-aad2-da1a1cae71e4) | ![screenshot-mod-ja_JP](https://github.com/user-attachments/assets/80f96738-9ed8-4200-a262-465c675d3c09) |

In my workspace, added a line below to `ja-JP.ini` and tested.
```ini
Basic.Stats.DiskFullIn.Text="%1 時間 %2 分"
```

- Checked the format of the remaining time does not change in US English.
- Checked the text in Japanese does not contain the comma `, `.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
