### PR TITLE
frontend: Avoid recreating YouTube dock 

### DIFF
--- a/frontend/oauth/YoutubeAuth.cpp
+++ b/frontend/oauth/YoutubeAuth.cpp
@@ -141,7 +141,9 @@ void YoutubeAuth::LoadUI()
 	}
 #endif
 
-	main->NewYouTubeAppDock();
+	if (!main->GetYouTubeAppDock()) {
+		main->NewYouTubeAppDock();
+	}
 
 	if (!firstLoad) {
 		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");


### PR DESCRIPTION
### Description
Fixes a crash when connecting a YouTube account when the Live Control Panel dock already exists.

### Motivation and Context
Crashes are bad and there's no need for this dock to actually get destroyed and recreated.

Fixes #12353

### How Has This Been Tested?
Disconnected and reconnected YouTube account

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
