### PR TITLE
frontend: Set Frontend-API QActions role to NoRole

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -314,7 +314,9 @@ bool OBSStudioAPI::obs_frontend_replay_buffer_active()
 void *OBSStudioAPI::obs_frontend_add_tools_menu_qaction(const char *name)
 {
 	main->ui->menuTools->setEnabled(true);
-	return (void *)main->ui->menuTools->addAction(QT_UTF8(name));
+	QAction *action = main->ui->menuTools->addAction(QT_UTF8(name));
+	action->setMenuRole(QAction::NoRole);
+	return static_cast<void *>(action);
 }
 
 void OBSStudioAPI::obs_frontend_add_tools_menu_item(const char *name, obs_frontend_cb callback, void *private_data)
@@ -326,6 +328,7 @@ void OBSStudioAPI::obs_frontend_add_tools_menu_item(const char *name, obs_fronte
 	};
 
 	QAction *action = main->ui->menuTools->addAction(QT_UTF8(name));
+	action->setMenuRole(QAction::NoRole);
 	QObject::connect(action, &QAction::triggered, func);
 }
 

--- a/frontend/widgets/OBSBasic_Docks.cpp
+++ b/frontend/widgets/OBSBasic_Docks.cpp
@@ -210,6 +210,7 @@ QAction *OBSBasic::AddDockWidget(QDockWidget *dock)
 	QAction *action = ui->menuDocks->addAction(dock->windowTitle());
 #endif
 	action->setCheckable(true);
+	action->setMenuRole(QAction::NoRole);
 	assignDockToggle(dock, action);
 	oldExtraDocks.push_back(dock);
 	oldExtraDockNames.push_back(dock->objectName());


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
When no role is set, the default is QAction::TextHeuristicRole. This means that the text of the item gets fuzzy-matched in Qt against a set of possible strings that could indicate that the menu should be in the application menu on macOS.
For us this meant however that on some languages, the translation of "WebSocket Server Settings" would begin with "Config", and as such the related QAction replaces our "Settings" action for the PreferencesRole, and clicking "Preferences..." in the application menu would open the websocket settings. It should probably be considered a bug in Qt that implicit matches via TextHeuristicRole can overwrite ones that are explicitly set (like our PreferencesRole). However we explicitly set our roles ourselves anyways and there is no scenario where a  plugin should overwrite them, we can just default actions added via the Frontend API to be NoRole; and worry about the Qt bug later.

Fixes #12261 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Saw #12261 and thought "lolwhat?! 😂"

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 15.5.
Switched OBS language to Català and clicked the `OBS -> Preferences...` menu, which now correctly opens the settings.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
