### PR TITLE
frontend: Fix canvas remove event

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1124,7 +1124,7 @@ public:
 	const OBS::Canvas &AddCanvas(const std::string &name, obs_video_info *ovi = nullptr, int flags = 0);
 
 public slots:
-	bool RemoveCanvas(obs_canvas_t *canvas);
+	bool RemoveCanvas(OBSCanvas canvas);
 
 	/* -------------------------------------
 	 * MARK: - OBSBasic_SceneItems

--- a/frontend/widgets/OBSBasic_Canvases.cpp
+++ b/frontend/widgets/OBSBasic_Canvases.cpp
@@ -31,7 +31,7 @@ const OBS::Canvas &OBSBasic::AddCanvas(const std::string &name, obs_video_info *
 	return it;
 }
 
-bool OBSBasic::RemoveCanvas(obs_canvas_t *canvas)
+bool OBSBasic::RemoveCanvas(OBSCanvas canvas)
 {
 	if (!canvas)
 		return false;


### PR DESCRIPTION
### Description
changed `RemoveCanvas(obs_canvas_t*)` to `RemoveCanvas(OBSCanvas)`

### Motivation and Context
Got the following message in my visual studio debug output:
```
QMetaObject::invokeMethod: No such method OBSBasic::RemoveCanvas(OBSCanvas)
Candidates are:
    RemoveCanvas(obs_canvas_t*)
```
it is called like this:
 `QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveCanvas", Q_ARG(OBSCanvas, OBSCanvas(canvas)));`


### How Has This Been Tested?
On windows 11 with a OBS plugin removing a canvas on scene collection cleanup event

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
