### PR TITLE
frontend, libobs: Add OBSProperties OBSPtr type

### DIFF
--- a/frontend/components/BrowserToolbar.cpp
+++ b/frontend/components/BrowserToolbar.cpp
@@ -18,6 +18,6 @@ void BrowserToolbar::on_refresh_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "refreshnocache");
+	obs_property_t *p = obs_properties_get(props, "refreshnocache");
 	obs_property_button_clicked(p, source.Get());
 }

--- a/frontend/components/ColorSourceToolbar.cpp
+++ b/frontend/components/ColorSourceToolbar.cpp
@@ -54,7 +54,7 @@ void ColorSourceToolbar::on_choose_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "color");
+	obs_property_t *p = obs_properties_get(props, "color");
 	const char *desc = obs_property_description(p);
 
 	QColorDialog::ColorDialogOptions options;

--- a/frontend/components/ComboSelectToolbar.cpp
+++ b/frontend/components/ComboSelectToolbar.cpp
@@ -77,7 +77,7 @@ void ComboSelectToolbar::Init()
 		return;
 	}
 
-	UpdateSourceComboToolbarProperties(ui->device, source, props.get(), prop_name, is_int);
+	UpdateSourceComboToolbarProperties(ui->device, source, props, prop_name, is_int);
 }
 
 void UpdateSourceComboToolbarValue(QComboBox *combo, OBSSource source, int idx, const char *prop_name, bool is_int)

--- a/frontend/components/GameCaptureToolbar.cpp
+++ b/frontend/components/GameCaptureToolbar.cpp
@@ -28,13 +28,13 @@ GameCaptureToolbar::GameCaptureToolbar(QWidget *parent, OBSSource source)
 	std::string cur_window = obs_data_get_string(settings, "window");
 
 	ui->mode->blockSignals(true);
-	p = obs_properties_get(props.get(), "capture_mode");
+	p = obs_properties_get(props, "capture_mode");
 	cur_idx = FillPropertyCombo(ui->mode, p, cur_mode);
 	ui->mode->setCurrentIndex(cur_idx);
 	ui->mode->blockSignals(false);
 
 	ui->window->blockSignals(true);
-	p = obs_properties_get(props.get(), "window");
+	p = obs_properties_get(props, "window");
 	cur_idx = FillPropertyCombo(ui->window, p, cur_window);
 	ui->window->setCurrentIndex(cur_idx);
 	ui->window->blockSignals(false);

--- a/frontend/components/ImageSourceToolbar.cpp
+++ b/frontend/components/ImageSourceToolbar.cpp
@@ -29,7 +29,7 @@ void ImageSourceToolbar::on_browse_clicked()
 		return;
 	}
 
-	obs_property_t *p = obs_properties_get(props.get(), "file");
+	obs_property_t *p = obs_properties_get(props, "file");
 	const char *desc = obs_property_description(p);
 	const char *filter = obs_property_path_filter(p);
 	const char *default_path = obs_property_path_default_path(p);

--- a/frontend/components/SourceToolbar.cpp
+++ b/frontend/components/SourceToolbar.cpp
@@ -7,7 +7,7 @@
 SourceToolbar::SourceToolbar(QWidget *parent, OBSSource source)
 	: QWidget(parent),
 	  weakSource(OBSGetWeakRef(source)),
-	  props(obs_source_properties(source), obs_properties_destroy)
+	  props(obs_source_properties(source))
 {
 }
 

--- a/frontend/components/SourceToolbar.hpp
+++ b/frontend/components/SourceToolbar.hpp
@@ -10,10 +10,7 @@ class SourceToolbar : public QWidget {
 	OBSWeakSource weakSource;
 
 protected:
-	using properties_delete_t = decltype(&obs_properties_destroy);
-	using properties_t = std::unique_ptr<obs_properties_t, properties_delete_t>;
-
-	properties_t props;
+	OBSProperties props;
 	OBSDataAutoRelease oldData;
 
 	void SaveOldProperties(obs_source_t *source);

--- a/frontend/components/TextSourceToolbar.cpp
+++ b/frontend/components/TextSourceToolbar.cpp
@@ -98,7 +98,7 @@ void TextSourceToolbar::on_selectColor_clicked()
 
 	bool freetype = strncmp(obs_source_get_id(source), "text_ft2_source", 15) == 0;
 
-	obs_property_t *p = obs_properties_get(props.get(), freetype ? "color1" : "color");
+	obs_property_t *p = obs_properties_get(props, freetype ? "color1" : "color");
 
 	const char *desc = obs_property_description(p);
 

--- a/frontend/plugins/frontend-tools/scripts.cpp
+++ b/frontend/plugins/frontend-tools/scripts.cpp
@@ -247,9 +247,8 @@ void ScriptsTool::ReloadScript(const char *path)
 
 			OBSDataAutoRelease settings = obs_script_get_settings(script);
 
-			obs_properties_t *prop = obs_script_get_properties(script);
+			OBSProperties prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
-			obs_properties_destroy(prop);
 
 			break;
 		}
