### PR TITLE
frontend: Add theming for checked QToolButtons

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -1316,6 +1316,19 @@ QToolButton:focus,
     background-color: var(--button_bg_hover);
 }
 
+QToolButton:checked,
+.btn-tool:checked {
+    background-color: var(--primary);
+    border-color: var(--primary_light);
+}
+
+QToolButton:checked:hover,
+QToolButton:checked:focus,
+.btn-tool:checked:hover,
+.btn-tool:checked:focus {
+    border-color: var(--primary_lighter);
+}
+
 QToolButton:pressed,
 QToolButton:pressed:hover,
 .btn-tool:pressed,


### PR DESCRIPTION
### Description
The Yami theme provides colours for checked QPushButtons, but does not do the same for checked QToolButton. This commit adds colors for the QToolButton:checked: state that match the QPushButton:checked: colors

### Motivation and Context
The ptz controls plugin has some checkable QToolButton. The buttons were originally QPushButtons, but have been switched to QToolButton because QPushButtons enforce some spacing and dimensions that do work with the grid layout they are in. However, when it was switched to QToolButton, the visual indication that the button was checked was lost because not all the QPushButton theme elements are applied to QToolButton

Tested with a clean build of OBS studio on MacOS

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
