### PR TITLE
frontend: Improve scene item cropping UI

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -788,7 +788,7 @@ private:
 	QColor cropColor;
 	QColor hoverColor;
 
-	bool drawSpacingHelpers = true;
+	bool previewSpacingHelpersEnabled = true;
 
 	float dpi = 1.0;
 

--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -44,6 +44,14 @@ void OBSBasicPreview::Init()
 	obs_leave_graphics();
 }
 
+void OBSBasicPreview::setAltPressed(bool pressed)
+{
+	altPressed = pressed;
+	if (!isAltPressed()) {
+		showCroppingOverlay = false;
+	}
+}
+
 vec2 OBSBasicPreview::GetMouseEventPos(QMouseEvent *event)
 {
 	OBSBasic *main = OBSBasic::Get();
@@ -73,7 +81,6 @@ static void RotatePos(vec2 *pos, float rot)
 struct SceneFindData {
 	const vec2 &pos;
 	OBSSceneItem item;
-	bool selectBelow;
 
 	obs_sceneitem_t *group = nullptr;
 
@@ -82,7 +89,7 @@ struct SceneFindData {
 	SceneFindData &operator=(const SceneFindData &) = delete;
 	SceneFindData &operator=(SceneFindData &&) = delete;
 
-	inline SceneFindData(const vec2 &pos_, bool selectBelow_) : pos(pos_), selectBelow(selectBelow_) {}
+	inline SceneFindData(const vec2 &pos_) : pos(pos_) {}
 };
 
 struct SceneFindBoxData {
@@ -129,19 +136,31 @@ static bool FindItemAtPos(obs_scene_t * /* scene */, obs_sceneitem_t *item, void
 
 	obs_sceneitem_get_box_transform(item, &transform);
 
+	if (obs_sceneitem_is_group(item)) {
+		data->group = item;
+		vec2 groupPos;
+		vec2 groupTransform;
+		vec2_set(&groupPos, data->pos.x, data->pos.y);
+		vec2_set(&groupTransform, transform.t.x, transform.t.y);
+		vec2_sub(&groupPos, &groupPos, &groupTransform);
+
+		SceneFindData groupData(groupPos);
+
+		obs_sceneitem_group_enum_items(item, FindItemAtPos, &groupData);
+		data->group = nullptr;
+
+		if (groupData.item) {
+			data->item = groupData.item;
+			return true;
+		}
+	}
+
 	matrix4_inv(&invTransform, &transform);
 	vec3_transform(&transformedPos, &pos3, &invTransform);
 	vec3_transform(&pos3_, &transformedPos, &transform);
 
 	if (CloseFloat(pos3.x, pos3_.x) && CloseFloat(pos3.y, pos3_.y) && transformedPos.x >= 0.0f &&
 	    transformedPos.x <= 1.0f && transformedPos.y >= 0.0f && transformedPos.y <= 1.0f) {
-		if (data->selectBelow && obs_sceneitem_selected(item)) {
-			if (data->item)
-				return false;
-			else
-				data->selectBelow = false;
-		}
-
 		data->item = item;
 	}
 
@@ -215,7 +234,7 @@ vec3 OBSBasicPreview::GetSnapOffset(const vec3 &tl, const vec3 &br)
 	return clampOffset;
 }
 
-OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos, bool selectBelow)
+OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos)
 {
 	OBSBasic *main = OBSBasic::Get();
 
@@ -223,7 +242,7 @@ OBSSceneItem OBSBasicPreview::GetItemAtPos(const vec2 &pos, bool selectBelow)
 	if (!scene)
 		return OBSSceneItem();
 
-	SceneFindData data(pos, selectBelow);
+	SceneFindData data(pos);
 	obs_scene_enum_items(scene, FindItemAtPos, &data);
 	return data.item;
 }
@@ -279,7 +298,7 @@ bool OBSBasicPreview::SelectedAtPos(const vec2 &pos)
 	if (!scene)
 		return false;
 
-	SceneFindData data(pos, false);
+	SceneFindData data(pos);
 	obs_scene_enum_items(scene, CheckItemSelected, &data);
 	return !!data.item;
 }
