### PR TITLE
rtmp-services: Rename Dolby Millicast to Dolby OptiView Real-time

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 279,
+    "version": 280,
     "files": [
         {
             "name": "services.json",
-            "version": 279
+            "version": 280
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3338,13 +3338,16 @@
             }
         },
         {
-            "name": "Dolby Millicast",
+            "name": "Dolby OptiView Real-time",
+            "alt_names": [
+                "Dolby Millicast"
+            ],
             "common": false,
-            "more_info_link": "https://docs.optiview.dolby.com/millicast/using-obs/",
+            "more_info_link": "https://optiview.dolby.com/docs/millicast/using-obs/",
             "stream_key_link": "https://streaming.dolby.io",
             "multitrack_video_configuration_url": "https://director.millicast.com/api/multitrackvideo/configuration",
             "multitrack_video_name": "Enhanced Broadcasting",
-            "multitrack_video_learn_more_link": "https://docs.optiview.dolby.com/millicast/obs-enhanced-broadcasting-multitrack-video/",
+            "multitrack_video_learn_more_link": "https://optiview.dolby.com/docs/millicast/obs-enhanced-broadcasting-multitrack-video/",
             "servers": [
                 {
                     "name": "Global (RTMPS)",


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Dolby Millicast was re-branded to Dolby OptiView.  The existing `/obs-studio/plugins/rtmp-services/data/services.json` entry for Dolby Millicast was updated to match.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This solves brand confusion for those using Dolby's streaming products

<!--- If it fixes an open GitHub Issue, or implements feature request -->
N/A
<!--- from the Ideas page, please link to the issue here. -->
N/A

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Only name changes and docs URLs were updated.  The JSON was validated prior to submission.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ x ] My code is not on the master branch.
- [ ] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ x ] I have included updates to all appropriate documentation.