@@ -351,9 +350,8 @@ void ScriptsTool::on_addScripts_clicked()
 
 			OBSDataAutoRelease settings = obs_script_get_settings(script);
 
-			obs_properties_t *prop = obs_script_get_properties(script);
+			OBSProperties prop = obs_script_get_properties(script);
 			obs_properties_apply_settings(prop, settings);
-			obs_properties_destroy(prop);
 
 			ui->scripts->setCurrentItem(item);
 		}

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -798,7 +798,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	connectScaleFilter(ui->advOutRecRescaleFilter, ui->advOutRecRescale);
 
 	// Get Bind to IP Addresses
-	obs_properties_t *ppts = obs_get_output_properties("rtmp_output");
+	OBSProperties ppts = obs_get_output_properties("rtmp_output");
 	obs_property_t *p = obs_properties_get(ppts, "bind_ip");
 
 	size_t count = obs_property_list_item_count(p);
@@ -819,8 +819,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 		ui->ipFamily->addItem(QT_UTF8(name), val);
 	}
-
-	obs_properties_destroy(ppts);
 
 	ui->multitrackVideoNoticeBox->setVisible(false);
 
@@ -2281,8 +2279,8 @@ void OBSBasicSettings::LoadAudioDevices()
 	const char *input_id = App()->InputAudioSource();
 	const char *output_id = App()->OutputAudioSource();
 
-	obs_properties_t *input_props = obs_get_source_properties(input_id);
-	obs_properties_t *output_props = obs_get_source_properties(output_id);
+	OBSProperties input_props = obs_get_source_properties(input_id);
+	OBSProperties output_props = obs_get_source_properties(output_id);
 
 	if (input_props) {
 		obs_property_t *inputs = obs_properties_get(input_props, "device_id");
@@ -2290,14 +2288,12 @@ void OBSBasicSettings::LoadAudioDevices()
 		LoadListValues(ui->auxAudioDevice2, inputs, 4);
 		LoadListValues(ui->auxAudioDevice3, inputs, 5);
 		LoadListValues(ui->auxAudioDevice4, inputs, 6);
-		obs_properties_destroy(input_props);
 	}
 
 	if (output_props) {
 		obs_property_t *outputs = obs_properties_get(output_props, "device_id");
 		LoadListValues(ui->desktopAudioDevice1, outputs, 1);
 		LoadListValues(ui->desktopAudioDevice2, outputs, 2);
-		obs_properties_destroy(output_props);
 	}
 
 	if (obs_video_active()) {
@@ -4844,7 +4840,7 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 
 		const char *name = get_simple_output_encoder(QT_TO_UTF8(encoder));
 		const bool isFFmpegEncoder = strncmp(name, "ffmpeg_", 7) == 0;
-		obs_properties_t *props = obs_get_encoder_properties(name);
+		OBSProperties props = obs_get_encoder_properties(name);
 
 		obs_property_t *p = obs_properties_get(props, isFFmpegEncoder ? "preset2" : "preset");
 		size_t num = obs_property_list_item_count(p);
@@ -4854,8 +4850,6 @@ void OBSBasicSettings::SimpleStreamingEncoderChanged()
 
 			ui->simpleOutPreset->addItem(QT_UTF8(name), val);
 		}
-
-		obs_properties_destroy(props);
 
 		defaultPreset = "default";
 		preset = curNVENCPreset;
@@ -5739,15 +5733,13 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 			auto service_name = ui->service->currentText();
 			auto custom_server = ui->customServer->text().trimmed();
 
-			obs_properties_t *props = obs_get_service_properties("rtmp_common");
+			OBSProperties props = obs_get_service_properties("rtmp_common");
 			obs_property_t *service = obs_properties_get(props, "service");
 
 			settings = obs_data_create();
 
 			obs_data_set_string(settings, "service", QT_TO_UTF8(service_name));
 			obs_property_modified(service, settings);