@@ -494,16 +513,22 @@ void OBSBasicPreview::GetStretchHandleData(const vec2 &pos, bool ignoreGroup)
 
 void OBSBasicPreview::keyPressEvent(QKeyEvent *event)
 {
-	if (!IsFixedScaling() || event->isAutoRepeat()) {
+	if (event->isAutoRepeat()) {
 		OBSQTDisplay::keyPressEvent(event);
 		return;
 	}
 
 	switch (event->key()) {
 	case Qt::Key_Space:
-		setCursor(Qt::OpenHandCursor);
-		scrollMode = true;
+		if (IsFixedScaling()) {
+			setCursor(Qt::OpenHandCursor);
+			scrollMode = true;
+		}
 		break;
+	case Qt::Key_Alt:
+		setAltPressed(true);
+		event->accept();
+		return;
 	}
 
 	OBSQTDisplay::keyPressEvent(event);
@@ -521,6 +546,10 @@ void OBSBasicPreview::keyReleaseEvent(QKeyEvent *event)
 		scrollMode = false;
 		setCursor(Qt::ArrowCursor);
 		break;
+	case Qt::Key_Alt:
+		setAltPressed(false);
+		event->accept();
+		return;
 	}
 
 	OBSQTDisplay::keyReleaseEvent(event);
@@ -566,10 +595,12 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 	float pixelRatio = main->GetDevicePixelRatio();
 	float x = pos.x() - main->previewX / pixelRatio;
 	float y = pos.y() - main->previewY / pixelRatio;
+
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
 	bool altDown = (modifiers & Qt::AltModifier);
 	bool shiftDown = (modifiers & Qt::ShiftModifier);
 	bool ctrlDown = (modifiers & Qt::ControlModifier);
+	setAltPressed(altDown);
 
 	OBSQTDisplay::mousePressEvent(event);
 
@@ -584,8 +615,9 @@ void OBSBasicPreview::mousePressEvent(QMouseEvent *event)
 		selectedItems.clear();
 	}
 
-	if (altDown)
-		cropping = true;
+	if (altDown) {
+		showCroppingOverlay = true;
+	}
 
 	if (altDown || shiftDown || ctrlDown) {
 		vec2 s;
@@ -687,14 +719,14 @@ void OBSBasicPreview::DoSelect(const vec2 &pos)
 	OBSBasic *main = OBSBasic::Get();
 
 	OBSScene scene = main->GetCurrentScene();
-	OBSSceneItem item = GetItemAtPos(pos, true);
+	OBSSceneItem item = GetItemAtPos(pos);
 
 	obs_scene_enum_items(scene, select_one, (obs_sceneitem_t *)item);
 }
 
 void OBSBasicPreview::DoCtrlSelect(const vec2 &pos)
 {
-	OBSSceneItem item = GetItemAtPos(pos, false);
+	OBSSceneItem item = GetItemAtPos(pos);
 	if (!item)
 		return;
 
@@ -706,10 +738,13 @@ void OBSBasicPreview::ProcessClick(const vec2 &pos)
 {
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
 
-	if (modifiers & Qt::ControlModifier)
+	if (modifiers & Qt::AltModifier && selectedItems.size() > 0) {
+		return;
+	} else if (modifiers & Qt::ControlModifier) {
 		DoCtrlSelect(pos);
-	else
+	} else {
 		DoSelect(pos);
+	}
 }
 
 void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
@@ -764,15 +799,16 @@ void OBSBasicPreview::mouseReleaseEvent(QMouseEvent *event)
 		stretchGroup = nullptr;
 		mouseDown = false;
 		mouseMoved = false;
-		cropping = false;
 		selectionBox = false;
 		unsetCursor();
 
-		OBSSceneItem item = GetItemAtPos(pos, true);
+		OBSSceneItem item = GetItemAtPos(pos);
 
 		std::lock_guard<std::mutex> lock(selectMutex);
 		hoveredPreviewItems.clear();
-		hoveredPreviewItems.push_back(item);
+		if (!isAltPressed()) {
+			hoveredPreviewItems.push_back(item);
+		}
 		selectedItems.clear();
 	}
 	OBSBasic *main = OBSBasic::Get();
