### PR TITLE
libobs: Amend timestamp semantics for async video and audio

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -919,6 +919,7 @@ struct obs_source {
 	uint32_t async_convert_width[MAX_AV_PLANES];
 	uint32_t async_convert_height[MAX_AV_PLANES];
 	uint64_t async_last_rendered_ts;
+	uint32_t async_not_close_needed_count;
 	uint32_t async_out_of_sequence_count;
 
 	pthread_mutex_t caption_cb_mutex;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -851,7 +851,7 @@ struct obs_source {
 	uint64_t next_audio_ts_min;
 	uint64_t next_audio_sys_ts_min;
 	uint64_t last_frame_ts;
-	uint64_t last_sys_timestamp;
+	uint64_t last_frame_sys_ts;
 	bool async_rendered;
 
 	/* audio */
@@ -1135,6 +1135,7 @@ extern bool update_async_textures(struct obs_source *source, const struct obs_so
 				  gs_texture_t *tex[MAX_AV_PLANES], gs_texrender_t *texrender);
 extern bool set_async_texture_size(struct obs_source *source, const struct obs_source_frame *frame);
 extern void remove_async_frame(obs_source_t *source, struct obs_source_frame *frame);
+extern void set_ready_frame_timing(obs_source_t *source, uint64_t frame_ts, uint64_t sys_time);
 
 extern void set_deinterlace_texture_size(obs_source_t *source);
 extern void deinterlace_process_last_frame(obs_source_t *source, uint64_t sys_time);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -919,6 +919,7 @@ struct obs_source {
 	uint32_t async_convert_width[MAX_AV_PLANES];
 	uint32_t async_convert_height[MAX_AV_PLANES];
 	uint64_t async_last_rendered_ts;
+	uint32_t async_out_of_sequence_count;
 
 	pthread_mutex_t caption_cb_mutex;
 	DARRAY(struct caption_cb_info) caption_cb_list;

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -850,6 +850,7 @@ struct obs_source {
 	uint64_t resample_offset;
 	uint64_t next_audio_ts_min;
 	uint64_t next_audio_sys_ts_min;
+	uint64_t discard_sys_ts;
 	uint64_t last_frame_ts;
 	uint64_t last_frame_sys_ts;
 	bool async_rendered;

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1333,6 +1333,7 @@ static void async_tick(obs_source_t *source)
 
 	if (deinterlacing_enabled(source)) {
 		deinterlace_process_last_frame(source, sys_time);
+		set_ready_frame_timing(source, source->last_frame_ts, sys_time);
 	} else {
 		if (source->cur_async_frame) {
 			remove_async_frame(source, source->cur_async_frame);
@@ -1341,8 +1342,6 @@ static void async_tick(obs_source_t *source)
 
 		source->cur_async_frame = get_closest_frame(source, sys_time);
 	}
-
-	set_ready_frame_timing(source, source->last_frame_ts, sys_time);
 
 	if (deinterlacing_enabled(source))
 		filter_frame(source, &source->prev_async_frame);
@@ -3512,6 +3511,7 @@ static inline struct obs_source_frame *cache_video(struct obs_source *source, co
 		free_async_cache(source);
 		source->last_frame_ts = 0;
 		source->last_frame_sys_ts = 0;
+		source->discard_sys_ts = 0;
 		pthread_mutex_unlock(&source->async_mutex);
 		return NULL;
 	}
@@ -3571,6 +3571,7 @@ static void obs_source_output_video_internal(obs_source_t *source, const struct 
 		source->async_active = false;
 		source->last_frame_ts = 0;
 		source->last_frame_sys_ts = 0;
+		source->discard_sys_ts = 0;
 		free_async_cache(source);
 		pthread_mutex_unlock(&source->async_mutex);
 		return;
@@ -4086,6 +4087,10 @@ void remove_async_frame(obs_source_t *source, struct obs_source_frame *frame)
 
 /* #define DEBUG_ASYNC_FRAMES 1 */
 
+/* Tolerance that allows a frame to be displayed as long as it is not too close
+ * to the video clock. */
+#define TS_JITTER_TOLERANCE 2000000ULL
+
 void set_ready_frame_timing(obs_source_t *source, uint64_t frame_ts, uint64_t sys_time)
 {
 	/* the timestamp provided by the source for the 'readied' frame */
@@ -4108,81 +4113,95 @@ struct obs_source_frame *ready_async_frame_unbuffered(obs_source_t *source, uint
 	return frame;
 }
 
-static bool ready_async_frame_buffered(obs_source_t *source, uint64_t sys_time)
+static bool restart_sequence_buffered(obs_source_t *source, uint64_t sys_time)
 {
-	struct obs_source_frame *next_frame = source->async_frames.array[0];
-	struct obs_source_frame *frame = NULL;
-	uint64_t sys_offset = sys_time - source->last_frame_sys_ts;
-	uint64_t frame_time = next_frame->timestamp;
-	uint64_t frame_offset = 0;
+	struct obs_source_frame *frame = source->async_frames.array[0];
 
-#if DEBUG_ASYNC_FRAMES
-	blog(LOG_DEBUG,
-	     "source->last_frame_ts: %llu, frame_time: %llu, "
-	     "sys_offset: %llu, frame_offset: %llu, "
-	     "number of frames: %lu",
-	     source->last_frame_ts, frame_time, sys_offset, frame_time - source->last_frame_ts,
-	     (unsigned long)source->async_frames.num);
-#endif
-
-	/* account for timestamp invalidation */
-	if (frame_out_of_bounds(source, frame_time)) {
-#if DEBUG_ASYNC_FRAMES
-		blog(LOG_DEBUG, "timing jump");
-#endif
-		set_ready_frame_timing(source, next_frame->timestamp, source->last_frame_sys_ts);
-		return true;
-	} else {
-		frame_offset = frame_time - source->last_frame_ts;
-		set_ready_frame_timing(source, source->last_frame_ts + sys_offset, source->last_frame_sys_ts);
-	}
-
-	while (source->last_frame_ts > next_frame->timestamp) {
-
-		/* this tries to reduce the needless frame duplication, also
-		 * helps smooth out async rendering to frame boundaries.  In
-		 * other words, tries to keep the framerate as smooth as
-		 * possible */
-		if (frame && (source->last_frame_ts - next_frame->timestamp) < 2000000)
-			break;
-
-		if (frame)
-			da_erase(source->async_frames, 0);
-
-#if DEBUG_ASYNC_FRAMES
-		blog(LOG_DEBUG,
-		     "new frame, "
-		     "source->last_frame_ts: %llu, "
-		     "next_frame->timestamp: %llu",
-		     source->last_frame_ts, next_frame->timestamp);
-#endif
-
-		remove_async_frame(source, frame);
-
+	/* first timestamp is an untrustworthy anchor (e.g. some webcams via
+	 * V4L2); discard timestamp and start sequence on next frame */
+	if (!source->discard_sys_ts) {
+		source->discard_sys_ts = sys_time;
 		if (source->async_frames.num == 1)
 			return true;
+	}
 
-		frame = next_frame;
-		next_frame = source->async_frames.array[1];
+	/* start sequence with assumption that the source and clock time-stamps
+	 * are (most) in-sync at the most recent frame */
+	while (source->async_frames.num > 1) {
+		da_erase(source->async_frames, 0);
+		remove_async_frame(source, frame);
+		frame = source->async_frames.array[0];
+	}
 
-		/* more timestamp checking and compensating */
-		if ((next_frame->timestamp - frame_time) > MAX_TS_VAR) {
-#if DEBUG_ASYNC_FRAMES
-			blog(LOG_DEBUG, "timing jump");
-#endif
-			set_ready_frame_timing(source, next_frame->timestamp - frame_offset, source->last_frame_sys_ts);
+	/* assume frame ready a half-jitter ago (sys_time > half-jit) */
+	set_ready_frame_timing(source, frame->timestamp, sys_time - TS_JITTER_TOLERANCE / 2);
+	return true;
+}
+
+static bool restart_interrupted_sequence_buffered(obs_source_t *source, uint64_t sys_time, uint64_t frame_ts)
+{
+	blog(LOG_DEBUG, "source '%s': timestamp sequence interrupted, restart from %" PRIu64 ")", source->context.name,
+	     frame_ts);
+	set_ready_frame_timing(source, 0, 0);
+	source->discard_sys_ts = 0;
+	return restart_sequence_buffered(source, sys_time);
+}
+
+static bool ready_async_frame_buffered(obs_source_t *source, uint64_t sys_time)
+{
+	struct obs_source_frame *frame = NULL;
+	uint64_t frame_ts = 0;
+	uint64_t frame_sys_ts = 0;
+
+	while ((!frame && source->async_frames.num != 0) || source->async_frames.num > 1) {
+		struct obs_source_frame *const peek_frame = source->async_frames.array[!frame ? 0 : 1];
+		const uint64_t peek_frame_ts = peek_frame->timestamp;
+		const uint64_t peek_frame_sys_ts =
+			source->last_frame_sys_ts + uint64_diff(source->last_frame_ts, peek_frame_ts);
+
+		if (frame_out_of_bounds(source, peek_frame_ts)) {
+			if (frame) {
+				da_erase(source->async_frames, 0);
+				remove_async_frame(source, frame);
+			}
+			return restart_interrupted_sequence_buffered(source, sys_time, peek_frame_ts);
 		}
 
-		frame_time = next_frame->timestamp;
-		frame_offset = frame_time - source->last_frame_ts;
+		/* out-of-sequence frames; discard */
+		if (peek_frame_ts < source->last_frame_ts) {
+			da_erase(source->async_frames, !frame ? 0 : 1);
+			remove_async_frame(source, peek_frame);
+			continue;
+		}
+
+		/* attempt to smooth out frame delivery by holding back frames
+		 * with timestamp too close to video clock */
+		if (frame && (source->last_frame_ts - peek_frame_ts) < TS_JITTER_TOLERANCE)
+				break;
+
+		if (peek_frame_sys_ts > sys_time + (TS_JITTER_TOLERANCE / 2))
+			break;
+
+		if (frame) {
+			da_erase(source->async_frames, 0);
+			remove_async_frame(source, frame);
+			set_ready_frame_timing(source, frame_ts, frame_sys_ts);
+		}
+
+		frame_sys_ts = peek_frame_sys_ts;
+		frame_ts = peek_frame_ts;
+		frame = peek_frame;
+	}
+
+	if (frame) {
+		set_ready_frame_timing(source, frame_ts, frame_sys_ts);
+		return true;
 	}
 
 #if DEBUG_ASYNC_FRAMES
-	if (!frame)
-		blog(LOG_DEBUG, "no frame!");
+	blog(LOG_DEBUG, "source '%s': no frame", source->context.name);
 #endif
-
-	return frame != NULL;
+	return false;
 }
 
 static inline struct obs_source_frame *get_closest_frame(obs_source_t *source, uint64_t sys_time)
@@ -4201,12 +4220,24 @@ static inline struct obs_source_frame *get_closest_frame(obs_source_t *source, u
 		return frame;
 	}
 
-	if (!source->last_frame_ts || ready_async_frame_buffered(source, sys_time)) {
+	if (!source->last_frame_sys_ts && restart_sequence_buffered(source, sys_time)) {
 		struct obs_source_frame *frame = source->async_frames.array[0];
+#if DEBUG_ASYNC_FRAMES
+		blog(LOG_DEBUG, "source '%s' buffered sequence started: queued=%lu, sys_ts=%lu, frame_ts=%lu",
+		     source->context.name, source->async_frames.num, sys_time, frame->timestamp);
+#endif
 		da_erase(source->async_frames, 0);
 
-		if (!source->last_frame_ts)
-			set_ready_frame_timing(source, frame->timestamp, source->last_frame_sys_ts);
+		return frame;
+	}
+
+	if (source->last_frame_sys_ts && ready_async_frame_buffered(source, sys_time)) {
+		struct obs_source_frame *frame = source->async_frames.array[0];
+#if DEBUG_ASYNC_FRAMES
+		blog(LOG_DEBUG, "source '%s' buffered-ready: queued=%lu, sys_ts=%lu, frame_ts=%lu",
+		     source->context.name, source->async_frames.num, sys_time, frame->timestamp);
+#endif
+		da_erase(source->async_frames, 0);
 
 		return frame;
 	}
@@ -5624,6 +5655,10 @@ void obs_source_set_async_unbuffered(obs_source_t *source, bool unbuffered)
 	if (!obs_source_valid(source, "obs_source_set_async_unbuffered"))
 		return;
 
+	if (source->async_unbuffered != unbuffered) {
+		set_ready_frame_timing(source, 0, 0);
+		source->discard_sys_ts = 0;
+	}
 	source->async_unbuffered = unbuffered;
 }
 


### PR DESCRIPTION
### Description

This fixes (kludgey?) assignments to `last_frame_ts`; restoring it to mean exactly the (supplied) timestamp of the last "readied" frame; and replaces `last_sys_timestamp` with `last_frame_sys_ts` - which tracks the system (video) time that corresponds to the last readied frames' (supplied) timestamp. This eliminates a faulty comparison between `last_frame_ts` and the incoming frames' timestamp(s).

Some small adjustments are made to the tolerance mechanism introduced in 11b0fe1 to ensure comparably smooth delivery of frames.

TODO:

-   ~~De-interlaced sources are not yet refactored (need a suitable test)~~ - this will be covered in another PR.
-   ~~This will be broken into smaller atomic commits.~~ 
-   ~~A timestamp invalidation check needs to be added back in (need a suitable test).~~


### Motivation and Context

1.  The issue is summarised in #12459. The issue illustrates a simple example of how the buffered async video (and audio) is broken using the "Sync Test (Async Video/Audio)" source from the _test-input_ plugin. 
    Instead of the tone playing while the square is white - the tone is being played while it is black.
2.  Moreover - multiple users have noted drift between "Video Capture Device (V4L2)" sources and the OBS video when using buffered mode; this is due to incoherent updates to `last_frame_ts`.
3.  Using debug output; it can be seen that master displays frames only when there is at least one more frame available; introducing a latency of one frame (and a false duplicate at the start of the sequence).


### How Has This Been Tested?

#### Using test input sources

I tested this with the "Sync Test (Async Video/Audio Source)" added to a scene and:

1.  Start with OBS opened at 5FPS output, record for about 5-10 seconds; then switch to 50FPS, record for 5-10 seconds, close OBS.
2.  Start with OBS opened at 50FPS, then 5FPS, as above.

With the recorded video I checked frame-by-frame (e.g. with _Shotcut_) that the audio and video were aligned when expected (i.e. that if the frame was black, the audio at the start of the frame is silent; and for a white frame, the audio starts with the tone).

One-frame latency was eliminated and audio was synchronised.


#### Gstreamer test source

Started a loopback device using `modprobe video_nr=10` and fed it a test via _gstreamer_:

```
gst-launch-1.0 videotestsrc horizontal_speed=1 ! \
    'video/x-raw,format=YUY2,width=1280,height=720,framerate=30/1' ! \
    v4l2sink device=/dev/video10
```

Added a "Video Capture Device (V4L2)" to a scene; and recorded with OBS at 30, 50, and 60 FPS. Checked frame-by-frame for audio synchronisation and _consistency of pattern of new frames_, e.g.:

-   At 30FPS, no dropped or duplicated frames.
-   At 50FPS, e.g. given 5 frames in recording, the 2nd and 4th duplicated (e.g. `T, T, F, T, F` if `T` when new frame)
-   At 60FPS, every frame duplicated once (e.g. `T,F,T,F,T,F` if `T` when new frame).

These were all the same results as master; except the one-frame latency is eliminated.


#### Logitech C270 webcam

Same tests as for _gstreamer_ test feed, but instead of _gstreamer_, use a real webcam. The camera tested is a Logitech C270 at "30FPS". The Logitech C270 produces frame intervals of 32ms, 32ms, 36ms and an actual frame rate of about 29.85 - so something of a 'stress' test of how to deliver smooth frames.

-  Recorded at 30FPS; frame duplication was minimal (every hundred frames or so due to the misaligned frame rate).
-  Recorded at 50FPS; the desired pattern holds for about 50 (output) frames, then a one-frame correction inserted.
-  Recorded at 60FPS; the desired pattern holds, with a duplication similar to the 30FPS case.

These all had the same (or very similar) result as master; except the one-frame latency is eliminated (false duplication at start of sequence).


#### Media source (FFMPEG)

Inserted a "Media Source" in the scene playing an MP4 at 25FPS (from sample-videos.com), recorded with OBS at 25, 30, and 50 FPS. Checked frame-by-frame for audio synchronisation and consistency of pattern of new frames.

Audio synchronisation was one-frame better than master (e.g. no longer advanced by one frame compared to video); pattern of new frames as per master except the one-frame latency is eliminated.


### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
