### PR TITLE
cmake: Group blake2 targets under same directory for IDEs

### DIFF
--- a/deps/blake2/CMakeLists.txt
+++ b/deps/blake2/CMakeLists.txt
@@ -17,4 +17,7 @@ if(OS_WINDOWS)
 
   target_include_directories(blake2_static PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
   set_target_properties(blake2_static PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+  set_target_properties(blake2 PROPERTIES FOLDER deps/blake2)
+  set_target_properties(blake2_static PROPERTIES FOLDER deps/blake2)
 endif()


### PR DESCRIPTION
### Description
Add missing `FOLDER` property for Windows-exclusive `blake2_static` target and group it with the global `blake2` target.

### Motivation and Context
The blake2_static target has no specific FOLDER property set and thus would appear ungrouped in Visual Studio's Solution Explorer.

With this change both the default blake2 target as well as blake2_static appear in their own "blake2" subdirectory.


### How Has This Been Tested?
Tested on Windows 11 with Visual Studio 17.13.6.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
