### PR TITLE
frontend: Re-set list spacing of source and scene tree to 0

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -530,6 +530,7 @@ QListWidget::item,
 QMenu::item {
     border-radius: var(--border_radius);
     color: var(--text);
+    border: 1px solid transparent;
 }
 
 SourceTreeItem {

--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -1033,8 +1033,9 @@
           <property name="defaultDropAction">
            <enum>Qt::TargetMoveAction</enum>
           </property>
+          <!-- Spacing must be 0 due to QTBUG-106395 -->
           <property name="spacing">
-           <number>1</number>
+           <number>0</number>
           </property>
           <addaction name="actionRemoveScene"/>
          </widget>
@@ -1155,8 +1156,9 @@
           <property name="selectionMode">
            <enum>QAbstractItemView::ExtendedSelection</enum>
           </property>
+          <!-- Spacing must be 0 due to QTBUG-106395 -->
           <property name="spacing">
-           <number>1</number>
+           <number>0</number>
           </property>
           <addaction name="actionRemoveSource"/>
          </widget>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This is needed due to [QTBUG-106395](https://bugreports.qt.io/browse/QTBUG-106395). With spacing, drag-and-drop would cause items to go to the bottom of the list if they are dropped in the spacing.

Effectively reverts most of 5fa4ea44d0b364bf9be18816c2d9b35b96bab939 (https://github.com/obsproject/obs-studio/pull/11557). See also #7321 and 860b309db86ac4e096df1d72b9cf8f99d60e8c56 (#7341) which was the first time where the spacing got removed.

The comments in the `.ui` file don't exactly survive a Qt Creator save but neither does a lot of the rest of that file (tested in Qt Creator 16.0.0), so perhaps they'll stay for a while at least. Also they'll be in the git log, so if someone tries to re-add the spacing again in the future maybe they'll see them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Don't want a regression like #7321 again.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Without this PR, the problem still occurs. With the PR, it doesn't.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
