### PR TITLE
libobs: Use absolute path for install prefix module load

### DIFF
--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -72,11 +72,13 @@ void add_default_module_paths(void)
 
 	if (module_bin_path && module_data_path) {
 		char *abs_module_bin_path = os_get_abs_path_ptr(module_bin_path);
+		char *abs_module_install_path = os_get_abs_path_ptr(OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION);
 
-		if (abs_module_bin_path &&
-		    strcmp(abs_module_bin_path, OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION) != 0) {
+		if (abs_module_bin_path && abs_module_install_path &&
+		    strcmp(abs_module_bin_path, abs_module_install_path) != 0) {
 			obs_add_module_path(module_bin_path, module_data_path);
 		}
+		bfree(abs_module_install_path);
 		bfree(abs_module_bin_path);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This uses an absolute path when evaluating `OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION` when adding it as a module path.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This fixes a bug where, if `OBS_INSTALL_PREFIX "/" OBS_PLUGIN_DESTINATION` contains any non-absolute components, the strcmp with `abs_module_bin_path` to returns false, even if both are the same path, causing both paths to be added, and modules to be loaded twice.
A trailing slash in the `CMAKE_INSTALL_PREFIX` and launching in portable mode is enough to cause this to happen.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Compiled and ran portable with a `CMAKE_INSTALL_PREFIX` with a trailing slash, verified it did not load plugins twice.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
