### PR TITLE
frontend: Fix metatype declaration for scenes and OBSBasic

### DIFF
--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -37,6 +37,19 @@ template<typename OBSRef> struct SignalContainer {
 	OBSRef ref;
 	vector<shared_ptr<OBSSignal>> handlers;
 };
+
+QDataStream &operator<<(QDataStream &out, const SignalContainer<OBSScene> &v)
+{
+	out << v.ref;
+	return out;
+}
+
+QDataStream &operator>>(QDataStream &in, SignalContainer<OBSScene> &v)
+{
+	in >> v.ref;
+	return in;
+}
+
 } // namespace
 
 Q_DECLARE_METATYPE(obs_order_movement);


### PR DESCRIPTION
### Description
Add missing operator declarations for `SignalContainer` type to fix warnings emitted by its use as a `QVariant`.

### Motivation and Context
Metatype declarations should occur as soon as possible after the underlying type has been declared and can be placed in shared header files, as the macro will expand to a struct with a static getter method that attempts to return the associated meta type ID within Qt's meta type registry if it has been registered already or create a new meta type based on the type and the "stringified" identifer of the type.

To be used as a QVariant, stream operators also need to be provided as the meta type will otherwise be considered "incomplete".

### How Has This Been Tested?
Tested on macOS 15 by changing scene order via drag and drop which would have otherwise triggered the issue.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
