### PR TITLE
frontend: Improve UX around recording paths

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1390,15 +1390,9 @@ string GetFormatExt(const char *container)
 
 string GetOutputFilename(const char *path, const char *container, bool noSpace, bool overwrite, const char *format)
 {
-	OBSBasic *main = OBSBasic::Get();
-
 	os_dir_t *dir = path && path[0] ? os_opendir(path) : nullptr;
 
 	if (!dir) {
-		if (main->isVisible())
-			OBSMessageBox::warning(main, QTStr("Output.BadPath.Title"), QTStr("Output.BadPath.Text"));
-		else
-			main->SysTrayNotify(QTStr("Output.BadPath.Text"), QSystemTrayIcon::Warning);
 		return "";
 	}
 

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -439,10 +439,12 @@ Output.RecordError.EncodeErrorMsg="An encoder error occurred while recording."
 Output.RecordError.EncodeErrorMsg.LastError="An encoder error occurred while recording:<br><br>%1"
 
 # output recording messages
-Output.BadPath.Title="Bad File Path"
+Output.Error.Title="Output Error"
+Output.BadPath.Title="Invalid Path"
 
 # "Recording Path" should match Basic.Settings.Output.Simple.SavePath
-Output.BadPath.Text="The configured Recording Path could not be opened. Please check your Recording Path under Settings → Output → Recording."
+Output.PathError.Text="The configured Recording Path could not be opened. The folder specified in Settings → Output → Recording does not exist."
+Output.BadPath.Text="Recording Path '%1' does not exist.\n\nWould you like to create it?"
 
 # broadcast setup messages
 Output.NoBroadcast.Title="No Broadcast Configured"
@@ -674,6 +676,7 @@ Basic.StatusBar.DelayStartingStoppingIn="Delay (stopping in %1 sec, starting in 
 Basic.StatusBar.RecordingSavedTo="Recording saved to '%1'"
 Basic.StatusBar.ReplayBufferSavedTo="Replay buffer saved to '%1'"
 Basic.StatusBar.ScreenshotSavedTo="Screenshot saved to '%1'"
+Basic.StatusBar.ScreenshotError="Error while saving screenshot"
 Basic.StatusBar.AutoRemuxedTo="Recording auto remuxed to '%1'"
 
 # filters window

--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -2615,6 +2615,9 @@
                            <property name="enabled">
                             <bool>true</bool>
                            </property>
+                           <property name="readOnly">
+                            <bool>true</bool>
+                           </property>
                           </widget>
                          </item>
                          <item>
@@ -3621,6 +3624,9 @@
                                      <horstretch>0</horstretch>
                                      <verstretch>0</verstretch>
                                     </sizepolicy>
+                                   </property>
+                                   <property name="readOnly">
+                                    <bool>true</bool>
                                    </property>
                                   </widget>
                                  </item>

--- a/frontend/utility/ScreenshotObj.hpp
+++ b/frontend/utility/ScreenshotObj.hpp
@@ -44,6 +44,7 @@ public:
 	uint32_t cx;
 	uint32_t cy;
 	std::thread th;
+	bool success = false;
 
 	int stage = 0;
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -728,6 +728,7 @@ private:
 
 	bool IsFFmpegOutputToURL() const;
 	bool OutputPathValid();
+	bool promptCreateOutputPath();
 	void OutputPathInvalidMessage();
 
 	// TODO: Unimplemented, remove.

--- a/frontend/widgets/OBSBasic_OutputHandler.cpp
+++ b/frontend/widgets/OBSBasic_OutputHandler.cpp
@@ -114,7 +114,7 @@ void OBSBasic::OutputPathInvalidMessage()
 {
 	blog(LOG_ERROR, "Recording stopped because of bad output path");
 
-	OBSMessageBox::critical(this, QTStr("Output.BadPath.Title"), QTStr("Output.BadPath.Text"));
+	OBSMessageBox::critical(this, QTStr("Output.Error.Title"), QTStr("Output.PathError.Text"));
 }
 
 bool OBSBasic::IsFFmpegOutputToURL() const
@@ -139,4 +139,28 @@ bool OBSBasic::OutputPathValid()
 
 	const char *path = GetCurrentOutputPath();
 	return path && *path && QDir(path).exists();
+}
+
+bool OBSBasic::promptCreateOutputPath()
+{
+	const char *path = GetCurrentOutputPath();
+
+	if (!path || !*path) {
+		return false;
+	}
+
+	auto result = OBSMessageBox::question(this, QTStr("Output.BadPath.Title"),
+					      QTStr("Output.BadPath.Text").arg(path),
+					      QMessageBox::Yes | QMessageBox::No);
+
+	if (result == QMessageBox::No) {
+		return false;
+	}
+
+	auto makeDirectory = os_mkdir(path);
+	if (makeDirectory == MKDIR_ERROR) {
+		OBSMessageBox::critical(this, QTStr("Error"), QTStr("Failed to create directory '%1'").arg(path));
+	}
+
+	return makeDirectory != MKDIR_ERROR;
 }

--- a/frontend/widgets/OBSBasic_Recording.cpp
+++ b/frontend/widgets/OBSBasic_Recording.cpp
@@ -36,7 +36,10 @@ void OBSBasic::on_actionShow_Recordings_triggered()
 				       : config_get_string(activeConfiguration, "AdvOut", "RecFilePath");
 	const char *path = strcmp(mode, "Advanced") ? config_get_string(activeConfiguration, "SimpleOutput", "FilePath")
 						    : adv_path;
-	QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+	bool success = QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+	if (!success) {
+		OutputPathInvalidMessage();
+	}
 }
 
 #define RECORDING_START "==== Recording Start ==============================================="
@@ -113,7 +116,7 @@ void OBSBasic::StartRecording()
 	if (disableOutputsRef)
 		return;
 
-	if (!OutputPathValid()) {
+	if (!OutputPathValid() && !promptCreateOutputPath()) {
 		OutputPathInvalidMessage();
 		return;
 	}

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -76,7 +76,7 @@ void OBSBasic::StartReplayBuffer()
 	if (!UIValidation::NoSourcesConfirmation(this))
 		return;
 
-	if (!OutputPathValid()) {
+	if (!OutputPathValid() && !promptCreateOutputPath()) {
 		OutputPathInvalidMessage();
 		return;
 	}


### PR DESCRIPTION
### Description
Better approach to trying to solve the underlying issue I was working towards in #10974

- Prompts to create the configured recording path folder if it does not exist
- Attempting to save a screenshot to an invalid recording path no longer erroneously says the screenshot was saved
- Display error when attempt to Show Recordings with an invalid path

### Motivation and Context
I want to smooth out problems for users with bad recording directories.

### How Has This Been Tested?
Started recordings, replay buffers and screenshots with a valid recording path, an invalid one in a valid parent directory, and with an invalid path to a non-existent drive.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
