### PR TITLE
media-playback: Fix possible crash on startup

### DIFF
--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -382,12 +382,6 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 	enum video_range_type new_range;
 	AVFrame *f = d->frame;
 
-	if (!f->width || !f->height) {
-		blog(LOG_ERROR, "MP: media frame width or height are zero ('%s': %" PRIu32 "x%" PRIu32 ")", m->path,
-		     f->width, f->height);
-		return;
-	}
-
 	if (!preload) {
 		if (!mp_media_can_play_frame(m, d))
 			return;
@@ -397,6 +391,12 @@ void mp_media_next_video(mp_media_t *m, bool preload)
 		if (!m->v_cb)
 			return;
 	} else if (!d->frame_ready) {
+		return;
+	}
+
+	if (!f->width || !f->height) {
+		blog(LOG_ERROR, "MP: media frame width or height are zero ('%s': %" PRIu32 "x%" PRIu32 ")", m->path,
+		     f->width, f->height);
 		return;
 	}
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
[Newly added frame width/height check](https://github.com/obsproject/obs-studio/pull/12024) crash if the frame is not given.

We can move the width/height check after other precondition checks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I tested the master branch on my machine, and encountered the following.

<img width="1138" alt="crash" src="https://github.com/user-attachments/assets/adee9b0d-2bbe-44b2-9f87-4c84d17f28b8" />


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
My local windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
