### PR TITLE
win-capture: Fix crash if cursor size is zero

### DIFF
--- a/plugins/win-capture/cursor-capture.c
+++ b/plugins/win-capture/cursor-capture.c
@@ -7,6 +7,9 @@ static uint8_t *get_bitmap_data(HBITMAP hbmp, BITMAP *bmp)
 	if (GetObject(hbmp, sizeof(*bmp), bmp) != 0) {
 		uint8_t *output;
 		unsigned int size = bmp->bmHeight * bmp->bmWidthBytes;
+		if (!size) {
+			return NULL;
+		}
 
 		output = bmalloc(size);
 		GetBitmapBits(hbmp, size, output);
@@ -99,6 +102,9 @@ static inline uint8_t *copy_from_mask(ICONINFO *ii, uint32_t *width, uint32_t *h
 	bmp.bmHeight /= 2;
 
 	pixels = bmp.bmHeight * bmp.bmWidth;
+	if (!pixels) {
+		return NULL;
+	}
 	output = bzalloc(pixels * 4);
 
 	bottom = bmp.bmWidthBytes * bmp.bmHeight;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix crash if cursor size is zero. Instead, in a condition where the cursor size is zero, don't attempt to allocate and draw a cursor.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Don't want to crash.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Built and ran locally on Windows 11.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
