### PR TITLE
win-capture: Add SDL_app to list of generic classes

### DIFF
--- a/libobs/util/windows/window-helpers.c
+++ b/libobs/util/windows/window-helpers.c
@@ -468,6 +468,7 @@ static int window_rating(HWND window, enum window_priority priority, const char 
 
 static const char *generic_class_substrings[] = {
 	"Chrome",
+	"SDL_app",
 	NULL,
 };
 


### PR DESCRIPTION
### Description

Adds `SDL_app` to list of generic window class names to avoid accidental matches.

### Motivation and Context

Similar to the original PR that introduced this (#3121) is't to avoid accidental fallback to an app using the same underlying technology but may not be something you want to capture accidentally.

In this case a streamer was capturing a "game" that uses SDL, then next stream OBS automatically window-captured his Steam DMs because Steam also uses the generic `SDL_app` window class, leaking some private info.

### How Has This Been Tested?

Tested locally using Windows capture in WGC mode with Umineko Project and Steam.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
