### PR TITLE
rtmp-services: fix bugs blocking WHIP services

### DIFF
--- a/plugins/rtmp-services/data/schema/service-schema-v5.json
+++ b/plugins/rtmp-services/data/schema/service-schema-v5.json
@@ -233,7 +233,7 @@
                     },
                     {
                         "$comment": "Require recommended output field if protocol field is not RTMP(S)",
-                        "if": { "required": ["protocol"], "properties": { "protocol": { "pattern": "^(HLS|SRT|RIST|WHIP)$" } } },
+                        "if": { "required": ["protocol"], "properties": { "protocol": { "pattern": "^(HLS|SRT|RIST)$" } } },
                         "then": { "properties": { "recommended": { "required": ["output"] } } }
                     }
                 ]

--- a/plugins/rtmp-services/rtmp-common.c
+++ b/plugins/rtmp-services/rtmp-common.c
@@ -1137,8 +1137,14 @@ static const char *rtmp_common_get_connect_info(void *data, uint32_t type)
 
 		break;
 	}
-	case OBS_SERVICE_CONNECT_INFO_BEARER_TOKEN:
-		return NULL;
+	case OBS_SERVICE_CONNECT_INFO_BEARER_TOKEN: {
+		const char *protocol = rtmp_common_get_protocol(data);
+
+		if ((strcmp(protocol, "WHIP") == 0))
+			return rtmp_common_key(data);
+
+		break;
+	}
 	}
 
 	return NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Two small changes:

1. This fixes the code for populating Bearer tokens for WHIP services defined in `services.json` — previously there was a segfault when attempting to call `rtmp_common_get_connect_info(data, OBS_SERVICE_CONNECT_INFO_BEARER_TOKEN)`. Shoutout to @Sean-Der to making this possible at all and @ImLunaHey for finding the fix!
2. WHIP services do not have an appropriate value for the `output` field. It wouldn't be correct for them to use a value like `rtmp_output`. I also didn't want to add an incorrect `whip_output` field to a deprecated enum? So I made `output` optional for services with `protocol: WHIP`. Not sure what the right answer is there.

### Motivation and Context
Enabling WHIP services to be added to services.json, such as [Streamplace](https://github.com/obsproject/obs-studio/pull/12032).

### How Has This Been Tested?
Tested by building and streaming using macOS 15.3.1 (in conjunction with https://github.com/obsproject/obs-studio/pull/12032)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
