### PR TITLE
libobs/util: Fix build on FreeBSD

### DIFF
--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -1087,6 +1087,20 @@ uint64_t os_get_proc_virtual_size(void)
 		return 0;
 	return (uint64_t)statm.virtual_size;
 }
+
+uint64_t os_get_sys_free_size(void)
+{
+	uint64_t free_memory = 0;
+#ifndef __OpenBSD__
+	struct sysinfo info;
+	if (sysinfo(&info) < 0)
+		return 0;
+
+	free_memory = ((uint64_t)info.freeram + (uint64_t)info.bufferram) * info.mem_unit;
+#endif
+
+	return free_memory;
+}
 #endif
 
 static uint64_t total_memory = 0;
@@ -1113,19 +1127,6 @@ uint64_t os_get_sys_total_size(void)
 	return total_memory;
 }
 
-uint64_t os_get_sys_free_size(void)
-{
-	uint64_t free_memory = 0;
-#ifndef __OpenBSD__
-	struct sysinfo info;
-	if (sysinfo(&info) < 0)
-		return 0;
-
-	free_memory = ((uint64_t)info.freeram + (uint64_t)info.bufferram) * info.mem_unit;
-#endif
-
-	return free_memory;
-}
 #endif
 
 #ifndef __APPLE__


### PR DESCRIPTION
FreeBSD already implemented os_get_free_size.  Move the new Linux implementation into the existing not-__FreeBSD__ block.

Fixes: 935613816fd8 ("libobs/util: Update `os_get_free_size()`")

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Avoid duplicate fn definition on FreeBSD

### Motivation and Context
Build fix

### How Has This Been Tested?
Build-tested on FreeBSD locally (with additional changes, to come).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
