### PR TITLE
frontend: Sync Preview/Program size and positioning

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -2103,6 +2103,12 @@ OBSBasicAdvAudio #scrollAreaWidgetContents {
     width: 16px;
 }
 
+#programSpacer {
+    background: var(--bg_preview);
+    min-height: 16px;
+    height: 16px;
+}
+
 #previewZoomInButton {
     border: none;
     border-radius: 0px;

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1414,6 +1414,7 @@ private:
 	void SetPreviewProgramMode(bool enabled);
 	void ResizeProgram(uint32_t cx, uint32_t cy);
 	static void RenderProgram(void *data, uint32_t cx, uint32_t cy);
+	void resizeProgramWidget();
 
 	void UpdatePreviewProgramIndicators();
 

--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -1630,6 +1630,14 @@ void OBSBasicPreview::leaveEvent(QEvent *)
 		hoveredPreviewItems.clear();
 }
 
+void OBSBasicPreview::resizeEvent(QResizeEvent *event)
+{
+	OBSBasic *main = OBSBasic::Get();
+	main->resizeProgramWidget();
+
+	OBSQTDisplay::resizeEvent(event);
+}
+
 static void DrawLine(float x1, float y1, float x2, float y2, float thickness, vec2 scale)
 {
 	float cx;

--- a/frontend/widgets/OBSBasicPreview.hpp
+++ b/frontend/widgets/OBSBasicPreview.hpp
@@ -137,6 +137,7 @@ public:
 	virtual void mouseReleaseEvent(QMouseEvent *event) override;
 	virtual void mouseMoveEvent(QMouseEvent *event) override;
 	virtual void leaveEvent(QEvent *event) override;
+	virtual void resizeEvent(QResizeEvent *event) override;
 
 	void DrawOverflow();
 	void DrawSceneEditing();

--- a/frontend/widgets/OBSBasic_StudioMode.cpp
+++ b/frontend/widgets/OBSBasic_StudioMode.cpp
@@ -220,6 +220,10 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		programLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 		programLabel->setProperty("class", "label-preview-title");
 
+		QFrame *programSpacer = new QFrame();
+		programSpacer->setObjectName("programSpacer");
+		programSpacer->setContentsMargins(0, 0, 0, 0);
+
 		programWidget = new QWidget();
 		programLayout = new QVBoxLayout();
 
@@ -228,6 +232,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 		programLayout->addWidget(programLabel);
 		programLayout->addWidget(program);
+		programLayout->addWidget(programSpacer);
 
 		programWidget->setLayout(programLayout);
 
@@ -282,6 +287,7 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 
 	ResetUI();
 	UpdateTitleBar();
+	resizeProgramWidget();
 }
 
 void OBSBasic::RenderProgram(void *data, uint32_t, uint32_t)
@@ -313,6 +319,30 @@ void OBSBasic::RenderProgram(void *data, uint32_t, uint32_t)
 	gs_viewport_pop();
 
 	GS_DEBUG_MARKER_END();
+}
+
+void OBSBasic::resizeProgramWidget()
+{
+	if (!programWidget) {
+		return;
+	}
+
+	if (!IsPreviewProgramMode()) {
+		programWidget->setMinimumWidth(0);
+		programWidget->setMaximumWidth(QWIDGETSIZE_MAX);
+		return;
+	}
+
+	if (abs(programWidget->width() - ui->preview->width()) >= 2) {
+		/* Changing the size of the program widget causes the preview to resize which triggers this method again.
+		 * Setting the maximum width to the average of the two causes the uneven space to get distributed evenly.
+		 */
+		programWidget->setMaximumWidth(round((programWidget->width() + ui->preview->width()) / 2));
+	}
+
+	if (ui->previewXContainer->isVisible()) {
+		programWidget->setMinimumWidth(ui->previewXContainer->minimumSizeHint().width());
+	}
 }
 
 void OBSBasic::ResizeProgram(uint32_t cx, uint32_t cy)

--- a/frontend/widgets/OBSQTDisplay.hpp
+++ b/frontend/widgets/OBSQTDisplay.hpp
@@ -14,6 +14,7 @@ class OBSQTDisplay : public QWidget {
 	OBSDisplay display;
 	bool destroying = false;
 
+protected:
 	virtual void paintEvent(QPaintEvent *event) override;
 	virtual void moveEvent(QMoveEvent *event) override;
 	virtual void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
### Description
Keeps the size of the Preview and Program widgets the same by dynamically restricting the Program widget width and adding a spacer.

### Motivation and Context
Because of the new Preview area controls, there is some padding around the preview area to fit them. This lead to a mismatch in the size of the Preview OBSQTDisplay and the Program OBSQTDisplay widgets, leading to the Program being a different size and slightly offset.

**Before**
<img width="1886" height="1013" alt="image" src="https://github.com/user-attachments/assets/5dcdc30b-13ef-4d18-b7ab-e83a001b2cc2" />

**After**
<img width="1884" height="971" alt="image" src="https://github.com/user-attachments/assets/33cbf4e6-e46c-487e-a8a4-f6f9c7b6b34c" />


### How Has This Been Tested?
Resized the window and docks a bunch. Ensured that the Preview and Program canvas areas were always the same size +/- a pixel.

### Types of changes
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
