### PR TITLE
libobs: Add obs_canvas_get_signal_handler

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -65,7 +65,7 @@ static inline void canvas_dosignal_source(const char *signal, obs_canvas_t *canv
 	calldata_set_ptr(&data, "canvas", canvas);
 	calldata_set_ptr(&data, "source", source);
 
-	signal_handler_signal(source->context.signals, signal, &data);
+	signal_handler_signal(canvas->context.signals, signal, &data);
 }
 
 /*** Reference Counting ***/

--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -418,6 +418,11 @@ bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info
 	return true;
 }
 
+signal_handler_t *obs_canvas_get_signal_handler(obs_canvas_t *canvas)
+{
+	return canvas->context.signals;
+}
+
 void obs_canvas_set_channel(obs_canvas_t *canvas, uint32_t channel, obs_source_t *source)
 {
 	assert(channel < MAX_CHANNELS);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2566,6 +2566,9 @@ EXPORT obs_weak_canvas_t *obs_canvas_get_weak_canvas(obs_canvas_t *canvas);
 /** Get strong reference from weak reference */
 EXPORT obs_canvas_t *obs_weak_canvas_get_canvas(obs_weak_canvas_t *weak);
 
+/** Returns the signal handler for a canvas */
+EXPORT signal_handler_t *obs_canvas_get_signal_handler(obs_canvas_t *canvas);
+
 /* Channels */
 /** Sets the source to be used for this canvas. */
 EXPORT void obs_canvas_set_channel(obs_canvas_t *canvas, uint32_t channel, obs_source_t *source);


### PR DESCRIPTION
### Description
Add obs_canvas_get_signal_handler

### Motivation and Context
The canvas has signals, but no way to get the signal handler

### How Has This Been Tested?
By getting signals from the canvas

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
