### PR TITLE
linux-pipewire: Fix render technique in captures again

### DIFF
--- a/plugins/linux-pipewire/pipewire.c
+++ b/plugins/linux-pipewire/pipewire.c
@@ -817,11 +817,10 @@ static void process_video_sync(obs_pipewire_stream *obs_pw_stream)
 		g_clear_pointer(&obs_pw_stream->texture, gs_texture_destroy);
 
 		use_modifiers = obs_pw_stream->format.info.raw.modifier != DRM_FORMAT_MOD_INVALID;
-		obs_pw_stream->texture = gs_texture_create_from_dmabuf(obs_pw_stream->format.info.raw.size.width,
-								       obs_pw_stream->format.info.raw.size.height,
-								       obs_pw_video_format.drm_format, GS_BGRX, planes,
-								       fds, strides, offsets,
-								       use_modifiers ? modifiers : NULL);
+		obs_pw_stream->texture = gs_texture_create_from_dmabuf(
+			obs_pw_stream->format.info.raw.size.width, obs_pw_stream->format.info.raw.size.height,
+			obs_pw_video_format.drm_format, obs_pw_video_format.gs_format, planes, fds, strides, offsets,
+			use_modifiers ? modifiers : NULL);
 
 		if (obs_pw_stream->texture == NULL) {
 			remove_modifier_from_format(obs_pw_stream, obs_pw_stream->format.info.raw.format,
@@ -1328,6 +1327,11 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 
 	gs_eparam_t *image;
 
+	const char *tech_name = "DrawSrgbDecompress";
+	gs_technique_t *tech;
+
+	const bool previous = gs_framebuffer_srgb_enabled();
+
 	if (!obs_pw_stream->texture)
 		return;
 
@@ -1338,8 +1342,14 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 		gs_sync_destroy(acquire_sync);
 	}
 
-	/* FIXME: Use obs_pw_stream->format.info.raw colorimetry info to handle
-	 * textures in their corresponding color space */
+	effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+
+	tech = gs_effect_get_technique(effect, tech_name);
+	gs_technique_begin(tech);
+	gs_technique_begin_pass(tech, 0);
+
+	gs_enable_framebuffer_srgb(true);
+
 	image = gs_effect_get_param_by_name(effect, "image");
 	gs_effect_set_texture(image, obs_pw_stream->texture);
 
@@ -1382,6 +1392,11 @@ void obs_pipewire_stream_video_render(obs_pipewire_stream *obs_pw_stream, gs_eff
 	}
 
 	gs_blend_state_pop();
+
+	gs_enable_framebuffer_srgb(previous);
+
+	gs_technique_end_pass(tech);
+	gs_technique_end(tech);
 
 	if (obs_pw_stream->sync.set) {
 		gs_sync_t *release_sync = gs_sync_create();

--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -736,7 +736,7 @@ void screencast_portal_load(void)
 	const struct obs_source_info screencast_portal_capture_info = {
 		.id = "pipewire-screen-capture-source",
 		.type = OBS_SOURCE_TYPE_INPUT,
-		.output_flags = OBS_SOURCE_VIDEO,
+		.output_flags = OBS_SOURCE_VIDEO | OBS_SOURCE_SRGB,
 		.get_name = screencast_portal_desktop_capture_get_name,
 		.create = screencast_portal_capture_create,
 		.destroy = screencast_portal_capture_destroy,


### PR DESCRIPTION
### Description
Fixes #12412 
Supersedes #12422 

Changes the linux-pipewire render code to use the correct rendering techniques

### Motivation and Context
Adding an effect to the pipewire capture source leads to a decrease in gamma.
While unsure about why exactly this happens, this PR copies the function for finding the right render technique from the Windows dc-capture and correctly handles the so far only supported non-linear format.

### How Has This Been Tested?
Tested each combination of:
- 10-bit vs 8-bit in my compositor settings
- 16-bit P416 vs 8-bit NV12 in obs settings
- Rec. 709 vs Rec. 2100 (PQ)
- With "Render Delay" effect vs without. (As from the original issue)

Additional testing with hardware cursor capable machine is required. Same for traditional 8-bit displays (I do not trust Hyprland, better be safe!)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
