### PR TITLE
frontend: Fix build on FreeBSD

### DIFF
--- a/frontend/cmake/os-freebsd.cmake
+++ b/frontend/cmake/os-freebsd.cmake
@@ -2,6 +2,9 @@ target_sources(obs-studio PRIVATE utility/platform-x11.cpp utility/system-info-p
 target_compile_definitions(obs-studio PRIVATE OBS_INSTALL_PREFIX="${OBS_INSTALL_PREFIX}")
 target_link_libraries(obs-studio PRIVATE Qt::GuiPrivate Qt::DBus procstat)
 
+find_package(Libpci REQUIRED)
+target_link_libraries(obs-studio PRIVATE Libpci::pci)
+
 if(TARGET OBS::python)
   find_package(Python REQUIRED COMPONENTS Interpreter Development)
   target_link_libraries(obs-studio PRIVATE Python::Python)


### PR DESCRIPTION
### Description

Add libpci to the build on FreeBSD.

### Motivation and Context

As of e1d2cf705dd9 ("frontend: Support enhanced broadcasting on Linux") the FreeBSD build fails w/o libpci.

### How Has This Been Tested?

Build tested on FreeBSD.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
