### PR TITLE
libobs/callback: Catch fail cases with missing error data

### DIFF
--- a/libobs/callback/decl.c
+++ b/libobs/callback/decl.c
@@ -182,7 +182,7 @@ bool parse_decl_string(struct decl_info *decl, const char *decl_string)
 	struct strref ret_type;
 	struct decl_param ret_param = {0};
 	int code;
-	bool success;
+	bool success = false;
 
 	decl->decl_string = decl_string;
 	ret_param.flags = CALL_PARAM_OUT;
@@ -210,9 +210,11 @@ bool parse_decl_string(struct decl_info *decl, const char *decl_string)
 		goto fail;
 
 	parse_params(&cfp, decl);
+	success = true;
 
 fail:
-	success = !error_data_has_errors(&cfp.error_list);
+	if (error_data_has_errors(&cfp.error_list))
+		success = false;
 
 	if (success && ret_param.type != CALL_PARAM_TYPE_VOID) {
 		ret_param.name = bstrdup("return");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

In the API `parse_decl_string`, it jumps to `fail` label if an error occurs. However, the `success` is calculated depending on `cfp.error_list`, which could be empty.

This PR ensures the API will return failure if `goto fail` is called.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->


I found a code below crashed at `proc_handler_call`.
```c
#include <stdio.h>
#include <obs.h>

int main()
{
	proc_handler_t *ph = proc_handler_create();
	proc_handler_add(ph, "", NULL, NULL);
	proc_handler_call(ph, "f", NULL);
	return 0;
}
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 40

Tested above code.

Without this PR, `proc_handler_add` returns success and `proc_handler_call` crashed.

With this PR, `proc_handler_add` returns failure and `proc_handler_call` does not crash.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
