### PR TITLE
frontend: Move Preview into dock widget

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -344,7 +344,7 @@ bool OBSStudioAPI::obs_frontend_add_dock_by_id(const char *id, const char *title
 	dock->setWindowTitle(QT_UTF8(title));
 	dock->setObjectName(QT_UTF8(id));
 
-	main->AddDockWidget(dock, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::BottomDockWidgetArea, dock);
 
 	dock->setVisible(false);
 	dock->setFloating(true);

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -861,7 +861,6 @@ Basic.MainMenu.View.SceneListMode="Scene List Mode"
 Basic.MainMenu.Docks="&Docks"
 Basic.MainMenu.Docks.ResetDocks="&Reset Docks"
 Basic.MainMenu.Docks.LockDocks="&Lock Docks"
-Basic.MainMenu.Docks.SideDocks="&Full-Height Docks"
 Basic.MainMenu.Docks.CustomBrowserDocks="&Custom Browser Docks"
 
 # basic mode profile/scene collection menus

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -842,6 +842,20 @@ OBSDock QToolBar QToolButton:disabled {
     background: var(--grey7);
 }
 
+/* Reset styling for the preview dock */
+#previewDock > QWidget {
+    background: var(--bg_base);
+    border-radius: var(--border_radius);
+    border: none;
+    border: 1px solid var(--border_color);
+}
+
+#previewFrame {
+    background: var(--grey7);
+    margin-top: var(--spacing_large);
+    border: 1px solid var(--grey7);
+}
+
 #transitionsFrame {
     padding: var(--padding_container);
 }
@@ -1039,6 +1053,9 @@ OBSDock QScrollBar:vertical {
     background-color: var(--bg_base);
     margin-top: 4px;
     border-radius: var(--border_radius);
+    margin-bottom: var(--spacing_base);
+    border-bottom-left-radius: var(--border_radius);
+    border-bottom-right-radius: var(--border_radius);
 }
 
 #contextContainer QPushButton {
@@ -2330,34 +2347,70 @@ OBSBasicAdvAudio #scrollAreaWidgetContents {
     background: var(--bg_base);
 }
 
-#previewScalePercent,
+#previewXContainer {
+    border-top: 1px solid var(--grey6);
+    max-height: var(--input_height_half);
+    padding: 0;
+    color: var(--text_muted);
+}
+
+#previewZoomOutButton,
+#previewZoomInButton,
 #previewScalingMode {
     background: transparent;
     color: var(--text_muted);
     font-size: var(--font_xsmall);
-    height: 14px;
-    max-height: 14px;
+    height: var(--input_height_half);
+    max-height: var(--input_height_half);
     padding: 0px;
     margin: 0;
-    border: none;
+    border: 1px solid transparent;
     border-radius: 0;
 }
 
-#previewXContainer {
-    border: 1px solid var(--grey6);
+#previewScalingMode,
+#previewScalePercent {
+    color: var(--text_muted);
+    font-size: var(--font_xsmall);
 }
 
-#previewScalePercent {
-    padding: 0px var(--input_text_padding);
-    min-width: var(--preview_scale_width);
+#previewZoomOutButton,
+#previewZoomInButton {
+    padding: 0px var(--padding_large);
 }
 
 #previewScalingMode {
     padding: 0px var(--input_text_padding);
-    border: 1px solid var(--grey6);
+    border-left-color: var(--grey6);
+    border-right-color: var(--grey6);
 }
 
-#previewScalingMode:hover,
+#previewScalingMode QAbstractItemView {
+    padding: 0;
+}
+
+#previewScalingMode QAbstractItemView::item {
+    height: var(--input_height_half);
+    padding: var(--padding_base) var(--padding_large);
+    border-radius: var(--border_radius_small);
+}
+
+#previewZoomOutButton:hover,
+#previewZoomInButton:hover,
+#previewScalingMode:hover {
+    background-color: var(--grey6);
+    border-color: transparent;
+    color: var(--white3);
+}
+
+#previewZoomOutButton:pressed,
+#previewZoomInButton:pressed,
+#previewScalingMode:pressed {
+    background-color: var(--button_down);
+}
+
+#previewZoomOutButton:focus,
+#previewZoomInButton:focus,
 #previewScalingMode:focus {
     border-color: var(--input_border_hover);
 }
@@ -2367,52 +2420,33 @@ OBSBasicAdvAudio #scrollAreaWidgetContents {
     border-color: var(--input_border_focus);
 }
 
