### PR TITLE
Adds support for macOS's open command with -g and -j args

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -51,6 +51,12 @@
 #include <sys/socket.h>
 #endif
 
+#ifdef __APPLE__
+#include <objc/objc-runtime.h>
+#include <QTimer>
+#include <utility/platform.hpp>
+#endif
+
 #include "moc_OBSApp.cpp"
 
 using namespace std;
@@ -64,6 +70,8 @@ extern bool safe_mode;
 extern bool disable_3p_plugins;
 extern bool opt_disable_updater;
 extern bool opt_disable_missing_files_check;
+extern bool opt_background_launch;
+extern bool opt_minimize_tray;
 extern string opt_starting_collection;
 extern string opt_starting_profile;
 
@@ -1121,6 +1129,16 @@ bool OBSApp::OBSInit()
 	setQuitOnLastWindowClosed(false);
 
 	mainWindow = new OBSBasic();
+
+#ifdef __APPLE__
+	QTimer::singleShot(0, this, [this]() {
+		if (isAppHidden()) {
+			opt_minimize_tray = true;
+		}
+	});
+
+	SetOBSApplicationFlags(!opt_background_launch);
+#endif
 
 	mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 	connect(mainWindow, &OBSBasic::destroyed, this, &OBSApp::quit);

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -72,6 +72,7 @@ bool opt_start_virtualcam = false;
 bool opt_minimize_tray = false;
 bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
+bool opt_background_launch = false;
 bool opt_disable_updater = false;
 bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
@@ -988,6 +989,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--always-on-top", nullptr)) {
 			opt_always_on_top = true;
 
+		} else if (arg_is(argv[i], "--no-focus", nullptr)) {
+			opt_background_launch = true;
+
 		} else if (arg_is(argv[i], "--unfiltered_log", nullptr)) {
 			unfiltered_log = true;
 
@@ -1055,6 +1059,9 @@ int main(int argc, char *argv[])
 				"--disable-shutdown-check: Disable unclean shutdown detection.\n"
 				"--verbose: Make log more verbose.\n"
 				"--always-on-top: Start in 'always on top' mode.\n\n"
+#ifdef __APPLE__
+				"--no-focus: Launch without stealing focus (macOS).\n"
+#endif
 				"--unfiltered_log: Make log unfiltered.\n\n"
 				"--disable-updater: Disable built-in updater (Windows/Mac only)\n\n"
 				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n";

--- a/frontend/utility/platform-osx.mm
+++ b/frontend/utility/platform-osx.mm
@@ -25,7 +25,14 @@
 #import <AppKit/AppKit.h>
 #import <dlfcn.h>
 
+#import <Cocoa/Cocoa.h>
+
 using namespace std;
+
+bool isAppHidden()
+{
+    return [NSApp isHidden];
+}
 
 bool isInBundle()
 {
@@ -328,6 +335,7 @@ void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
 
 @interface OBSApplication : NSApplication <CrAppProtocol>
 @property (nonatomic, getter=isHandlingSendEvent) BOOL handlingSendEvent;
+@property (nonatomic) BOOL shouldFocusOnLaunch;
 @end
 
 @implementation OBSApplication
@@ -337,6 +345,15 @@ void TaskbarOverlaySetStatus(TaskbarOverlayStatus status)
     _handlingSendEvent = YES;
     [super sendEvent:event];
     _handlingSendEvent = NO;
+}
+
+- (void)finishLaunching
+{
+    [super finishLaunching];
+
+    if (!self.shouldFocusOnLaunch) {
+        [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
+    }
 }
 
 @end
@@ -358,4 +375,10 @@ void InstallNSApplicationSubclass()
 bool HighContrastEnabled()
 {
     return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldIncreaseContrast];
+}
+
+void SetOBSApplicationFlags(bool shouldFocusOnLaunch)
+{
+    OBSApplication *app = [OBSApplication sharedApplication];
+    app.shouldFocusOnLaunch = shouldFocusOnLaunch;
 }

--- a/frontend/utility/platform.hpp
+++ b/frontend/utility/platform.hpp
@@ -101,6 +101,8 @@ void InstallNSApplicationSubclass();
 void InstallNSThreadLocks();
 void disableColorSpaceConversion(QWidget *window);
 void SetMacOSDarkMode(bool dark);
+void SetOBSApplicationFlags(bool shouldFocusOnLaunch);
+bool isAppHidden();
 
 MacPermissionStatus CheckPermissionWithPrompt(MacPermissionType type, bool prompt_for_permission);
 #define CheckPermission(x) CheckPermissionWithPrompt(x, false)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
macOS has the command "open" which opens applications/files. This command has the arguments -j and -g, which tells the application launch hidden or without stealing focus respectively. I have added support for these to options. For the -j option, OBS launches with the --minimize-to-tray option. For -g I have implemented new logic to support this.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
First and foremost, because it wasn't supported and didn't require too much work to implement. But this is also nice in case the user is using an external program to control OBS (for example with the websocket plugin) so launching the controller program can launch OBS in the background.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested with both options for the open command (and also launching it normally from Finder).
Tested on an M4 MacBook Air on macOS 15.4.1. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
