### PR TITLE
linux-v4l2: Consolidate non-linux virtual camera procedure

### DIFF
--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -292,11 +292,6 @@ static bool virtualcam_start(void *data)
 	for (int i = 0; i < n; i++) {
 		char device[32] = {0};
 
-#if !defined(__linux__)
-		if (strstr(list[i]->d_name, "video") != list[i]->d_name)
-			continue;
-#endif
-
 		// Use the return value of snprintf to prevent truncation warning.
 		int written = snprintf(device, 32, "/dev/%s", list[i]->d_name);
 		if (written >= 32)

--- a/plugins/linux-v4l2/v4l2-output.c
+++ b/plugins/linux-v4l2/v4l2-output.c
@@ -105,27 +105,8 @@ static int loopback_module_load()
 #else
 bool loopback_module_available()
 {
-	struct v4l2_capability capability;
-	char new_device[16];
-	int fd;
-	int i;
-
-	for (i = 0; i != 32; i++) {
-		snprintf(new_device, 16, "/dev/video%d", i);
-		fd = open(new_device, O_RDWR);
-		if (fd < 0)
-			continue;
-		if (ioctl(fd, VIDIOC_QUERYCAP, &capability) < 0) {
-			close(fd);
-			continue;
-		}
-		if (capability.capabilities & V4L2_CAP_VIDEO_OUTPUT) {
-			close(fd);
-			return true;
-		}
-		close(fd);
-	}
-	return false;
+	// Short-circuit; will use virtualcam_start to find an output device.
+	return true;
 }
 #endif
 


### PR DESCRIPTION

### Description

Within the virtual camera component of the linux-v4l2 plugin:

-   short-circuit the non-linux test for device capabilities - instead this is performed in `virtualcam_start` as on linux, and;
-   remove redundant test of the device names in `virtualcam_start` on non-linux.


### Motivation and Context

Recently PR #12073:

> ... provides FreeBSD support for (the) Virtual Camera feature.

This added a test (on e.g. _FreeBSD_) for video capabilities to determine _loopback_ module availability (in `loopback_module_available`); returning true if a device with output capabilities is found. As it turns out, this check is _also_ performed in `virtualcam_start`, which was recently updated to ensure better compliance with V4L2 _and_, crucially, performs a 'capability reset' workaround which is needed for certain versions of _v4l2loopback_ (see PR #11906 and issue #4808).

According to the original bug report for _FreeBSD_, https://bugs.freebsd.org/bugzilla//show_bug.cgi?id=257624, _FreeBSD_ adds loopback devices via [_webcamd_](https://www.freshports.org/multimedia/webcamd), which in turn uses _v4l2loopback_ [ported at version 12.5](https://github.com/swills/v4l2loopback/tree/my-build). This is one of the versions that needs the reset-capability workaround∴ the non-linux `loopback_module_available` function introduced in PR #12073 may fail if the device has been used.

Functionality will be improved and the code will be simpler if, instead of performing two tests on device capabilities, we simply check once in `virtualcam_start` which has the workaround needed. The 'module available' test is skipped on FreeBSD until a better test can be identified.


### How Has This Been Tested?

TODO: I will try to test on a VM, however I've never used FreeBSD. _Happy for others to test._


### Types of changes

- Bug fix
- Code cleanup


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
