### PR TITLE
linux-v4l2: Use VIDIOC_S_FMT return values in vcam

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -164,8 +164,6 @@ static bool try_connect(void *data, const char *device)
 	uint32_t width = obs_output_get_width(vcam->output);
 	uint32_t height = obs_output_get_height(vcam->output);
 
-	vcam->frame_size = width * height * 2;
-
 	vcam->device = open(device, O_RDWR);
 
 	if (vcam->device < 0)
@@ -183,14 +181,27 @@ static bool try_connect(void *data, const char *device)
 	vcam->use_caps_workaround = use_caps_workaround;
 
 	format.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
+	format.fmt.pix.width = width;
+	format.fmt.pix.height = height;
+	format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
 
-	if (ioctl(vcam->device, VIDIOC_G_FMT, &format) < 0)
+	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) < 0)
 		goto fail_close_device;
+
+	if (format.fmt.pix.pixelformat != V4L2_PIX_FMT_YUYV)
+		goto fail_close_device;
+
+	vcam->frame_size = format.fmt.pix.bytesperline * format.fmt.pix.height;
+
+	struct video_scale_info vsi = {0};
+	vsi.format = VIDEO_FORMAT_YUY2;
+	vsi.width = format.fmt.pix.width;
+	vsi.height = format.fmt.pix.height;
+	obs_output_set_video_conversion(vcam->output, &vsi);
 
 	struct obs_video_info ovi;
 	obs_get_video_info(&ovi);
 
-	memset(&parm, 0, sizeof(parm));
 	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
 	parm.parm.output.capability = V4L2_CAP_TIMEPERFRAME;
@@ -199,23 +210,6 @@ static bool try_connect(void *data, const char *device)
 
 	if (ioctl(vcam->device, VIDIOC_S_PARM, &parm) < 0)
 		goto fail_close_device;
-
-	format.fmt.pix.width = width;
-	format.fmt.pix.height = height;
-	format.fmt.pix.pixelformat = V4L2_PIX_FMT_YUYV;
-	format.fmt.pix.sizeimage = vcam->frame_size;
-
-	if (ioctl(vcam->device, VIDIOC_S_FMT, &format) < 0)
-		goto fail_close_device;
-
-	struct video_scale_info vsi = {0};
-	vsi.format = VIDEO_FORMAT_YUY2;
-	vsi.width = width;
-	vsi.height = height;
-	obs_output_set_video_conversion(vcam->output, &vsi);
-
-	memset(&parm, 0, sizeof(parm));
-	parm.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;
 
 	if (vcam->use_caps_workaround && ioctl(vcam->device, VIDIOC_STREAMON, &format.type) < 0) {
 		blog(LOG_ERROR, "Failed to start streaming on '%s' (%s)", device, strerror(errno));


### PR DESCRIPTION

### Description

When the virtual camera is opened, use the format returned by ioctl VIDIOC_S_FMT to; 1) confirm that the (YUYV) pixel format is expected, and; 2) configure the video scaling for the virtual camera.

This means that if the loopback device is constrained to a different size - then OBS studio will scale the output to the loopback device. If the pixel format of the loopback device is incorrect; the virtual camera will fail to open.


### Motivation and Context

The current behaviour when a loopback device is constrained/fixed to a different size is shown in issue #12081.

There are two typical scenarios in which the loopback device will have a fixed format that could differ from OBS's output:

1.  The loopback device is already open by a _reader_; e.g. it is open in a browser, or some other application.
2.  The user fixed the format of the loopback device via `v4l2loopback-ctl set-caps`.

Ideally; some sensible cropping might be applied if the aspect ratio is not the same between the loopback device and OBS's output, but this hasn't been implemented here. Instead, the output is 'squeezed' into the aspect ratio of the loopback device.


### How Has This Been Tested?

Built on Ubuntu 24.04 with v4l2loopback 0.14.0; then tested by following similar steps for reproduction in #12081

1.  Start loopback device and select a fixed format `sudo modprobe v4l2loopback video_nr=10`, then `v4l2loopback-ctl set-caps /dev/video10 "YUYV:640x360".
4.  Open OBS studio with a scene, video output set to 1280x720, select 'Start virtual camera'.
5.  Play the virtual camera in `ffplay /dev/video10`

Here's the output scaled from 1280x720 (OBS) to 640x360 (loopback):

![Screenshot at 2025-04-24 18-01-06](https://github.com/user-attachments/assets/71b88c60-72ad-4c23-929b-968c02bc0a10)


### Types of changes

-   Bug fix: fixes #12081


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
