### PR TITLE
frontend: Fix visibility issues of meta type stream operators

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -30,10 +30,7 @@
 
 #include <obs-frontend-internal.hpp>
 #include <obs.hpp>
-
-Q_DECLARE_METATYPE(OBSScene);
-Q_DECLARE_METATYPE(OBSSceneItem);
-Q_DECLARE_METATYPE(OBSSource);
+#include <qt-wrappers.hpp>
 
 #include <graphics/matrix4.h>
 #include <util/platform.h>

--- a/shared/qt/wrappers/qt-wrappers.hpp
+++ b/shared/qt/wrappers/qt-wrappers.hpp
@@ -63,6 +63,10 @@ QDataStream &operator>>(QDataStream &in, OBSScene &scene);
 QDataStream &operator<<(QDataStream &out, const OBSSource &source);
 QDataStream &operator>>(QDataStream &in, OBSSource &source);
 
+Q_DECLARE_METATYPE(OBSScene);
+Q_DECLARE_METATYPE(OBSSceneItem);
+Q_DECLARE_METATYPE(OBSSource);
+
 QThread *CreateQThread(std::function<void()> func);
 
 void ExecuteFuncSafeBlock(std::function<void()> func);


### PR DESCRIPTION
### Description
Moves meta type declaration of several classes into `qt-wrappers.hpp` where their necessary stream operators are already declared and ensure that the header itself is always included by `OBSBasic.hpp`.

### Motivation and Context
For custom types to become usable as QVariants they not only need to be declared as meta types, but also need to have appropriate stream operators declared.

These declarations (both of the meta type itself, which provides a static meta type ID getter via the macro, as well as the operators) need to be visible to the compiler in any compilation unit where they might be used in their QVariant form, otherwise the templates will be incomplete.

A blanket include of "qt-wrappers.hpp" in "OBSBasic.hpp" is not the most subtle fix, but it's necessary to ensure that the meta types are always "complete". Putting both declarations in the qt-wrappers header (instead of splitting them up) ensures that (as the classes themselves are declared in "obs.hpp", which is included by "qt-wrappers.hpp", and thus qt-wrappers can provide a complete class.

### How Has This Been Tested?
Tested on Windows 11 (where this lead to issues), macOS never had the associated issues but was tested to work with this as well.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
