### PR TITLE
libobs: Fix audio duplication bug

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -824,6 +824,8 @@ struct obs_source {
 	int64_t sync_offset;
 	int64_t last_sync_offset;
 	float balance;
+	/* audio_is_duplicated: tracks whether a source appears multiple times in the audio tree during this tick */
+	bool audio_is_duplicated;
 
 	/* async video data */
 	gs_texture_t *async_textures[MAX_AV_PLANES];

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -237,7 +237,6 @@ static void scene_destroy(void *data)
 
 	pthread_mutex_destroy(&scene->video_mutex);
 	pthread_mutex_destroy(&scene->audio_mutex);
-	da_free(scene->mix_sources);
 	bfree(scene);
 }
 
@@ -1611,26 +1610,14 @@ static inline void mix_audio(float *p_out, float *p_in, size_t pos, size_t count
 		*(out++) += *(in++);
 }
 
-static inline struct scene_source_mix *get_source_mix(struct obs_scene *scene, struct obs_source *source)
-{
-	for (size_t i = 0; i < scene->mix_sources.num; i++) {
-		struct scene_source_mix *mix = &scene->mix_sources.array[i];
-		if (mix->source == source)
-			return mix;
-	}
-
-	return NULL;
-}
-
-static bool scene_audio_render_internal(struct obs_scene *scene, struct obs_scene *parent, uint64_t *ts_out,
-					struct obs_source_audio_mix *audio_output, uint32_t mixers, size_t channels,
-					size_t sample_rate, float *parent_buf)
+static bool scene_audio_render(void *data, uint64_t *ts_out, struct obs_source_audio_mix *audio_output, uint32_t mixers,
+			       size_t channels, size_t sample_rate)
 {
 	uint64_t timestamp = 0;
 	float buf[AUDIO_OUTPUT_FRAMES];
 	struct obs_source_audio_mix child_audio;
+	struct obs_scene *scene = data;
 	struct obs_scene_item *item;
-	struct obs_scene *mix_scene = parent ? parent : scene;
 
 	audio_lock(scene);
 
@@ -1671,9 +1658,9 @@ static bool scene_audio_render_internal(struct obs_scene *scene, struct obs_scen
 	while (item) {
 		uint64_t source_ts;
 		size_t pos;
+		size_t count;
 		bool apply_buf;
 		struct obs_source *source;
-		struct scene_source_mix *source_mix;
 
 		if (item->visible && transition_active(item->show_transition))
 			source = item->show_transition;
@@ -1702,80 +1689,14 @@ static bool scene_audio_render_internal(struct obs_scene *scene, struct obs_scen
 			continue;
 		}
 
+		count = AUDIO_OUTPUT_FRAMES - pos;
+
 		if (!apply_buf && !item->visible && !transition_active(item->hide_transition)) {
 			item = item->next;
 			continue;
 		}
 
-		size_t count = AUDIO_OUTPUT_FRAMES - pos;
-
-		/* Update buf so that parent mute state applies to all current
-		 * scene items as well */
-		if (parent_buf && (!apply_buf || memcmp(buf, parent_buf, sizeof(float) * count) != 0)) {
-			for (size_t i = 0; i < count; i++) {
-				if (!apply_buf) {
-					buf[i] = parent_buf[i];
-				} else {
-					buf[i] = buf[i] < parent_buf[i] ? buf[i] : parent_buf[i];
-				}
-			}
-
-			apply_buf = true;
-		}
-
-		/* If "source" is a group/scene and has no transition,
-		 * add their items to the current list */
-		if (source == item->source && (obs_source_is_group(source) || obs_source_is_scene(source))) {
-			scene_audio_render_internal(source->context.data, mix_scene, NULL, NULL, 0, 0, sample_rate,
-						    apply_buf ? buf : NULL);
-			item = item->next;
-			continue;
-		}
-
-		source_mix = get_source_mix(mix_scene, item->source);
-
-		if (!source_mix) {
-			source_mix = da_push_back_new(mix_scene->mix_sources);
-			source_mix->source = item->source;
-			source_mix->transition = source != item->source ? source : NULL;
-			source_mix->apply_buf = apply_buf;
-			source_mix->pos = pos;
-			source_mix->count = count;
-			if (apply_buf) {
-				memcpy(source_mix->buf, buf, sizeof(float) * source_mix->count);
-			}
-		} else {
-			/* Only transition audio if there are no
-			 * non-transitioning scene items. */
-			if (source_mix->transition && source == item->source)
-				source_mix->transition = NULL;
-			/* Only apply buf to mix if all scene items for this
-			 * source require it. */
-			source_mix->apply_buf = source_mix->apply_buf && apply_buf;
-			/* Update buf so that only highest value across all
-			 * items is used. */
-			if (source_mix->apply_buf &&
-			    memcmp(source_mix->buf, buf, source_mix->count * sizeof(float)) != 0) {
-				for (size_t i = 0; i < source_mix->count; i++) {
-					if (buf[i] > source_mix->buf[i])
-						source_mix->buf[i] = buf[i];
-				}
-			}
-		}
-
-		item = item->next;
-	}
-
-	if (!audio_output) {
-		audio_unlock(scene);
-		return true;
-	}
-
-	for (size_t i = 0; i < scene->mix_sources.num; i++) {
-		struct scene_source_mix *source_mix = &scene->mix_sources.array[i];
-		obs_source_get_audio_mix(source_mix->transition ? source_mix->transition : source_mix->source,
-					 &child_audio);
-
+		obs_source_get_audio_mix(source, &child_audio);
 		for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
 			if ((mixers & (1 << mix)) == 0)
 				continue;
@@ -1783,29 +1704,19 @@ static bool scene_audio_render_internal(struct obs_scene *scene, struct obs_scen
 			for (size_t ch = 0; ch < channels; ch++) {
 				float *out = audio_output->output[mix].data[ch];
 				float *in = child_audio.output[mix].data[ch];
-
-				if (source_mix->apply_buf)
-					mix_audio_with_buf(out, in, source_mix->buf, source_mix->pos,
-							   source_mix->count);
+				if (apply_buf)
+					mix_audio_with_buf(out, in, buf, pos, count);
 				else
-					mix_audio(out, in, source_mix->pos, source_mix->count);
+					mix_audio(out, in, pos, count);
 			}
 		}
+		item = item->next;
 	}
-
-	da_clear(scene->mix_sources);
 
 	*ts_out = timestamp;
 	audio_unlock(scene);
 
 	return true;
-}
-
-static bool scene_audio_render(void *data, uint64_t *ts_out, struct obs_source_audio_mix *audio_output, uint32_t mixers,
-			       size_t channels, size_t sample_rate)
-{
-	struct obs_scene *scene = data;
-	return scene_audio_render_internal(scene, NULL, ts_out, audio_output, mixers, channels, sample_rate, NULL);
 }
 
 enum gs_color_space scene_video_get_color_space(void *data, size_t count, const enum gs_color_space *preferred_spaces)

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1697,19 +1697,23 @@ static bool scene_audio_render(void *data, uint64_t *ts_out, struct obs_source_a
 		}
 
 		obs_source_get_audio_mix(source, &child_audio);
-		for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
-			if ((mixers & (1 << mix)) == 0)
-				continue;
 
-			for (size_t ch = 0; ch < channels; ch++) {
-				float *out = audio_output->output[mix].data[ch];
-				float *in = child_audio.output[mix].data[ch];
-				if (apply_buf)
-					mix_audio_with_buf(out, in, buf, pos, count);
-				else
-					mix_audio(out, in, pos, count);
+		if (!source->audio_is_duplicated) {
+			for (size_t mix = 0; mix < MAX_AUDIO_MIXES; mix++) {
+				if ((mixers & (1 << mix)) == 0)
+					continue;
+
+				for (size_t ch = 0; ch < channels; ch++) {
+					float *out = audio_output->output[mix].data[ch];
+					float *in = child_audio.output[mix].data[ch];
+					if (apply_buf)
+						mix_audio_with_buf(out, in, buf, pos, count);
+					else
+						mix_audio(out, in, pos, count);
+				}
 			}
 		}
+
 		item = item->next;
 	}
 

--- a/libobs/obs-scene.h
+++ b/libobs/obs-scene.h
@@ -96,15 +96,6 @@ struct obs_scene_item {
 	struct obs_scene_item *next;
 };
 
-struct scene_source_mix {
-	obs_source_t *source;
-	obs_source_t *transition;
-	size_t pos;
-	size_t count;
-	bool apply_buf;
-	float buf[AUDIO_OUTPUT_FRAMES];
-};
-
 struct obs_scene {
 	struct obs_source *source;
 
@@ -122,6 +113,4 @@ struct obs_scene {
 	pthread_mutex_t video_mutex;
 	pthread_mutex_t audio_mutex;
 	struct obs_scene_item *first_item;
-
-	DARRAY(struct scene_source_mix) mix_sources;
 };

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -854,7 +854,7 @@ static void process_audio(obs_source_t *transition, obs_source_t *child, struct 
 			  uint64_t min_ts, uint32_t mixers, size_t channels, size_t sample_rate,
 			  obs_transition_audio_mix_callback_t mix)
 {
-	bool valid = child && !child->audio_pending && child->audio_ts;
+	bool valid = child && !child->audio_pending && child->audio_ts && !child->audio_is_duplicated;
 	struct obs_source_audio_mix child_audio;
 	uint64_t ts;
 	size_t pos;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -393,6 +393,9 @@ static obs_source_t *obs_source_create_internal(const char *id, const char *name
 	source->flags = source->default_flags;
 	source->enabled = true;
 
+	/* audio deduplication initialization */
+	source->audio_is_duplicated = false;
+
 	obs_source_init_finalize(source, canvas);
 	if (!private) {
 		if (canvas)


### PR DESCRIPTION
### Description
This is split from the original PR https://github.com/obsproject/obs-studio/pull/12175 to  facilitate the reviewing.
PR #12175 fixed two audio bugs but the fixes are conceptually different.

The current bug consists in an increased audio level when a source is duplicated in a scene or through a nested scene.
The bug implies that the same audio samples will be mixed several times resulting in a coherent addition. For duplicate sources
this implies a doubling of the audio amplitude or a constant +6 dBFS level increase.

The bug was mostly fixed in commits 8a38e33 [1] and 72924ac [2]. But it was fixed at the scene level and this left an edge case where a nested scene has a Show/Hide transition. It implies an increase of +6 dBFS for any duplicated source.
An example of valid use case is a Media Source or Browser source which is duplicated and cropped to different areas. Or a nested scene. We want to be able to transition from  scene A to scene B with nested scene A, without any change in audio level for instance, if the same audio is used across scenes.

[1] [libobs: Mix audio of each source in a scene only once](https://github.com/obsproject/obs-studio/commit/8a38e3375b63692b01e5088d37f531f36a5d39f9)
[2] [libobs: Deduplicate audio for nested scenes/groups if not transitioning](https://github.com/obsproject/obs-studio/commit/72924ac1f3c4c55de038fe1f03a0e197a155d5e7)

### Motivation and Context
We fix the bug in this manner:
- at each audio tick, when the audio tree is built, we tag duplicate audio sources;
- they are then bypassed in the audio rendering of any scenes or transitions they're involved;
- they're mixed in the final mix as root_nodes exactly like global audio sources.
This intrinsically prevents any duplication within a scene, across scenes and in transitions.
This is a better solution than the previous one because it is not limited to intra-scene deduplication.
This fixes for instance the edge case of Show/Hide transition to a nested scene.

### How Has This Been Tested?
This has been tested extensively on windows 11 pro 23H2 by myself  using:
- a sine tone at 1000 Hz, generated by lavfi filter in Media Source, of amplitude 1/8, which means -21.1 dBFS.
- the music from a splatoon clip.
The audio level of the sine was checked using the FFmpeg volumedetect filter:
ffmpeg -i '.\input.mp4' -filter:a volumedetect -f null /dev/null
Recordings were made in mp4 container with 16 bit pcm raw audio.
The waveforms were checked and compared between OBS 31.0.3 (current release) and this PR in Reaper DAW.

@Warchamp7 did also extensive tests which helped me dodge a few dangerous bullets (crashes and what not). Thanks a lot for his help !

#### Profiling results ####
**We found negligible impact of the current PR on the audio_callback.**
1. no output( no recording nor streaming:
 obs master: 
```
audio_thread(Audio): min=0.002 ms, median=0.018 ms, max=0.422 ms, 99th percentile=0.09 ms
 ┗audio_callback: min=0 ms, median=0.012 ms, max=0.411 ms, 99th percentile=0.08 ms
```
- this PR:
```
audio_thread(Audio): min=0.001 ms, median=0.021 ms, max=0.074 ms, 99th percentile=0.043 ms
 ┗audio_callback: min=0 ms, median=0.016 ms, max=0.065 ms, 99th percentile=0.032 ms
```
2. after a 5 seconds recording:
- obs master: 
```
audio_thread(Audio): min=0.001 ms, median=0.031 ms, max=0.248 ms, 99th percentile=0.073 ms
 ┣audio_callback: min=0 ms, median=0.016 ms, max=0.11 ms, 99th percentile=0.04 ms
 ┗receive_audio: min=0.001 ms, median=0.016 ms, max=0.224 ms, 99th percentile=0.044 ms, 0.428969 calls per parent call
   ┣buffer_audio: min=0 ms, median=0 ms, max=0.038 ms, 99th percentile=0.003 ms
   ┗do_encode: min=0.002 ms, median=0.015 ms, max=0.224 ms, 99th percentile=0.043 ms
     ┣encode(Track1): min=0.001 ms, median=0.005 ms, max=0.033 ms, 99th percentile=0.01 ms 
```
- this PR:
```
audio_thread(Audio): min=0.002 ms, median=0.028 ms, max=0.35 ms, 99th percentile=0.071 ms
 ┣audio_callback: min=0 ms, median=0.015 ms, max=0.199 ms, 99th percentile=0.03 ms
 ┗receive_audio: min=0.001 ms, median=0.015 ms, max=0.136 ms, 99th percentile=0.043 ms, 0.40137 calls per parent call
   ┣buffer_audio: min=0 ms, median=0 ms, max=0.004 ms, 99th percentile=0.002 ms
   ┗do_encode: min=0.002 ms, median=0.014 ms, max=0.135 ms, 99th percentile=0.042 ms
     ┣encode(Track1): min=0.001 ms, median=0.005 ms, max=0.032 ms, 99th percentile=0.012 ms
     ┗send_packet: min=0 ms, median=0.009 ms, max=0.129 ms, 99th percentile=0.034 ms
```
#### Tests ####
the following tests were done:
1. scene with two sines,
3. show/hide transition for a sine in a scene with duplicated sine, 
4. fade transition between a scene A with single sine to scene B w/ duplicated sine,
5. scene A with sine, nested in scene B which also has the sine as a source.
7. same as 4 with a show/hide transition on the sine in scene B (not shown, same result as 4.)
![dup5](https://github.com/user-attachments/assets/31562274-977f-463c-855b-76e50aea9a16)

8. same tests on a audio clip (splatoon): identical results. There is no regression on this PR.

9. same as 4. w/ a show/hide transition on the nested scene A:
- left: current release: there is a bump at the transition; level does not stay nominal;
- right: this PR: no bump, level stays nominal.
![dup6](https://github.com/user-attachments/assets/943134ae-f98a-49b2-8e27-ef168d12a098)

Additional tests:
- Fade transition  (300 ms) between scene A with a 10 kHz sine at -21.12 dBFS to scene B with a 480 Hz sine at -30 dBFs.
- top: current release,
- bottom: this PR. No difference.
![dup7](https://github.com/user-attachments/assets/968e0547-a4f8-4731-aa3f-094439325c9d)

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