-#previewXScrollBar,
-#previewYScrollBar {
+#previewScalePercent {
+    padding: 0px var(--input_text_padding);
+    min-width: var(--preview_scale_width);
+}
+
+#previewContainer QScrollBar {
     background: transparent;
-    border: 1px solid var(--grey6);
+    border: none;
     border-radius: 0;
+    margin: 0;
 }
 
-#previewXScrollBar {
-    border-left: none;
-    height: 16px;
-}
-
-#previewXScrollBar::handle,
-#previewYScrollBar::handle {
+#previewContainer QScrollBar::handle {
     margin: 3px;
 }
 
-#previewYScrollBar {
+#previewContainer QScrollBar::handle:pressed {
+    background-color: var(--grey6);
+}
+
+#previewContainer #previewXScrollBar {
+    height: 16px;
+}
+
+#previewContainer #previewYScrollBar {
     width: 16px;
-}
-
-#previewZoomInButton {
-    border: none;
-    border-radius: 0px;
-    outline: none;
-}
-
-#previewZoomOutButton {
-    border: none;
-    border-radius: 0px;
-    outline: none;
-}
-
-#previewZoomInButton:!hover,
-#previewZoomOutButton:!hover {
-    background-color: transparent;
-}
-
-#previewZoomInButton:pressed,
-#previewZoomOutButton:pressed {
-    background-color: var(--button_bg);
-}
-
-#previewZoomInButton:focus,
-#previewZoomOutButton:focus {
-    border: 1px solid var(--input_border_hover);
+    border-left: 1px solid var(--grey6);
 }
 
 /* Idian Widgets */

--- a/frontend/docks/YouTubeAppDock.cpp
+++ b/frontend/docks/YouTubeAppDock.cpp
@@ -111,7 +111,7 @@ void YouTubeAppDock::AddYouTubeAppDock()
 	this->setMinimumSize(400, 300);
 	this->setAllowedAreas(Qt::AllDockWidgetAreas);
 
