### PR TITLE
Revert "linux-pipewire: Fix 10- and 16-bit captures"

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -806,10 +806,11 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		g_clear_pointer(&obs_pw_stream->texture, gs_texture_destroy);
 
 		use_modifiers = obs_pw_stream->format.info.raw.modifier != DRM_FORMAT_MOD_INVALID;
-		obs_pw_stream->texture = gs_texture_create_from_dmabuf(
-			obs_pw_stream->format.info.raw.size.width, obs_pw_stream->format.info.raw.size.height,
-			obs_pw_video_format.drm_format, obs_pw_video_format.gs_format, planes, fds, strides, offsets,
-			use_modifiers ? modifiers : NULL);
+		obs_pw_stream->texture = gs_texture_create_from_dmabuf(obs_pw_stream->format.info.raw.size.width,
+								       obs_pw_stream->format.info.raw.size.height,
+								       obs_pw_video_format.drm_format, GS_BGRX, planes,
+								       fds, strides, offsets,
+								       use_modifiers ? modifiers : NULL);
 
 		if (obs_pw_stream->texture == NULL) {
 			remove_modifier_from_format(obs_pw_stream, obs_pw_stream->format.info.raw.format,
@@ -1326,20 +1327,10 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_sync_destroy(acquire_sync);
 	}
 
-	effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
-	gs_technique_t *tech = gs_effect_get_technique(effect, "DrawSrgbDecompress");
-	gs_technique_begin(tech);
-	gs_technique_begin_pass(tech, 0);
-
-	const bool linear_srgb = gs_get_linear_srgb();
-	const bool previous = gs_framebuffer_srgb_enabled();
-	gs_enable_framebuffer_srgb(linear_srgb);
-
+	/* FIXME: Use obs_pw_stream->format.info.raw colorimetry info to handle
+	 * textures in their corresponding color space */
 	image = gs_effect_get_param_by_name(effect, "image");
-	if (linear_srgb)
-		gs_effect_set_texture_srgb(image, obs_pw_stream->texture);
-	else
-		gs_effect_set_texture(image, obs_pw_stream->texture);
+	gs_effect_set_texture(image, obs_pw_stream->texture);
 
 	rotated = push_rotation(obs_pw_stream);
 
@@ -1373,21 +1364,13 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_matrix_push();
 		gs_matrix_translate3f(cursor_x, cursor_y, 0.0f);
 
-		if (linear_srgb)
-			gs_effect_set_texture_srgb(image, obs_pw_stream->cursor.texture);
-		else
-			gs_effect_set_texture(image, obs_pw_stream->cursor.texture);
+		gs_effect_set_texture(image, obs_pw_stream->cursor.texture);
 		gs_draw_sprite(obs_pw_stream->texture, 0, obs_pw_stream->cursor.width, obs_pw_stream->cursor.height);
 
 		gs_matrix_pop();
 	}
 
 	gs_blend_state_pop();
-
-	gs_enable_framebuffer_srgb(previous);
-
-	gs_technique_end_pass(tech);
-	gs_technique_end(tech);
 
 	if (obs_pw_stream->sync.set) {
 		gs_sync_t *release_sync = gs_sync_create();

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -736,7 +736,7 @@ void screencast_portal_load(void)
 	const struct obs_source_info screencast_portal_capture_info = {
 		.id = "pipewire-screen-capture-source",
 		.type = OBS_SOURCE_TYPE_INPUT,
-		.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
+		.output_flags = OBS_SOURCE_VIDEO,
 		.get_name = screencast_portal_desktop_capture_get_name,
 		.create = screencast_portal_capture_create,
 		.destroy = screencast_portal_capture_destroy,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes #12412

This reverts commit 4dfd0b31e4988601ffab045a495ba319e45e8c16.

Also adds a FIXME comment.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

#11207 generated issues on SDR users.
And the PR itself tries to handle color space the wrong way, the portal implementation should provide a node with PipeWire colorimetry info in its formats for OBS Studio to handle textures correctly.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
