### PR TITLE
frontend: Fix settings scrollbar size

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -139,6 +139,7 @@
     --volume_slider_label: calc(var(--volume_slider_box) * 2);
 
     --scrollbar_size: 12px;
+    --settings_scrollbar_size: calc(var(--scrollbar_size) + 9px);
     --scrollbar_handle: var(--grey4);
     
     --scrollbar_bg: var(--grey6);
@@ -634,10 +635,12 @@ QListWidget QLineEdit:focus {
 
 OBSBasicSettings QScrollBar:vertical {
     width: var(--scrollbar_size);
+    width: var(--settings_scrollbar_size);
+    margin-left: 9px;
 }
 
 OBSBasicSettings QScrollBar:horizontal {
-    height: var(--scrollbar_size);
+    height: var(--settings_scrollbar_size);
 }
 
 /* Settings properties view */
@@ -734,6 +737,11 @@ QDockWidget::float-button:pressed {
 
 QAbstractScrollArea {
     border-radius: var(--border_radius);
+}
+
+/* ScrollAreaContents */
+QScrollArea > QWidget > QWidget {
+    background: transparent;
 }
 
 /* Qt enforces a padding inside its status bar, so we


### PR DESCRIPTION
### Description
Fixes sizing of scrollbars in the Settings window.

Fixes #12384 

### Motivation and Context
Changes to the layout margins and spacing in the settings window caused scrollbars to get scrunched up a bit. This fixes that so they appear as they did before.

<img width="983" height="762" alt="image" src="https://github.com/user-attachments/assets/a1976c97-a97a-436d-bfe3-9beec9a45c96" />


### How Has This Been Tested?
👀

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
