### PR TITLE
linux-pipewire: Fix render technique in captures

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -1309,7 +1309,7 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_sync_destroy(acquire_sync);
 	}
 
-	effect = obs_get_base_effect(OBS_EFFECT_OPAQUE);
+	effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
 	gs_technique_t *tech = gs_effect_get_technique(effect, "DrawSrgbDecompress");
 	gs_technique_begin(tech);
 	gs_technique_begin_pass(tech, 0);


### PR DESCRIPTION
### Description
Use the default rendering technique instead of the opaque one.

### Motivation and Context

Cursors and transparent windows currently have a black background, because the wrong render technique is used.

Fixes #12091 

### How Has This Been Tested?

Requires proper testing, I simply loaded up KDE and ensured the black background is gone.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
