### PR TITLE
frontend: Fix compilation failure when using low-version FFmpeg

### DIFF
--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -26,6 +26,34 @@ static const char *hevc_main = "Main";
 static const char *hevc_main10 = "Main 10";
 static const char *av1_main = "Main";
 
+#if !defined(AV_PROFILE_H264_MAIN) && defined(FF_PROFILE_H264_MAIN)
+#define AV_PROFILE_H264_MAIN FF_PROFILE_H264_MAIN
+#endif
+
+#if !defined(AV_PROFILE_H264_HIGH) && defined(FF_PROFILE_H264_HIGH)
+#define AV_PROFILE_H264_HIGH FF_PROFILE_H264_HIGH
+#endif
+
+#if !defined(AV_PROFILE_H264_CONSTRAINED_BASELINE) && defined(FF_PROFILE_H264_CONSTRAINED_BASELINE)
+#define AV_PROFILE_H264_CONSTRAINED_BASELINE FF_PROFILE_H264_CONSTRAINED_BASELINE
+#endif
+
+#if !defined(AV_PROFILE_HEVC_MAIN) && defined(FF_PROFILE_HEVC_MAIN)
+#define AV_PROFILE_HEVC_MAIN FF_PROFILE_HEVC_MAIN
+#endif
+
+#if !defined(AV_PROFILE_HEVC_MAIN_10) && defined(FF_PROFILE_HEVC_MAIN_10)
+#define AV_PROFILE_HEVC_MAIN_10 FF_PROFILE_HEVC_MAIN_10
+#endif
+
+#if !defined(AV_PROFILE_AV1_MAIN) && defined(FF_PROFILE_AV1_MAIN)
+#define AV_PROFILE_AV1_MAIN FF_PROFILE_AV1_MAIN
+#endif
+
+#if !defined(AV_PROFILE_UNKNOWN) && defined(FF_PROFILE_UNKNOWN)
+#define AV_PROFILE_UNKNOWN FF_PROFILE_UNKNOWN
+#endif
+
 // Maximum reconnect attempts with an invalid key error before giving up (roughly 30 seconds with default start value)
 static constexpr uint8_t MAX_RECONNECT_ATTEMPTS = 5;
 


### PR DESCRIPTION
### Description

When `AV_PROFILE_*` macros are not present in FFmpeg, use `FF_PROFILE_*` macros (if defined) as substitutes to avoid compilation failure.

### Motivation and Context

The `AV_PROFILE_*` macros used in OBS were added by FFmpeg on September 7, 2023 in [this modification](https://github.com/FFmpeg/FFmpeg/commit/8238bc0b5e3dba271217b1223a901b3f9713dc6e#diff-9bbefd81549f199518cbb84a3b036e67662b828308cb54def3e52edd5a125373).
(in detail, FFmpeg added `AV_PROFILE_*` macros  to replace `FF_PROFILE_*` macros)

However, many users still use FFmpeg versions without `AV_PROFILE_*` defines, including：
1. Versions released before September 7, 2023.
2. The latest major version is 7.x.x, and major versions above 2.x.x are still maintained. Notably, four major versions (2.x.x to 5.x.x) do not include `AV_PROFILE_*` macros.

Given the above context and that the compatibility code changes are simple and non-breaking, I hope this PR can be merged. Thank you.

### How Has This Been Tested?

Tested on macOS 15.5, with FFmpeg 4.4.6

### Types of changes

- Tweak (non-breaking change to improve existing functionality) 

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
