### PR TITLE
libobs/util: Fix os_process_pipe_create on Linux

### DIFF
--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -124,7 +124,7 @@ os_process_pipe_t *os_process_pipe_create(const char *cmd_line, const char *type
 	if (!cmd_line)
 		return NULL;
 
-	char *argv[3] = {"-c", (char *)cmd_line, NULL};
+	char *argv[4] = {"sh", "-c", (char *)cmd_line, NULL};
 	return os_process_pipe_create_internal("/bin/sh", argv, type);
 }
 


### PR DESCRIPTION
### Description

This fixes a regression on Linux, introduced in commit 9bc3082.

According to the POSIX specification for the exec family of commands,  "The first argument is the filename or pathname of the executable to  be executed". This was done correctly before, but the above commit  removed "sh" from the arguments, breaking the pipe function on Linux.

### Motivation and Context

In OBS 31.0.3 on GNU/Linux, the os_process_pipe_create function fails silently, as the /bin/sh shipped with most Linux distros "eats" the first argument and so no program is launched.

### How Has This Been Tested?

Compiled and used for a day in production. Given that this is essentially a revert of one line back to 30.1.0, you could say it has been tested quite extensively.

OS: Arch Linux    
Used plugins: websocket, NDI, obs-ssp (my fork, this is where I discovered the issue)

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:

- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