-	OBSBasic::Get()->AddDockWidget(this, Qt::RightDockWidgetArea);
+	OBSBasic::Get()->addDockWidget(Qt::RightDockWidgetArea, this);
 
 	if (IsYTServiceSelected()) {
 		const std::string url = InitYTUserUrl();

--- a/frontend/forms/OBSBasic.ui
+++ b/frontend/forms/OBSBasic.ui
@@ -7,7 +7,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1280</width>
+    <width>1474</width>
     <height>960</height>
    </rect>
   </property>
@@ -33,11 +33,20 @@
   <property name="styleSheet">
    <string notr="true"/>
   </property>
+  <property name="animated">
+   <bool>false</bool>
+  </property>
   <property name="dockOptions">
    <set>QMainWindow::AllowNestedDocks|QMainWindow::AllowTabbedDocks</set>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="maximumSize">
+    <size>
+     <width>16777215</width>
+     <height>0</height>
+    </size>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_8">
     <property name="spacing">
      <number>0</number>
     </property>
@@ -53,659 +62,6 @@
     <property name="bottomMargin">
      <number>0</number>
     </property>
-    <item>
-     <widget class="QWidget" name="canvasEditor" native="true">
-      <layout class="QHBoxLayout" name="previewLayout">
-       <property name="spacing">
-        <number>2</number>
-       </property>
-       <property name="leftMargin">
-        <number>1</number>
-       </property>
-       <property name="topMargin">
-        <number>1</number>
-       </property>
-       <property name="rightMargin">
-        <number>1</number>
-       </property>
-       <property name="bottomMargin">
-        <number>1</number>
-       </property>
-       <item>
-        <widget class="QFrame" name="previewDisabledWidget">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>1</number>
-          </property>
-          <property name="topMargin">
-           <number>1</number>
-          </property>
-          <property name="rightMargin">
-           <number>1</number>
-          </property>
-          <property name="bottomMargin">
-           <number>1</number>
-          </property>
-          <item>
-           <spacer name="verticalSpacer_2">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Basic.Main.PreviewDisabled</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="enablePreviewButton">
-              <property name="text">
-               <string>Basic.Main.PreviewConextMenu.Enable</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <spacer name="verticalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QWidget" name="previewContainer" native="true">
-         <layout class="QVBoxLayout" name="previewTextLayout">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="previewLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>StudioMode.PreviewSceneName</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-            <property name="class" stdset="0">
-             <string>label-preview-title</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="gridLayout">
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <item row="1" column="0" colspan="2">
-             <widget class="OBSBasicPreview" name="preview" native="true">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>32</width>
-                <height>32</height>
-               </size>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::ClickFocus</enum>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::CustomContextMenu</enum>
-              </property>
-              <addaction name="actionRemoveSource"/>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QWidget" name="previewXContainer" native="true">
-              <layout class="QHBoxLayout" name="horizontalLayout_7">
-               <property name="spacing">
-                <number>0</number>
-               </property>
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QPushButton" name="previewZoomOutButton">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>20</width>
-                   <height>16</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>20</width>
-                   <height>16</height>
-                  </size>
-                 </property>
-                 <property name="toolTip">
-                  <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="obs.qrc">
-                   <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>8</width>
-                   <height>8</height>
-                  </size>
-                 </property>
-                 <property name="toolButton" stdset="0">
-                  <bool>true</bool>
-                 </property>
-                 <property name="class" stdset="0">
-                  <string>icon-minus</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="OBSPreviewScalingLabel" name="previewScalePercent">
-                 <property name="text">
-                  <string>100%</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QPushButton" name="previewZoomInButton">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimumSize">
-                  <size>
-                   <width>20</width>
-                   <height>16</height>
-                  </size>
-                 </property>
-                 <property name="maximumSize">
-                  <size>
-                   <width>20</width>
-                   <height>16</height>
-                  </size>
-                 </property>
-                 <property name="toolTip">
-                  <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
-                 </property>
-                 <property name="accessibleName">
-                  <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
-                 </property>
-                 <property name="text">
-                  <string/>
-                 </property>
-                 <property name="icon">
-                  <iconset resource="obs.qrc">
-                   <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>8</width>
-                   <height>8</height>
-                  </size>
-                 </property>
-                 <property name="toolButton" stdset="0">
-                  <bool>true</bool>
-                 </property>
-                 <property name="class" stdset="0">
-                  <string>icon-plus</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="OBSPreviewScalingComboBox" name="previewScalingMode">
-                 <item>
-                  <property name="text">
-                   <string>Basic.MainMenu.Edit.Scale.Window</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Basic.MainMenu.Edit.Scale.Canvas</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Fixed</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>4</width>
-                   <height>0</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QScrollBar" name="previewXScrollBar">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="minimum">
-                  <number>-200</number>
-                 </property>
-                 <property name="maximum">
-                  <number>200</number>
-                 </property>
-                 <property name="singleStep">
-                  <number>10</number>
-                 </property>
-                 <property name="pageStep">
-                  <number>100</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QScrollBar" name="previewYScrollBar">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QFrame" name="contextContainer">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>0</height>
-       </size>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout9">
-       <property name="spacing">
-        <number>6</number>
-       </property>
-       <property name="sizeConstraint">
-        <enum>QLayout::SetDefaultConstraint</enum>
-       </property>
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>4</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>4</number>
-       </property>
-       <item>
-        <widget class="QFrame" name="contextSubContainer">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <property name="spacing">
-           <number>6</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <widget class="QLabel" name="contextSourceIcon">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="contextSourceLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>160</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>160</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="text">
-             <string>TextLabel</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="contextSourceIconSpacer">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>22</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line_3">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="sourcePropertiesButton">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>SourceProperties</string>
-            </property>
-            <property name="text">
-             <string>Properties</string>
-            </property>
-            <property name="icon">
-             <iconset resource="obs.qrc">
-              <normaloff>:/settings/images/settings/general.svg</normaloff>:/settings/images/settings/general.svg</iconset>
-            </property>
-            <property name="flat">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="sourceFiltersButton">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>SourceFilters</string>
-            </property>
-            <property name="text">
-             <string>Filters</string>
-            </property>
-            <property name="icon">
-             <iconset resource="obs.qrc">
-              <normaloff>:/res/images/filter.svg</normaloff>:/res/images/filter.svg</iconset>
-            </property>
-            <property name="flat">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="sourceInteractButton">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>22</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Interact</string>
-            </property>
-            <property name="text">
-             <string>Interact</string>
-            </property>
-            <property name="icon">
-             <iconset resource="obs.qrc">
-              <normaloff>:/res/images/interact.svg</normaloff>:/res/images/interact.svg</iconset>
-            </property>
-            <property name="flat">
-             <bool>false</bool>
-            </property>
-            <property name="class" stdset="0">
-             <string notr="true">icon-touch</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QFrame" name="emptySpace">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>22</height>
-          </size>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <property name="spacing">
-           <number>0</number>
-          </property>
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
    </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
@@ -956,7 +312,6 @@
      <string>Basic.MainMenu.Docks</string>
     </property>
     <addaction name="lockDocks"/>
-    <addaction name="sideDocks"/>
     <addaction name="resetDocks"/>
     <addaction name="separator"/>
    </widget>
@@ -973,6 +328,9 @@
   <widget class="OBSDock" name="scenesDock">
    <property name="features">
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::BottomDockWidgetArea</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Scenes</string>
@@ -1102,6 +460,9 @@
   <widget class="OBSDock" name="sourcesDock">
    <property name="features">
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::BottomDockWidgetArea</set>
    </property>
    <property name="windowTitle">
     <string>Basic.Main.Sources</string>
@@ -1264,6 +625,9 @@
   <widget class="OBSDock" name="transitionsDock">
    <property name="features">
     <set>QDockWidget::DockWidgetClosable|QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::BottomDockWidgetArea</set>
    </property>
    <property name="windowTitle">
     <string>Basic.SceneTransitions</string>
@@ -1486,6 +850,663 @@
            </size>
           </property>
          </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="OBSDock" name="previewDock">
+   <property name="features">
+    <set>QDockWidget::NoDockWidgetFeatures</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::BottomDockWidgetArea</set>
+   </property>
+   <property name="windowTitle">
+    <string>Canvas</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>8</number>
+   </attribute>
+   <widget class="QWidget" name="dockWidgetContents_10">
+    <layout class="QVBoxLayout" name="verticalLayout_10">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <property name="leftMargin">
+      <number>4</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <property name="rightMargin">
+      <number>4</number>
+     </property>
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QFrame" name="previewFrame">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>2</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <layout class="QHBoxLayout" name="previewLayout">
+          <property name="spacing">
+           <number>2</number>
+          </property>
+          <item>
+           <widget class="QFrame" name="previewDisabledWidget">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_7">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>1</number>
+             </property>
+             <property name="topMargin">
+              <number>1</number>
+             </property>
+             <property name="rightMargin">
+              <number>1</number>
+             </property>
+             <property name="bottomMargin">
+              <number>1</number>
+             </property>
+             <item>
+              <spacer name="verticalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>Basic.Main.PreviewDisabled</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout">
+               <item>
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="enablePreviewButton">
+                 <property name="text">
+                  <string>Basic.Main.PreviewConextMenu.Enable</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="previewContainer" native="true">
+            <layout class="QVBoxLayout" name="previewTextLayout">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="previewLabel">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Ignored" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="text">
+                <string>StudioMode.PreviewSceneName</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+               </property>
+               <property name="class" stdset="0">
+                <string>label-preview-title</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QGridLayout" name="gridLayout">
+               <property name="spacing">
+                <number>0</number>
+               </property>
+               <item row="1" column="0" colspan="2">
+                <widget class="OBSBasicPreview" name="preview" native="true">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>32</width>
+                   <height>32</height>
+                  </size>
+                 </property>
+                 <property name="focusPolicy">
+                  <enum>Qt::ClickFocus</enum>
+                 </property>
+                 <property name="contextMenuPolicy">
+                  <enum>Qt::CustomContextMenu</enum>
+                 </property>
+                 <addaction name="actionRemoveSource"/>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QWidget" name="previewXContainer" native="true">
+                 <layout class="QHBoxLayout" name="horizontalLayout_7">
+                  <property name="spacing">
+                   <number>0</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>0</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>0</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="previewZoomInButton">
+                    <property name="toolTip">
+                     <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Basic.MainMenu.Edit.Scale.ZoomIn</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="obs.qrc">
+                      <normaloff>:/res/images/plus.svg</normaloff>:/res/images/plus.svg</iconset>
+                    </property>
+                    <property name="iconSize">
+                     <size>
+                      <width>8</width>
+                      <height>8</height>
+                     </size>
+                    </property>
+                    <property name="toolButton" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <property name="class" stdset="0">
+                     <string>icon-plus</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="OBSPreviewScalingLabel" name="previewScalePercent">
+                    <property name="text">
+                     <string>Basic.MainMenu.Edit.Scale.Canvas</string>
+                    </property>
+                    <property name="alignment">
+                     <set>Qt::AlignCenter</set>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="previewZoomOutButton">
+                    <property name="toolTip">
+                     <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                    </property>
+                    <property name="accessibleName">
+                     <string>Basic.MainMenu.Edit.Scale.ZoomOut</string>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="icon">
+                     <iconset resource="obs.qrc">
+                      <normaloff>:/res/images/minus.svg</normaloff>:/res/images/minus.svg</iconset>
+                    </property>
+                    <property name="iconSize">
+                     <size>
+                      <width>8</width>
+                      <height>8</height>
+                     </size>
+                    </property>
+                    <property name="toolButton" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <property name="class" stdset="0">
+                     <string>icon-minus</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="OBSPreviewScalingComboBox" name="previewScalingMode">
+                    <item>
+                     <property name="text">
+                      <string>Basic.MainMenu.Edit.Scale.Window</string>
+                     </property>
+                    </item>
+                    <item>
+                     <property name="text">
+                      <string>Basic.MainMenu.Edit.Scale.Canvas</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="horizontalSpacer_5">
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>4</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QScrollBar" name="previewXScrollBar">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimum">
+                     <number>-200</number>
+                    </property>
+                    <property name="maximum">
+                     <number>200</number>
+                    </property>
+                    <property name="singleStep">
+                     <number>10</number>
+                    </property>
+                    <property name="pageStep">
+                     <number>100</number>
+                    </property>
+                    <property name="orientation">
+                     <enum>Qt::Horizontal</enum>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item row="1" column="2">
+                <widget class="QScrollBar" name="previewYScrollBar">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFrame" name="contextContainer">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout9">
+        <property name="spacing">
+         <number>6</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="leftMargin">
+         <number>6</number>
+        </property>
+        <property name="topMargin">
+         <number>4</number>
+        </property>
+        <property name="rightMargin">
+         <number>6</number>
+        </property>
+        <property name="bottomMargin">
+         <number>4</number>
+        </property>
+        <item>
+         <widget class="QFrame" name="contextSubContainer">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="contextSourceIcon">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="contextSourceLabel">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>160</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>160</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>TextLabel</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="contextSourceIconSpacer">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>22</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="line_3">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sourcePropertiesButton">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>SourceProperties</string>
+             </property>
+             <property name="text">
+              <string>Properties</string>
+             </property>
+             <property name="icon">
+              <iconset resource="obs.qrc">
+               <normaloff>:/settings/images/settings/general.svg</normaloff>:/settings/images/settings/general.svg</iconset>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sourceFiltersButton">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>SourceFilters</string>
+             </property>
+             <property name="text">
+              <string>Filters</string>
+             </property>
+             <property name="icon">
+              <iconset resource="obs.qrc">
+               <normaloff>:/res/images/filter.svg</normaloff>:/res/images/filter.svg</iconset>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="sourceInteractButton">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>22</height>
+              </size>
+             </property>
+             <property name="toolTip">
+              <string>Interact</string>
+             </property>
+             <property name="text">
+              <string>Interact</string>
+             </property>
+             <property name="icon">
+              <iconset resource="obs.qrc">
+               <normaloff>:/res/images/interact.svg</normaloff>:/res/images/interact.svg</iconset>
+             </property>
+             <property name="flat">
+              <bool>false</bool>
+             </property>
+             <property name="class" stdset="0">
+              <string notr="true">icon-touch</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="Line" name="line">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QFrame" name="emptySpace">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>22</height>
+           </size>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -2066,17 +2087,6 @@
    </property>
    <property name="text">
     <string>Basic.MainMenu.Docks.LockDocks</string>
-   </property>
-  </action>
-  <action name="sideDocks">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="checked">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Basic.MainMenu.Docks.SideDocks</string>
    </property>
   </action>
   <action name="actionHelpPortal">

--- a/frontend/oauth/RestreamAuth.cpp
+++ b/frontend/oauth/RestreamAuth.cpp
@@ -103,7 +103,7 @@ try {
 void RestreamAuth::SaveInternal()
 {
 	OBSBasic *main = OBSBasic::Get();
-	config_set_string(main->Config(), service(), "DockState", main->saveState().toBase64().constData());
+	config_set_string(main->Config(), service(), "DockState2", main->saveState().toBase64().constData());
 	OAuthStreamKey::SaveInternal();
 }
 
@@ -152,7 +152,7 @@ void RestreamAuth::LoadUI()
 	browser = cef->create_widget(chat, url, panel_cookies);
 	chat->SetWidget(browser);
 
-	main->AddDockWidget(chat, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, chat);
 
 	/* ----------------------------------- */
 
@@ -168,7 +168,7 @@ void RestreamAuth::LoadUI()
 	browser = cef->create_widget(info, url, panel_cookies);
 	info->SetWidget(browser);
 
-	main->AddDockWidget(info, Qt::LeftDockWidgetArea);
+	main->addDockWidget(Qt::BottomDockWidgetArea, info);
 
 	/* ----------------------------------- */
 
@@ -184,7 +184,7 @@ void RestreamAuth::LoadUI()
 	browser = cef->create_widget(channels, url, panel_cookies);
 	channels->SetWidget(browser);
 
-	main->AddDockWidget(channels, Qt::LeftDockWidgetArea);
+	main->addDockWidget(Qt::BottomDockWidgetArea, channels);
 
 	/* ----------------------------------- */
 
@@ -201,7 +201,7 @@ void RestreamAuth::LoadUI()
 		info->setVisible(true);
 		channels->setVisible(true);
 	} else {
-		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
+		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState2");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
 		main->restoreState(dockState);
 	}

--- a/frontend/oauth/TwitchAuth.cpp
+++ b/frontend/oauth/TwitchAuth.cpp
@@ -154,7 +154,7 @@ void TwitchAuth::SaveInternal()
 	config_set_string(main->Config(), service(), "UUID", uuid.c_str());
 
 	if (uiLoaded) {
-		config_set_string(main->Config(), service(), "DockState", main->saveState().toBase64().constData());
+		config_set_string(main->Config(), service(), "DockState2", main->saveState().toBase64().constData());
 	}
 	OAuthStreamKey::SaveInternal();
 }