-
-			obs_properties_destroy(props);
 		}
 
 		auto multitrack_video_name = QTStr("Basic.Settings.Stream.MultitrackVideoLabel");

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -378,7 +378,7 @@ void OBSBasicSettings::UpdateMoreInfoLink()
 	}
 
 	QString serviceName = ui->service->currentText();
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -394,7 +394,6 @@ void OBSBasicSettings::UpdateMoreInfoLink()
 		ui->moreInfoButton->setTargetUrl(QUrl(more_info_link));
 		ui->moreInfoButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::UpdateKeyLink()
@@ -403,7 +402,7 @@ void OBSBasicSettings::UpdateKeyLink()
 	QString customServer = ui->customServer->text().trimmed();
 	QString streamKeyLink;
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -449,12 +448,11 @@ void OBSBasicSettings::UpdateKeyLink()
 		ui->getStreamKeyButton->setTargetUrl(QUrl(streamKeyLink));
 		ui->getStreamKeyButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::LoadServices(bool showAll)
 {
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 
 	OBSDataAutoRelease settings = obs_data_create();
 
@@ -497,8 +495,6 @@ void OBSBasicSettings::LoadServices(bool showAll)
 		if (idx != -1)
 			ui->service->setCurrentIndex(idx);
 	}
-
-	obs_properties_destroy(props);
 
 	ui->service->blockSignals(false);
 }
@@ -691,15 +687,13 @@ QString OBSBasicSettings::FindProtocol()
 			return QString("RIST");
 
 	} else {
-		obs_properties_t *props = obs_get_service_properties("rtmp_common");
+		OBSProperties props = obs_get_service_properties("rtmp_common");
 		obs_property_t *services = obs_properties_get(props, "service");
 
 		OBSDataAutoRelease settings = obs_data_create();
 
 		obs_data_set_string(settings, "service", QT_TO_UTF8(ui->service->currentText()));
 		obs_property_modified(services, settings);
-
-		obs_properties_destroy(props);
 
 		const char *protocol = obs_data_get_string(settings, "protocol");
 		if (protocol && *protocol)
@@ -715,7 +709,7 @@ void OBSBasicSettings::UpdateServerList()
 
 	lastService = serviceName;
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -737,8 +731,6 @@ void OBSBasicSettings::UpdateServerList()
 	if (serviceName == "Twitch" || serviceName == "Amazon IVS") {
 		ui->server->addItem(QTStr("Basic.Settings.Stream.SpecifyCustomServer"), CustomServerUUID());
 	}
-
-	obs_properties_destroy(props);
 }
 
 void OBSBasicSettings::on_show_clicked()

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -427,7 +427,7 @@ void SimpleOutput::UpdateRecordingSettings_x264_crf(int crf)
 
 static bool icq_available(obs_encoder_t *encoder)
 {
-	obs_properties_t *props = obs_encoder_properties(encoder);
+	OBSProperties props = obs_encoder_properties(encoder);
 	obs_property_t *p = obs_properties_get(props, "rate_control");
 	bool icq_found = false;
 
@@ -440,7 +440,6 @@ static bool icq_available(obs_encoder_t *encoder)
 		}
 	}
 
-	obs_properties_destroy(props);
 	return icq_found;
 }
 

--- a/frontend/utility/audio-encoders.cpp
+++ b/frontend/utility/audio-encoders.cpp
@@ -1,6 +1,7 @@
 #include "audio-encoders.hpp"
 
 #include <OBSApp.hpp>
+#include <obs.hpp>
 #include <widgets/OBSMainWindow.hpp>
 
 #include <mutex>
