### PR TITLE
cmake: Use CMake INTERPROCEDURAL_OPTIMIZATION target property for LTO/LTCG optimisation

### DIFF
--- a/cmake/common/compiler_common.cmake
+++ b/cmake/common/compiler_common.cmake
@@ -85,3 +85,41 @@ endif()
 if(NOT DEFINED CMAKE_COMPILE_WARNING_AS_ERROR)
   set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
 endif()
+
+# Enable interprocedural optimization
+message(STATUS "Checking for interprocedural optimization support")
+if(NOT DEFINED HAS_INTERPROCEDURAL_OPTIMIZATION)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT _ipo_result OUTPUT _ipo_output)
+  set(
+    HAS_INTERPROCEDURAL_OPTIMIZATION
+    ${_ipo_result}
+    CACHE BOOL
+    "Result of compiler check for interprocedural optimization"
+    FORCE
+  )
+
+  if(HAS_INTERPROCEDURAL_OPTIMIZATION)
+    message(STATUS "Checking for interprocedural optimization support - available")
+  else()
+    message(STATUS "Checking for interprocedural optimization support - unavailable")
+  endif()
+
+  mark_as_advanced(HAS_INTERPROCEDURAL_OPTIMIZATION)
+  unset(_ipo_result)
+  unset(_ipo_output)
+endif()
+
+if(HAS_INTERPROCEDURAL_OPTIMIZATION)
+  message(STATUS "Checking for interprocedural optimization support - enabled [Release, MinSizeRel]")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL ON)
+else()
+  message(STATUS "Checking for interprocedural optimization support - disabled")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG OFF)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO OFF)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE OFF)
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_MINSIZEREL OFF)
+endif()

--- a/cmake/windows/compilerconfig.cmake
+++ b/cmake/windows/compilerconfig.cmake
@@ -73,7 +73,6 @@ add_compile_options(
   "$<$<COMPILE_LANG_AND_ID:C,Clang>:${_obs_clang_c_options}>"
   "$<$<COMPILE_LANG_AND_ID:CXX,Clang>:${_obs_clang_cxx_options}>"
   $<$<NOT:$<CONFIG:Debug>>:/Gy>
-  $<$<NOT:$<CONFIG:Debug>>:/GL>
   $<$<NOT:$<CONFIG:Debug>>:/Oi>
 )
 
@@ -87,11 +86,12 @@ add_compile_definitions(
   $<$<CONFIG:DEBUG>:_DEBUG>
 )
 
+# Visual Studio sets "/LTCG:INCREMENTAL" when "Whole Program Optimization" is enabled for a x86 or x64 target. To
+# ensure "proper" link-time optimization, the LTCG flag has to be explicitly added here.
 add_link_options(
-  $<$<NOT:$<CONFIG:Debug>>:/OPT:REF>
-  $<$<NOT:$<CONFIG:Debug>>:/OPT:ICF>
-  $<$<NOT:$<CONFIG:Debug>>:/LTCG>
-  $<$<NOT:$<CONFIG:Debug>>:/INCREMENTAL:NO>
+  $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:/LTCG>
+  $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:/OPT:REF>
+  $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:/OPT:ICF>
   /DEBUG
   /Brepro
 )


### PR DESCRIPTION
### Description
Enables interprocedural optimisations for all platforms and compilers known to CMake to be capable of the optimisation and replaces manual setting of corresponding compiler/linker flags that had been implemented for Windows only.

### Motivation and Context
The `INTERPROCEDURAL_OPTIMIZATION` target property enables the following compiler flags if the specific compiler is detected by the `check_ipo_supported` helper script:

* Windows: The associated settings are called "Whole Program Optimization" and "Link Time Code Generation" in Visual Studio
    * These correspond to adding the `/GL` compiler and `/LTCG` linker flags, as well as removing the `/INCREMENTAL` linker flag
    * Both flags were manually enabled for all build configurations but Debug before
    * As the generation of program database files (PDB) is enabled by default for all configurations (`/DEBUG`), the `/INCREMENTAL` flag is implicitly enabled again (counteracting the CMake setting). 
    * To fix this, `/OPT:REF` and `/OPT:ICF` are added manually for "Release" and "MinSizeRel" configurations. Both settings force the linker to do a "full link", undoing the implicit `/INCREMENTAL` introduced by `/DEBUG`
    * When using `clang-cl`, the same flags as for `AppleClang` or `clang` are added (see below)
* macOS: Requires `AppleClang` 8.0 or more recent
    * For `AppleClang` version 8.0 and up it adds `-flto=thin`
    * Otherwise it adds `-flto`
    * This is translated to the Xcode setting `LLVM_LTO` set to either `YES_THIN` or `YES` respectively
* Linux: Requires `gcc` version 4.5 or more recent, or `clang`
    * For `gcc` versions 10.1 and up it adds `-flto=auto`
    * For `gcc` versions 4.5 until 10.1 it adds `-flto`
    * For `gcc` versions 4.7 and up it additionally adds `-fno-fat-lto-objects`
    * For `clang` versions 3.9 and up it adds `-flto=thin`
    * For all other `clang` versions it adds `-flto`

LTO (Link Time Optimization) makes the compiler generate bitcode instead of object files, which are then combined into a single module to be more fully optimised and inlined (as the optimiser sees "the entire code of the binary").

The "thin" variant still produces bit code for every compilation module, but with additional "summaries" of each module, which are then used by the optimiser instead of a "fat" single module. This gives back the ability to analyse and optimise in parallel and heavily reduces the memory requirement of the link operation. In some cases "ThinLTO" has produced even better optimised code than normal "LTO" because the parallel processing allowed for more aggressive optimisations.

Microsoft's "Whole Program Optimization" and "Link Time Code Generation" work very similar, though there doesn't seem to be an equivalent "thin" option. For that reason the optimisation has been "downgraded" to be applied for "Release" and "MinSizeRel" builds only (CI uses "Release" for version tags automatically), otherwise the effective flags used on Windows are identical to the flags set manually before.

### How Has This Been Tested?
Tested compilation and running OBS Studio in Release configuration on Windows 11 and macOS 15.

### Types of changes
- Performance enhancement (non-breaking change which improves efficiency)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