@@ -261,17 +261,17 @@ void TwitchAuth::LoadUI()
 
 	browser->setStartupScript(script);
 
-	main->AddDockWidget(chat, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, chat);
 
 	/* ----------------------------------- */
 
-	chat->setFloating(true);
+	//chat->setFloating(true);
 	chat->move(pos.x() + size.width() - chat->width() - 50, pos.y() + 50);
 
 	if (firstLoad) {
 		chat->setVisible(true);
 	} else {
-		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
+		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState2");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
 		main->restoreState(dockState);
 	}
@@ -328,7 +328,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	info->SetWidget(browser);
 	browser->setStartupScript(script);
 
-	main->AddDockWidget(info, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, info);
 
 	/* ----------------------------------- */
 
@@ -347,7 +347,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	stats->SetWidget(browser);
 	browser->setStartupScript(script);
 
-	main->AddDockWidget(stats, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, stats);
 
 	/* ----------------------------------- */
 
@@ -367,13 +367,13 @@ void TwitchAuth::LoadSecondaryUIPanes()
 	feed->SetWidget(browser);
 	browser->setStartupScript(script);
 
-	main->AddDockWidget(feed, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, feed);
 
 	/* ----------------------------------- */
 
-	info->setFloating(true);
-	stats->setFloating(true);
-	feed->setFloating(true);
+	//info->setFloating(true);
+	//stats->setFloating(true);
+	//feed->setFloating(true);
 
 	QSize statSize = stats->frameSize();
 
