### PR TITLE
libobs: Only load modules once

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -131,6 +131,11 @@ int obs_open_module(obs_module_t **module, const char *path, const char *data_pa
 	mod.data_path = bstrdup(data_path);
 	mod.next = obs->first_module;
 
+	if (obs_get_module(mod.mod_name)) {
+		blog(LOG_WARNING, "Module %s already exists", mod.mod_name);
+		return MODULE_ERROR;
+	}
+
 	if (mod.file) {
 		blog(LOG_DEBUG, "Loading module: %s", mod.file);
 	}


### PR DESCRIPTION
### Description
This makes modules with same name load once.

### Motivation and Context
With the new plugin template, plugins are now loaded from %PROGRAMDATA%. If the plugin is still in the old location, the plugin will be loaded twice.

### How Has This Been Tested?
Had plugin in two different folders, and made sure it only showed up once in OBS.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
