### PR TITLE
frontend: Explicitly set titlebar item padding

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -495,6 +495,7 @@ QMenu::right-arrow {
 /* Top Menu Bar Items */
 QMenuBar::item {
     background-color: transparent;
+    padding: var(--padding_large) var(--padding_xlarge);
 }
 
 QMenuBar::item:selected {


### PR DESCRIPTION
### Description
Fixes the padding of the top QMenuBar entries on Windows 11 (I hope)

### Motivation and Context
Something in Qt changed that seems to affect the default padding of QMenuBar entries on Win11 (Likely meant to match how Windows 11 itself shows menu bars). This explicitly sets the padding on the menu items to fix it. (I hope)

### How Has This Been Tested?
It has not been as all my systems are on Windows 10 someone please help thanx

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
