### PR TITLE
linux-pipewire: Dup syncobj fds to prevent use-after-free hang & ensure release point is always signaled

### DIFF
--- a/plugins/linux-pipewire/CMakeLists.txt
+++ b/plugins/linux-pipewire/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT ENABLE_PIPEWIRE)
 endif()
 
 find_package(PipeWire 0.3.33 REQUIRED)
-find_package(Gio REQUIRED)
+find_package(Gio 2.76 REQUIRED)
 find_package(Libdrm REQUIRED)
 get_target_property(libdrm_include_directories Libdrm::Libdrm INTERFACE_INCLUDE_DIRECTORIES)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

PipeWire format renegotiation runs in parallel with video rendering.

When the stream format is renegotiated, PipeWire removes the existing buffers and closes the syncobj file descriptors. At the same time, the video rendering thread may try to import the (already closed) syncobj acquire fd, and hang on waiting for the fence to become available.

This is not a problem for the dmabuf fd because it's imported into a texture right away, which doesn't disappear when PipeWire closes the fd.

The first commit adds duping to the syncobj fds so that they too remain open as long as the rendering thread may access them.

The second commit fixes a separate issue with explicit sync.

Since video rendering happens on a separate thread from PipeWire buffer ingestion, it may happen that two buffers are ingested in quick succession without the rendering thread ever getting to them. Since, prior to this commit, the release sync point is only "primed" (set to signal in the future) only on the video rendering thread, this results in the buffer being returned to PipeWire's pool without anything ever signaling the release point, effectively blocking it from ever getting reused in the future. This quickly clogs up the buffer pool and leaves only one buffer to circulate between the screencast source and OBS.

The second commit adds a flag tracking whether the release point had been primed. If, when ingesting a new PW buffer, the old buffer's release point hadn't been primed, that means the video rendering thread never got to that buffer, so the release point is immediately signaled, marking the buffer reusable by the screencast source.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

First commit: fixes an OBS hang that can occur during renegotiation of a PipeWire stream with explicit sync.

Second commit: fixes PipeWire streams with explicit sync quickly running out of all but one available buffers.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I'm adding explicit sync to PipeWire screencasts in the niri Wayland compositor: https://github.com/YaLTeR/niri/pull/2087

I tested this change using that niri PR, and OBS built in Fedora 42. OBS needs to be built with PipeWire >= 1.2.0 to enable explicit sync.

The easiest way to trigger the problem is to start a window cast, then resize the window. Unlike GNOME, niri sizes the stream exactly, and renegotiates the stream every time the size changes. So resizing the window causes a flood of rapid PW renegotiations, easily triggering the issue.

Note that this will also trigger [an fd leak](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/4807) in PipeWire that I found, causing it to rapidly fill up with syncobj fds. You may need to `systemctl --user restart pipewire` afterwards to clean it up.

The second commit was tested using debug output in the aforementioned niri PR that logs pending PipeWire buffers, their signaled and pending release points.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

Style note: GLib has [`g_clear_fd()`](https://docs.gtk.org/glib/func.clear_fd.html) that could clean this diff up a little, but it needs a higher GLib version than the OBS build system uses by default, and I'm not sure whether that's wanted, or how to best set the requirement.
