### PR TITLE
CI: Fix failures of analyze workflow runs due to GitHub policy change

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -124,7 +124,7 @@ jobs:
 
           pushd ${analytics_root}
 
-          npx @microsoft/sarif-multitool merge *.sarif
+          npx @microsoft/sarif-multitool merge --merge-runs *.sarif
 
           popd
 


### PR DESCRIPTION
### Description
Ensures that merged SARIF report files generated via `clang-analyze` use a single `run` object only.

### Motivation and Context
GitHub introduced a policy change on 2024-05-06 which deprecated support for SARIF files that contain multiple runs for the same tool.

### How Has This Been Tested?
Tested on local fork via workflow dispatch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
