### PR TITLE
frontend: Don't mark OBSHotkeyEdit as read-only on macOS

### DIFF
--- a/frontend/settings/OBSHotkeyEdit.hpp
+++ b/frontend/settings/OBSHotkeyEdit.hpp
@@ -43,11 +43,6 @@ public:
 		  original(original),
 		  settings(settings)
 	{
-#ifdef __APPLE__
-		// disable the input cursor on OSX, focus should be clear
-		// enough with the default focus frame
-		setReadOnly(true);
-#endif
 		setAttribute(Qt::WA_InputMethodEnabled, false);
 		setAttribute(Qt::WA_MacShowFocusRect, true);
 		InitSignalHandler();
@@ -55,11 +50,6 @@ public:
 	}
 	OBSHotkeyEdit(QWidget *parent = nullptr) : QLineEdit(parent), original({}), settings(nullptr)
 	{
-#ifdef __APPLE__
-		// disable the input cursor on OSX, focus should be clear
-		// enough with the default focus frame
-		setReadOnly(true);
-#endif
 		setAttribute(Qt::WA_InputMethodEnabled, false);
 		setAttribute(Qt::WA_MacShowFocusRect, true);
 		InitSignalHandler();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Recent styling changes mean read-only QLineEdits no longer visually take focus. There are better ways to remove the input cursor, and if we do that that should probably be all operating systems anyways.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently (including in the latest release), the hotkey edit fields always look like this, even when in focus:

<img width="653" height="189" alt="image" src="https://github.com/user-attachments/assets/f30ac3cf-dbbb-4cc1-a671-18a4abb8f0ca" />

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 26, now they look correct again:

<img width="600" height="161" alt="image" src="https://github.com/user-attachments/assets/d9911ca1-147d-4c16-8fff-2c8b6446d3b0" />

However, they do have a cursor now. The discussion whether or not a cursor is wanted should be handled separately from this bug fix (see #12466)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
