### PR TITLE
linux-capture/xcomposite-input.c: Add a backup texture to store previous contents of a window

### DIFF
--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <ctype.h>
 
+#include "graphics/graphics.h"
 #include "xhelpers.h"
 #include "xcursor-xcb.h"
 #include "xcomposite-input.h"
@@ -60,6 +61,7 @@ struct xcompcap {
 
 	Pixmap pixmap;
 	gs_texture_t *gltex;
+	gs_texture_t *backup_gltex;
 
 	pthread_mutex_t lock;
 
@@ -379,16 +381,24 @@ void xcomp_create_pixmap(xcb_connection_t *conn, struct xcompcap *s, int log_lev
 		return;
 
 	s->pixmap = xcb_generate_id(conn);
-	xcb_void_cookie_t name_cookie = xcb_composite_name_window_pixmap_checked(conn, s->win, s->pixmap);
+
 	err = NULL;
+	xcb_void_cookie_t name_cookie;
+	name_cookie = xcb_composite_name_window_pixmap_checked(conn, s->win, s->pixmap);
+
 	if ((err = xcb_request_check(conn, name_cookie)) != NULL) {
 		blog(log_level, "xcb_composite_name_window_pixmap failed");
 		s->pixmap = 0;
 		return;
 	}
-
 	XErrorHandler prev = XSetErrorHandler(silence_x11_errors);
 	s->gltex = gs_texture_create_from_pixmap(s->width, s->height, GS_BGRA_UNORM, GL_TEXTURE_2D, (void *)s->pixmap);
+	if (s->backup_gltex) {
+		gs_texture_destroy(s->backup_gltex);
+		s->backup_gltex = 0;
+	}
+	s->backup_gltex =
+		gs_texture_create_from_pixmap(s->width, s->height, GS_BGRA_UNORM, GL_TEXTURE_2D, (void *)s->pixmap);
 	XSetErrorHandler(prev);
 }
 
@@ -525,7 +535,7 @@ static void xcompcap_get_hooked(void *data, calldata_t *cd)
 static uint32_t xcompcap_get_width(void *data)
 {
 	struct xcompcap *s = (struct xcompcap *)data;
-	if (!s->gltex)
+	if (!s->gltex && !s->backup_gltex)
 		return 0;
 
 	int32_t border = s->crop_left + s->crop_right + 2 * s->border;
@@ -536,7 +546,7 @@ static uint32_t xcompcap_get_width(void *data)
 static uint32_t xcompcap_get_height(void *data)
 {
 	struct xcompcap *s = (struct xcompcap *)data;
-	if (!s->gltex)
+	if (!s->gltex && !s->backup_gltex)
 		return 0;
 
 	int32_t border = s->crop_bot + s->crop_top + 2 * s->border;
@@ -577,6 +587,10 @@ static void xcompcap_destroy(void *data)
 
 	watcher_unregister(conn, s);
 	xcomp_cleanup_pixmap(disp, s);
+	if (s->backup_gltex) {
+		gs_texture_destroy(s->backup_gltex);
+		s->backup_gltex = 0;
+	}
 
 	if (s->cursor)
 		xcb_xcursor_destroy(s->cursor);
@@ -641,15 +655,15 @@ static void xcompcap_video_tick(void *data, float seconds)
 		}
 
 		watcher_register(conn, s);
+
 		xcomp_cleanup_pixmap(disp, s);
-		// Avoid excessive logging. We expect this to fail while windows are
-		// minimized or on offscreen workspaces or already captured on NVIDIA.
 		xcomp_create_pixmap(conn, s, LOG_DEBUG);
+
 		xcb_xcursor_offset_win(conn, s->cursor, s->win);
 		xcb_xcursor_offset(s->cursor, s->cursor->x_org + s->crop_left, s->cursor->y_org + s->crop_top);
 	}
 
-	if (!s->gltex)
+	if (!s->gltex && !s->backup_gltex)
 		goto done;
 
 	if (xcompcap_get_height(s) == 0 || xcompcap_get_width(s) == 0)
@@ -674,26 +688,42 @@ static void xcompcap_video_render(void *data, gs_effect_t *effect)
 
 	pthread_mutex_lock(&s->lock);
 
-	if (!s->gltex)
-		goto done;
-
-	effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-	if (s->exclude_alpha)
-		effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
-
-	image = gs_effect_get_param_by_name(effect, "image");
-	gs_effect_set_texture(image, s->gltex);
-
-	while (gs_effect_loop(effect, "Draw")) {
-		gs_draw_sprite_subregion(s->gltex, 0, s->crop_left, s->crop_top, xcompcap_get_width(s),
-					 xcompcap_get_height(s));
-	}
-
-	if (s->gltex && s->show_cursor && !s->cursor_outside) {
+	if (s->gltex || s->backup_gltex) {
 		effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+		if (s->exclude_alpha)
+			effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
+		image = gs_effect_get_param_by_name(effect, "image");
+		if (s->gltex) {
 
-		while (gs_effect_loop(effect, "Draw")) {
-			xcb_xcursor_render(s->cursor);
+			gs_effect_set_texture(image, s->gltex);
+
+			while (gs_effect_loop(effect, "Draw")) {
+				gs_draw_sprite_subregion(s->gltex, 0, s->crop_left, s->crop_top, xcompcap_get_width(s),
+							 xcompcap_get_height(s));
+			}
+
+			if (s->gltex && s->show_cursor && !s->cursor_outside) {
+				effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
+				while (gs_effect_loop(effect, "Draw")) {
+					xcb_xcursor_render(s->cursor);
+				}
+			}
+		} else if (s->backup_gltex) {
+			gs_effect_set_texture(image, s->backup_gltex);
+
+			while (gs_effect_loop(effect, "Draw")) {
+				gs_draw_sprite_subregion(s->backup_gltex, 0, s->crop_left, s->crop_top,
+							 xcompcap_get_width(s), xcompcap_get_height(s));
+			}
+
+			if (s->backup_gltex && s->show_cursor && !s->cursor_outside) {
+				effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
+				while (gs_effect_loop(effect, "Draw")) {
+					xcb_xcursor_render(s->cursor);
+				}
+			}
 		}
 	}
 
@@ -906,7 +936,12 @@ static void xcompcap_update(void *data, obs_data_t *settings)
 	}
 
 	watcher_register(conn, s);
+
 	xcomp_cleanup_pixmap(disp, s);
+	if (s->backup_gltex) {
+		gs_texture_destroy(s->backup_gltex);
+		s->backup_gltex = 0;
+	}
 	xcomp_create_pixmap(conn, s, LOG_ERROR);
 	xcb_xcursor_offset_win(conn, s->cursor, s->win);
 	xcb_xcursor_offset(s->cursor, s->cursor->x_org + s->crop_left, s->cursor->y_org + s->crop_top);

--- a/plugins/linux-capture/xcomposite-input.c
+++ b/plugins/linux-capture/xcomposite-input.c
@@ -387,7 +387,11 @@ void xcomp_create_pixmap(xcb_connection_t *conn, struct xcompcap *s, int log_lev
 	name_cookie = xcb_composite_name_window_pixmap_checked(conn, s->win, s->pixmap);
 
 	if ((err = xcb_request_check(conn, name_cookie)) != NULL) {
-		blog(log_level, "xcb_composite_name_window_pixmap failed");
+		if (err->error_code == XCB_MATCH) {
+			blog(log_level, "could not get pixmap due to window being unviewable");
+		} else {
+			blog(log_level, "xcb_composite_name_window_pixmap failed");
+		}
 		s->pixmap = 0;
 		return;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
1. Add extra texture to store previous contents of X window, so that when it is unmapped by window manager, e.g. when  
switching a workspace, preview does not got black, but shows some amount of preview.
2. Add more descriptive fail message for xcb_composite_name_window_pixmap when the window is unmapped.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
When X window is unmapped xcb_composite_name_window_pixmap fails and does not retrieve the pixmap,
which makes preview screen and recording screen go black, when for example switching workspace, which
is at least aesthetically unpleasing. Also when the said function fails a rather cryptic message is printed
that the function just failed does not note the fact that retrieval failed because the window is unmapped, 
which is kind of confusing.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
This PR kind of fixes this issue:
https://github.com/obsproject/obs-studio/issues/4160

<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I opened up some application that had changing contents.
The preview screen was updating as well. Then I moved the changing window to another workspace
as expected the image froze, as the window is unmapped, but previous contents stayed.
Then I moved the window back up and preview screen was updating with the window.
Then I repeated the same procedure with recording, which yielded the same result.
Also logs showed that xcb_composite_name_window_pixmap was failing due to the window being unmapped
and stopped printing this error as soon as the window became viewable again.

<!--- Include details of your testing environment (hardware, OS version, etc.),-->
testing environment:
OS: ArchLinux
Kernel: 6.12.20-lts
WM: AwesomeWM
GPU: Nvidia GeForce GTX 1050Ti
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
Bug fix (non-breaking change which fixes an issue)
Tweak (non-breaking change to improve existing functionality)
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
