### PR TITLE
obs-outputs: Correct FLV CTS calculation

### DIFF
--- a/plugins/obs-outputs/flv-mux.c
+++ b/plugins/obs-outputs/flv-mux.c
@@ -307,7 +307,7 @@ static int32_t last_time = 0;
 
 static void flv_video(struct serializer *s, int32_t dts_offset, struct encoder_packet *packet, bool is_header)
 {
-	int64_t offset = packet->pts - packet->dts;
+	int32_t ct_offset_ms = get_ms_time(packet, packet->pts) - get_ms_time(packet, packet->dts);
 	int32_t time_ms = get_ms_time(packet, packet->dts) - dts_offset;
 
 	if (!packet->data || !packet->size)
@@ -332,7 +332,7 @@ static void flv_video(struct serializer *s, int32_t dts_offset, struct encoder_p
 	/* these are the 5 extra bytes mentioned above */
 	s_w8(s, packet->keyframe ? 0x17 : 0x27);
 	s_w8(s, is_header ? 0 : 1);
-	s_wb24(s, get_ms_time(packet, offset));
+	s_wb24(s, ct_offset_ms);
 	s_write(s, packet->data, packet->size);
 
 	write_previous_tag_size(s);
@@ -486,7 +486,8 @@ void flv_packet_ex(struct encoder_packet *packet, enum video_id_t codec_id, int3
 
 	// H.264/HEVC composition time offset
 	if ((codec_id == CODEC_H264 || codec_id == CODEC_HEVC) && type == PACKETTYPE_FRAMES) {
-		s_wb24(&s, get_ms_time(packet, packet->pts - packet->dts));
+		int32_t ct_offset_ms = get_ms_time(packet, packet->pts) - get_ms_time(packet, packet->dts);
+		s_wb24(&s, ct_offset_ms);
 	}
 
 	// packet data


### PR DESCRIPTION
### Description

Fixes the CTS (composition timestamp/offset) calculation in OBS's native FLV muxer.

### Motivation and Context

Currently the offset calculation will round down both the DTS and CTS, resulting in an off-by-one error when in the assembled PTS (DTS+CTS) timestamp.

To illustrate the problem:

```python
def get_ms_time(ts: int, den: int):
    return ts * 1000 // den

timebase_den = 60 # 60 FPS: 1/60

# 0 b-frames
dts = pts = 120
cts = pts - dts # == 0

dts_ms = get_ms_time(dts, timebase_den) # 2000
cts_ms = get_ms_time(cts, timebase_den) # 0

pts_ms = dts_ms + cts_ms
print(pts_ms) # prints "2000"

# 1 b-frame
pts = 120
dts = pts - 1 # 1 frame of delay
cts = pts - dts # == 1

dts_ms = get_ms_time(dts, timebase_den) # 1983 (we lost 0.3̅)
cts_ms = get_ms_time(cts, timebase_den) # 16 (we lost 0.6̅)

pts_ms = dts_ms + cts_ms
print(pts_ms) # prints "1999"
```

However, if we convert both parts to milliseconds _before_ calculating the difference, the math works out:

```python
# 1 b-frame
pts = 120
dts = pts - 1 # 1 frame of delay

dts_ms = get_ms_time(dts, timebase_den) # 1983 (we lost 0.3̅)
cts_ms = get_ms_time(pts, timebase_den) - get_ms_time(dts, timebase_den) # 17 (we gained 0.3̅)

pts_ms = dts_ms + cts_ms
print(pts_ms) # prints "2000"
```

### How Has This Been Tested?

Copious amounts of logging. Also verified that FFmpeg will produce a file with the expected PTS alignments.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
