### PR TITLE
frontend: Enforce minimum height for QList items

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -550,6 +550,13 @@ SourceTreeItem {
     color: var(--text);
 }
 
+/* Temporary fix for plugins affected by fix in #11555 */
+QListView::item,
+QListWidget::item,
+SourceTreeItem {
+    min-height: var(--padding_menu);
+}
+
 SourceTreeItem .checkbox-icon {
     margin-right: 0;
     margin-left: var(--spacing_large);


### PR DESCRIPTION
### Description
Adds a minimum height for QList items.

> [!NOTE]
> This PR is only really intended for 31.1 and would be reverted in a later release. If it's preferred/easier it should only be merged into the release branch as a pre-emptive hotfix and never included in master.

### Motivation and Context
A Fix in #11555 means that our SourceTreeItemDelegates now return a proper sizeHint and the source list is styled with that in consideration.

Unfortunately a large number of plugins have copied our delegate code, and now do not display properly due to returning a height of 0

![image](https://github.com/user-attachments/assets/aa8eba58-21ca-4070-9e21-5d7bfa48d938)

This PR adds a minimum height as a temporary solution so that those lists remain useable while intentionally using a value that does not look correct, to make it clear to plugin authors a proper fix is still needed on their end.

![image](https://github.com/user-attachments/assets/41f9e17c-273f-4d50-b8f9-40709ca653fc)


### How Has This Been Tested?
👁

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
