### PR TITLE
CI: Add CEF and enable obs-browser for Windows on ARM

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -134,7 +134,7 @@
         "GPU_PRIORITY_VAL": {"type": "STRING", "value": "$penv{GPU_PRIORITY_VAL}"},
         "VIRTUALCAM_GUID": {"type": "STRING", "value": "A3FCE0F5-3493-419F-958A-ABA1250EC20B"},
         "ENABLE_AJA": false,
-        "ENABLE_BROWSER": false,
+        "ENABLE_BROWSER": true,
         "ENABLE_SCRIPTING": false,
         "ENABLE_VST": false
       }

--- a/buildspec.json
+++ b/buildspec.json
@@ -34,7 +34,8 @@
                 "macos-arm64": "1bb59dbb759150e170796f641a4a84c59c0dea4ffef89477e9d811520af5d15a",
                 "ubuntu-x86_64": "cb7225c7a937ac4cdc9c41700061f45cccc640d696902357782e57f8250bf43a",
                 "ubuntu-aarch64": "f92df7f076bdc8cac2e3c77e27be418008b7168723201cb73fdbc2f6d91bc778",
-                "windows-x64": "922efbda1f2f8be9e5b2754d878a14d90afc81f04e94fc9101a7513e2b5cecc1"
+                "windows-x64": "922efbda1f2f8be9e5b2754d878a14d90afc81f04e94fc9101a7513e2b5cecc1",
+                "windows-arm64": "df9df4bd85826b4c071c6db404fd59cf93efd9c58ec3ab64e204466ae19bb02a"
             },
             "revision": {
                 "macos-x86_64": 3,

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -10,7 +10,7 @@ endif()
 set_property(GLOBAL APPEND PROPERTY OBS_FEATURES_ENABLED "Plugin Support")
 
 macro(check_obs_browser)
-  if((OS_WINDOWS AND CMAKE_VS_PLATFORM_NAME MATCHES "(Win32|x64)") OR OS_MACOS OR OS_LINUX)
+  if((OS_WINDOWS AND CMAKE_VS_PLATFORM_NAME MATCHES "(ARM64|x64)") OR OS_MACOS OR OS_LINUX)
     if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/obs-browser/CMakeLists.txt")
       message(FATAL_ERROR "Required submodule 'obs-browser' not available.")
     else()


### PR DESCRIPTION
### Description

This enables obs-browser and provides a compatible CEF build for Windows on ARM.

![image](https://github.com/user-attachments/assets/4851ca70-9f48-48c6-8527-dea539d20450)

### Motivation and Context

Ideally, first-party OBS builds have all standard functionality, including the browser.

### How Has This Been Tested?

Launched OBS on a Windows on ARM VM via UTM on an Apple Mac Mini M1 and ensured both `obs64.exe and `obs-browser-page.exe` indicated Arm64 architecture in Task Manager. Created both browser sources and browser docks.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
