### PR TITLE
frontend: Replace add source dropdown with dialog

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -616,15 +616,20 @@ RenameProfile.Title="Rename Profile"
 Basic.Main.MixerRename.Title="Rename Audio Source"
 Basic.Main.MixerRename.Text="Please enter the name of the audio source"
 
-
 # preview window disabled
 Basic.Main.PreviewDisabled="Preview is currently disabled"
 
 # add source dialog
-Basic.SourceSelect="Create/Select Source"
-Basic.SourceSelect.CreateNew="Create new"
-Basic.SourceSelect.AddExisting="Add Existing"
+Basic.SourceSelect="Add Source"
+Basic.SourceSelect.SelectType="Source Type"
+Basic.SourceSelect.Recent="Recently Added"
+Basic.SourceSelect.NewSource="New Source"
+Basic.SourceSelect.Existing="Existing Sources"
+Basic.SourceSelect.CreateButton="Create"
 Basic.SourceSelect.AddVisible="Make source visible"
+Basic.SourceSelect.NoExisting="No existing %1 sources"
+Basic.SourceSelect.Accessible.SourceName="Source Name"
+Basic.SourceSelect.Accessible.Existing="Add an Existing Source"
 
 # source box
 Basic.Main.Sources.Visibility="Visibility"
@@ -760,6 +765,7 @@ Basic.Main.ShowContextBar="Show Source Toolbar"
 Basic.Main.HideContextBar="Hide Source Toolbar"
 Basic.Main.StopVirtualCam="Stop Virtual Camera"
 Basic.Main.Group="Group %1"
+Basic.Main.NewGroup="New Group"
 Basic.Main.GroupItems="Group Selected Items"
 Basic.Main.Ungroup="Ungroup"
 Basic.Main.GridMode="Grid Mode"

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -251,6 +251,11 @@
     background-color: var(--bg_base);
 }
 
+.text-title {
+    font-size: var(--font_large);
+    font-weight: bold;
+}
+
 .text-heading {
     font-size: var(--font_heading);
     font-weight: bold;
@@ -288,6 +293,48 @@
 
 .frame-notice QLabel {
     padding: var(--padding_large) 0px;
+}
+
+.dialog-container {
+    padding: var(--padding_large) var(--padding_xlarge);
+}
+
+.dialog-frame {
+    background-color: var(--grey6);
+    border-radius: var(--border_radius);
+    border: 1px solid var(--border_color);
+    margin: var(--spacing_base);
+}
+
+.dialog-frame > QWidget {
+    margin: var(--spacing_base) 0;
+}
+
+
+.add-item-button {
+    background-color: var(--grey5);
+    border-width: 1px;
+    border-color: var(--grey3);
+    padding: var(--padding_xlarge) var(--padding_wide);
+    border-radius: var(--border_radius_small);
+    outline: none;
+}
+
+.add-item-button:focus {
+    border-color: var(--white1);
+}
+
+.add-item-button:hover {
+    border-color: var(--primary_lighter);
+}
+
+.add-item-button:hover,
+.add-item-button:focus {
+    background: var(--primary);
+    background-image: url(theme:Dark/plus.svg);
+    background-repeat: no-repeat;
+    background-position: center right;
+    background-origin: content;
 }
 
 /* Icon Overrides */
@@ -449,7 +496,6 @@ QListWidget QWidget {
     border: 1px solid var(--bg_base);
 }
 
-
 /* Misc */
 
 QAbstractItemView {
@@ -588,6 +634,7 @@ QListWidget QLineEdit:focus {
 /* Settings QList */
 
 OBSBasicSettings QScrollBar:vertical {
+    background-color: var(--grey6);
     width: var(--settings_scrollbar_size);
     margin-left: 9px;
 }
@@ -2022,4 +2069,42 @@ OBSBasicAdvAudio #scrollAreaWidgetContents {
 #previewZoomInButton:focus,
 #previewZoomOutButton:focus {
     border: 1px solid var(--input_border_hover);
+}
+
+/* Add Source Dialog */
+
+#selectTypeFrame QPushButton,
+#selectSourceContainer QPushButton {
+    text-align: left;
+}
+
+#selectTypeFrame QPushButton {
+    background: var(--grey5);
+    border: 1px solid transparent;
+    padding: var(--padding_xlarge) var(--padding_wide);
+    margin: var(--spacing_large);
+    outline: none;
+}
+
+#selectTypeFrame QPushButton:hover {
+    background-color: var(--grey3);
+    border-color: var(--grey1);
+    border-style: solid;
+}
+
+#selectTypeFrame QPushButton:checked {
+    background-color: var(--purple4);
+    border-color: var(--purple2);
+    border-style: solid;
+}
+
+#selectTypeFrame QPushButton:focus {
+    border-color: var(--white1);
+    border-style: solid;
+}
+
+#selectTypeFrame QPushButton:pressed {
+    background-color: var(--grey6);
+    border-color: var(--grey3);
+    border-style: solid;
 }

--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -17,7 +17,11 @@
 
 #include "OBSBasicSourceSelect.hpp"
 
-#include <qt-wrappers.hpp>
+#include <QMessageBox>
+#include <QList>
+
+#include "qt-wrappers.hpp"
+#include "OBSApp.hpp"
 
 #include "moc_OBSBasicSourceSelect.cpp"
 
@@ -34,80 +38,31 @@ struct AddSourceData {
 	obs_sceneitem_t *scene_item = nullptr;
 };
 
-bool OBSBasicSourceSelect::EnumSources(void *data, obs_source_t *source)
+static inline const char *getSourceDisplayName(const char *id)
 {
-	if (obs_source_is_hidden(source))
-		return true;
-
-	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
-	const char *name = obs_source_get_name(source);
-	const char *id = obs_source_get_unversioned_id(source);
-
-	if (strcmp(id, window->id) == 0)
-		window->ui->sourceList->addItem(QT_UTF8(name));
-
-	return true;
+	if (strcmp(id, "scene") == 0) {
+		return Str("Basic.Scene");
+	}
+	const char *v_id = obs_get_latest_input_type_id(id);
+	return obs_source_get_display_name(v_id);
 }
 
