### PR TITLE
frontend: Make sure all QObject subclasses have Q_OBJECT macro

### DIFF
--- a/frontend/components/DelButton.hpp
+++ b/frontend/components/DelButton.hpp
@@ -1,8 +1,11 @@
 #pragma once
 
+#include <QPersistentModelIndex>
 #include <QPushButton>
 
 class DelButton : public QPushButton {
+	Q_OBJECT
+
 public:
 	inline DelButton(QModelIndex index_) : QPushButton(), index(index_) {}
 

--- a/frontend/components/EditWidget.hpp
+++ b/frontend/components/EditWidget.hpp
@@ -6,6 +6,8 @@
 class QPersistentModelIndex;
 
 class EditWidget : public QLineEdit {
+	Q_OBJECT
+
 public:
 	inline EditWidget(QWidget *parent, QModelIndex index_) : QLineEdit(parent), index(index_) {}
 

--- a/frontend/utility/OBSProxyStyle.cpp
+++ b/frontend/utility/OBSProxyStyle.cpp
@@ -1,6 +1,7 @@
 #include "OBSProxyStyle.hpp"
 
 #include <QStyleOption>
+#include "moc_OBSProxyStyle.cpp"
 
 static inline uint qt_intensity(uint r, uint g, uint b)
 {

--- a/frontend/utility/OBSProxyStyle.hpp
+++ b/frontend/utility/OBSProxyStyle.hpp
@@ -3,6 +3,8 @@
 #include <QProxyStyle>
 
 class OBSProxyStyle : public QProxyStyle {
+	Q_OBJECT
+
 public:
 	OBSProxyStyle() : QProxyStyle() {}
 

--- a/frontend/utility/SettingsEventFilter.hpp
+++ b/frontend/utility/SettingsEventFilter.hpp
@@ -25,6 +25,8 @@
 #include <QObject>
 
 class SettingsEventFilter : public QObject {
+	Q_OBJECT
+
 	QScopedPointer<OBSEventFilter> shortcutFilter;
 
 public:

--- a/frontend/utility/SurfaceEventFilter.hpp
+++ b/frontend/utility/SurfaceEventFilter.hpp
@@ -6,6 +6,8 @@
 #include <QPlatformSurfaceEvent>
 
 class SurfaceEventFilter : public QObject {
+	Q_OBJECT
+
 	OBSQTDisplay *display;
 
 public:

--- a/frontend/widgets/ColorSelect.cpp
+++ b/frontend/widgets/ColorSelect.cpp
@@ -18,6 +18,7 @@
 ******************************************************************************/
 
 #include "ColorSelect.hpp"
+#include "moc_ColorSelect.cpp"
 
 ColorSelect::ColorSelect(QWidget *parent) : QWidget(parent), ui(new Ui::ColorSelect)
 {

--- a/frontend/widgets/ColorSelect.hpp
+++ b/frontend/widgets/ColorSelect.hpp
@@ -22,6 +22,7 @@
 #include <QWidget>
 
 class ColorSelect : public QWidget {
+	Q_OBJECT
 
 public:
 	explicit ColorSelect(QWidget *parent = 0);


### PR DESCRIPTION
### Description
Went through and found all QObject subclasses that didn't have a Q_OBJECT macro.

### Motivation and Context
https://github.com/obsproject/obs-studio/pull/11784 still doesn't compile

### How Has This Been Tested?
It compiled

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
