### PR TITLE
frontend: Do not depend on X11 for Wayland

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1050,7 +1050,7 @@ bool OBSApp::OBSInit()
 
 #if !defined(_WIN32) && !defined(__APPLE__)
 	if (QApplication::platformName() == "xcb") {
-#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+#if !defined(ENABLE_WAYLAND) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
 		auto native = qGuiApp->nativeInterface<QNativeInterface::QX11Application>();
 
 		obs_set_nix_platform_display(native->display());


### PR DESCRIPTION
### Description
Previously failed to build with Qt compiled without X support on a Wayland-only system:
`frontend/OBSApp.cpp:1054:60: error: no member named 'QX11Application' in namespace 'QNativeInterface'`

### Motivation and Context
Build dependency on X11 is undesirable given that OBS works perfectly without it on a Wayland system.

### How Has This Been Tested?
With this extra condition obs-studio builds successfully with Wayland-only Qt6 and works as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
