### PR TITLE
libobs/util: Fix coprocess not having environment variables

### DIFF
--- a/libobs/util/pipe-posix.c
+++ b/libobs/util/pipe-posix.c
@@ -24,6 +24,8 @@
 #include "bmem.h"
 #include "pipe.h"
 
+extern char **environ;
+
 struct os_process_pipe {
 	bool read_pipe;
 	int pid;
@@ -88,7 +90,7 @@ os_process_pipe_t *os_process_pipe_create_internal(const char *bin, char **argv,
 	posix_spawn_file_actions_adddup2(&file_actions, errfds[1], STDERR_FILENO);
 
 	int pid;
-	int ret = posix_spawn(&pid, bin, &file_actions, NULL, (char *const *)argv, NULL);
+	int ret = posix_spawn(&pid, bin, &file_actions, NULL, (char *const *)argv, environ);
 
 	posix_spawn_file_actions_destroy(&file_actions);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Pass `environ` to `posix_spawn` so that the child process can see the same environment variables.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

To develop the code of OBS Studio, I configured obs-studio with `-D CMAKE_INSTALL_PREFIX=/home/user/.local` and am running with `env LD_LIBRARY_PATH=/home/user/.local/lib64: obs`.
However, now `obs-ffmpeg-mux` depends `libobs.so.30` and the shared object cannot be found with my configuration.

Before 71d963a7, we used `popen` so that the environment variables were implicitely passed to the child process.

Another motivation is that the code is shared with macOS and the man page of `posix_spawn` does not say it is ok to pass `NULL` as `envp`. Though it's silently ignored, I think it's better to fix it.
- [Mac OS X Man Pages / `posix_spawn`](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/posix_spawn.2.html)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora release 41

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
