### PR TITLE
frontend: Fix misaligned progress percentage in Remux dialog #12378

### DIFF
--- a/frontend/dialogs/OBSRemux.cpp
+++ b/frontend/dialogs/OBSRemux.cpp
@@ -46,6 +46,7 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
 	ui->setupUi(this);
 
 	ui->progressBar->setVisible(false);
+	ui->progressLabel->setVisible(false);
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 	ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(false);
 
@@ -59,6 +60,7 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
 	ui->progressBar->setMinimum(0);
 	ui->progressBar->setMaximum(1000);
 	ui->progressBar->setValue(0);
+	ui->progressLabel->setText("0%");
 
 	ui->tableView->setModel(queueModel);
 	ui->tableView->setItemDelegateForColumn(RemuxEntryColumn::InputPath,
@@ -222,6 +224,7 @@ void OBSRemux::beginRemux()
 	queueModel->beginProcessing();
 
 	ui->progressBar->setVisible(true);
+	ui->progressLabel->setVisible(true);
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setText(QTStr("Remux.Stop"));
 	setAcceptDrops(false);
 
@@ -232,6 +235,7 @@ void OBSRemux::AutoRemux(QString inFile, QString outFile)
 {
 	if (inFile != "" && outFile != "" && autoRemux) {
 		ui->progressBar->setVisible(true);
+		ui->progressLabel->setVisible(true);
 		emit remux(inFile, outFile);
 		autoRemuxFile = outFile;
 	}
@@ -255,6 +259,7 @@ void OBSRemux::remuxNextEntry()
 		}
 
 		ui->progressBar->setVisible(autoRemux);
+		ui->progressLabel->setVisible(autoRemux);
 		ui->buttonBox->button(QDialogButtonBox::Ok)->setText(QTStr("Remux.Remux"));
 		ui->buttonBox->button(QDialogButtonBox::RestoreDefaults)->setEnabled(true);
 		ui->buttonBox->button(QDialogButtonBox::Reset)->setEnabled(queueModel->canClearFinished());
@@ -281,6 +286,7 @@ void OBSRemux::reject()
 void OBSRemux::updateProgress(float percent)
 {
 	ui->progressBar->setValue(percent * 10);
+	ui->progressLabel->setText(QString::number(static_cast<int>(percent)) + "%");
 }
 
 void OBSRemux::remuxFinished(bool success)

--- a/frontend/forms/OBSRemux.ui
+++ b/frontend/forms/OBSRemux.ui
@@ -58,11 +58,31 @@
     </widget>
    </item>
    <item row="2" column="0">
-    <widget class="QProgressBar" name="progressBar">
-     <property name="value">
-      <number>24</number>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="progressLayout">
+     <item>
+      <widget class="QProgressBar" name="progressBar">
+       <property name="value">
+        <number>24</number>
+       </property>
+       <property name="textVisible">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="progressLabel">
+       <property name="text">
+        <string>0%</string>
+       </property>
+       <property name="visible">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignHCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The Remux progress bar using the default progress text of QProgressBar, which was not aligned properly, and would be overlaid on the progress bar itself. I changed it to be a QLabel that is aligned properly to the right of the progress bar, in its same horizontal row. 
<img width="1135" height="853" alt="image" src="https://github.com/user-attachments/assets/120f045a-ec17-4ff7-8757-a8f291595a42" />
<img width="1246" height="824" alt="image" src="https://github.com/user-attachments/assets/0e24e250-7fc2-4c59-acd2-bb53079629c1" />



### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #12378

This is a fix for the open issue https://github.com/obsproject/obs-studio/issues/12378
The progress percentage looked like this before the change, and the number was not visible properly
<img width="843" height="454" alt="image" src="https://github.com/user-attachments/assets/a23c5a43-440b-4266-b020-769e76ac4aeb" />


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I tested this manually by building after the changes and tested remuxing multiple files. The output and UI changes were obtained as in the screenshots provided. 
I tested on Windows 11 10.0.26100 using the windows-x64 RelWithDebInfo build configuration

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
