### PR TITLE
Improve UI behavior when available codecs/settings change

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -3719,8 +3719,7 @@ bool OBSBasicSettings::QueryAllowedToClose()
 	bool invalidFormat = false;
 	bool invalidTracks = false;
 	if (simple) {
-		if (ui->simpleOutRecEncoder->currentIndex() == -1 || ui->simpleOutStrEncoder->currentIndex() == -1 ||
-		    ui->simpleOutRecAEncoder->currentIndex() == -1 || ui->simpleOutStrAEncoder->currentIndex() == -1)
+		if (ui->simpleOutStrEncoder->currentIndex() == -1 || ui->simpleOutStrAEncoder->currentIndex() == -1)
 			invalidEncoder = true;
 
 		if (ui->simpleOutRecFormat->currentIndex() == -1)
@@ -3730,6 +3729,10 @@ bool OBSBasicSettings::QueryAllowedToClose()
 		QString format = ui->simpleOutRecFormat->currentData().toString();
 		if (SimpleOutGetSelectedAudioTracks() == 0 && qual != "Stream" && format != "flv")
 			invalidTracks = true;
+
+		if (qual != "Stream" &&
+		    (ui->simpleOutRecEncoder->currentIndex() == -1 || ui->simpleOutRecAEncoder->currentIndex() == -1))
+			invalidEncoder = true;
 	} else {
 		if (ui->advOutRecEncoder->currentIndex() == -1 || ui->advOutEncoder->currentIndex() == -1 ||
 		    ui->advOutRecAEncoder->currentIndex() == -1 || ui->advOutAEncoder->currentIndex() == -1)

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -1737,19 +1737,30 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 	ui->simpleOutAdvanced->setChecked(advanced);
 	ui->simpleOutCustom->setText(custom);
 
+	bool outputSettingReset = false;
+
 	idx = ui->simpleOutRecQuality->findData(QString(recQual));
-	if (idx == -1)
+	if (idx == -1) {
+		ui->simpleOutRecQuality->setProperty("changed", QVariant(true));
 		idx = 0;
+		outputSettingReset = true;
+	}
 	ui->simpleOutRecQuality->setCurrentIndex(idx);
 
 	idx = ui->simpleOutStrEncoder->findData(QString(streamEnc));
-	if (idx == -1)
+	if (idx == -1) {
+		ui->simpleOutStrEncoder->setProperty("changed", QVariant(true));
 		idx = 0;
+		outputSettingReset = true;
+	}
 	ui->simpleOutStrEncoder->setCurrentIndex(idx);
 
 	idx = ui->simpleOutStrAEncoder->findData(QString(streamAudioEnc));
-	if (idx == -1)
+	if (idx == -1) {
+		ui->simpleOutStrAEncoder->setProperty("changed", QVariant(true));
 		idx = 0;
+		outputSettingReset = true;
+	}
 	ui->simpleOutStrAEncoder->setCurrentIndex(idx);
 
 	idx = ui->simpleOutRecEncoder->findData(QString(recEnc));
@@ -1765,6 +1776,10 @@ void OBSBasicSettings::LoadSimpleOutputSettings()
 	ui->simpleRBMegsMax->setValue(rbSize);
 
 	SimpleStreamingEncoderChanged();
+	if (outputSettingReset) {
+		outputsChanged = true;
+		EnableApplyButton(true);
+	}
 }
 
 static inline QString makeFormatToolTip()
@@ -1905,6 +1920,10 @@ void OBSBasicSettings::LoadAdvOutputStreamingEncoderProperties()
 
 			ui->advOutEncoder->insertItem(0, encName, QT_UTF8(type));
 			SetComboByValue(ui->advOutEncoder, type);
+		} else {
+			ui->advOutEncoder->setProperty("changed", QVariant(true));
+			outputsChanged = true;
+			EnableApplyButton(true);
 		}
 	}
 
@@ -2011,6 +2030,9 @@ void OBSBasicSettings::LoadAdvOutputRecordingEncoderProperties()
 			SetComboByValue(ui->advOutRecEncoder, type);
 		} else {
 			ui->advOutRecEncoder->setCurrentIndex(-1);
+			ui->advOutRecEncoder->setProperty("changed", QVariant(true));
+			outputsChanged = true;
+			EnableApplyButton(true);
 		}
 	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
When a codec becomes available or unavailable (e.g. if a plugin is added or removed), make it possible to correct the setting in the UI. Currently, when this happens, it can be impossible to change to a different encoder/setting entirely, leaving the profile broken.

### Motivation and Context
I stumbled upon this in the context of #8529, but the fixes apply more generally. If the x264 plugin (which is a separate RPM Fusion package in the Fedora world) is installed, OpenH264 is hidden from the simple encoder settings, but if x264 is the only encoder choice, there's no way to "change" the codec in the combo box, so the codec in the profile config remains stuck at OpenH264 while the UI says the codec is x264. Conversely, if the x264 plugin is removed, the profile becomes invalid and unusable, but there's no way to correct the codec in the simple encoder settings UI if OpenH264 becomes the only option. This also applies to the advanced settings when x264 is removed (the combo box defaults to OpenH264 but it's not evident this can be saved without flipping through the codecs at least once).

In addition, if the recording codec is set to x264 and the plugin is removed, the UI refuses to save settings because the recording codec combo box is unselected. However, if the quality is set to "same as stream", then that setting is actually irrelevant. Fix it so that the error only appears if the quality is not "same as stream" (at which point the combo box clearly prompts the user to select a codec).

Although this change was discovered in the context of #8529, it should apply to other scenarios too with e.g. hardware codecs becoming available or unavailable for whatever reason.

Note: This still requires the user to go through a trip into codec settings when a codec choice is invalidated (recording/streaming will fail to start until this). I think this is better behavior than silently changing settings on startup, since then simply opening OBS with an incomplete install could change the user's profile without their knowledge, and the change would stick after the installation issue is resolved, which is unexpected silent behavior. I think it's better to explicitly tell the user there's a problem with their existing config, and require them to open up the settings, even if the only thing they have to do then is click "apply" to actually commit to the new default.

### How Has This Been Tested?
Local build & tested all the scenarios of removing and adding back the x264 plugin.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
