### PR TITLE
frontend: Add template for Qt's invokeMethod

### DIFF
--- a/frontend/components/MediaControls.hpp
+++ b/frontend/components/MediaControls.hpp
@@ -28,13 +28,6 @@ private:
 	void SetScene(OBSScene scene);
 	int64_t GetSliderTime(int val);
 
-	static void OBSMediaStopped(void *data, calldata_t *calldata);
-	static void OBSMediaPlay(void *data, calldata_t *calldata);
-	static void OBSMediaPause(void *data, calldata_t *calldata);
-	static void OBSMediaStarted(void *data, calldata_t *calldata);
-	static void OBSMediaNext(void *data, calldata_t *calldata);
-	static void OBSMediaPrevious(void *data, calldata_t *calldata);
-
 	std::unique_ptr<Ui_MediaControls> ui;
 
 private slots:

--- a/frontend/dialogs/OBSBasicFilters.hpp
+++ b/frontend/dialogs/OBSBasicFilters.hpp
@@ -49,12 +49,6 @@ private:
 	void UpdateSplitter(bool show_splitter_frame);
 	void UpdatePropertiesView(int row, bool async);
 
-	static void OBSSourceFilterAdded(void *param, calldata_t *data);
-	static void OBSSourceFilterRemoved(void *param, calldata_t *data);
-	static void OBSSourceReordered(void *param, calldata_t *data);
-	static void SourceRemoved(void *param, calldata_t *data);
-	static void SourceRenamed(void *param, calldata_t *data);
-	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
 
 	QMenu *CreateAddFilterPopupMenu(bool async);
@@ -111,6 +105,8 @@ private slots:
 
 	void FiltersMoved(const QModelIndex &srcParent, int srcIdxStart, int srcIdxEnd, const QModelIndex &dstParent,
 			  int dstIdx);
+
+	void UpdateSourceName();
 
 public:
 	OBSBasicFilters(QWidget *parent, OBSSource source_);


### PR DESCRIPTION
### Description
This adds a template for when OBS signals are called, so we don't have to call invokeMethod each time. This only works if the invokeMethod doesn't have calldata_t used with it.

### Motivation and Context
Wanted to find a way so we didn't have to write a invokeMethod function for each OBS signal.

This is only used in MediaControls at this time. If this is accepted, I'll PR for other places later.

### How Has This Been Tested?
Used media controls to make sure everything works as expected.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
