### PR TITLE
[librist] Fix global logging initialization to prevent crash on uninitialized callback

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -3,6 +3,7 @@
 #include <libavutil/avutil.h>
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
+#include <librist/logging.h>
 
 #ifdef _WIN32
 #define INITGUID
@@ -343,6 +344,16 @@ static void register_encoder_if_available(struct obs_encoder_info *info, const c
 
 bool obs_module_load(void)
 {
+	static bool rist_logging_global_initialized = false;
+	if (!rist_logging_global_initialized) {
+		struct rist_logging_settings global_logging_settings = {0};
+		global_logging_settings.log_level = RIST_LOG_DISABLE;
+		global_logging_settings.log_cb = NULL;
+		global_logging_settings.log_cb_arg = NULL;
+		rist_logging_set_global(&global_logging_settings);
+		rist_logging_global_initialized = true;
+	}
+
 	obs_register_source(&ffmpeg_source);
 	obs_register_output(&ffmpeg_output);
 	obs_register_output(&ffmpeg_muxer);


### PR DESCRIPTION
Added a safeguard to ensure `rist_logging_set_global` is called only once, disabling logging by default with a NULL callback. Prevents potential crashes due to uninitialized global logging state before calling `rist_logging_set`.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This patch initializes the global librist logging configuration early in the RIST setup process. It sets the global logging callback to NULL and disables log output, preventing unexpected behavior or crashes caused by an uninitialized global logging state.

A static guard ensures `rist_logging_set_global` is only called once.

### Motivation and Context
Without this change, `rist_logging_set` may crash or behave unpredictably if no global logging callback has been set beforehand. This fix ensures that the librist logging infrastructure is safely initialized, even in minimal configurations that do not explicitly provide a callback.

### How Has This Been Tested?
Tested on macOS 14.4.1 (Apple Silicon) with a custom OBS build including the librist integration. Verified that:
- `rist_logging_set` no longer crashes without prior logging setup.
- Logging remains disabled unless explicitly configured.
- No regressions observed in other modules using librist.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