@@ -393,7 +393,7 @@ void TwitchAuth::LoadSecondaryUIPanes()
 			feed->setVisible(false);
 		}
 
-		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
+		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState2");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
 
 		if (main->isVisible() || !main->isMaximized())

--- a/frontend/oauth/YoutubeAuth.cpp
+++ b/frontend/oauth/YoutubeAuth.cpp
@@ -77,7 +77,7 @@ bool YoutubeAuth::RetryLogin()
 void YoutubeAuth::SaveInternal()
 {
 	OBSBasic *main = OBSBasic::Get();
-	config_set_string(main->Config(), service(), "DockState", main->saveState().toBase64().constData());
+	config_set_string(main->Config(), service(), "DockState2", main->saveState().toBase64().constData());
 
 	const char *section_name = section.c_str();
 	config_set_string(main->Config(), section_name, "RefreshToken", refresh_token.c_str());
@@ -131,7 +131,7 @@ void YoutubeAuth::LoadUI()
 	browser = cef->create_widget(chat, YOUTUBE_CHAT_PLACEHOLDER_URL, panel_cookies);
 
 	chat->SetWidget(browser);
-	main->AddDockWidget(chat, Qt::RightDockWidgetArea);
+	main->addDockWidget(Qt::RightDockWidgetArea, chat);
 
 	chat->setFloating(true);
 	chat->move(pos.x() + size.width() - chat->width() - 50, pos.y() + 50);
@@ -146,7 +146,7 @@ void YoutubeAuth::LoadUI()
 	}
 
 	if (!firstLoad) {
-		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
+		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState2");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
 		main->restoreState(dockState);
 	}

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -286,6 +286,7 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	controlsDock->setWindowTitle(QTStr("Basic.Main.Controls"));
 	/* Parenting is done there so controls will be deleted alongside controlsDock */
 	controlsDock->setWidget(controls);