@@ -981,22 +1017,67 @@ static bool move_items(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *p
 	return true;
 }
 
+static bool move_crop(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)
+{
+	if (obs_sceneitem_locked(item))
+		return true;
+
+	bool selected = obs_sceneitem_selected(item);
+	vec2 *offset = static_cast<vec2 *>(param);
+
+	if (obs_sceneitem_is_group(item) && !selected) {
+		matrix4 transform;
+		vec3 new_offset;
+		vec3_set(&new_offset, offset->x, offset->y, 0.0f);
+
+		obs_sceneitem_get_draw_transform(item, &transform);
+		vec4_set(&transform.t, 0.0f, 0.0f, 0.0f, 1.0f);
+		matrix4_inv(&transform, &transform);
+		vec3_transform(&new_offset, &new_offset, &transform);
+		obs_sceneitem_group_enum_items(item, move_crop, &new_offset);
+	}
+
+	if (selected) {
+		obs_sceneitem_crop crop;
+		obs_sceneitem_get_crop(item, &crop);
+
+		/* Move Source inside Crop */
+		int xOffset = std::clamp((int)offset->x, -crop.right, crop.left);
+		int yOffset = std::clamp((int)offset->y, -crop.bottom, crop.top);
+
+		crop.left -= xOffset;
+		crop.right += xOffset;
+		crop.top -= yOffset;
+		crop.bottom += yOffset;
+
+		obs_sceneitem_set_crop(item, &crop);
+	}
+
+	return true;
+}
+
 void OBSBasicPreview::MoveItems(const vec2 &pos)
 {
 	Qt::KeyboardModifiers modifiers = QGuiApplication::keyboardModifiers();
 	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 
-	vec2 offset, moveOffset;
+	vec2 offset, moveOffset, invertedOffset;
 	vec2_sub(&offset, &pos, &startPos);
 	vec2_sub(&moveOffset, &offset, &lastMoveOffset);
+	vec2_neg(&invertedOffset, &moveOffset);
 
-	if (!(modifiers & Qt::ControlModifier))
+	if (!(modifiers & Qt::ControlModifier) && !isAltPressed()) {
 		SnapItemMovement(moveOffset);
+	}
 
 	vec2_add(&lastMoveOffset, &lastMoveOffset, &moveOffset);
 
-	obs_scene_enum_items(scene, move_items, &moveOffset);
+	if (isAltPressed()) {
+		obs_scene_enum_items(scene, move_crop, &moveOffset);
+	} else {
+		obs_scene_enum_items(scene, move_items, &moveOffset);
+	}
 }
 
 static bool CounterClockwise(float x1, float x2, float x3, float y1, float y2, float y3)
