### PR TITLE
frontend: Round display size for projectors

### DIFF
--- a/frontend/widgets/OBSBasic_Projectors.cpp
+++ b/frontend/widgets/OBSBasic_Projectors.cpp
@@ -105,7 +105,7 @@ QList<QString> OBSBasic::GetProjectorMenuMonitorsFormatted()
 	for (int i = 0; i < screens.size(); i++) {
 		QScreen *screen = screens[i];
 		QRect screenGeometry = screen->geometry();
-		qreal ratio = screen->devicePixelRatio();
+		qreal screenPixelRatio = screen->devicePixelRatio();
 		QString name = "";
 #if defined(__APPLE__) || defined(_WIN32)
 		name = screen->name();
@@ -120,9 +120,12 @@ QList<QString> OBSBasic::GetProjectorMenuMonitorsFormatted()
 		if (name.length() == 0) {
 			name = QString("%1 %2").arg(QTStr("Display")).arg(QString::number(i + 1));
 		}
+
+		int screenPixelWidth = 2 * qRound((screenGeometry.width() * screenPixelRatio) / 2);
+		int screenPixelHeight = 2 * qRound((screenGeometry.height() * screenPixelRatio) / 2);
+
 		QString str = QString("%1: %2x%3 @ %4,%5")
-				      .arg(name, QString::number(screenGeometry.width() * ratio),
-					   QString::number(screenGeometry.height() * ratio),
+				      .arg(name, QString::number(screenPixelWidth), QString::number(screenPixelHeight),
 					   QString::number(screenGeometry.x()), QString::number(screenGeometry.y()));
 		projectorsFormatted.push_back(str);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Rounds the width and height for screen dimensions to the nearest integer, and then rounds to a multiple of 2.

### Motivation and Context
When display scaling of some kind is enabled, we have to calculate screen size using the reported geometry multiplied by devicePixelRatio. For certain resolutions and scaling ratios, this can result in a non-integer value which is both not correct and confusing.

This PR ensures the display size is always a whole number and rounded in a way that is expected.

| Before | After |
| ------------- | ------------- |
| <img width="545" height="289" alt="obs64_A2NDRdwDdf" src="https://github.com/user-attachments/assets/47692cbf-2866-49dc-8f78-3aeafb33099e" /> | <img width="502" height="283" alt="c9ItfO6SeQ" src="https://github.com/user-attachments/assets/6956b669-8223-4398-a28d-e6213a0d7a76" /> |
| <img width="539" height="288" alt="obs64_49bDThkzLA" src="https://github.com/user-attachments/assets/61a4ca90-0a7e-4458-87e5-f427c0b6c331" /> | forgot this one I promise it's fixed |
| <img width="531" height="294" alt="obs64_Lj9XzpGTUC" src="https://github.com/user-attachments/assets/3b6e9684-0e0a-4944-9df7-d09e1d86c70a" /> | <img width="508" height="295" alt="obs64_CMAr7lvLzG" src="https://github.com/user-attachments/assets/06fc11b8-4528-48cc-b491-57adb6eeb9d5" /> |



### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
