### PR TITLE
libobs: Add checks to some graphics API functions

### DIFF
--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -325,22 +325,54 @@ const char *gs_get_device_name(void)
 
 const char *gs_get_driver_version(void)
 {
-	return gs_valid("gs_get_driver_version") ? thread_graphics->exports.gpu_get_driver_version() : NULL;
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_get_driver_version"))
+		return NULL;
+
+	if (graphics->exports.gpu_get_driver_version)
+		return (graphics->exports.gpu_get_driver_version());
+	else
+		return NULL;
 }
 
 const char *gs_get_renderer(void)
 {
-	return gs_valid("gs_get_renderer") ? thread_graphics->exports.gpu_get_renderer() : NULL;
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_get_renderer"))
+		return NULL;
+
+	if (graphics->exports.gpu_get_renderer)
+		return (graphics->exports.gpu_get_renderer());
+	else
+		return NULL;
 }
 
 uint64_t gs_get_gpu_dmem(void)
 {
-	return gs_valid("gs_get_gpu_dmem") ? thread_graphics->exports.gpu_get_dmem() : 0;
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_get_gpu_dmem"))
+		return 0;
+
+	if (graphics->exports.gpu_get_dmem)
+		return (graphics->exports.gpu_get_dmem());
+	else
+		return 0;
 }
 
 uint64_t gs_get_gpu_smem(void)
 {
-	return gs_valid("gs_get_gpu_smem") ? thread_graphics->exports.gpu_get_smem() : 0;
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_get_gpu_smem"))
+		return 0;
+
+	if (graphics->exports.gpu_get_smem)
+		return (graphics->exports.gpu_get_smem());
+	else
+		return 0;
 }
 
 int gs_get_device_type(void)


### PR DESCRIPTION
### Description

A few recently introduced graphics API functions needed for Enhanced Broadcasting support on Linux were marked as `GRAPHICS_IMPORT_OPTIONAL`. Add the proper checks in the wrapper to ensure they are safe on platforms that do not implement the underlying function.

### Motivation and Context
Prevent possible crashes on platforms that do not implement the APIs marked as optional. 

### How Has This Been Tested?
Tested with local builds on Windows and Linux. 

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
