### PR TITLE
frontend/forms: Fix text cut off in multitrack video info

### DIFF
--- a/frontend/forms/AutoConfigStreamPage.ui
+++ b/frontend/forms/AutoConfigStreamPage.ui
@@ -457,6 +457,12 @@
        </item>
        <item row="9" column="1">
         <widget class="QLabel" name="multitrackVideoInfo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>MultitrackVideo.Info</string>
          </property>
@@ -468,9 +474,6 @@
          </property>
          <property name="openExternalLinks">
           <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <enum>QSizePolicy::MinimumExpanding, QSizePolicy::Minimum</enum>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix issue where multitrack video info text gets cut off
Please close this PR if the change is incorrect.

* Issue does not occur in 31.0.3  
![31_0_3](https://github.com/user-attachments/assets/8b78dffe-425d-4486-b5d8-04b2e47ac54e)

* Issue occurs in 31.1.0 beta1 (before fix)  
![31_1_0_beta1](https://github.com/user-attachments/assets/6811ba36-53d3-4490-b792-7488272db251)

* Fixed in this PR (after)
![Fixed](https://github.com/user-attachments/assets/ac392381-7dfd-45ea-85be-69c3da401929)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I want to resolve this issue.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested on Windows 11 24H2 using a local build.

**Steps to Reproduce**
1. Menu bar → Tools → Auto-Configuration Wizard
2. Click Next without changing any options
3. Click Next again without changing video settings
4. click "Use Stream Key"

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