+	controlsDock->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 
 	connect(controls, &OBSBasicControls::StreamButtonClicked, this, &OBSBasic::StreamActionTriggered);
 
@@ -347,11 +348,17 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 
 	/* Scenes and Sources dock on left
 	 * This specific arrangement can't be set up in Qt Designer */
-	addDockWidget(Qt::LeftDockWidgetArea, ui->scenesDock);
+
+	splitDockWidget(ui->scenesDock, ui->previewDock, Qt::Horizontal);
 	splitDockWidget(ui->scenesDock, ui->sourcesDock, Qt::Vertical);
+
+	splitDockWidget(ui->previewDock, ui->mixerDock, Qt::Vertical);
+
+	splitDockWidget(ui->mixerDock, ui->transitionsDock, Qt::Horizontal);
+	splitDockWidget(ui->transitionsDock, controlsDock, Qt::Horizontal);
+
 	int sideDockWidth = std::min(width() * 30 / 100, 320);
 	resizeDocks({ui->scenesDock, ui->sourcesDock}, {sideDockWidth, sideDockWidth}, Qt::Horizontal);
-	addDockWidget(Qt::BottomDockWidgetArea, controlsDock);
 
 	startingDockLayout = saveState();
 
@@ -582,6 +589,9 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	UpdatePreviewSafeAreas();
 	UpdatePreviewSpacingHelpers();
 	UpdatePreviewOverflowSettings();
