### PR TITLE
win-capture: Add Wuthering Waves to compatibility list

### DIFF
--- a/plugins/win-capture/data/compatibility.json
+++ b/plugins/win-capture/data/compatibility.json
@@ -645,6 +645,20 @@
             "window_capture_wgc": false,
             "message": "Roblox cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
             "url": ""
+        },
+        {
+            "name": "Wuthering Waves",
+            "translation_key": "Compatibility.GameCapture.Admin",
+            "severity": 1,
+            "executable": "Client-Win64-Shipping.exe",
+            "window_class": "",
+            "window_title": "Wuthering Waves",
+            "match_flags": 3,
+            "game_capture": true,
+            "window_capture": false,
+            "window_capture_wgc": false,
+            "message": "Wuthering Waves may require OBS to be run as admin to use Game Capture.",
+            "url": "https://obsproject.com/kb/game-capture-troubleshooting"
         }
     ]
 }

--- a/plugins/win-capture/data/package.json
+++ b/plugins/win-capture/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/win-capture/v1",
-    "version": 8,
+    "version": 9,
     "files": [
         {
             "name": "compatibility.json",
-            "version": 8
+            "version": 9
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds the game Wuthering Waves to the compatibility list for win-capture.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
People being able to probably game capture the game.

Wuthering Waves runs by default with administrative privileges which requires OBS Studio to run with administrative privileges as well for game capture to work.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Selected the game in the game capture source and the warning message showed up like it should. Also made sure that the warning does not show up for other games with the same .exe name.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
