### PR TITLE
libobs: Improve readability of scene duplication type

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1996,8 +1996,8 @@ static inline void duplicate_item_data(struct obs_scene_item *dst, struct obs_sc
 
 obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name, enum obs_scene_duplicate_type type)
 {
-	bool make_unique = ((int)type & (1 << 0)) != 0;
-	bool make_private = ((int)type & (1 << 1)) != 0;
+	bool make_unique = type == OBS_SCENE_DUP_COPY || type == OBS_SCENE_DUP_PRIVATE_COPY;
+	bool make_private = type == OBS_SCENE_DUP_PRIVATE_REFS || type == OBS_SCENE_DUP_PRIVATE_COPY;
 	obs_scene_item_ptr_array_t items;
 	struct obs_scene *new_scene;
 	struct obs_scene_item *item;


### PR DESCRIPTION
### Description

Improve this so others don't have to go through the same annoyances I did in figuring out what is happening here.

### Motivation and Context

We have 120 lines now, no need for being clever.

### How Has This Been Tested?

Locally, nothing seems to change.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
