### PR TITLE
frontend: Clip source names when dock too small

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -58,6 +58,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 		QPixmap pixmap = icon.pixmap(QSize(16, 16));
 
 		iconLabel = new QLabel();
+		iconLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 		iconLabel->setPixmap(pixmap);
 		iconLabel->setEnabled(sourceVisible);
 		iconLabel->setStyleSheet("background: none");
@@ -77,8 +78,7 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 	lock->setAccessibleDescription(QTStr("Basic.Main.Sources.LockDescription").arg(name));
 
 	label = new OBSSourceLabel(source);
-	label->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-	label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
+	label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 	label->setAttribute(Qt::WA_TranslucentBackground);
 	label->setEnabled(sourceVisible);
 

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -538,6 +538,11 @@ SourceTreeItem {
     color: var(--text);
 }
 
+SourceTreeItem .checkbox-icon {
+    margin-right: 0;
+    margin-left: var(--spacing_large);
+}
+
 QMenu::item:selected,
 QListView::item:selected,
 QListWidget::item:selected {


### PR DESCRIPTION
### Description
Causes the name of sources in the Sources list to be clipped when the dock is too small.

### Motivation and Context
This restores previous behaviour of the sources list prior to #11555. Prior to that PR, the source names were clipped as a byproduct of us lying to Qt about the size of the item.

Now that we are reporting an actual sizeHint, Qt was creating a horizontal scrollbar with long source names, which put the Visibility and Lock icons offscreen. This PR adjusts the sizePolicy of the widgets to restore the old behaviour properly now.

**31.0.2**
![image](https://github.com/user-attachments/assets/2958517c-e8fb-4595-8d94-34f53812aadf)

**Current Bug**
![image](https://github.com/user-attachments/assets/838dfe9e-a1ee-4775-bcc3-0d96ad8ed4b9) ![image](https://github.com/user-attachments/assets/961c234f-d342-4363-ac3f-a2c4f370281e)


**This PR**
![image](https://github.com/user-attachments/assets/d6cbc5d1-e90d-4748-a44c-1bdbd46ef680)


### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
