### PR TITLE
Fixes #12477: ‘QX11Application’ is not a member of ‘QNativeInterface’;

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1048,6 +1048,7 @@ bool OBSApp::OBSInit()
 
 	qRegisterMetaType<VoidFunc>("VoidFunc");
 
+#if !defined(ENABLE_WAYLAND)
 #if !defined(_WIN32) && !defined(__APPLE__)
 	if (QApplication::platformName() == "xcb") {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -1060,6 +1061,7 @@ bool OBSApp::OBSInit()
 
 		blog(LOG_INFO, "Using EGL/X11");
 	}
+#endif
 
 #ifdef ENABLE_WAYLAND
 	if (QApplication::platformName().contains("wayland")) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes https://github.com/obsproject/obs-studio/issues/12477

### Motivation and Context
https://bugs.gentoo.org/960634

### How Has This Been Tested?
Built locally on my Wayland-only Gentoo machine.

### Types of changes
None, fixes a check for Wayland that prevents building on non-X11 systems.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
