### PR TITLE
frontend: Make OBSAbout self contained

### DIFF
--- a/frontend/dialogs/OBSAbout.cpp
+++ b/frontend/dialogs/OBSAbout.cpp
@@ -1,13 +1,17 @@
 #include "OBSAbout.hpp"
-
-#include <widgets/OBSBasic.hpp>
+#include <OBSApp.hpp>
 #include <utility/RemoteTextThread.hpp>
+#include <utility/platform.hpp>
 
 #include <qt-wrappers.hpp>
 
 #include <json11.hpp>
 
 #include "moc_OBSAbout.cpp"
+
+namespace {
+std::string patronJson;
+} // namespace
 
 using namespace json11;
 
@@ -61,30 +65,43 @@ OBSAbout::OBSAbout(QWidget *parent) : QDialog(parent), ui(new Ui::OBSAbout)
 	connect(ui->authors, &ClickableLabel::clicked, this, &OBSAbout::ShowAuthors);
 	connect(ui->license, &ClickableLabel::clicked, this, &OBSAbout::ShowLicense);
 
-	QPointer<OBSAbout> about(this);
-
-	OBSBasic *main = OBSBasic::Get();
-	if (main->patronJson.empty() && !main->patronJsonThread) {
+	if (patronJson.empty()) {
 		RemoteTextThread *thread =
 			new RemoteTextThread("https://obsproject.com/patreon/about-box.json", "application/json");
-		QObject::connect(thread, &RemoteTextThread::Result, main, &OBSBasic::UpdatePatronJson);
-		QObject::connect(thread, &RemoteTextThread::Result, this, &OBSAbout::ShowAbout);
-		main->patronJsonThread.reset(thread);
+		connect(thread, &RemoteTextThread::Result, this, &OBSAbout::updatePatronJson);
+		patronJsonThread.reset(thread);
 		thread->start();
 	} else {
 		ShowAbout();
 	}
 }
 
+OBSAbout::~OBSAbout()
+{
+	if (patronJsonThread && patronJsonThread->isRunning()) {
+		patronJsonThread->wait();
+	}
+}
+
+void OBSAbout::updatePatronJson(const std::string &text, const std::string &error)
+{
+	if (!error.empty()) {
+		return;
+	}
+
+	patronJson = text;
+
+	ShowAbout();
+}
+
 void OBSAbout::ShowAbout()
 {
-	OBSBasic *main = OBSBasic::Get();
-
-	if (main->patronJson.empty())
+	if (patronJson.empty()) {
 		return;
+	}
 
 	std::string error;
-	Json json = Json::parse(main->patronJson, error);
+	Json json = Json::parse(patronJson, error);
 	const Json::array &patrons = json.array_items();
 	QString text;
 

--- a/frontend/dialogs/OBSAbout.hpp
+++ b/frontend/dialogs/OBSAbout.hpp
@@ -7,8 +7,12 @@
 class OBSAbout : public QDialog {
 	Q_OBJECT
 
+private:
+	QScopedPointer<QThread> patronJsonThread;
+
 public:
 	explicit OBSAbout(QWidget *parent = 0);
+	~OBSAbout();
 
 	std::unique_ptr<Ui::OBSAbout> ui;
 
@@ -16,4 +20,6 @@ private slots:
 	void ShowAbout();
 	void ShowAuthors();
 	void ShowLicense();
+
+	void updatePatronJson(const std::string &text, const std::string &error);
 };

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1403,9 +1403,6 @@ void OBSBasic::applicationShutdown() noexcept
 	if (updateCheckThread && updateCheckThread->isRunning())
 		updateCheckThread->wait();
 
-	if (patronJsonThread && patronJsonThread->isRunning())
-		patronJsonThread->wait();
-
 	delete screenshotData;
 	delete previewProjectorSource;
 	delete previewProjectorMain;
@@ -2106,14 +2103,6 @@ void OBSBasic::UpdateTitleBar()
 OBSBasic *OBSBasic::Get()
 {
 	return reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
-}
-
-void OBSBasic::UpdatePatronJson(const std::string &text, const std::string &error)
-{
-	if (!error.empty())
-		return;
-
-	patronJson = text;
 }
 
 void OBSBasic::SetDisplayAffinity(QWindow *window)

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -199,7 +199,6 @@ class OBSBasic : public OBSMainWindow {
 	Q_PROPERTY(QIcon audioProcessOutputIcon READ GetAudioProcessOutputIcon WRITE SetAudioProcessOutputIcon
 			   DESIGNABLE true)
 
-	friend class OBSAbout;
 	friend class OBSBasicPreview;
 	friend class OBSBasicStatusBar;
 	friend class OBSBasicSourceSelect;
@@ -254,9 +253,6 @@ private:
 
 	ConfigFile activeConfiguration;
 
-	QScopedPointer<QThread> patronJsonThread;
-	std::string patronJson;
-
 	std::unique_ptr<Ui::OBSBasic> ui;
 
 	void OnEvent(enum obs_frontend_event event);
@@ -284,7 +280,6 @@ private:
 
 public slots:
 	void close();
-	void UpdatePatronJson(const std::string &text, const std::string &error);
 	void UpdateEditMenu();
 	void applicationShutdown() noexcept;
 	void toggleMixerLayout();


### PR DESCRIPTION
### Description
This makes it so OBSAbout isn't tangled with OBSBasic.

### Motivation and Context
Make frontend less messy

### How Has This Been Tested?
Opened about dialog to make sure it still worked

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
