### PR TITLE
frontend: Do not set maximum_video_tracks if user has set it to "Auto"

### DIFF
--- a/frontend/utility/GoLiveAPI_PostData.cpp
+++ b/frontend/utility/GoLiveAPI_PostData.cpp
@@ -73,13 +73,11 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 
 	if (maximum_aggregate_bitrate.has_value())
 		preferences.maximum_aggregate_bitrate = maximum_aggregate_bitrate.value();
-	if (maximum_video_tracks.has_value())
-		preferences.maximum_video_tracks = maximum_video_tracks.value();
 
-	/* Always cap to maximum number of output encoders. */
-	if (!preferences.maximum_video_tracks.has_value() ||
-	    preferences.maximum_video_tracks.value() > MAX_OUTPUT_VIDEO_ENCODERS) {
-		preferences.maximum_video_tracks = MAX_OUTPUT_VIDEO_ENCODERS;
+	if (maximum_video_tracks.has_value()) {
+		/* Cap to maximum supported number of output encoders. */
+		preferences.maximum_video_tracks =
+			std::min(maximum_video_tracks.value(), static_cast<uint32_t>(MAX_OUTPUT_VIDEO_ENCODERS));
 	}
 
 	return post_data;


### PR DESCRIPTION
### Description

Removes a conditional that would have set the maximum video tracks to the OBS output maximum if the user has not specified a value.

### Motivation and Context

If the user does not set a value this should remain `null` since it is meant to communicate a user preference, not a software limitation. Communicating software limits will require future additions to the GCC API specification.

### How Has This Been Tested?

Confirmed value sent is now `null` again.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