+
+	QWidget *emptyTitle = new QWidget();
+	ui->previewDock->setTitleBarWidget(emptyTitle);
 }
 
 static const double scaled_vals[] = {1.0, 1.25, (1.0 / 0.75), 1.5, (1.0 / 0.6), 1.75, 2.0, 2.25, 2.5, 2.75, 3.0, 0.0};
@@ -1219,7 +1229,7 @@ void OBSBasic::OBSInit()
 		NewYouTubeAppDock();
 #endif
 
-	const char *dockStateStr = config_get_string(App()->GetUserConfig(), "BasicWindow", "DockState");
+	const char *dockStateStr = config_get_string(App()->GetUserConfig(), "BasicWindow", "DockState2");
 
 	if (!dockStateStr) {
 		on_resetDocks_triggered(true);
@@ -1245,9 +1255,7 @@ void OBSBasic::OBSInit()
 	ui->lockDocks->setChecked(docksLocked);
 	ui->lockDocks->blockSignals(false);
 
-	bool sideDocks = config_get_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks");
-	ui->sideDocks->setChecked(sideDocks);
-	setDockCornersVertical(sideDocks);
+	setDockCornersVertical(true);
 
 	SystemTray(true);
 
@@ -1852,7 +1860,7 @@ void OBSBasic::saveAll()
 	Auth::Save();
 	SaveProjectNow();
 
-	config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState", saveState().toBase64().constData());
+	config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState2", saveState().toBase64().constData());
 
 #ifdef BROWSER_AVAILABLE
 	if (cef) {
@@ -1870,7 +1878,6 @@ void OBSBasic::saveAll()
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "EditPropertiesMode", editPropertiesMode);
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "PreviewProgramMode", IsPreviewProgramMode());
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "DocksLocked", ui->lockDocks->isChecked());
-	config_set_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks", ui->sideDocks->isChecked());
 	config_save_safe(App()->GetUserConfig(), "tmp", nullptr);
 }
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -445,7 +445,7 @@ private:
 	QPointer<OBSDock> mixerDock;
 
 public:
-	void AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area, bool extraBrowser = false);
+	void addDockWidget(Qt::DockWidgetArea area, QDockWidget *dock, bool extraBrowser = false);
 	void RemoveDockWidget(const QString &name);
 	bool IsDockObjectNameUsed(const QString &name);
 	void AddCustomDockWidget(QDockWidget *dock);
