### PR TITLE
frontend: Rearrange default dock positions

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -287,7 +287,7 @@ void OBSApp::InitUserConfigDefaults()
 	config_set_default_bool(userConfig, "BasicWindow", "ShowContextToolbars", true);
 	config_set_default_bool(userConfig, "BasicWindow", "StudioModeLabels", true);
 
-	config_set_default_bool(userConfig, "BasicWindow", "VerticalVolControl", false);
+	config_set_default_bool(userConfig, "BasicWindow", "VerticalVolControl", true);
 
 	config_set_default_bool(userConfig, "BasicWindow", "MultiviewMouseSwitch", true);
 

--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -7,8 +7,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1086</width>
-    <height>729</height>
+    <width>1280</width>
+    <height>960</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -703,7 +703,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1086</width>
+     <width>1280</width>
      <height>22</height>
     </rect>
    </property>
@@ -1275,7 +1275,7 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>323</width>
+              <width>380</width>
               <height>16</height>
              </rect>
             </property>
@@ -2183,7 +2183,7 @@
     <bool>true</bool>
    </property>
    <property name="checked">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="text">
     <string>Basic.MainMenu.Docks.SideDocks</string>

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -264,7 +264,6 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	controlsDock->setWindowTitle(QTStr("Basic.Main.Controls"));
 	/* Parenting is done there so controls will be deleted alongside controlsDock */
 	controlsDock->setWidget(controls);
-	addDockWidget(Qt::BottomDockWidgetArea, controlsDock);
 
 	connect(controls, &OBSBasicControls::StreamButtonClicked, this, &OBSBasic::StreamActionTriggered);
 
@@ -286,6 +285,17 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	connect(controls, &OBSBasicControls::StudioModeButtonClicked, this, &OBSBasic::TogglePreviewProgramMode);
 
 	connect(controls, &OBSBasicControls::SettingsButtonClicked, this, &OBSBasic::on_action_Settings_triggered);
+
+	/* Main window default layout */
+	setDockCornersVertical(true);
+
+	/* Scenes and Sources dock on left
+	 * This specific arrangement can't be set up in Qt Designer */
+	addDockWidget(Qt::LeftDockWidgetArea, ui->scenesDock);
+	splitDockWidget(ui->scenesDock, ui->sourcesDock, Qt::Vertical);
+	int sideDockWidth = std::min(width() * 30 / 100, 320);
+	resizeDocks({ui->scenesDock, ui->sourcesDock}, {sideDockWidth, sideDockWidth}, Qt::Horizontal);
+	addDockWidget(Qt::BottomDockWidgetArea, controlsDock);
 
 	startingDockLayout = saveState();
 
@@ -1175,10 +1185,8 @@ void OBSBasic::OBSInit()
 	ui->lockDocks->blockSignals(false);
 
 	bool sideDocks = config_get_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks");
-	on_sideDocks_toggled(sideDocks);
-	ui->sideDocks->blockSignals(true);
 	ui->sideDocks->setChecked(sideDocks);
-	ui->sideDocks->blockSignals(false);
+	setDockCornersVertical(sideDocks);
 
 	SystemTray(true);
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -447,6 +447,7 @@ public:
 	void RemoveDockWidget(const QString &name);
 	bool IsDockObjectNameUsed(const QString &name);
 	void AddCustomDockWidget(QDockWidget *dock);
+	void setDockCornersVertical(bool vertical);
 
 private slots:
 	void on_resetDocks_triggered(bool force = false);

--- a/frontend/widgets/OBSBasic_Docks.cpp
+++ b/frontend/widgets/OBSBasic_Docks.cpp
@@ -111,21 +111,12 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 #undef RESET_DOCKLIST
 
 	restoreState(startingDockLayout);
+	ui->sideDocks->setChecked(true);
 
 	int cx = width();
-	int cy = height();
+	int bottomDocksHeight = height();
 
-	int cx22_5 = cx * 225 / 1000;
-	int cx5 = cx * 5 / 100;
-	int cx21 = cx * 21 / 100;
-
-	cy = cy * 225 / 1000;
-
-	int mixerSize = cx - (cx22_5 * 2 + cx5 + cx21);
-
-	QList<QDockWidget *> docks{ui->scenesDock, ui->sourcesDock, ui->mixerDock, ui->transitionsDock, controlsDock};
-
-	QList<int> sizes{cx22_5, cx22_5, mixerSize, cx5, cx21};
+	bottomDocksHeight = bottomDocksHeight * 225 / 1000;
 
 	ui->scenesDock->setVisible(true);
 	ui->sourcesDock->setVisible(true);
@@ -135,8 +126,13 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 	statsDock->setVisible(false);
 	statsDock->setFloating(true);
 
-	resizeDocks(docks, {cy, cy, cy, cy, cy}, Qt::Vertical);
-	resizeDocks(docks, sizes, Qt::Horizontal);
+	QList<QDockWidget *> bottomDocks{ui->mixerDock, ui->transitionsDock, controlsDock};
+
+	resizeDocks(bottomDocks, {bottomDocksHeight, bottomDocksHeight, bottomDocksHeight}, Qt::Vertical);
+	resizeDocks(bottomDocks, {cx * 45 / 100, cx * 14 / 100, cx * 16 / 100}, Qt::Horizontal);
+
+	int sideDockWidth = std::min(width() * 30 / 100, 280);
+	resizeDocks({ui->scenesDock, ui->sourcesDock}, {sideDockWidth, sideDockWidth}, Qt::Horizontal);
 
 	activateWindow();
 }
@@ -181,17 +177,9 @@ void OBSBasic::on_lockDocks_toggled(bool lock)
 
 void OBSBasic::on_sideDocks_toggled(bool side)
 {
-	if (side) {
-		setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
-		setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
-		setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
-		setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
-	} else {
-		setCorner(Qt::TopLeftCorner, Qt::TopDockWidgetArea);
-		setCorner(Qt::TopRightCorner, Qt::TopDockWidgetArea);
-		setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
-		setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
-	}
+	config_set_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks", side);
+
+	setDockCornersVertical(side);
 }
 
 QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
@@ -332,6 +320,21 @@ void OBSBasic::AddCustomDockWidget(QDockWidget *dock)
 
 	extraCustomDockNames.push_back(dock->objectName());
 	extraCustomDocks.push_back(dock);
+}
+
+void OBSBasic::setDockCornersVertical(bool vertical)
+{
+	if (vertical) {
+		setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
+		setCorner(Qt::TopRightCorner, Qt::RightDockWidgetArea);
+		setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
+		setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
+	} else {
+		setCorner(Qt::TopLeftCorner, Qt::TopDockWidgetArea);
+		setCorner(Qt::TopRightCorner, Qt::TopDockWidgetArea);
+		setCorner(Qt::BottomLeftCorner, Qt::BottomDockWidgetArea);
+		setCorner(Qt::BottomRightCorner, Qt::BottomDockWidgetArea);
+	}
 }
 
 void OBSBasic::RepairCustomExtraDockName()


### PR DESCRIPTION
### Description
Changes the default arrangement of docks in the main window.

Only affects fresh installs and when resetting the UI. Existing users layouts will remain unchanged.

Indirectly fixes a bug with the Full-Height Docks menu item sometimes becoming desynced from the actual state when resetting docks.

### Motivation and Context
Better use of window space and friendlier layout.

![image](https://github.com/user-attachments/assets/72c862d5-a8cf-4ec0-a179-7f8113a4883f)

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
