### PR TITLE
libobs, frontend: Reject non-default modules in obs-plugins directory

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -195,6 +195,19 @@ static void SetSafeModuleNames()
 #endif
 }
 
+static void SetDefaultModuleNames()
+{
+#ifndef SAFE_MODULES
+	return;
+#else
+	string module;
+	stringstream modules(SAFE_MODULES);
+
+	while (getline(modules, module, '|'))
+		obs_add_default_module(module.c_str());
+#endif
+}
+
 extern void setupDockAction(QDockWidget *dock);
 
 OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new Ui::OBSBasic)
@@ -951,6 +964,9 @@ void OBSBasic::OBSInit()
 	LoadLibraryW(L"Qt6Network");
 #endif
 	struct obs_module_failure_info mfi;
+
+	if (!portable_mode)
+		SetDefaultModuleNames();
 
 	/* Safe Mode disables third-party plugins so we don't need to add earch
 	 * paths outside the OBS bundle/installation. */

--- a/libobs/obs-cocoa.m
+++ b/libobs/obs-cocoa.m
@@ -41,7 +41,7 @@ void add_default_module_paths(void)
     NSString *pluginModulePath = [[pluginURL path] stringByAppendingString:@"/%module%.plugin/Contents/MacOS/"];
     NSString *pluginDataPath = [[pluginURL path] stringByAppendingString:@"/%module%.plugin/Contents/Resources/"];
 
-    obs_add_module_path(pluginModulePath.UTF8String, pluginDataPath.UTF8String);
+    obs_add_default_module_path(pluginModulePath.UTF8String, pluginDataPath.UTF8String);
 }
 
 char *find_libobs_data_file(const char *file)

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -133,6 +133,7 @@ extern void free_module(struct obs_module *mod);
 struct obs_module_path {
 	char *bin;
 	char *data;
+	bool is_default;
 };
 
 static inline void free_module_path(struct obs_module_path *omp)
@@ -489,6 +490,7 @@ struct obs_core {
 	struct obs_module *first_module;
 	DARRAY(struct obs_module_path) module_paths;
 	DARRAY(char *) safe_modules;
+	DARRAY(char *) default_modules;
 
 	obs_source_info_array_t source_types;
 	obs_source_info_array_t input_types;

--- a/libobs/obs-nix.c
+++ b/libobs/obs-nix.c
@@ -86,7 +86,7 @@ void add_default_module_paths(void)
 	bfree(module_data_path);
 
 	for (int i = 0; i < module_patterns_size; i++) {
-		obs_add_module_path(module_bin[i], module_data[i]);
+		obs_add_default_module_path(module_bin[i], module_data[i]);
 	}
 }
 

--- a/libobs/obs-windows.c
+++ b/libobs/obs-windows.c
@@ -43,7 +43,7 @@ static const int module_patterns_size = sizeof(module_bin) / sizeof(module_bin[0
 void add_default_module_paths(void)
 {
 	for (int i = 0; i < module_patterns_size; i++)
-		obs_add_module_path(module_bin[i], module_data[i]);
+		obs_add_default_module_path(module_bin[i], module_data[i]);
 }
 
 /* on windows, points to [base directory]/data/libobs */

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1420,6 +1420,10 @@ void obs_shutdown(void)
 		bfree(obs->safe_modules.array[i]);
 	da_free(obs->safe_modules);
 
+	for (size_t i = 0; i < obs->default_modules.num; i++)
+		bfree(obs->default_modules.array[i]);
+	da_free(obs->default_modules);
+
 	if (obs->name_store_owned)
 		profiler_name_store_free(obs->name_store);
 

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -526,12 +526,27 @@ EXPORT const char *obs_get_module_data_path(obs_module_t *module);
 EXPORT void obs_add_module_path(const char *bin, const char *data);
 
 /**
+ * Adds a search path for default modules.
+ *
+ * @param  bin   Specifies the default module's binary directory search path.
+ * @param  data  Specifies the default module's data directory search path.
+ */
+EXPORT void obs_add_default_module_path(const char *bin, const char *data);
+
+/**
  * Adds a module to the list of modules allowed to load in Safe Mode.
  * If the list is empty, all modules are allowed.
  *
  * @param  name  Specifies the module's name (filename sans extension).
  */
 EXPORT void obs_add_safe_module(const char *name);
+
+/**
+ * Adds a module to the list of default modules
+ *
+ * @param  name  Specifies the module's name (filename sans extension).
+ */
+EXPORT void obs_add_default_module(const char *name);
 
 /** Automatically loads all modules from module paths (convenience function) */
 EXPORT void obs_load_all_modules(void);


### PR DESCRIPTION
### Description
If a third party plugin is in the OBS main directory, and OBS is not in portable mode, reject the plugin.

### Motivation and Context
Replaces #12290 

### How Has This Been Tested?
Loaded third party plugin in main directory and made sure it wasn't loaded.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
