### PR TITLE
frontend: Fix and simplify initialization of supported_codecs

### DIFF
--- a/frontend/utility/GoLiveAPI_PostData.cpp
+++ b/frontend/utility/GoLiveAPI_PostData.cpp
@@ -21,14 +21,6 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 	client.name = "obs-studio";
 	client.version = obs_get_version_string();
 
-	auto add_codec = [&](const char *codec) {
-		auto it = std::find(std::begin(client.supported_codecs), std::end(client.supported_codecs), codec);
-		if (it != std::end(client.supported_codecs))
-			return;
-
-		client.supported_codecs.push_back(codec);
-	};
-
 	const char *encoder_id = nullptr;
 	for (size_t i = 0; obs_enum_encoder_types(i, &encoder_id); i++) {
 		auto codec = obs_get_encoder_codec(encoder_id);
@@ -36,13 +28,13 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 			continue;
 
 		if (qstricmp(codec, "h264") == 0) {
-			add_codec("h264");
+			client.supported_codecs.emplace("h264");
 #ifdef ENABLE_HEVC
-		} else if (qstricmp(codec, "hevc")) {
-			add_codec("h265");
+		} else if (qstricmp(codec, "hevc") == 0) {
+			client.supported_codecs.emplace("h265");
 #endif
-		} else if (qstricmp(codec, "av1")) {
-			add_codec("av1");
+		} else if (qstricmp(codec, "av1") == 0) {
+			client.supported_codecs.emplace("av1");
 		}
 	}
 

--- a/frontend/utility/models/multitrack-video.hpp
+++ b/frontend/utility/models/multitrack-video.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 #include <optional>
+#include <unordered_set>
 
 #include <obs.h>
 
@@ -94,7 +95,7 @@ using json = nlohmann::json;
 struct Client {
 	string name = "obs-studio";
 	string version;
-	std::vector<string> supported_codecs;
+	std::unordered_set<std::string> supported_codecs;
 
 	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Client, name, version, supported_codecs)
 };


### PR DESCRIPTION
### Description

Fixes codec string comparison and also simplifies things by using an automatically deduplicated container.

### Motivation and Context

Easier to read and not broken.

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
