### PR TITLE
media-playback: Fix possible crash if frame width or height is zero

### DIFF
--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -382,6 +382,12 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	enum video_range_type new_range;
 	AVFrame *f = d->frame;
 
+	if (!f->width || !f->height) {
+		blog(LOG_ERROR, "MP: media frame width or height are zero ('%s': %" PRIu32 "x%" PRIu32 ")", m->path,
+		     f->width, f->height);
+		return;
+	}
+
 	if (!preload) {
 		if (!mp_media_can_play_frame(m, d))
 			return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

If a frame has a width or height of zero, this value will make it into libobs/media-io/video-frame.c:video_frame_init and cause linesizes or heights to be zero, which will result in a bmalloc(0) call and OBS will crash.

Instead of letting the call stack get that far, check the frame width and height here at the source, log an error, and return early if the frame width or height are zero.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

https://obsproject.com/logs/3ApOqPpoBR2XcHqO
[2025-03-30 23-01-46-1.txt](https://github.com/user-attachments/files/19556395/2025-03-30.23-01-46-1.txt)

See also:
* https://github.com/obsproject/obs-studio/pull/11861

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally by forcing width or height to zero to see if OBS crashes or not.

I have not been able to spontaneously reproduce this crash otherwise.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
