### PR TITLE
frontend: fix libprocstat dependecies

### DIFF
--- a/frontend/utility/platform-x11.cpp
+++ b/frontend/utility/platform-x11.cpp
@@ -39,15 +39,18 @@
 #include <vector>
 
 #if defined(__FreeBSD__) || defined(__DragonFly__)
-#include <fcntl.h>
-#include <libprocstat.h>
-#include <pthread_np.h>
-#endif
-#if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/queue.h>
 #endif
 #ifdef __linux__
 #include <sys/socket.h>
+#endif
+
+#if defined(__FreeBSD__) || defined(__DragonFly__)
+#include <fcntl.h>
+#include <libprocstat.h>
+#include <pthread_np.h>
 #endif
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <sys/sysctl.h>


### PR DESCRIPTION
### Description

When building obs-studio from souce following the instructions at:
https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-FreeBSD

After:

``` shell
cmake -S . -B ./build -G Ninja \
    -DENABLE_RELOCATABLE=ON \
    -DENABLE_PORTABLE_CONFIG=ON \
    -DENABLE_PIPEWIRE=ON \
    -DENABLE_PULSEAUDIO=OFF \
    -DENABLE_SNDIO=ON

cmake --build build
```


The following errors are occuring:

``` shell
[1/2] Building CXX object frontend/CMakeFiles/obs-studio.dir/utility/platform-x11.cpp.o
FAILED: frontend/CMakeFiles/obs-studio.dir/utility/platform-x11.cpp.o 
/usr/bin/c++ -DDL_D3D11=\"\" -DDL_METAL=\"\" -DDL_OPENGL=\"libobs-opengl.so.30\" -DENABLE_HEVC -DOBS_INSTALL_PREFIX=\"/usr/local\" -DQT_CORE_LIB -DQT_DBUS_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_SVG_LIB -DQT_WIDGETS_LIB -DQT_XML_LIB -DSAFE_MODULES="\"image-source|linux-alsa|linux-capture|linux-pipewire|linux-v4l2|obs-ffmpeg|obs-filters|obs-outputs|obs-transitions|obs-webrtc|obs-websocket|obs-x264|oss-audio|rtmp-services|sndio|text-freetype2|vlc-video|obslua|obspython|frontend-tools\"" -DSIMDE_ENABLE_OPENMP -I/home/base/Workspace/external/obs-studio/build/frontend -I/home/base/Workspace/external/obs-studio/frontend -I/home/base/Workspace/external/obs-studio/build/config -I/home/base/Workspace/external/obs-studio/libobs -I/home/base/Workspace/external/obs-studio/frontend/api -I/home/base/Workspace/external/obs-studio/deps/json11 -I/home/base/Workspace/external/obs-studio/shared/bpm -I/home/base/Workspace/external/obs-studio/deps/libcaption -I/home/base/Workspace/external/obs-studio/shared/qt/slider-ignorewheel -I/home/base/Workspace/external/obs-studio/shared/properties-view -I/home/base/Workspace/external/obs-studio/shared/qt/wrappers -I/home/base/Workspace/external/obs-studio/shared/qt/plain-text-edit -I/home/base/Workspace/external/obs-studio/shared/qt/vertical-scroll-area -I/home/base/Workspace/external/obs-studio/shared/qt/icon-label -isystem /home/base/Workspace/external/obs-studio/build/frontend/obs-studio_autogen/include -isystem /usr/local/include -isystem /usr/local/include/qt6/QtCore -isystem /usr/local/include/qt6 -isystem /usr/local/lib/qt6/mkspecs/freebsd-clang -isystem /usr/local/include/qt6/QtWidgets -isystem /usr/local/include/qt6/QtGui -isystem /usr/local/include/qt6/QtSvg -isystem /usr/local/include/qt6/QtXml -isystem /usr/local/include/qt6/QtNetwork -isystem /usr/local/include/qt6/QtGui/6.9.1 -isystem /usr/local/include/qt6/QtGui/6.9.1/QtGui -isystem /usr/local/include/qt6/QtCore/6.9.1 -isystem /usr/local/include/qt6/QtCore/6.9.1/QtCore -isystem /usr/local/include/qt6/QtDBus -isystem /usr/local/include/pci -isystem /usr/local/include/python3.11 -O2 -g -DNDEBUG -std=c++17 -fvisibility=hidden -fvisibility-inlines-hidden -fopenmp-simd -fno-strict-aliasing -Wno-trigraphs -Wno-missing-field-initializers -Wno-missing-prototypes -Werror=return-type -Wunreachable-code -Wquoted-include-in-framework-header -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wno-unknown-pragmas -Wfour-char-constants -Wconstant-conversion -Wno-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wnon-literal-null-conversion -Wsign-compare -Wshorten-64-to-32 -Wpointer-sign -Wnewline-eof -Wno-implicit-fallthrough -Wdeprecated-declarations -Wno-sign-conversion -Winfinite-recursion -Wcomma -Wno-strict-prototypes -Wno-semicolon-before-method-body -Wformat-security -Wvla -Wno-error=shorten-64-to-32 -Wno-non-virtual-dtor -Wno-overloaded-virtual -Wno-exit-time-destructors -Wno-shadow -Winvalid-offsetof -Wmove -Werror=block-capture-autoreleasing -Wrange-loop-analysis -pthread -Wno-unqualified-std-cast-call -fPIC -Werror -MD -MT frontend/CMakeFiles/obs-studio.dir/utility/platform-x11.cpp.o -MF frontend/CMakeFiles/obs-studio.dir/utility/platform-x11.cpp.o.d -o frontend/CMakeFiles/obs-studio.dir/utility/platform-x11.cpp.o -c /home/base/Workspace/external/obs-studio/frontend/utility/platform-x11.cpp
In file included from /home/base/Workspace/external/obs-studio/frontend/utility/platform-x11.cpp:43:
/usr/include/libprocstat.h:127:2: error: unknown type name 'STAILQ_ENTRY'
  127 |         STAILQ_ENTRY(filestat)  next;
      |         ^
/usr/include/libprocstat.h:127:24: error: expected ';' at end of declaration list
  127 |         STAILQ_ENTRY(filestat)  next;
      |                               ^
/usr/include/libprocstat.h:138:19: error: use of undeclared identifier 'SPECNAMELEN'
  138 |         char            vn_devname[SPECNAMELEN + 1];
      |                                    ^
/usr/include/libprocstat.h:142:16: error: use of undeclared identifier 'SPECNAMELEN'
  142 |         char            devname[SPECNAMELEN + 1];
      |                                 ^
/usr/include/libprocstat.h:166:26: error: field has incomplete type 'struct sockaddr_storage'
  166 |         struct sockaddr_storage sa_local;       /* Socket address. */
      |                                 ^
/usr/include/libprocstat.h:166:9: note: forward declaration of 'sockaddr_storage'
  166 |         struct sockaddr_storage sa_local;       /* Socket address. */
      |                ^
/usr/include/libprocstat.h:167:26: error: field has incomplete type 'struct sockaddr_storage'
  167 |         struct sockaddr_storage sa_peer;        /* Peer address. */
      |                                 ^
/usr/include/libprocstat.h:166:9: note: forward declaration of 'sockaddr_storage'
  166 |         struct sockaddr_storage sa_local;       /* Socket address. */
      |                ^
/usr/include/libprocstat.h:174:13: error: unknown type name 'filestat_list'
  174 | STAILQ_HEAD(filestat_list, filestat);
      |             ^
/usr/include/libprocstat.h:174:1: error: a type specifier is required for all declarations
  174 | STAILQ_HEAD(filestat_list, filestat);
      | ^
/usr/include/libprocstat.h:187:2: error: unknown type name 'STAILQ_ENTRY'
  187 |         STAILQ_ENTRY(advlock)   next;
      |         ^
/usr/include/libprocstat.h:187:23: error: expected ';' at end of declaration list
  187 |         STAILQ_ENTRY(advlock)   next;
      |                              ^
/usr/include/libprocstat.h:197:13: error: unknown type name 'advlock_list'
  197 | STAILQ_HEAD(advlock_list, advlock);
      |             ^
/usr/include/libprocstat.h:197:1: error: a type specifier is required for all declarations
  197 | STAILQ_HEAD(advlock_list, advlock);
      | ^
12 errors generated.
ninja: build stopped: subcommand failed.
```

### Motivation and Context
This change fix the build of obs-studio in FreeBSD
There is no issues related: https://github.com/obsproject/obs-studio/issues?q=libprocstat

### How Has This Been Tested?
Tested with FreeBSD 14.3-RELEASE amd64

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