@@ -1444,7 +1525,7 @@ void OBSBasicPreview::StretchItem(const vec2 &pos)
 	vec2_set(&size, br.x - tl.x, br.y - tl.y);
 
 	if (boundsType != OBS_BOUNDS_NONE) {
-		if (shiftDown)
+		if (!shiftDown)
 			ClampAspect(tl, br, size, baseSize);
 
 		if (tl.x > br.x)
@@ -1551,7 +1632,7 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 	if (mouseDown) {
 		vec2 pos = GetMouseEventPos(event);
 
-		if (!mouseMoved && !mouseOverItems && stretchHandle == ItemHandle::None) {
+		if (!mouseMoved && !mouseOverItems && stretchHandle == ItemHandle::None && !isAltPressed()) {
 			ProcessClick(startPos);
 			mouseOverItems = SelectedAtPos(startPos);
 		}
@@ -1578,17 +1659,18 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 			if (stretchHandle == ItemHandle::Rot) {
 				RotateItem(pos);
 				setCursor(Qt::ClosedHandCursor);
-			} else if (cropping)
+			} else if (showCroppingOverlay) {
 				CropItem(pos);
-			else
+			} else {
 				StretchItem(pos);
+			}
 
 		} else if (mouseOverItems) {
 			if (cursor().shape() != Qt::SizeAllCursor)
 				setCursor(Qt::SizeAllCursor);
 			selectionBox = false;
 			MoveItems(pos);
-		} else {
+		} else if (!isAltPressed()) {
 			selectionBox = true;
 			if (!mouseMoved)
 				DoSelect(startPos);
@@ -1599,13 +1681,17 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 		mousePos = pos;
 	} else {
 		vec2 pos = GetMouseEventPos(event);
-		OBSSceneItem item = GetItemAtPos(pos, true);
+		OBSSceneItem item = GetItemAtPos(pos);
+
+		bool selected = obs_sceneitem_selected(item);
 
 		std::lock_guard<std::mutex> lock(selectMutex);
 		hoveredPreviewItems.clear();
-		hoveredPreviewItems.push_back(item);
+		if (!isAltPressed() || !selected) {
+			hoveredPreviewItems.push_back(item);
+		}
 
-		if (!mouseMoved && hoveredPreviewItems.size() > 0) {
+		if ((!mouseMoved && hoveredPreviewItems.size() > 0) || isAltPressed()) {
 			mousePos = pos;
 			OBSBasic *main = OBSBasic::Get();
 			float scale = main->GetDevicePixelRatio();
@@ -1625,9 +1711,15 @@ void OBSBasicPreview::mouseMoveEvent(QMouseEvent *event)
 
 void OBSBasicPreview::leaveEvent(QEvent *)
 {
+
 	std::lock_guard<std::mutex> lock(selectMutex);
 	if (!selectionBox)
 		hoveredPreviewItems.clear();
+}
+
+void OBSBasicPreview::focusOutEvent(QFocusEvent *)
+{
+	setAltPressed(false);
 }
 
 static void DrawLine(float x1, float y1, float x2, float y2, float thickness, vec2 scale)
@@ -1887,7 +1979,6 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 	}
 
 	OBSBasic *main = OBSBasic::Get();
-
 	float pixelRatio = main->GetDevicePixelRatio();
 
 	bool hovered = false;
@@ -1954,50 +2045,71 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 	obs_transform_info info;
 	obs_sceneitem_get_info2(item, &info);
 
-	gs_matrix_push();
-	gs_matrix_mul(&boxTransform);
-
 	obs_sceneitem_crop crop;
 	obs_sceneitem_get_crop(item, &crop);
 
-	if (info.bounds_type == OBS_BOUNDS_NONE && crop_enabled(&crop)) {
-#define DRAW_SIDE(side, x1, y1, x2, y2)                                                                \
-	if (hovered && !selected) {                                                                    \
-		gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");       \
-		gs_effect_set_vec4(colParam, &blue);                                                   \
-		while (gs_effect_loop(prev->solidEffect, "Solid")) {                                   \
-			DrawLine(x1, y1, x2, y2, HANDLE_RADIUS *pixelRatio / 2, boxScale);             \
-		}                                                                                      \
-	} else if (crop.side > 0) {                                                                    \
-		gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->stripedLineEffect, "color"); \
-		gs_effect_set_vec4(colParam, &green);                                                  \
-		prev->DrawStripedLine(x1, y1, x2, y2, HANDLE_RADIUS *pixelRatio / 2, boxScale);        \
-	} else {                                                                                       \
-		gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");       \
-		gs_effect_set_vec4(colParam, &red);                                                    \
-		while (gs_effect_loop(prev->solidEffect, "Solid")) {                                   \
-			DrawLine(x1, y1, x2, y2, HANDLE_RADIUS *pixelRatio / 2, boxScale);             \
-		}                                                                                      \
+	if (selected && prev->isAltPressed()) {
+		prev->showCroppingOverlay = true;
+		drawCropping(item, param);
 	}
 
-		DRAW_SIDE(left, 0.0f, 0.0f, 0.0f, 1.0f);
-		DRAW_SIDE(top, 0.0f, 0.0f, 1.0f, 0.0f);
-		DRAW_SIDE(right, 1.0f, 0.0f, 1.0f, 1.0f);
-		DRAW_SIDE(bottom, 0.0f, 1.0f, 1.0f, 1.0f);
-#undef DRAW_SIDE
-	} else {
-		if (!selected) {
-			gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");
-			gs_effect_set_vec4(colParam, &blue);
-			while (gs_effect_loop(prev->solidEffect, "Solid")) {
-				DrawRect(HANDLE_RADIUS * pixelRatio / 2, boxScale);
-			}
+	gs_matrix_push();
+	gs_matrix_mul(&boxTransform);
+
+	if (selected && crop_enabled(&crop)) {
+		gs_eparam_t *stripedParam = gs_effect_get_param_by_name(prev->stripedLineEffect, "color");
+		gs_eparam_t *lineParam = gs_effect_get_param_by_name(prev->solidEffect, "color");
+
+		if (crop.left > 0) {
+			gs_effect_set_vec4(stripedParam, &green);
+			prev->DrawStripedLine(0.0f, 0.0f, 0.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
 		} else {
-			gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");
-			gs_effect_set_vec4(colParam, &red);
+			gs_effect_set_vec4(lineParam, &red);
 			while (gs_effect_loop(prev->solidEffect, "Solid")) {
-				DrawRect(HANDLE_RADIUS * pixelRatio / 2, boxScale);
+				DrawLine(0.0f, 0.0f, 0.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
 			}
+		}
+
+		if (crop.top > 0) {
+			gs_effect_set_vec4(stripedParam, &green);
+			prev->DrawStripedLine(0.0f, 0.0f, 1.0f, 0.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+		} else {
+			gs_effect_set_vec4(lineParam, &red);
+			while (gs_effect_loop(prev->solidEffect, "Solid")) {
+				DrawLine(0.0f, 0.0f, 1.0f, 0.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+			}
+		}
+
+		if (crop.right > 0) {
+			gs_effect_set_vec4(stripedParam, &green);
+			prev->DrawStripedLine(1.0f, 0.0f, 1.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+		} else {
+			gs_effect_set_vec4(lineParam, &red);
+			while (gs_effect_loop(prev->solidEffect, "Solid")) {
+				DrawLine(1.0f, 0.0f, 1.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+			}
+		}
+
+		if (crop.bottom > 0) {
+			gs_effect_set_vec4(stripedParam, &green);
+			prev->DrawStripedLine(0.0f, 1.0f, 1.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+		} else {
+			gs_effect_set_vec4(lineParam, &red);
+			while (gs_effect_loop(prev->solidEffect, "Solid")) {
+				DrawLine(0.0f, 1.0f, 1.0f, 1.0f, HANDLE_RADIUS * pixelRatio / 2, boxScale);
+			}
+		}
+	} else if (selected) {
+		gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");
+		gs_effect_set_vec4(colParam, &red);
+		while (gs_effect_loop(prev->solidEffect, "Solid")) {
+			DrawRect(HANDLE_RADIUS * pixelRatio / 2, boxScale);
+		}
+	} else {
+		gs_eparam_t *colParam = gs_effect_get_param_by_name(prev->solidEffect, "color");
+		gs_effect_set_vec4(colParam, &blue);
+		while (gs_effect_loop(prev->solidEffect, "Solid")) {
+			DrawRect(HANDLE_RADIUS * pixelRatio / 2, boxScale);
 		}
 	}
 
@@ -2007,19 +2119,9 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 	gs_technique_begin(tech);
 	gs_technique_begin_pass(tech, 0);
 
-	gs_load_vertexbuffer(main->box);
 	gs_effect_set_vec4(colParam, &red);
 
 	if (selected) {
-		DrawSquareAtPos(0.0f, 0.0f, pixelRatio);
-		DrawSquareAtPos(0.0f, 1.0f, pixelRatio);
-		DrawSquareAtPos(1.0f, 0.0f, pixelRatio);
-		DrawSquareAtPos(1.0f, 1.0f, pixelRatio);
-		DrawSquareAtPos(0.5f, 0.0f, pixelRatio);
-		DrawSquareAtPos(0.0f, 0.5f, pixelRatio);
-		DrawSquareAtPos(0.5f, 1.0f, pixelRatio);
-		DrawSquareAtPos(1.0f, 0.5f, pixelRatio);
-
 		if (!prev->circleFill) {
 			gs_render_start(true);
 
@@ -2036,6 +2138,21 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 
 		bool invert = info.scale.y < 0.0f && info.bounds_type == OBS_BOUNDS_NONE;
 		DrawRotationHandle(prev->circleFill, info.rot + prev->groupRot, pixelRatio, invert);
+
+		if (prev->isAltPressed()) {
+			gs_effect_set_vec4(colParam, &green);
+		}
+
+		gs_load_vertexbuffer(main->box);
+
+		DrawSquareAtPos(0.0f, 0.0f, pixelRatio);
+		DrawSquareAtPos(0.0f, 1.0f, pixelRatio);
+		DrawSquareAtPos(1.0f, 0.0f, pixelRatio);
+		DrawSquareAtPos(1.0f, 1.0f, pixelRatio);
+		DrawSquareAtPos(0.5f, 0.0f, pixelRatio);
+		DrawSquareAtPos(0.0f, 0.5f, pixelRatio);
+		DrawSquareAtPos(0.5f, 1.0f, pixelRatio);
+		DrawSquareAtPos(1.0f, 0.5f, pixelRatio);
 	}
 
 	gs_matrix_pop();
@@ -2089,6 +2206,94 @@ bool OBSBasicPreview::DrawSelectionBox(float x1, float y1, float x2, float y2, g
 	return true;
 }
 
+bool OBSBasicPreview::drawCropping(obs_sceneitem_t *item, void *param)
+{
+	OBSBasicPreview *prev = static_cast<OBSBasicPreview *>(param);
+
+	gs_matrix_push();
+
+	matrix4 drawTransform;
+	obs_sceneitem_get_draw_transform(item, &drawTransform);
+	gs_matrix_mul(&drawTransform);
+
+	obs_source_t *source = obs_sceneitem_get_source(item);
+	uint32_t sourceWidth = obs_source_get_width(source);
+	uint32_t sourceHeight = obs_source_get_height(source);
+
+	auto boundsType = obs_sceneitem_get_bounds_type(item);
+
+	obs_sceneitem_crop crop;
+	obs_sceneitem_get_crop(item, &crop);
+
+	/* We have to adjust these regions when Crop to Bounds is enabled as it affects the draw position */
+	if (obs_sceneitem_get_bounds_crop(item) && boundsType != OBS_BOUNDS_NONE) {
+		obs_sceneitem_crop croppedBounds;
+		obs_sceneitem_get_bounds_crop_sizes(item, &croppedBounds);
+
+		crop.left += croppedBounds.left;
+		crop.right += croppedBounds.right;
+
+		crop.top += croppedBounds.top;
+		crop.bottom += croppedBounds.bottom;
+	}
+
+	/* Render the entire source at it's current position offset by any crop */
+	gs_matrix_translate3f(-crop.left, -crop.top, 0.0f);
+	obs_source_video_render(source);
+
+	/* Draw darkened overlay over each cropped side */
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);
+
+	vec4 black;
+	vec4_set(&black, 0.0f, 0.0f, 0.0f, 0.5f);
+
+	gs_eparam_t *color_param = gs_effect_get_param_by_name(prev->solidEffect, "color");
+	gs_effect_set_vec4(color_param, &black);
+
+	float visibleWidth = sourceWidth - crop.left - crop.right;
+
+	OBSBasic *main = OBSBasic::Get();
+
+	vec4 green;
+	QColor cropColor = main->GetCropColor();
+	vec4_set(&green, cropColor.redF(), cropColor.greenF(), cropColor.blueF(), 1.0f);
+
+	while (gs_effect_loop(prev->solidEffect, "Solid")) {
+		if (crop.left > 0) {
+			gs_matrix_push();
+			gs_draw_sprite(NULL, 0, crop.left, sourceHeight);
+			gs_matrix_pop();
+		}
+
+		if (crop.right > 0) {
+			gs_matrix_push();
+			gs_matrix_translate3f(sourceWidth - crop.right, 0.0f, 0.0f);
+			gs_draw_sprite(NULL, 0, crop.right, sourceHeight);
+			gs_matrix_pop();
+		}
+
+		if (crop.top > 0) {
+			gs_matrix_push();
+			gs_matrix_translate3f(crop.left, 0.0f, 0.0f);
+			gs_draw_sprite(NULL, 0, visibleWidth, crop.top);
+			gs_matrix_pop();
+		}
+
+		if (crop.bottom > 0) {
+			gs_matrix_push();
+			gs_matrix_translate3f(crop.left, sourceHeight - crop.bottom, 0.0f);
+			gs_draw_sprite(NULL, 0, visibleWidth, crop.bottom);
+			gs_matrix_pop();
+		}
+	}
+
+	gs_blend_state_pop();
+	gs_matrix_pop();
+
+	return true;
+}
+
 void OBSBasicPreview::DrawOverflow()
 {
 	if (locked)
@@ -2129,8 +2334,13 @@ void OBSBasicPreview::DrawSceneEditing()
 	GS_DEBUG_MARKER_BEGIN(GS_DEBUG_COLOR_DEFAULT, "DrawSceneEditing");
 
 	OBSBasic *main = OBSBasic::Get();
-
 	OBSScene scene = main->GetCurrentScene();
+
+	if (showCroppingOverlay) {
+		drawCroppingOverlay();
+	} else if (main->previewSpacingHelpersEnabled) {
+		drawSpacingHelpers();
+	}
 
 	if (scene) {
 		gs_matrix_push();
@@ -2378,7 +2588,33 @@ static void RenderSpacingHelper(int sourceIndex, vec3 &start, vec3 &end, vec3 &v
 	DrawLabel(source, labelPos, viewport);
 }
 
-void OBSBasicPreview::DrawSpacingHelpers()
+void OBSBasicPreview::drawCroppingOverlay()
+{
+	OBSBasic *main = OBSBasic::Get();
+
+	vec4 overlay;
+	vec4_set(&overlay, 0.05f, 0.05f, 0.08f, 0.75f);
+
+	gs_matrix_push();
+	gs_reset_viewport();
+	gs_matrix_translate3f(-(float)main->previewX, -(float)main->previewY, 0.0f);
+
+	/* Draw a darkened overlay on the preview area */
+	gs_blend_state_push();
+	gs_blend_function(GS_BLEND_SRCALPHA, GS_BLEND_INVSRCALPHA);
+
+	gs_eparam_t *previewBg = gs_effect_get_param_by_name(solidEffect, "color");
+	gs_effect_set_vec4(previewBg, &overlay);
+
+	while (gs_effect_loop(solidEffect, "Solid")) {
+		gs_draw_sprite(NULL, 0, width(), height());
+	}
+
+	gs_blend_state_pop();
+	gs_matrix_pop();
+}
+
+void OBSBasicPreview::drawSpacingHelpers()
 {
 	if (locked)
 		return;

--- a/frontend/widgets/OBSBasicPreview.hpp
+++ b/frontend/widgets/OBSBasicPreview.hpp
@@ -66,7 +66,7 @@ private:
 	bool mouseDown = false;
 	bool mouseMoved = false;
 	bool mouseOverItems = false;
-	bool cropping = false;
+	bool altPressed = false;
 	bool locked = false;
 	bool scrollMode = false;
 	bool fixedScaling = false;
@@ -79,6 +79,9 @@ private:
 	float groupRot = 0.0f;
 	bool updatingXScrollBar = false;
 	bool updatingYScrollBar = false;
+	bool showCroppingOverlay = false;
+	void setAltPressed(bool pressed);
+	bool isAltPressed() { return altPressed; }
 
 	std::vector<obs_sceneitem_t *> hoveredPreviewItems;
 	std::vector<obs_sceneitem_t *> selectedItems;
@@ -89,8 +92,9 @@ private:
 	static bool DrawSelectedOverflow(obs_scene_t *scene, obs_sceneitem_t *item, void *param);
 	static bool DrawSelectedItem(obs_scene_t *scene, obs_sceneitem_t *item, void *param);
 	static bool DrawSelectionBox(float x1, float y1, float x2, float y2, gs_vertbuffer_t *box);
+	static bool drawCropping(obs_sceneitem_t *item, void *param);
 
-	static OBSSceneItem GetItemAtPos(const vec2 &pos, bool selectBelow);
+	static OBSSceneItem GetItemAtPos(const vec2 &pos);
 	static bool SelectedAtPos(const vec2 &pos);
 
 	static void DoSelect(const vec2 &pos);
@@ -137,6 +141,7 @@ public:
 	virtual void mouseReleaseEvent(QMouseEvent *event) override;
 	virtual void mouseMoveEvent(QMouseEvent *event) override;
 	virtual void leaveEvent(QEvent *event) override;
+	virtual void focusOutEvent(QFocusEvent *event) override;
 
 	void DrawOverflow();
 	void DrawSceneEditing();
@@ -189,7 +194,8 @@ public:
 	OBSSourceAutoRelease spacerLabel[4];
 	int spacerPx[4] = {0};
 
-	void DrawSpacingHelpers();
+	void drawCroppingOverlay();
+	void drawSpacingHelpers();
 	void ClampScrollingOffsets();
 	void UpdateXScrollBar(float cx);
 	void UpdateYScrollBar(float cy);

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -189,9 +189,6 @@ void OBSBasic::RenderMain(void *data, uint32_t, uint32_t)
 
 	window->ui->preview->DrawSceneEditing();
 
-	if (window->drawSpacingHelpers)
-		window->ui->preview->DrawSpacingHelpers();
-
 	/* --------------------------------------- */
 
 	gs_projection_pop();
@@ -617,7 +614,7 @@ QColor OBSBasic::GetHoverColor() const
 
 void OBSBasic::UpdatePreviewSpacingHelpers()
 {
-	drawSpacingHelpers = config_get_bool(App()->GetUserConfig(), "BasicWindow", "SpacingHelpersEnabled");
+	previewSpacingHelpersEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow", "SpacingHelpersEnabled");
 }
 
 float OBSBasic::GetDevicePixelRatio()

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3331,6 +3331,14 @@ void obs_sceneitem_get_crop(const obs_sceneitem_t *item, struct obs_sceneitem_cr
 	memcpy(crop, &item->crop, sizeof(*crop));
 }
 
+void obs_sceneitem_get_bounds_crop_sizes(const obs_sceneitem_t *item, struct obs_sceneitem_crop *cropped)
+{
+	if (!obs_ptr_valid(item, "obs_sceneitem_get_bounds_crop"))
+		return;
+
+	memcpy(cropped, &item->bounds_crop, sizeof(*cropped));
+}
+
 void obs_sceneitem_set_scale_filter(obs_sceneitem_t *item, enum obs_scale_type filter)
 {
 	if (!obs_ptr_valid(item, "obs_sceneitem_set_scale_filter"))

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1745,6 +1745,8 @@ struct obs_sceneitem_crop {
 EXPORT void obs_sceneitem_set_crop(obs_sceneitem_t *item, const struct obs_sceneitem_crop *crop);
 EXPORT void obs_sceneitem_get_crop(const obs_sceneitem_t *item, struct obs_sceneitem_crop *crop);
 
+EXPORT void obs_sceneitem_get_bounds_crop_sizes(const obs_sceneitem_t *item, struct obs_sceneitem_crop *crop);
+
 EXPORT void obs_sceneitem_set_scale_filter(obs_sceneitem_t *item, enum obs_scale_type filter);
 EXPORT enum obs_scale_type obs_sceneitem_get_scale_filter(obs_sceneitem_t *item);
 


### PR DESCRIPTION
### Description
Makes a number of improvements to cropping items via a new visual UI.

While Alt is held down with a source selected, a dark overlay is drawn over the preview along with showing the cropped out regions of the source. The stretch handles also change to green to help indicate that a different action will take place when dragging one.

Dragging the source with Alt held down will now move the source within the cropped region.
<img width="1674" height="890" alt="obs64_qQARy8twdr" src="https://github.com/user-attachments/assets/6b196369-2397-4c25-87b0-66dcb5fc1535" />

### Motivation and Context
Cropping can be a bit unintuitive when using alternative bounding box types. I wanted to improve that as well as give a visual aid to exactly what is outside the cropped area.

https://github.com/user-attachments/assets/02d7de10-7459-4866-8abb-6ab4559b81e5


### How Has This Been Tested?
Tested cropping a source on all sides, in all bounding box types, and with all bounding box alignments.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