-bool OBSBasicSourceSelect::EnumGroups(void *data, obs_source_t *source)
+char *getNewSourceName(const char *name, const char *format)
 {
-	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
-	const char *name = obs_source_get_name(source);
-	const char *id = obs_source_get_unversioned_id(source);
+	struct dstr new_name = {0};
+	int inc = 0;
 
-	if (strcmp(id, window->id) == 0) {
-		OBSBasic *main = OBSBasic::Get();
-		OBSScene scene = main->GetCurrentScene();
+	dstr_copy(&new_name, name);
 
-		obs_sceneitem_t *existing = obs_scene_get_group(scene, name);
-		if (!existing)
-			window->ui->sourceList->addItem(QT_UTF8(name));
+	for (;;) {
+		OBSSourceAutoRelease existing_source = obs_get_source_by_name(new_name.array);
+		if (!existing_source)
+			break;
+
+		dstr_printf(&new_name, format, name, ++inc + 1);
 	}
 
-	return true;
-}
-
-void OBSBasicSourceSelect::OBSSourceAdded(void *data, calldata_t *calldata)
-{
-	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
-	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
-
-	QMetaObject::invokeMethod(window, "SourceAdded", Q_ARG(OBSSource, source));
-}
-
-void OBSBasicSourceSelect::OBSSourceRemoved(void *data, calldata_t *calldata)
-{
-	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
-	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
-
-	QMetaObject::invokeMethod(window, "SourceRemoved", Q_ARG(OBSSource, source));
-}
-
-void OBSBasicSourceSelect::SourceAdded(OBSSource source)
-{
-	const char *name = obs_source_get_name(source);
-	const char *sourceId = obs_source_get_unversioned_id(source);
-
-	if (strcmp(sourceId, id) != 0)
-		return;
-
-	ui->sourceList->addItem(name);
-}
-
-void OBSBasicSourceSelect::SourceRemoved(OBSSource source)
-{
-	const char *name = obs_source_get_name(source);
-	const char *sourceId = obs_source_get_unversioned_id(source);
-
-	if (strcmp(sourceId, id) != 0)
-		return;
-
-	QList<QListWidgetItem *> items = ui->sourceList->findItems(name, Qt::MatchFixedString);
-
-	if (!items.count())
-		return;
-
-	delete items[0];
+	return new_name.array;
 }
 
 static void AddSource(void *_data, obs_scene_t *scene)
@@ -131,24 +86,6 @@ static void AddSource(void *_data, obs_scene_t *scene)
 	data->scene_item = sceneitem;
 }
 
