### PR TITLE
Fix HEVC packet priority issues

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -577,10 +577,8 @@ static void convert_to_encoder_packet(amf_base *enc, AMFDataPtr &data, encoder_p
 			packet->priority = OBS_NAL_PRIORITY_HIGHEST;
 			break;
 		case AMF_VIDEO_ENCODER_OUTPUT_DATA_TYPE_I:
-			packet->priority = OBS_NAL_PRIORITY_HIGH;
-			break;
 		case AMF_VIDEO_ENCODER_OUTPUT_DATA_TYPE_P:
-			packet->priority = OBS_NAL_PRIORITY_LOW;
+			packet->priority = OBS_NAL_PRIORITY_HIGH;
 			break;
 		case AMF_VIDEO_ENCODER_OUTPUT_DATA_TYPE_B:
 			packet->priority = OBS_NAL_PRIORITY_DISPOSABLE;

--- a/plugins/obs-nvenc/nvenc-internal.h
+++ b/plugins/obs-nvenc/nvenc-internal.h
@@ -86,6 +86,7 @@ struct nvenc_data {
 	DARRAY(uint8_t) packet_data;
 	int64_t packet_pts;
 	bool packet_keyframe;
+	int packet_priority;
 
 #ifdef _WIN32
 	DARRAY(struct nv_texture) textures;


### PR DESCRIPTION
### Description

Improves the HEVC packet drop priority determination by differentiating between reference (typically P) and non-reference (typically B) frames.

Also fixes AMF P-frame priority to bring it in line with other encoders and adds priority assignment to NVENC.

### Motivation and Context

Currently all non-I frames are assigned the "high" priority, meaning that the frame dropping code will have to start dropping both reference and non-reference pictures as soon as congestion is hit. This can lead to decoding errors due to missing reference pictures.

With this change non-reference pictures are assigned a lower priority so they can be dropped before reference pictures to avoid decoding errors.

### How Has This Been Tested?

Streamed locally with drop testing enabled and dropped some frames.

Also compared output of the new code with the encoder-based assignments (NVENC) and they matched, with b-frames being marked as "disposable", p-frames as "high", and idrs as "highest".

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
