### PR TITLE
libobs: Fix error when used with wayland multi-seat

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -176,7 +176,7 @@ static void platform_seat_capabilities(void *data, struct wl_seat *seat, uint32_
 	bool kb_present = capabilities & WL_SEAT_CAPABILITY_KEYBOARD;
 
 	if (kb_present && plat->keyboard == NULL) {
-		plat->keyboard = wl_seat_get_keyboard(plat->seat);
+		plat->keyboard = wl_seat_get_keyboard(seat);
 		wl_keyboard_add_listener(plat->keyboard, &keyboard_listener, plat);
 	} else if (!kb_present && plat->keyboard != NULL) {
 		wl_keyboard_release(plat->keyboard);


### PR DESCRIPTION
### Description
libobs has a callback when the capability of any seat is announced. It checks the capabilities of that seat, but then fetches the keyboard of the last announced seat. This would break is the first announced seat only has a pointer, and a second seat had a keyboard.

Keyboard removal with multi-seat is broken and not addressed in this patch, but it won't crash.

### Motivation and Context
I had a bug filed against Qt, the author there posts the crash https://bugreports.qt.io/browse/QTBUG-137374

### How Has This Been Tested?
It has not.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [NA ] I have included updates to all appropriate documentation.