@@ -454,7 +454,6 @@ public:
 private slots:
 	void on_resetDocks_triggered(bool force = false);
 	void on_lockDocks_toggled(bool lock);
-	void on_sideDocks_toggled(bool side);
 
 	void RepairCustomExtraDockName();
 

--- a/frontend/widgets/OBSBasic_Browser.cpp
+++ b/frontend/widgets/OBSBasic_Browser.cpp
@@ -139,7 +139,7 @@ void OBSBasic::AddExtraBrowserDock(const QString &title, const QString &url, con
 		}
 	}
 
-	AddDockWidget(dock, Qt::RightDockWidgetArea, true);
+	addDockWidget(Qt::BottomDockWidgetArea, dock, true);
 	extraBrowserDocks.push_back(std::shared_ptr<QDockWidget>(dock));
 	extraBrowserDockNames.push_back(title);
 	extraBrowserDockTargets.push_back(url);

--- a/frontend/widgets/OBSBasic_ContextToolbar.cpp
+++ b/frontend/widgets/OBSBasic_ContextToolbar.cpp
@@ -70,7 +70,7 @@ void OBSBasic::ClearContextBar()
 
 void OBSBasic::UpdateContextBarVisibility()
 {
-	int width = ui->centralwidget->size().width();
+	int width = ui->previewFrame->width();
 
 	ContextBarSize contextBarSizeNew;
 	if (width >= 740) {

--- a/frontend/widgets/OBSBasic_Docks.cpp
+++ b/frontend/widgets/OBSBasic_Docks.cpp
@@ -74,7 +74,6 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 #undef RESET_DOCKLIST
 
 	restoreState(startingDockLayout);
-	ui->sideDocks->setChecked(true);
 
 	int cx = width();
 	int bottomDocksHeight = height();
@@ -91,6 +90,7 @@ void OBSBasic::on_resetDocks_triggered(bool force)
 
 	QList<QDockWidget *> bottomDocks{ui->mixerDock, ui->transitionsDock, controlsDock};
 
+	resizeDocks({ui->previewDock}, {height() * 750 / 100}, Qt::Vertical);
 	resizeDocks(bottomDocks, {bottomDocksHeight, bottomDocksHeight, bottomDocksHeight}, Qt::Vertical);
 	resizeDocks(bottomDocks, {cx * 45 / 100, cx * 14 / 100, cx * 16 / 100}, Qt::Horizontal);
 
@@ -129,14 +129,7 @@ void OBSBasic::on_lockDocks_toggled(bool lock)
 #endif
 }
 
-void OBSBasic::on_sideDocks_toggled(bool side)
-{
-	config_set_bool(App()->GetUserConfig(), "BasicWindow", "SideDocks", side);
-
-	setDockCornersVertical(side);
-}
-
-void OBSBasic::AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area, bool extraBrowser)
+void OBSBasic::addDockWidget(Qt::DockWidgetArea area, QDockWidget *dock, bool extraBrowser)
 {
 	if (dock->objectName().isEmpty())
 		return;
@@ -149,7 +142,7 @@ void OBSBasic::AddDockWidget(QDockWidget *dock, Qt::DockWidgetArea area, bool ex
 
 	setupDockAction(dock);
 	dock->setFeatures(features);
-	addDockWidget(area, dock);
+	QMainWindow::addDockWidget(area, dock);
 
 #ifdef BROWSER_AVAILABLE
 	if (extraBrowser && extraBrowserMenuDocksSeparator.isNull())


### PR DESCRIPTION
### Description
Moves the widgets for the preview into an OBSDock within the main window. Instead of the preview being the centralwidget, a new dummy one is added to the top of the window, and all docks have their allowedAreas set to `BottomDockWidgetArea` only.

Depends on #12188

> [!NOTE]  
> Still need to update Browser Docks to have their allowedAreas set correctly, as well as probably override the `addDock` method to force set it.

The Preview dock cannot be moved, undocked or hidden and has an empty widget for it's title bar. Functionally it is effectively identical to before.

![image](https://github.com/user-attachments/assets/275d3a50-1075-463e-a33e-4854fd3ce856)


### Motivation and Context
This makes certain dock layouts much more intuitive to set up, moves us a small step closer to more encapsulation of main window functionality. This is also a requirement for additional UI changes in the future that I am experimenting with involving either a top toolbar or a dedicated sidebar as a revamped home for Outputs, contextual controls, and eventually canvases.

### How Has This Been Tested?
Interacted with the preview and ensured functionality matched main.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
