### PR TITLE
libobs: Actually mark obs_[add|remove]_data_path as deprecated

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1273,15 +1273,13 @@ char *obs_find_data_file(const char *file)
 	return NULL;
 }
 
-// TODO: Remove after deprecation grace period
-OBS_DEPRECATED void obs_add_data_path(const char *path)
+void obs_add_data_path(const char *path)
 {
 	struct dstr *new_path = da_push_back_new(core_module_paths);
 	dstr_init_copy(new_path, path);
 }
 
-// TODO: Remove after deprecation grace period
-OBS_DEPRECATED bool obs_remove_data_path(const char *path)
+bool obs_remove_data_path(const char *path)
 {
 	for (size_t i = 0; i < core_module_paths.num; ++i) {
 		int result = dstr_cmp(&core_module_paths.array[i], path);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -321,13 +321,15 @@ struct obs_cmdline_args {
  */
 EXPORT char *obs_find_data_file(const char *file);
 
+// TODO: Remove after deprecation grace period
 /**
  * Add a path to search libobs data files in.
  * @param path Full path to directory to look in.
  *             The string is copied.
  */
-EXPORT void obs_add_data_path(const char *path);
+OBS_DEPRECATED EXPORT void obs_add_data_path(const char *path);
 
+// TODO: Remove after deprecation grace period
 /**
  * Remove a path from libobs core data paths.
  * @param path The path to compare to currently set paths.
@@ -336,7 +338,7 @@ EXPORT void obs_add_data_path(const char *path);
  * @return Whether or not the path was successfully removed.
  *         If false, the path could not be found.
  */
-EXPORT bool obs_remove_data_path(const char *path);
+OBS_DEPRECATED EXPORT bool obs_remove_data_path(const char *path);
 
 /**
  * Initializes OBS


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
3311a7105e2df15825ed9a5915543257f18eacb8 (#9978) was meant to mark these as deprecated, but put the deprecated marker in the .c file which doesn't work.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Noticed while working on deprecating something else. Want deprecations to actually show.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Put a `obs_add_data_path("")` call in the frontend which now (unlike before) gets a deprecation warning.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
