### PR TITLE
frontend: Swap preview zoom buttons

### DIFF
--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -250,63 +250,6 @@
                  <number>0</number>
                 </property>
                 <item>
-                 <widget class="QPushButton" name="previewZoomInButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>20</width>
-                    <height>16</height>
-                   </size>
-                  </property>
-                  <property name="maximumSize">
-                   <size>
-                    <width>20</width>
-                    <height>16</height>
-                   </size>
-                  </property>
-                  <property name="toolTip">
-                   <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
-                  </property>
-                  <property name="accessibleName">
-                   <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
-                  </property>
-                  <property name="text">
-                   <string/>
-                  </property>
-                  <property name="icon">
-                   <iconset resource="obs.qrc">
-                    <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
-                  </property>
-                  <property name="iconSize">
-                   <size>
-                    <width>8</width>
-                    <height>8</height>
-                   </size>
-                  </property>
-                  <property name="toolButton" stdset="0">
-                   <bool>true</bool>
-                  </property>
-                  <property name="class" stdset="0">
-                   <string>icon-plus</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="OBSPreviewScalingLabel" name="previewScalePercent">
-                  <property name="text">
-                   <string>100%</string>
-                  </property>
-                  <property name="alignment">
-                   <set>Qt::AlignCenter</set>
-                  </property>
-                 </widget>
-                </item>
-                <item>
                  <widget class="QPushButton" name="previewZoomOutButton">
                   <property name="sizePolicy">
                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -327,10 +270,10 @@
                    </size>
                   </property>
                   <property name="toolTip">
-                   <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                   <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
                   </property>
                   <property name="accessibleName">
-                   <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                   <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
                   </property>
                   <property name="text">
                    <string/>
@@ -350,6 +293,63 @@
                   </property>
                   <property name="class" stdset="0">
                    <string>icon-minus</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="OBSPreviewScalingLabel" name="previewScalePercent">
+                  <property name="text">
+                   <string>100%</string>
+                  </property>
+                  <property name="alignment">
+                   <set>Qt::AlignCenter</set>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="previewZoomInButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>20</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>20</width>
+                    <height>16</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                  </property>
+                  <property name="accessibleName">
+                   <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="icon">
+                   <iconset resource="obs.qrc">
+                    <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
+                  </property>
+                  <property name="iconSize">
+                   <size>
+                    <width>8</width>
+                    <height>8</height>
+                   </size>
+                  </property>
+                  <property name="toolButton" stdset="0">
+                   <bool>true</bool>
+                  </property>
+                  <property name="class" stdset="0">
+                   <string>icon-plus</string>
                   </property>
                  </widget>
                 </item>


### PR DESCRIPTION
### Description
Swaps the new preview zoom out and zoom in buttons to have zoom out on the left and zoom in on the right

![image](https://github.com/user-attachments/assets/0e27e30c-2ffb-4eeb-91ae-5b4b4835f2af)

### Motivation and Context
This was the intended order, but I think I swapped them while testing the PR that added them and forgot to switch them back.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