@@ -80,11 +81,7 @@ static void HandleSampleRate(obs_property_t *prop, const char *id)
 
 static void HandleEncoderProperties(const char *id, std::vector<int> &bitrates)
 {
-	auto DestroyProperties = [](obs_properties_t *props) {
-		obs_properties_destroy(props);
-	};
-	std::unique_ptr<obs_properties_t, decltype(DestroyProperties)> props{obs_get_encoder_properties(id),
-									     DestroyProperties};
+	OBSProperties props = obs_get_encoder_properties(id);
 
 	if (!props) {
 		blog(LOG_ERROR,
@@ -94,11 +91,11 @@ static void HandleEncoderProperties(const char *id, std::vector<int> &bitrates)
 		return;
 	}
 
-	obs_property_t *samplerate = obs_properties_get(props.get(), "samplerate");
+	obs_property_t *samplerate = obs_properties_get(props, "samplerate");
 	if (samplerate)
 		HandleSampleRate(samplerate, id);
 
-	obs_property_t *bitrate = obs_properties_get(props.get(), "bitrate");
+	obs_property_t *bitrate = obs_properties_get(props, "bitrate");
 
 	obs_property_type type = obs_property_get_type(bitrate);
 	switch (type) {

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -38,7 +38,7 @@ using namespace std;
 static inline bool HasAudioDevices(const char *source_id)
 {
 	const char *output_id = source_id;
-	obs_properties_t *props = obs_get_source_properties(output_id);
+	OBSProperties props = obs_get_source_properties(output_id);
 	size_t count = 0;
 
 	if (!props)
@@ -47,8 +47,6 @@ static inline bool HasAudioDevices(const char *source_id)
 	obs_property_t *devices = obs_properties_get(props, "device_id");
 	if (devices)
 		count = obs_property_list_item_count(devices);
-
-	obs_properties_destroy(props);
 
 	return count != 0;
 }

--- a/frontend/wizards/AutoConfig.cpp
+++ b/frontend/wizards/AutoConfig.cpp
@@ -98,14 +98,12 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 
 	obs_data_set_string(twitchSettings, "service", "Twitch");
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_properties_apply_settings(props, twitchSettings);
 
 	obs_property_t *p = obs_properties_get(props, "server");
 	const char *first = obs_property_list_item_string(p, 0);
 	twitchAuto = strcmp(first, "auto") == 0;
-
-	obs_properties_destroy(props);
 
 	/* ----------------------------------------- */
 	/* check to see if Amazon IVS "auto" entries are available */
@@ -120,8 +118,6 @@ AutoConfig::AutoConfig(QWidget *parent) : QWizard(parent)
 	p = obs_properties_get(props, "server");
 	first = obs_property_list_item_string(p, 0);
 	amazonIVSAuto = strncmp(first, "auto", 4) == 0;
-
-	obs_properties_destroy(props);
 
 	/* ----------------------------------------- */
 	/* load service/servers                      */

--- a/frontend/wizards/AutoConfigStreamPage.cpp
+++ b/frontend/wizards/AutoConfigStreamPage.cpp
@@ -534,7 +534,7 @@ void AutoConfigStreamPage::UpdateMoreInfoLink()
 	}
 
 	QString serviceName = ui->service->currentText();
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -550,7 +550,6 @@ void AutoConfigStreamPage::UpdateMoreInfoLink()
 		ui->moreInfoButton->setTargetUrl(QUrl(more_info_link));
 		ui->moreInfoButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::UpdateKeyLink()
@@ -559,7 +558,7 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	QString customServer = ui->customServer->text().trimmed();
 	QString streamKeyLink;
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -596,12 +595,11 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		ui->streamKeyButton->setTargetUrl(QUrl(streamKeyLink));
 		ui->streamKeyButton->show();
 	}
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::LoadServices(bool showAll)
 {
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 
 	OBSDataAutoRelease settings = obs_data_create();
 
@@ -641,8 +639,6 @@ void AutoConfigStreamPage::LoadServices(bool showAll)
 			ui->service->setCurrentIndex(idx);
 	}
 
-	obs_properties_destroy(props);
-
 	ui->service->blockSignals(false);
 }
 
@@ -659,7 +655,7 @@ void AutoConfigStreamPage::UpdateServerList()
 		lastService = serviceName;
 	}
 
-	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	OBSProperties props = obs_get_service_properties("rtmp_common");
 	obs_property_t *services = obs_properties_get(props, "service");
 
 	OBSDataAutoRelease settings = obs_data_create();
@@ -677,8 +673,6 @@ void AutoConfigStreamPage::UpdateServerList()
 		const char *server = obs_property_list_item_string(servers, i);
 		ui->server->addItem(name, server);
 	}
-
-	obs_properties_destroy(props);
 }
 
 void AutoConfigStreamPage::UpdateCompleted()

--- a/frontend/wizards/AutoConfigTestPage.cpp
+++ b/frontend/wizards/AutoConfigTestPage.cpp
@@ -54,7 +54,7 @@ void AutoConfigTestPage::GetServers(std::vector<ServerInfo> &servers)
 	OBSDataAutoRelease settings = obs_data_create();
 	obs_data_set_string(settings, "service", wiz->serviceName.c_str());
 
