### PR TITLE
libobs: Start video output even if there is no mix to fix DeckLink outputs

### DIFF
--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -3047,18 +3047,22 @@ void start_raw_video(video_t *v, const struct video_scale_info *conversion, uint
 		     void (*callback)(void *param, struct video_data *frame), void *param)
 {
 	struct obs_core_video_mix *video = get_mix_for_video(v);
-	if (!video)
-		return;
-	if (video_output_connect2(v, conversion, frame_rate_divisor, callback, param))
+
+	// TODO: Make affected outputs use views/canvasses, and revert this later.
+	// https://github.com/obsproject/obs-studio/pull/12379
+	// https://github.com/obsproject/obs-studio/issues/12366
+	if (video_output_connect2(v, conversion, frame_rate_divisor, callback, param) && video)
 		os_atomic_inc_long(&video->raw_active);
 }
 
 void stop_raw_video(video_t *v, void (*callback)(void *param, struct video_data *frame), void *param)
 {
 	struct obs_core_video_mix *video = get_mix_for_video(v);
-	if (!video)
-		return;
-	if (video_output_disconnect2(v, callback, param))
+
+	// TODO: Make affected outputs use views/canvasses, and revert this later.
+	// https://github.com/obsproject/obs-studio/pull/12379
+	// https://github.com/obsproject/obs-studio/issues/12366
+	if (video_output_disconnect2(v, callback, param) && video)
 		os_atomic_dec_long(&video->raw_active);
 }
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This fixes a change in #11605 that breaks Decklink video outputs. get_mix_for_video() returns NULL for those outputs, causing start_raw_video() to return before connecting the output.

Fixes #12366.

### Motivation and Context
Decklink outputs do not output video. 

### How Has This Been Tested?
Verified that decklink video output works again by starting a decklink output.
Verified that the problem that #11605 fixes was still fixed by following the reproduction steps in #11329.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