-char *get_new_source_name(const char *name, const char *format)
-{
-	struct dstr new_name = {0};
-	int inc = 0;
-
-	dstr_copy(&new_name, name);
-
-	for (;;) {
-		OBSSourceAutoRelease existing_source = obs_get_source_by_name(new_name.array);
-		if (!existing_source)
-			break;
-
-		dstr_printf(&new_name, format, name, ++inc + 1);
-	}
-
-	return new_name.array;
-}
-
 static void AddExisting(OBSSource source, bool visible, bool duplicate, obs_transform_info *transform,
 			obs_sceneitem_crop *crop, obs_blending_method *blend_method, obs_blending_type *blend_mode)
 {
@@ -159,7 +96,7 @@ static void AddExisting(OBSSource source, bool visible, bool duplicate, obs_tran
 
 	if (duplicate) {
 		OBSSource from = source;
-		char *new_name = get_new_source_name(obs_source_get_name(source), "%s %d");
+		char *new_name = getNewSourceName(obs_source_get_name(source), "%s %d");
 		source = obs_source_duplicate(from, new_name, false);
 		obs_source_release(source);
 		bfree(new_name);
@@ -232,18 +169,299 @@ bool AddNew(QWidget *parent, const char *id, const char *name, const bool visibl
 	return success;
 }
 
-void OBSBasicSourceSelect::on_buttonBox_accepted()
+OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, undo_stack &undo_s)
+	: QDialog(parent),
+	  ui(new Ui::OBSBasicSourceSelect),
+	  undo_s(undo_s)
 {
-	bool useExisting = ui->selectExisting->isChecked();
+	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+	ui->setupUi(this);
+
+	/* The scroll viewport is not accessible via Designer, so we have to disable autoFillBackground here.
+	 * 
+	 * Additionally when Qt calls setWidget on a scrollArea to set the contents widget, it force sets
+	 * autoFillBackground to true overriding whatever is set in Designer so we have to do that here too.
+	 */
+	ui->sourceTypeScrollArea->viewport()->setAutoFillBackground(false);
+	ui->scrollAreaWidgetContents->setAutoFillBackground(false);
+
+	ui->recentScrollArea->viewport()->setAutoFillBackground(false);
+	ui->recentScrollContents->setAutoFillBackground(false);
+
+	ui->existingScrollArea->viewport()->setAutoFillBackground(false);
+	ui->existingScrollContents->setAutoFillBackground(false);
+
+	ui->selectRecentFrame->setVisible(true);
+	ui->selectExistingFrame->setVisible(false);
+	ui->createNewFrame->setVisible(false);
+
+	getSourceTypes();
+	getSources();
+	updateRecentSources();
+
+	connect(ui->lineEdit, &QLineEdit::returnPressed, this, &OBSBasicSourceSelect::createNewSource);
+	connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+	App()->DisableHotkeys();
+}
+
+OBSBasicSourceSelect::~OBSBasicSourceSelect()
+{
+	App()->UpdateHotkeyFocusSetting();
+}
+
+void OBSBasicSourceSelect::getSources()
+{
+	sources.clear();
+
+	obs_enum_sources(enumSourcesCallback, this);
+	emit sourcesUpdated();
+}
+
+void OBSBasicSourceSelect::updateRecentSources()
+{
+	int count = 0;
+	for (const obs_source_t *source : sources) {
+		if (count >= 6) {
+			return;
+		}
+
+		const char *name = obs_source_get_name(source);
+
+		QPushButton *button = new QPushButton(name);
+		button->setProperty("class", "add-item-button");
+		connect(button, &QPushButton::clicked, this, &OBSBasicSourceSelect::addExistingSource);
+		ui->recentListLayout->insertWidget(0, button);
+
+		count++;
+	}
+}
+
+void OBSBasicSourceSelect::updateExistingSources()
+{
+	for (const obs_source_t *source : sources) {
+		const char *id = obs_source_get_unversioned_id(source);
+
+		if (strcmp(id, sourceTypeId.c_str()) == 0) {
+			const char *name = obs_source_get_name(source);
+
+			QPushButton *button = new QPushButton(name);
+			button->setProperty("class", "add-item-button");
+			connect(button, &QPushButton::clicked, this, &OBSBasicSourceSelect::addExistingSource);
+			ui->existingListLayout->insertWidget(0, button);
+		}
+	}
+}
+
+bool OBSBasicSourceSelect::enumSourcesCallback(void *data, obs_source_t *source)
+{
+	if (obs_source_is_hidden(source))
+		return true;
+
+	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
+
+	const char *name = obs_source_get_name(source);
+	const char *id = obs_source_get_unversioned_id(source);
+
+	if (strcmp(id, window->sourceTypeId.c_str()) == 0) {
+		/*QPushButton *button = new QPushButton(name);
+		connect(button, &QPushButton::clicked, window, &OBSBasicSourceSelect::addExistingSource);
+		window->ui->existingListLayout->insertWidget(0, button);*/
+	}
+
+	window->sources.push_back(source);
+
+	return true;
+}
+
+bool OBSBasicSourceSelect::enumGroupsCallback(void *data, obs_source_t *source)
+{
+	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
+	const char *name = obs_source_get_name(source);
+	const char *id = obs_source_get_unversioned_id(source);
+
+	if (strcmp(id, window->sourceTypeId.c_str()) == 0) {
+		OBSBasic *main = OBSBasic::Get();
+		OBSScene scene = main->GetCurrentScene();
+
+		obs_sceneitem_t *existing = obs_scene_get_group(scene, name);
+		if (!existing) {
+			QPushButton *button = new QPushButton(name);
+			connect(button, &QPushButton::clicked, window, &OBSBasicSourceSelect::addExistingSource);
+			window->ui->existingListFrame->layout()->addWidget(button);
+		}
+	}
+
+	return true;
+}
+
+void OBSBasicSourceSelect::OBSSourceAdded(void *data, calldata_t *calldata)
+{
+	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
+	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
+
+	QMetaObject::invokeMethod(window, "SourceAdded", Q_ARG(OBSSource, source));
+}
+
+int OBSBasicSourceSelect::getSortedButtonPosition(const QList<QPushButton *> *list, const char *name)
+{
+	QString qname = QT_UTF8(name);
+
+	const int total = list->size();
+	for (int i = 0; i < total; ++i) {
+		QPushButton *btn = list->at(i);
+		if (btn && btn->text().compare(name) >= 0)
+			return i;
+	}
+	return total;
+}
+
+QPointer<QPushButton> OBSBasicSourceSelect::createTypeButton(const char *type, const char *name)
+{
+	OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+
+	QString qname = QT_UTF8(name);
+	QPushButton *sourceBtn = new QPushButton(qname, this);
+	sourceBtn->setCheckable(true);
+	sourceBtn->setProperty("obs_type", QT_UTF8(type));
+
+	QIcon icon;
+	if (strcmp(type, "scene") == 0)
+		icon = main->GetSceneIcon();
+	else
+		icon = main->GetSourceIcon(type);
+
+	sourceBtn->setIcon(icon);
+
+	return sourceBtn;
+}
+
+void OBSBasicSourceSelect::getSourceTypes()
+{
+	const char *unversioned_type;
+	const char *type;
+
+	size_t idx = 0;
+
+	sourceButtons = new QButtonGroup(this);
+	QList<QPushButton *> *list = new QList<QPushButton *>();
+
+	while (obs_enum_input_types2(idx++, &type, &unversioned_type)) {
+		const char *name = obs_source_get_display_name(type);
+		uint32_t caps = obs_get_source_output_flags(type);
+
+		if ((caps & OBS_SOURCE_CAP_DISABLED) != 0)
+			continue;
+
+		QPushButton *typeBtn = createTypeButton(unversioned_type, name);
+		int after = getSortedButtonPosition(list, name);
+		list->insert(after, typeBtn);
+		sourceButtons->addButton(typeBtn);
+	}
+
+	QPushButton *typeBtn = createTypeButton("scene", Str("Basic.Scene"));
+	int after = getSortedButtonPosition(list, Str("Basic.Scene"));
+	list->insert(after, typeBtn);
+	sourceButtons->addButton(typeBtn);
+
+	QLayout *layout = ui->typeButtonsGrid->layout();
+	QGridLayout *grid = (QGridLayout *)layout;
+	int row = 1;
+	int column = 0;
+	for (int i = 0; i < list->size(); ++i) {
+		if (column == 2) {
+			row += 1;
+			column = 0;
+		}
+		QPushButton *btn = list->at(i);
+
+		grid->addWidget(btn, row, column);
+		column += 1;
+
+		if (i == 0) {
+			setTabOrder(ui->sourceTypeScrollArea, btn);
+		}
+	}
+
+	ui->sourceTypeScrollArea->setFocus();
+
+	row += 1;
+	QSpacerItem *spacer = new QSpacerItem(10, 20, QSizePolicy::Fixed, QSizePolicy::Expanding);
+	//layout->addItem(spacer);
+	grid->addItem(spacer, row, 1, 1, Qt::AlignHCenter);
+	connect(sourceButtons, &QButtonGroup::buttonClicked, this, &OBSBasicSourceSelect::sourceTypeClicked);
+}
+
+void OBSBasicSourceSelect::OBSSourceRemoved(void *data, calldata_t *calldata)
+{
+	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
+	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
+
+	QMetaObject::invokeMethod(window, "SourceRemoved", Q_ARG(OBSSource, source));
+}
+
+void OBSBasicSourceSelect::createNewSource()
+{
 	bool visible = ui->sourceVisible->isChecked();
 
-	if (useExisting) {
-		QListWidgetItem *item = ui->sourceList->currentItem();
-		if (!item)
-			return;
+	if (ui->lineEdit->text().isEmpty())
+		return;
 
-		QString source_name = item->text();
-		AddExisting(QT_TO_UTF8(source_name), visible, false, nullptr, nullptr, nullptr, nullptr);
+	OBSSceneItem item;
+	if (!AddNew(this, sourceTypeId.c_str(), QT_TO_UTF8(ui->lineEdit->text()), visible, newSource, item))
+		return;
+
+	if (newSource && strcmp(obs_source_get_id(newSource.Get()), "group") != 0) {
+		OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
+		std::string scene_name = obs_source_get_name(main->GetCurrentSceneSource());
+		auto undo = [scene_name, main](const std::string &data) {
+			OBSSourceAutoRelease source = obs_get_source_by_name(data.c_str());
+			obs_source_remove(source);
+
+			OBSSourceAutoRelease scene_source = obs_get_source_by_name(scene_name.c_str());
+			main->SetCurrentScene(scene_source.Get(), true);
+		};
+		OBSDataAutoRelease wrapper = obs_data_create();
+		obs_data_set_string(wrapper, "id", sourceTypeId.c_str());
+		obs_data_set_int(wrapper, "item_id", obs_sceneitem_get_id(item));
+		obs_data_set_string(wrapper, "name", ui->lineEdit->text().toUtf8().constData());
+		obs_data_set_bool(wrapper, "visible", visible);
+
+		auto redo = [scene_name, main](const std::string &data) {
+			OBSSourceAutoRelease scene_source = obs_get_source_by_name(scene_name.c_str());
+			main->SetCurrentScene(scene_source.Get(), true);
+
+			OBSDataAutoRelease dat = obs_data_create_from_json(data.c_str());
+			OBSSource source;
+			OBSSceneItem item;
+			AddNew(NULL, obs_data_get_string(dat, "id"), obs_data_get_string(dat, "name"),
+			       obs_data_get_bool(dat, "visible"), source, item);
+			obs_sceneitem_set_id(item, (int64_t)obs_data_get_int(dat, "item_id"));
+		};
+		undo_s.add_action(QTStr("Undo.Add").arg(ui->lineEdit->text()), undo, redo,
+				  std::string(obs_source_get_name(newSource)), std::string(obs_data_get_json(wrapper)));
+
+		main->CreatePropertiesWindow(newSource);
+	}
+	close();
+}
+
+void OBSBasicSourceSelect::on_createNewSource_clicked(bool checked)
+{
+	createNewSource();
+	UNUSED_PARAMETER(checked);
+}
+
+void OBSBasicSourceSelect::addExistingSource(bool checked)
+{
+	QPushButton *btn = (QPushButton *)sender();
+	bool visible = ui->sourceVisible->isChecked();
+
+	QString source_name = btn->text();
+	OBSSourceAutoRelease source = obs_get_source_by_name(source_name.toStdString().c_str());
+	if (source) {
+		AddExisting(source.Get(), visible, false, nullptr, nullptr, nullptr, nullptr);
 
 		OBSBasic *main = OBSBasic::Get();
 		const char *scene_name = obs_source_get_name(main->GetCurrentSceneSource());
@@ -274,77 +492,20 @@ void OBSBasicSourceSelect::on_buttonBox_accepted()
 		};
 
 		undo_s.add_action(QTStr("Undo.Add").arg(source_name), undo, redo, "", "");
-	} else {
-		if (ui->sourceName->text().isEmpty()) {
-			OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
-			return;
-		}
-
-		OBSSceneItem item;
-		if (!AddNew(this, id, QT_TO_UTF8(ui->sourceName->text()), visible, newSource, item))
-			return;
-
-		OBSBasic *main = OBSBasic::Get();
-		std::string scene_name = obs_source_get_name(main->GetCurrentSceneSource());
-		auto undo = [scene_name, main](const std::string &data) {
-			OBSSourceAutoRelease source = obs_get_source_by_name(data.c_str());
-			obs_source_remove(source);
-
-			OBSSourceAutoRelease scene_source = obs_get_source_by_name(scene_name.c_str());
-			main->SetCurrentScene(scene_source.Get(), true);
-		};
-		OBSDataAutoRelease wrapper = obs_data_create();
-		obs_data_set_string(wrapper, "id", id);
-		obs_data_set_int(wrapper, "item_id", obs_sceneitem_get_id(item));
-		obs_data_set_string(wrapper, "name", ui->sourceName->text().toUtf8().constData());
-		obs_data_set_bool(wrapper, "visible", visible);
-
-		auto redo = [scene_name, main](const std::string &data) {
-			OBSSourceAutoRelease scene_source = obs_get_source_by_name(scene_name.c_str());
-			main->SetCurrentScene(scene_source.Get(), true);
-
-			OBSDataAutoRelease dat = obs_data_create_from_json(data.c_str());
-			OBSSource source;
-			OBSSceneItem item;
-			AddNew(NULL, obs_data_get_string(dat, "id"), obs_data_get_string(dat, "name"),
-			       obs_data_get_bool(dat, "visible"), source, item);
-			obs_sceneitem_set_id(item, (int64_t)obs_data_get_int(dat, "item_id"));
-		};
-		undo_s.add_action(QTStr("Undo.Add").arg(ui->sourceName->text()), undo, redo,
-				  std::string(obs_source_get_name(newSource)), std::string(obs_data_get_json(wrapper)));
 	}
-
-	done(DialogCode::Accepted);
+	close();
+	UNUSED_PARAMETER(checked);
 }
 
-void OBSBasicSourceSelect::on_buttonBox_rejected()
+void OBSBasicSourceSelect::sourceTypeClicked(QAbstractButton *button)
 {
-	done(DialogCode::Rejected);
-}
+	QString type = button->property("obs_type").toString();
+	if (type.toStdString().compare(sourceTypeId) == 0)
+		return;
 
-static inline const char *GetSourceDisplayName(const char *id)
-{
-	if (strcmp(id, "scene") == 0)
-		return Str("Basic.Scene");
-	else if (strcmp(id, "group") == 0)
-		return Str("Group");
-	const char *v_id = obs_get_latest_input_type_id(id);
-	return obs_source_get_display_name(v_id);
-}
+	sourceTypeId = type.toUtf8();
 
-OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_, undo_stack &undo_s)
-	: QDialog(parent),
-	  ui(new Ui::OBSBasicSourceSelect),
-	  id(id_),
-	  undo_s(undo_s)
-{
-	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-
-	ui->setupUi(this);
-
-	ui->sourceList->setAttribute(Qt::WA_MacShowFocusRect, false);
-
-	QString placeHolderText{QT_UTF8(GetSourceDisplayName(id))};
+	QString placeHolderText{QT_UTF8(getSourceDisplayName(sourceTypeId.c_str()))};
 
 	QString text{placeHolderText};
 	int i = 2;
@@ -353,38 +514,26 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_, un
 		text = QString("%1 %2").arg(placeHolderText).arg(i++);
 	}
 
-	ui->sourceName->setText(text);
-	ui->sourceName->setFocus(); //Fixes deselect of text.
-	ui->sourceName->selectAll();
+	ui->lineEdit->setText(text);
+	ui->lineEdit->setFocus(); //Fixes deselect of text.
+	ui->lineEdit->selectAll();
 
-	installEventFilter(CreateShortcutFilter());
+	QLayout *layout = ui->existingListFrame->layout();
 
-	connect(ui->createNew, &QRadioButton::pressed, [&]() {
-		QPushButton *button = ui->buttonBox->button(QDialogButtonBox::Ok);
-		if (!button->isEnabled())
-			button->setEnabled(true);
-	});
-	connect(ui->selectExisting, &QRadioButton::pressed, [&]() {
-		QPushButton *button = ui->buttonBox->button(QDialogButtonBox::Ok);
-		bool enabled = ui->sourceList->selectedItems().size() != 0;
-		if (button->isEnabled() != enabled)
-			button->setEnabled(enabled);
-	});
-	connect(ui->sourceList, &QListWidget::itemSelectionChanged, [&]() {
-		QPushButton *button = ui->buttonBox->button(QDialogButtonBox::Ok);
-		if (!button->isEnabled())
-			button->setEnabled(true);
-	});
+	// Clear existing buttons when switching types
+	QLayoutItem *child = nullptr;
+	while ((child = layout->takeAt(0)) != nullptr) {
+		delete child->widget();
+		delete child;
+	}
 
-	if (strcmp(id_, "scene") == 0) {
-		OBSBasic *main = OBSBasic::Get();
+	ui->selectRecentFrame->setVisible(false);
+	ui->selectExistingFrame->setVisible(true);
+	ui->createNewFrame->setVisible(true);
+
+	if (strcmp(sourceTypeId.c_str(), "scene") == 0) {
+		OBSBasic *main = reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 		OBSSource curSceneSource = main->GetCurrentSceneSource();
-
-		ui->selectExisting->setChecked(true);
-		ui->createNew->setChecked(false);
-		ui->createNew->setEnabled(false);
-		ui->sourceName->setEnabled(false);
-		ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
 		int count = main->ui->scenes->count();
 		for (int i = 0; i < count; i++) {
@@ -396,12 +545,27 @@ OBSBasicSourceSelect::OBSBasicSourceSelect(OBSBasic *parent, const char *id_, un
 				continue;
 
 			const char *name = obs_source_get_name(sceneSource);
-			ui->sourceList->addItem(QT_UTF8(name));
+			QPushButton *button = new QPushButton(name);
+			button->setProperty("class", "add-item-button");
+			button->setAccessibleDescription(QTStr("Basic.SourceSelect.Accessible.Existing"));
+			connect(button, &QPushButton::clicked, this, &OBSBasicSourceSelect::addExistingSource);
+			layout->addWidget(button);
+
+			if (i == 0) {
+				setTabOrder(ui->existingScrollArea, button);
+			}
 		}
-	} else if (strcmp(id_, "group") == 0) {
-		obs_enum_sources(EnumGroups, this);
+	} else if (strcmp(sourceTypeId.c_str(), "group") == 0) {
+		obs_enum_sources(enumGroupsCallback, this);
 	} else {
-		obs_enum_sources(EnumSources, this);
+		updateExistingSources();
+	}
+
+	if (layout->count() == 0) {
+		QLabel *noExisting = new QLabel();
+		noExisting->setText(QTStr("Basic.SourceSelect.NoExisting").arg(getSourceDisplayName(sourceTypeId.c_str())));
+		noExisting->setProperty("class", "text-muted");
+		layout->addWidget(noExisting);
 	}
 }
 

--- a/frontend/dialogs/OBSBasicSourceSelect.hpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.hpp
@@ -19,10 +19,11 @@
 
 #include "ui_OBSBasicSourceSelect.h"
 
+#include <QButtonGroup>
 #include <utility/undo_stack.hpp>
 #include <widgets/OBSBasic.hpp>
 
-#include <obs.hpp>
+#include "OBSApp.hpp"
 
 #include <QDialog>
 
@@ -31,24 +32,44 @@ class OBSBasicSourceSelect : public QDialog {
 
 private:
 	std::unique_ptr<Ui::OBSBasicSourceSelect> ui;
-	const char *id;
+	std::string sourceTypeId;
 	undo_stack &undo_s;
 
-	static bool EnumSources(void *data, obs_source_t *source);
-	static bool EnumGroups(void *data, obs_source_t *source);
+	QPointer<QButtonGroup> sourceButtons;
+
+	std::vector<obs_source_t *> sources;
+	std::vector<obs_source_t *> groups;
+
+	void getSources();
+	void updateRecentSources();
+	void updateExistingSources();
+
+	static bool enumSourcesCallback(void *data, obs_source_t *source);
+	static bool enumGroupsCallback(void *data, obs_source_t *source);
 
 	static void OBSSourceRemoved(void *data, calldata_t *calldata);
 	static void OBSSourceAdded(void *data, calldata_t *calldata);
 
-private slots:
-	void on_buttonBox_accepted();
-	void on_buttonBox_rejected();
+	static int getSortedButtonPosition(const QList<QPushButton *> *list, const char *name);
+	QPointer<QPushButton> createTypeButton(const char *type, const char *name);
+	void getSourceTypes();
 
-	void SourceAdded(OBSSource source);
-	void SourceRemoved(OBSSource source);
+	void createNewSource();
+
+signals:
+	void sourcesUpdated();
+
+private slots:
+	void on_createNewSource_clicked(bool checked);
+	void addExistingSource(bool checked);
+
+	// void SourceAdded(OBSSource source);
+	// void SourceRemoved(OBSSource source);
+	void sourceTypeClicked(QAbstractButton *button);
 
 public:
-	OBSBasicSourceSelect(OBSBasic *parent, const char *id, undo_stack &undo_s);
+	OBSBasicSourceSelect(OBSBasic *parent, undo_stack &undo_s);
+	~OBSBasicSourceSelect();
 
 	OBSSource newSource;
 

--- a/frontend/forms/OBSBasicSourceSelect.ui
+++ b/frontend/forms/OBSBasicSourceSelect.ui
@@ -3,106 +3,761 @@
  <class>OBSBasicSourceSelect</class>
  <widget class="QDialog" name="OBSBasicSourceSelect">
   <property name="windowModality">
-   <enum>Qt::WindowModal</enum>
+   <enum>Qt::WindowModality::NonModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>352</width>
-    <height>314</height>
+    <width>920</width>
+    <height>500</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>920</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>1000</width>
+    <height>900</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Basic.SourceSelect</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <property name="class" stdset="0">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_7">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QRadioButton" name="createNew">
-       <property name="text">
-        <string>Basic.SourceSelect.CreateNew</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="sourceName"/>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="selectExisting">
-       <property name="text">
-        <string>Basic.SourceSelect.AddExisting</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="sourceList">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sortingEnabled">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="sourceVisible">
-       <property name="text">
-        <string>Basic.SourceSelect.AddVisible</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <widget class="QFrame" name="dialogInner">
+     <property name="frameShape">
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
+     <property name="frameShadow">
+      <enum>QFrame::Shadow::Plain</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="class" stdset="0">
+      <string>dialog-container</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_5">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QFrame" name="frame">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="class" stdset="0">
+         <string/>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout" stretch="5,3">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QFrame" name="selectTypeFrame">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="accessibleName">
+            <string>Basic.SourceSelect.SelectType</string>
+           </property>
+           <property name="class" stdset="0">
+            <string>dialog-container dialog-frame</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Basic.SourceSelect.SelectType</string>
+              </property>
+              <property name="class" stdset="0">
+               <string>text-title</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QScrollArea" name="sourceTypeScrollArea">
+              <property name="focusPolicy">
+               <enum>Qt::FocusPolicy::ClickFocus</enum>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::Shape::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Shadow::Plain</enum>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="verticalScrollBarPolicy">
+               <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
+              </property>
+              <property name="horizontalScrollBarPolicy">
+               <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
+              </property>
+              <property name="sizeAdjustPolicy">
+               <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustIgnored</enum>
+              </property>
+              <property name="widgetResizable">
+               <bool>true</bool>
+              </property>
+              <widget class="QWidget" name="scrollAreaWidgetContents">
+               <property name="geometry">
+                <rect>
+                 <x>0</x>
+                 <y>0</y>
+                 <width>575</width>
+                 <height>456</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_8">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QFrame" name="typeButtonsGrid">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="lineWidth">
+                   <number>0</number>
+                  </property>
+                  <layout class="QGridLayout" name="gridLayout">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <item row="0" column="0">
+                    <spacer name="horizontalSpacer_4">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>4</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item row="0" column="1">
+                    <spacer name="horizontalSpacer_3">
+                     <property name="orientation">
+                      <enum>Qt::Orientation::Horizontal</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>40</width>
+                       <height>2</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Policy::Minimum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>17</width>
+                <height>4</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QFrame" name="selectSourceContainer">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Shape::NoFrame</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Shadow::Plain</enum>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="class" stdset="0">
+            <string/>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QFrame" name="selectRecentFrame">
+              <property name="accessibleName">
+               <string>Basic.SourceSelect.AddExisting</string>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Shadow::Plain</enum>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="class" stdset="0">
+               <string>dialog-container dialog-frame</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_9">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="recentLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Basic.SourceSelect.Recent</string>
+                 </property>
+                 <property name="class" stdset="0">
+                  <string>text-title</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QScrollArea" name="recentScrollArea">
+                 <property name="focusPolicy">
+                  <enum>Qt::FocusPolicy::NoFocus</enum>
+                 </property>
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Shadow::Plain</enum>
+                 </property>
+                 <property name="lineWidth">
+                  <number>0</number>
+                 </property>
+                 <property name="widgetResizable">
+                  <bool>true</bool>
+                 </property>
+                 <widget class="QWidget" name="recentScrollContents">
+                  <property name="geometry">
+                   <rect>
+                    <x>0</x>
+                    <y>0</y>
+                    <width>345</width>
+                    <height>191</height>
+                   </rect>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_10">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item alignment="Qt::AlignmentFlag::AlignTop">
+                    <widget class="QFrame" name="recentListFrame">
+                     <property name="minimumSize">
+                      <size>
+                       <width>200</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="frameShape">
+                      <enum>QFrame::Shape::NoFrame</enum>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Shadow::Plain</enum>
+                     </property>
+                     <property name="lineWidth">
+                      <number>0</number>
+                     </property>
+                     <layout class="QVBoxLayout" name="recentListLayout">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="selectExistingFrame">
+              <property name="accessibleName">
+               <string>Basic.SourceSelect.AddExisting</string>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Shadow::Plain</enum>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="class" stdset="0">
+               <string>dialog-container dialog-frame</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="existingLabel">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Basic.SourceSelect.Existing</string>
+                 </property>
+                 <property name="class" stdset="0">
+                  <string>text-title</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QScrollArea" name="existingScrollArea">
+                 <property name="focusPolicy">
+                  <enum>Qt::FocusPolicy::NoFocus</enum>
+                 </property>
+                 <property name="frameShape">
+                  <enum>QFrame::Shape::NoFrame</enum>
+                 </property>
+                 <property name="frameShadow">
+                  <enum>QFrame::Shadow::Plain</enum>
+                 </property>
+                 <property name="lineWidth">
+                  <number>0</number>
+                 </property>
+                 <property name="widgetResizable">
+                  <bool>true</bool>
+                 </property>
+                 <widget class="QWidget" name="existingScrollContents">
+                  <property name="geometry">
+                   <rect>
+                    <x>0</x>
+                    <y>0</y>
+                    <width>345</width>
+                    <height>191</height>
+                   </rect>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_4">
+                   <property name="spacing">
+                    <number>0</number>
+                   </property>
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
+                    <number>0</number>
+                   </property>
+                   <item alignment="Qt::AlignmentFlag::AlignTop">
+                    <widget class="QFrame" name="existingListFrame">
+                     <property name="minimumSize">
+                      <size>
+                       <width>200</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                     <property name="frameShape">
+                      <enum>QFrame::Shape::NoFrame</enum>
+                     </property>
+                     <property name="frameShadow">
+                      <enum>QFrame::Shadow::Plain</enum>
+                     </property>
+                     <property name="lineWidth">
+                      <number>0</number>
+                     </property>
+                     <layout class="QVBoxLayout" name="existingListLayout">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                     </layout>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QFrame" name="createNewFrame">
+              <property name="frameShape">
+               <enum>QFrame::Shape::NoFrame</enum>
+              </property>
+              <property name="frameShadow">
+               <enum>QFrame::Shadow::Plain</enum>
+              </property>
+              <property name="lineWidth">
+               <number>0</number>
+              </property>
+              <property name="class" stdset="0">
+               <string>dialog-container dialog-frame</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_3">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="label">
+                 <property name="text">
+                  <string>Basic.SourceSelect.NewSource</string>
+                 </property>
+                 <property name="class" stdset="0">
+                  <string>text-title</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lineEdit">
+                 <property name="accessibleName">
+                  <string>Basic.SourceSelect.Accessible.SourceName</string>
+                 </property>
+                </widget>
+               </item>
+               <item alignment="Qt::AlignmentFlag::AlignRight">
+                <widget class="QPushButton" name="createNewSource">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Basic.SourceSelect.CreateButton</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>100</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QFrame" name="frame_2">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
+        </property>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Plain</enum>
+        </property>
+        <property name="lineWidth">
+         <number>0</number>
+        </property>
+        <property name="class" stdset="0">
+         <string>dialog-container</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="sourceVisible">
+           <property name="text">
+            <string>Basic.SourceSelect.AddVisible</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QDialogButtonBox" name="buttonBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="standardButtons">
+            <set>QDialogButtonBox::StandardButton::Cancel</set>
+           </property>
+           <property name="centerButtons">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
- <connections>
-  <connection>
-   <sender>createNew</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>sourceName</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>79</x>
-     <y>29</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>108</x>
-     <y>53</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>selectExisting</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>sourceList</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>51</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>65</x>
-     <y>128</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <tabstops>
+  <tabstop>sourceTypeScrollArea</tabstop>
+  <tabstop>existingScrollArea</tabstop>
+  <tabstop>lineEdit</tabstop>
+  <tabstop>createNewSource</tabstop>
+  <tabstop>sourceVisible</tabstop>
+ </tabstops>
+ <resources>
+  <include location="obs.qrc"/>
+ </resources>
+ <connections/>
 </ui>

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -562,6 +562,7 @@ private:
 	QPointer<OBSBasicAdvAudio> advAudioWindow;
 	QPointer<OBSBasicFilters> filters;
 	QPointer<OBSAbout> about;
+	QPointer<OBSBasicSourceSelect> addWindow;
 	QPointer<OBSLogViewer> logView;
 	QPointer<QWidget> stats;
 	QPointer<QWidget> remux;
@@ -1143,11 +1144,8 @@ private:
 	static void SourceAudioDeactivated(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
 
-	void AddSource(const char *id);
-	QMenu *CreateAddSourcePopupMenu();
-	void AddSourcePopupMenu(const QPoint &pos);
-
 private slots:
+	void AddSourceDialog();
 	void RenameSources(OBSSource source, QString newName, QString prevName);
 
 	void ActivateAudioSource(OBSSource source);

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -330,7 +330,7 @@ void OBSBasic::SourceRenamed(void *data, calldata_t *params)
 	blog(LOG_INFO, "Source '%s' renamed to '%s'", prevName, newName);
 }
 
-extern char *get_new_source_name(const char *name, const char *format);
+extern char *getNewSourceName(const char *name, const char *format);
 
 void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId, const char *deviceDesc, int channel)
 {
@@ -352,7 +352,7 @@ void OBSBasic::ResetAudioDevice(const char *sourceId, const char *deviceId, cons
 		}
 
 	} else if (!disable) {
-		BPtr<char> name = get_new_source_name(deviceDesc, "%s (%d)");
+		BPtr<char> name = getNewSourceName(deviceDesc, "%s (%d)");
 
 		settings = obs_data_create();
 		obs_data_set_string(settings, "device_id", deviceId);
@@ -592,10 +592,14 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 	}
 
 	// Add new source
-	QPointer<QMenu> addSourceMenu = CreateAddSourcePopupMenu();
-	if (addSourceMenu) {
-		popup.addMenu(addSourceMenu);
-		popup.addSeparator();
+	QAction *addSource = popup.addAction(QTStr("AddSource"), this, SLOT(AddSourceDialog()));
+	popup.addAction(addSource);
+	popup.addSeparator();
+
+	if (!preview && !sourceSelected) {
+		QAction *addGroup = new QAction(QTStr("Basic.Main.NewGroup"), this);
+		connect(addGroup, &QAction::triggered, ui->sources, &SourceTree::AddGroup);
+		popup.addAction(addGroup);
 	}
 
 	// Preview menu entries
@@ -704,14 +708,12 @@ void OBSBasic::CreateSourcePopupMenu(int idx, bool preview)
 
 		// Source grouping
 		if (ui->sources->MultipleBaseSelected()) {
-			popup.addSeparator();
 			popup.addAction(QTStr("Basic.Main.GroupItems"), ui->sources, &SourceTree::GroupSelectedItems);
-
-		} else if (ui->sources->GroupsSelected()) {
 			popup.addSeparator();
+		} else if (ui->sources->GroupsSelected()) {
 			popup.addAction(QTStr("Basic.Main.Ungroup"), ui->sources, &SourceTree::UngroupSelectedGroups);
+			popup.addSeparator();
 		}
-		popup.addSeparator();
 
 		popup.addAction(ui->actionCopySource);
 		popup.addAction(ui->actionPasteRef);
@@ -767,115 +769,24 @@ static inline bool should_show_properties(obs_source_t *source, const char *id)
 	return true;
 }
 
-void OBSBasic::AddSource(const char *id)
+void OBSBasic::AddSourceDialog()
 {
-	if (id && *id) {
-		OBSBasicSourceSelect sourceSelect(this, id, undo_s);
-		sourceSelect.exec();
-		if (should_show_properties(sourceSelect.newSource, id)) {
-			CreatePropertiesWindow(sourceSelect.newSource);
-		}
-	}
-}
-
-QMenu *OBSBasic::CreateAddSourcePopupMenu()
-{
-	const char *unversioned_type;
-	const char *type;
-	bool foundValues = false;
-	bool foundDeprecated = false;
-	size_t idx = 0;
-
-	QMenu *popup = new QMenu(QTStr("Add"), this);
-	QMenu *deprecated = new QMenu(QTStr("Deprecated"), popup);
-
-	auto getActionAfter = [](QMenu *menu, const QString &name) {
-		QList<QAction *> actions = menu->actions();
-
-		for (QAction *menuAction : actions) {
-			if (menuAction->text().compare(name, Qt::CaseInsensitive) >= 0)
-				return menuAction;
-		}
-
-		return (QAction *)nullptr;
-	};
-
-	auto addSource = [this, getActionAfter](QMenu *popup, const char *type, const char *name) {
-		QString qname = QT_UTF8(name);
-		QAction *popupItem = new QAction(qname, this);
-		connect(popupItem, &QAction::triggered, [this, type]() { AddSource(type); });
-
-		QIcon icon;
-
-		if (strcmp(type, "scene") == 0)
-			icon = GetSceneIcon();
-		else
-			icon = GetSourceIcon(type);
-
-		popupItem->setIcon(icon);
-
-		QAction *after = getActionAfter(popup, qname);
-		popup->insertAction(after, popupItem);
-	};
-
-	while (obs_enum_input_types2(idx++, &type, &unversioned_type)) {
-		const char *name = obs_source_get_display_name(type);
-		uint32_t caps = obs_get_source_output_flags(type);
-
-		if ((caps & OBS_SOURCE_CAP_DISABLED) != 0)
-			continue;
-
-		if ((caps & OBS_SOURCE_DEPRECATED) == 0) {
-			addSource(popup, unversioned_type, name);
-		} else {
-			addSource(deprecated, unversioned_type, name);
-			foundDeprecated = true;
-		}
-		foundValues = true;
-	}
-
-	addSource(popup, "scene", Str("Basic.Scene"));
-
-	popup->addSeparator();
-	QAction *addGroup = new QAction(QTStr("Group"), this);
-	addGroup->setIcon(GetGroupIcon());
-	connect(addGroup, &QAction::triggered, [this]() { AddSource("group"); });
-	popup->addAction(addGroup);
-
-	if (!foundDeprecated) {
-		delete deprecated;
-		deprecated = nullptr;
-	}
-
-	if (!foundValues) {
-		delete popup;
-		popup = nullptr;
-
-	} else if (foundDeprecated) {
-		popup->addSeparator();
-		popup->addMenu(deprecated);
-	}
-
-	return popup;
-}
-
-void OBSBasic::AddSourcePopupMenu(const QPoint &pos)
-{
-	if (!GetCurrentScene()) {
-		// Tell the user he needs a scene first (help beginners).
-		OBSMessageBox::information(this, QTStr("Basic.Main.AddSourceHelp.Title"),
-					   QTStr("Basic.Main.AddSourceHelp.Text"));
+	QAction *action = qobject_cast<QAction *>(sender());
+	if (!action)
 		return;
-	}
 
-	QScopedPointer<QMenu> popup(CreateAddSourcePopupMenu());
-	if (popup)
-		popup->exec(pos);
+	if (addWindow)
+		addWindow->close();
+
+	addWindow = new OBSBasicSourceSelect(this, undo_s);
+	addWindow->show();
+
+	addWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 }
 
 void OBSBasic::on_actionAddSource_triggered()
 {
-	AddSourcePopupMenu(QCursor::pos());
+	AddSourceDialog();
 }
 
 static bool remove_items(obs_scene_t *, obs_sceneitem_t *item, void *param)


### PR DESCRIPTION
### Description
Replaces the add source context menu with a brand new window

**Sources Dock Menu**
![image](https://github.com/user-attachments/assets/8e663f72-1c81-4f32-a552-d8182cde8e0a)

**New Window**
![image](https://github.com/user-attachments/assets/83ddc61b-e232-4299-883b-3952ebaaabde)

**Type Selected**
![image](https://github.com/user-attachments/assets/3824432a-c482-4526-9383-9bc2d1635796)

**Existing Source Hover**
![image](https://github.com/user-attachments/assets/f8bbbc07-125a-4139-91de-0252f838a226)


https://github.com/user-attachments/assets/95dc0a94-99b1-476f-ad1f-f9e7883051c0


### Motivation and Context
The current process for adding a source is rather cumbersome, especially when adding a source that already exists. Ideally users should be re-using Sources whenever it makes sense, so one of the goals of this PR is exposing that better than the old radio button and list selection.

### How Has This Been Tested?
Created a number of different sources.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