-	obs_properties_t *ppts = obs_get_service_properties("rtmp_common");
+	OBSProperties ppts = obs_get_service_properties("rtmp_common");
 	obs_property_t *p = obs_properties_get(ppts, "service");
 	obs_property_modified(p, settings);
 
@@ -71,8 +71,6 @@ void AutoConfigTestPage::GetServers(std::vector<ServerInfo> &servers)
 			servers.push_back(info);
 		}
 	}
-
-	obs_properties_destroy(ppts);
 }
 
 static inline void string_depad_key(string &key)

--- a/libobs/obs.hpp
+++ b/libobs/obs.hpp
@@ -267,6 +267,7 @@ using OBSDisplay = OBSPtr<obs_display_t *, obs_display_destroy>;
 using OBSView = OBSPtr<obs_view_t *, obs_view_destroy>;
 using OBSFader = OBSPtr<obs_fader_t *, obs_fader_destroy>;
 using OBSVolMeter = OBSPtr<obs_volmeter_t *, obs_volmeter_destroy>;
+using OBSProperties = OBSPtr<obs_properties_t *, obs_properties_destroy>;
 
 /* signal handler connection */
 class OBSSignal {

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -94,13 +94,13 @@ void OBSPropertiesView::ReloadProperties()
 		OBSObject strongObj = GetObject();
 		void *obj = strongObj ? strongObj.Get() : rawObj;
 		if (obj)
-			properties.reset(reloadCallback(obj));
+			properties = reloadCallback(obj);
 	} else {
-		properties.reset(reloadCallback((void *)type.c_str()));
-		obs_properties_apply_settings(properties.get(), settings);
+		properties = reloadCallback((void *)type.c_str());
+		obs_properties_apply_settings(properties, settings);
 	}
 
-	uint32_t flags = obs_properties_get_flags(properties.get());
+	uint32_t flags = obs_properties_get_flags(properties);
 	deferUpdate = enableDefer && (flags & OBS_PROPERTIES_DEFER_UPDATE) != 0;
 
 	RefreshProperties();
@@ -128,7 +128,7 @@ void OBSPropertiesView::RefreshProperties()
 
 	layout->setLabelAlignment(Qt::AlignRight);
 
-	obs_property_t *property = obs_properties_first(properties.get());
+	obs_property_t *property = obs_properties_first(properties);
 	bool hasNoProperties = !property;
 
 	while (property) {
@@ -195,7 +195,6 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, obs_object_t *obj, Prope
 				     PropertiesUpdateCallback callback_, PropertiesVisualUpdateCb visUpdateCb_,
 				     int minSize_)
 	: VScrollArea(nullptr),
-	  properties(nullptr, obs_properties_destroy),
 	  settings(settings_),
 	  weakObj(obs_object_get_weak_object(obj)),
 	  reloadCallback(reloadCallback),
@@ -211,7 +210,6 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesRel
 				     PropertiesUpdateCallback callback_, PropertiesVisualUpdateCb visUpdateCb_,
 				     int minSize_)
 	: VScrollArea(nullptr),
-	  properties(nullptr, obs_properties_destroy),
 	  settings(settings_),
 	  rawObj(obj),
 	  reloadCallback(reloadCallback),
@@ -226,7 +224,6 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesRel
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_, PropertiesReloadCallback reloadCallback_,
 				     int minSize_)
 	: VScrollArea(nullptr),
-	  properties(nullptr, obs_properties_destroy),
 	  settings(settings_),
 	  type(type_),
 	  reloadCallback(reloadCallback_),

--- a/shared/properties-view/properties-view.hpp
+++ b/shared/properties-view/properties-view.hpp
@@ -86,12 +86,9 @@ class OBSPropertiesView : public VScrollArea {
 
 	friend class WidgetInfo;
 
-	using properties_delete_t = decltype(&obs_properties_destroy);
-	using properties_t = std::unique_ptr<obs_properties_t, properties_delete_t>;
-
 private:
 	QWidget *widget = nullptr;
-	properties_t properties;
+	OBSProperties properties;
 	OBSData settings;
 	OBSWeakObjectAutoRelease weakObj;
 	void *rawObj = nullptr;


### PR DESCRIPTION
### Description
We no longer have to manually destroy obs_properties_t.

### Motivation and Context
RAII is better

### How Has This Been Tested?
Opened properties in different places of OBS to make sure nothing broke.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
