### PR TITLE
plugins: Fix warnings with Visual Studio 2022 17.14

### DIFF
--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -41,7 +41,7 @@
 #define S_STRENGTH_DEFAULT 0.5
 #define TEXT_MODE_BLUR_STRENGTH MT_("Nvvfx.Method.Blur.Strength")
 
-enum nvvfx_filter_id { S_FX_AIGS, S_FX_BLUR, S_FX_BG_BLUR };
+enum nvvfx_fx_id { S_FX_AIGS, S_FX_BLUR, S_FX_BG_BLUR };
 
 bool nvvfx_loaded = false;
 bool nvvfx_new_sdk = false;
@@ -91,7 +91,7 @@ struct nvvfx_data {
 	int processing_counter;
 
 	/* blur specific */
-	enum nvvfx_filter_id filter_id;
+	enum nvvfx_fx_id filter_id;
 	NvVFX_Handle handle_blur;
 	CUstream stream_blur;        // cuda stream
 	float strength;              // from 0 to 1, default = 0.5

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -762,7 +762,7 @@ static void update_settings_visibility(obs_properties_t *props, struct duplicato
 {
 	pthread_mutex_lock(&capture->update_mutex);
 
-	const enum window_capture_method method = capture->method;
+	const enum display_capture_method method = capture->method;
 	const bool dxgi_options = method == METHOD_DXGI;
 	const bool wgc_options = method == METHOD_WGC;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Following errors occur with msvc 2022 preview and win-sdk 10.0.26100.

> nvidia-videofx-filter.c(133,9): error C2220: the following warning is treated as an error nvidia-videofx-filter.c(133,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning

> duplicator-monitor-capture.c(766,35): error C2220: the following warning is treated as an error duplicator-monitor-capture.c(766,35): warning C5287: operands are different enum types 'window_capture_method' and 'display_capture_method'; use an explicit cast to silence this warning

Warnings are reasonable, so change mismatched enum type.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I couldn't build without this change.

<details>
<summary>
Partial build log before this change due to 64k PR body limit.
</summary>

```plaintext
Build FAILED.

D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(133,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(133,28): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(134,17): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(143,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(143,28): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(128,30): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\ 
obs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(253,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(253,28): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(267,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(267,28): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(226,30): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\ 
obs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(229,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(232,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(235,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(298,22): warning C5286: implicit conversion from enum type 'nvvfx_fx_id' to enum type 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\ 
obs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(318,22): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(323,10): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(336,26): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio 
\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(647,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(657,9): warning C5287: operands are different enum types 'nvvfx_fx_id' and 'nvvfx_filter_id'; use an explicit cast to silence this warning [D:\obs-studio\ 
build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(610,30): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\ 
obs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(615,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(616,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(619,7): warning C5286: implicit conversion from enum type 'nvvfx_filter_id' to enum type 'nvvfx_fx_id'; use an explicit cast to silence this warning [D:\o 
bs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\win-capture\duplicator-monitor-capture.c(766,35): warning C5287: operands are different enum types 'window_capture_method' and 'display_capture_method'; use an explicit cast to silence this warning [D:\Repos\c 
lone\2022\06\obs-studio\build_x64\plugins\win-capture\win-capture.vcxproj]
D:\obs-studio\plugins\win-capture\duplicator-monitor-capture.c(767,34): warning C5287: operands are different enum types 'window_capture_method' and 'display_capture_method'; use an explicit cast to silence this warning [D:\Repos\c 
lone\2022\06\obs-studio\build_x64\plugins\win-capture\win-capture.vcxproj]
D:\obs-studio\plugins\win-capture\duplicator-monitor-capture.c(765,51): warning C5286: implicit conversion from enum type 'display_capture_method' to enum type 'window_capture_method'; use an explicit cast to silence this warning [ 
D:\obs-studio\build_x64\plugins\win-capture\win-capture.vcxproj]
D:\obs-studio\plugins\nv-filters\nvidia-videofx-filter.c(133,9): error C2220: the following warning is treated as an error [D:\obs-studio\build_x64\plugins\nv-filters\nv-filters.vcxproj]
D:\obs-studio\plugins\win-capture\duplicator-monitor-capture.c(766,35): error C2220: the following warning is treated as an error [D:\obs-studio\build_x64\plugins\win-capture\win-capture.vcxproj]
    27 Warning(s)
    2 Error(s)
```
</details>

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I built this on my windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
