### PR TITLE
libobs: Add obs_canvas_rename_source()

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -683,6 +683,7 @@ extern void obs_free_canvas_mixes(void);
 extern bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi);
 extern void obs_canvas_insert_source(obs_canvas_t *canvas, obs_source_t *source);
 extern void obs_canvas_remove_source(obs_source_t *source);
+extern void obs_canvas_rename_source(obs_source_t *source, const char *name);
 
 /* ------------------------------------------------------------------------- */
 /* sources  */

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -4144,24 +4144,28 @@ void obs_source_set_name(obs_source_t *source, const char *name)
 		return;
 
 	if (!name || !*name || !source->context.name || strcmp(name, source->context.name) != 0) {
-		struct calldata data;
-		char *prev_name = bstrdup(source->context.name);
-
-		if (!source->context.private) {
-			obs_context_data_setname_ht(&source->context, name, &obs->data.public_sources);
+		if (requires_canvas(source)) {
+			obs_canvas_rename_source(source, name);
 		} else {
-			obs_context_data_setname(&source->context, name);
-		}
+			struct calldata data;
+			char *prev_name = bstrdup(source->context.name);
 
-		calldata_init(&data);
-		calldata_set_ptr(&data, "source", source);
-		calldata_set_string(&data, "new_name", source->context.name);
-		calldata_set_string(&data, "prev_name", prev_name);
-		if (!source->context.private)
-			signal_handler_signal(obs->signals, "source_rename", &data);
-		signal_handler_signal(source->context.signals, "rename", &data);
-		calldata_free(&data);
-		bfree(prev_name);
+			if (!source->context.private) {
+				obs_context_data_setname_ht(&source->context, name, &obs->data.public_sources);
+			} else {
+				obs_context_data_setname(&source->context, name);
+			}
+
+			calldata_init(&data);
+			calldata_set_ptr(&data, "source", source);
+			calldata_set_string(&data, "new_name", source->context.name);
+			calldata_set_string(&data, "prev_name", prev_name);
+			if (!source->context.private)
+				signal_handler_signal(obs->signals, "source_rename", &data);
+			signal_handler_signal(source->context.signals, "rename", &data);
+			calldata_free(&data);
+			bfree(prev_name);
+		}
 	}
 }
 


### PR DESCRIPTION
### Description

Adds a function and signal for renaming sources held by a canvas (mainly scenes).
This also fixes two crashes (one at runtime, one during shutdown) that can occur when/after renaming a scene within a canvas, as previously it would use the wrong hash table (global sources) rather than the local canvas one.

### Motivation and Context

Crash when renaming singular scene reported on TEB Discord, additionally discovered the second one during debugging.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
