### PR TITLE
frontend: Fix character encoding issue during profile import

### DIFF
--- a/frontend/widgets/OBSBasic_Profiles.cpp
+++ b/frontend/widgets/OBSBasic_Profiles.cpp
@@ -554,7 +554,7 @@ void OBSBasic::on_actionImportProfile_triggered()
 
 	if (!sourceDirectory.isEmpty() && !sourceDirectory.isNull()) {
 		const std::filesystem::path sourcePath = std::filesystem::u8path(sourceDirectory.toStdString());
-		const std::string directoryName = sourcePath.filename().string();
+		const std::string directoryName = sourcePath.filename().u8string();
 
 		if (auto profile = GetProfileByDirectoryName(directoryName)) {
 			OBSMessageBox::warning(this, QTStr("Basic.MainMenu.Profile.Import"),


### PR DESCRIPTION
### Description
Ensures that path string passed into `libobs` APIs use UTF-8 encoding.

The use of the UTF-8 specific API calls in `std::filesystem` is consistent throughout the code, this instance has fallen through the cracks during review.

### Motivation and Context
The directory name string passed into libobs functions needs to be converted into a 8-bit based encoding (e.g., UTF-8) to avoid mangling of characters and encoding issues particularly on Windows systems which use UTF-16 for file names.

Fixes #12101

### How Has This Been Tested?
Requires testing by affected users.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
