### PR TITLE
libobs: Fall back to main canvas dimensions if canvas invalid

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -344,7 +344,7 @@ static uint32_t canvas_getheight(obs_weak_canvas_t *weak);
 static inline void get_scene_dimensions(const obs_sceneitem_t *item, float *x, float *y)
 {
 	obs_scene_t *parent = item->parent;
-	if (!parent) {
+	if (!parent || (parent->is_group && !parent->source->canvas)) {
 		*x = (float)obs->data.main_canvas->mix->ovi.base_width;
 		*y = (float)obs->data.main_canvas->mix->ovi.base_height;
 	} else if (parent->is_group) {


### PR DESCRIPTION
### Description

Fall back to main canvas dimensions when attempting to get canvas size in scene sources.

### Motivation and Context

Issue reported on TEB Discord.

In the case of "Studio Mode" with "Duplicate Sources" groups would not have a canvas reference, which caused them to fail to render as they could not determine the size of the canvas they exist on. Scenes themselves were fine since they would use a differnet code path that already has a fallback.

Note that the private source situation isn't great, as private sources will always use the main canvas as a size reference, since they technically don't belong to any canvas. I could not come up with a good solution for integrating canvases and private sources right now, but this change will at least prevent regressions by falling back to the old behaviour.  
I think perhaps we'll need to rethink whether or not we want to even have private sources going forward, and come up with a different solution for dealing with studio mode and duplicated scenes (e.g. use a different canvas for program entirely, that only holds the duplicated scenes). Most use-cases for private sources (e.g. vcam output, multiview) could probably be served by replacing private sources with a separate (private) canvas. Though preview labels and friends remain a problem.

### How Has This Been Tested?

Based on reproduction steps and video found here: https://discord.com/channels/1171528364000018442/1195049039985647656/1365407672299687937

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
