### PR TITLE
cmake: Add obs_modules to MacOS build dependencies

### DIFF
--- a/cmake/macos/helpers.cmake
+++ b/cmake/macos/helpers.cmake
@@ -86,7 +86,8 @@ function(set_target_properties_obs target)
       endif()
 
       get_property(obs_executables GLOBAL PROPERTY _OBS_EXECUTABLES)
-      add_dependencies(${target} ${obs_executables})
+      get_property(obs_modules GLOBAL PROPERTY OBS_MODULES_ENABLED)
+      add_dependencies(${target} ${obs_executables} ${obs_modules})
       foreach(executable IN LISTS obs_executables)
         set_target_xcode_properties(${executable} PROPERTIES INSTALL_PATH
                                     "$(LOCAL_APPS_DIR)/$<TARGET_BUNDLE_DIR_NAME:${target}>/Contents/MacOS"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
This fix an error when building a plugin using OBS 31.1.1 as base. (in plugin's buildspec.json)

This change add the variable obs_modules to the dependencies for building on macos.
It also makes it consistent with how Windows & linux are built. (could have been missed)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Solves Issue : #12381 
Align all 3 OS on the same behaviour / build requirement (at least for that part)
Allow to build plugin based on OBS 31.1 (and start adding support/test for WoA support too)


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Tested on DistroAV plugin locally and on github actions.
[Result of the github action](https://github.com/DistroAV/DistroAV/actions/runs/16245420429/job/45867669786) on the DistroAV project (using this fix + obs-deps from 2025-07-11)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
