### PR TITLE
Fix Clang compilation error with std::optional<Canvas> in OBSCanvas

### DIFF
--- a/frontend/utility/OBSCanvas.cpp
+++ b/frontend/utility/OBSCanvas.cpp
@@ -55,15 +55,15 @@ std::optional<OBSDataAutoRelease> Canvas::Save() const
 	return std::nullopt;
 }
 
-std::optional<Canvas> Canvas::Load(obs_data_t *data)
+std::unique_ptr<Canvas> Canvas::Load(obs_data_t *data)
 {
 	if (OBSDataAutoRelease canvas_data = obs_data_get_obj(data, "info")) {
 		if (obs_canvas_t *canvas = obs_load_canvas(canvas_data)) {
-			return canvas;
+			return std::make_unique<Canvas>(canvas);
 		}
 	}
 
-	return std::nullopt;
+	return nullptr;
 }
 
 std::vector<Canvas> Canvas::LoadCanvases(obs_data_array_t *canvases)

--- a/frontend/utility/OBSCanvas.hpp
+++ b/frontend/utility/OBSCanvas.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <optional>
+#include <memory>
 #include <vector>
 
 #include "obs.h"
@@ -41,7 +42,7 @@ public:
 	operator obs_canvas_t *() const { return canvas; }
 
 	[[nodiscard]] std::optional<OBSDataAutoRelease> Save() const;
-	static std::optional<Canvas> Load(obs_data_t *data);
+	static std::unique_ptr<Canvas> Load(obs_data_t *data);
 	static std::vector<Canvas> LoadCanvases(obs_data_array_t *canvases);
 	static OBSDataArrayAutoRelease SaveCanvases(const std::vector<Canvas> &canvases);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commits resolves a Clang 20 compilation error introduced by improper use of std::optional<Canvas>, where Canvas is a non-copyable, move-only type.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Clang 20 (and recent Clang versions in general) are more strict about types used inside std::optional. Specifically, they require a copy constructor to exist (even if not used), or else emit a hard error when attempting to instantiate std::optional.
This pull request fixes a compilation bug in recent Clang compilers (20.1.7) - that's what I came across myself in Mandriva a few hours ago #12357

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Commit has been tested by me for a bug that prevented me from compiling obs-studio 31.1.0 with Clang 20.1.7 on OpenMandriva Linux.

After applying this patch:
- Compiling obs 31.1.0 with Clang 20.1.7 on OpenMandriva was successful.
-The obs application compiled in this way starts and works without problems (recording works).
- Compiling obs 31.1.0 with GCC 15.1.0 on OpenMandriva also works without problems.
-The application compiled in this way starts and works without problems.

I have not observed any problems caused by this patch. It looks like does not negatively affect GCC.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
The patch replaces std::optional<Canvas> with std::unique_ptr<Canvas>, which semantically represents an optional move-only value and is fully compatible with both Clang and GCC.

This fixes the build with Clang 20 and newer, while preserving the original logic and semantics of the code.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
