### PR TITLE
media-playback: Fix null pointer dereference

### DIFF
--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -348,7 +348,6 @@ void mp_media_next_audio(mp_media_t *m)
 	struct mp_decode *d = &m->a;
 	struct obs_source_audio audio = {0};
 	AVFrame *f = d->frame;
-	int channels = f->ch_layout.nb_channels;
 
 	if (!mp_media_can_play_frame(m, d))
 		return;
@@ -361,7 +360,7 @@ void mp_media_next_audio(mp_media_t *m)
 		audio.data[i] = f->data[i];
 
 	audio.samples_per_sec = f->sample_rate * m->speed / 100;
-	audio.speakers = convert_speaker_layout(channels);
+	audio.speakers = convert_speaker_layout(f->ch_layout.nb_channels);
 	audio.format = convert_sample_format(f->format);
 	audio.frames = f->nb_samples;
 	audio.timestamp = m->full_decode ? d->frame_pts


### PR DESCRIPTION
### Description
Move channels value assignment below mp_media_can_play_frame check.

### Motivation and Context
Channels value was being assigned before mp_media_can_play_frame check occurred resulting in a null pointer de-reference exception. This fixes media source crashing issue - fixes #11851.  

### How Has This Been Tested?
Tested by following recreation steps using attached file and observing OBS crash. Made code change and re-ran test following same recreation steps. No crash was observed after fix.

OS Version: Windows 11

Channels variable was not used in function before mp_media_can_play_frame check, moving to after the check should not affect any other areas of code.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
