### PR TITLE
win-capture: Fix display capture for identical monitors

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -195,15 +195,20 @@ static BOOL CALLBACK enum_monitor(HMONITOR handle, HDC hdc, LPRECT rect, LPARAM 
 	if (GetMonitorInfoA(handle, (LPMONITORINFO)&mi)) {
 		DISPLAY_DEVICEA device;
 		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
-			match = strcmp(monitor->device_id, device.DeviceName) == 0;
-			if (match) {
-				strcpy_s(monitor->id, _countof(monitor->id), device.DeviceID);
-				strcpy_s(monitor->alt_id, _countof(monitor->alt_id), mi.szDevice);
-				GetMonitorName(handle, monitor->name, _countof(monitor->name));
-				monitor->rect = *rect;
-				monitor->handle = handle;
+		DWORD dev_num = 0;
+		while (EnumDisplayDevicesA(mi.szDevice, dev_num, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+			if ((device.StateFlags & DISPLAY_DEVICE_ACTIVE) == DISPLAY_DEVICE_ACTIVE) {
+				match = strcmp(monitor->device_id, device.DeviceID) == 0;
+				if (match) {
+					strcpy_s(monitor->id, _countof(monitor->id), device.DeviceID);
+					strcpy_s(monitor->alt_id, _countof(monitor->alt_id), mi.szDevice);
+					GetMonitorName(handle, monitor->name, _countof(monitor->name));
+					monitor->rect = *rect;
+					monitor->handle = handle;
+				}
 			}
+
+			dev_num++;
 		}
 	}
 
@@ -744,15 +749,18 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect, L
 
 		DISPLAY_DEVICEA device;
 		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
-			/* device.DeviceID, provided by EnumDisplayDevicesA, is same for identical monitors.
-			   identical monitors means monitor from same manufacturer, same model.
-			   We should add the value to obs properties as "monitor_id" which uniquely identifies
-			   the monitor, and use it to update/create the monitor capture.
-			   Using "device.DeviceName" works.
-			*/
-			obs_property_list_add_string(monitor_list, monitor_desc.array, device.DeviceName);
-		} else {
+		DWORD dev_num = 0;
+		bool use_fallback = true;
+		while (EnumDisplayDevicesA(mi.szDevice, dev_num, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+			if ((device.StateFlags & DISPLAY_DEVICE_ACTIVE) == DISPLAY_DEVICE_ACTIVE) {
+				obs_property_list_add_string(monitor_list, monitor_desc.array, device.DeviceID);
+				use_fallback = false;
+			}
+
+			dev_num++;
+		}
+
+		if (use_fallback) {
 			blog(LOG_WARNING,
 			     "[duplicator-monitor-capture] EnumDisplayDevices failed for monitor (%s), falling back to szDevice",
 			     monitor_name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixed an issue where OBS Studio is unable to properly select between identical monitors in Display Capture source.
In `win-capture` plugin, we use `EnumDisplayDevicesA` Windows API fn that enumerates display devices in the system.
Currently, we are using `DeviceID` to uniquely identify the monitor, it fails to work when the connected monitor are from
same manufacturer and same model, as `DeviceID` returned is same for both monitor, resulting in failure to select between multiple monitor.

This fix uses `DeviceName` instead of `DeviceID`, `DeviceName` is unique and works fine as identifier. I have passed the value of `DeviceName` for field `monitor_id` in `obs_get_source_properties` instead of `DeviceID`. Later, we register the source using the `DeviceName`.

For reference, these are the available fields on device returned by `EnumDisplayDevicesA`:
![image](https://github.com/user-attachments/assets/a03746f2-ccd8-49d7-b059-5299b635e9c0)


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #12244

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Windows 11
Tested locally using both WGC and DXGI capture method on the set of `BenQ GW2790 68.58 cm (27 inch)` and set of `BenQ GW2786TC 68.58 cm (27 inch)` monitors, also normally tested the working on other monitors along with connecting and disconnecting these monitors.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
