### PR TITLE
fix: audio_capture_type compare

### DIFF
--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -183,7 +183,7 @@ API_AVAILABLE(macos(13.0)) static void *sck_audio_capture_create(obs_data_t *set
     sc->audio_capture_type = (unsigned int) obs_data_get_int(settings, "type");
 
     os_sem_init(&sc->shareable_content_available, 1);
-    screen_capture_build_content_list(sc, sc->capture_type == ScreenCaptureAudioDesktopStream);
+    screen_capture_build_content_list(sc, sc->audio_capture_type == ScreenCaptureAudioDesktopStream);
 
     sc->capture_delegate = [[ScreenCaptureDelegate alloc] init];
     sc->capture_delegate.sc = sc;


### PR DESCRIPTION
### Description

The original implementation cannot build on my machine, M4 Pro, macOS 15.4.1 (24E263).

```objective-c
screen_capture_build_content_list(sc, sc->capture_type == ScreenCaptureAudioDesktopStream);
```

The stream type is mismatched.

So I modified the code to 

```objective-c
screen_capture_build_content_list(sc, sc->audio_capture_type == ScreenCaptureAudioDesktopStream);
```

### Motivation and Context

Fixes #12034

### How Has This Been Tested?
simple build bug fix :)

### Types of changes
- Bug fix

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
