### PR TITLE
obs-qsv11: Dynamic bitrate control support update

### DIFF
--- a/plugins/obs-qsv11/QSV_Encoder.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder.cpp
@@ -163,33 +163,18 @@ int qsv_encoder_encode(qsv_t *pContext, uint64_t ts, uint8_t *pDataY, uint8_t *p
 		       uint32_t strideUV, mfxBitstream **pBS)
 {
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
-	mfxStatus sts = MFX_ERR_NONE;
 
 	if (pDataY != NULL && pDataUV != NULL)
-		sts = pEncoder->Encode(ts, pDataY, pDataUV, strideY, strideUV, pBS);
-
-	if (sts == MFX_ERR_NONE)
-		return 0;
-	else if (sts == MFX_ERR_MORE_DATA)
-		return 1;
+		return pEncoder->Encode(ts, pDataY, pDataUV, strideY, strideUV, pBS);
 	else
-		return -1;
+		return 0;
 }
 
 int qsv_encoder_encode_tex(qsv_t *pContext, uint64_t ts, void *tex, uint64_t lock_key, uint64_t *next_key,
 			   mfxBitstream **pBS)
 {
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
-	mfxStatus sts = MFX_ERR_NONE;
-
-	sts = pEncoder->Encode_tex(ts, tex, lock_key, next_key, pBS);
-
-	if (sts == MFX_ERR_NONE)
-		return 0;
-	else if (sts == MFX_ERR_MORE_DATA)
-		return 1;
-	else
-		return -1;
+	return pEncoder->Encode_tex(ts, tex, lock_key, next_key, pBS);
 }
 
 int qsv_encoder_close(qsv_t *pContext)
@@ -224,9 +209,9 @@ int qsv_param_apply_profile(qsv_param_t *, const char *profile)
 int qsv_encoder_reconfig(qsv_t *pContext, qsv_param_t *pParams)
 {
 	QSV_Encoder_Internal *pEncoder = (QSV_Encoder_Internal *)pContext;
-	pEncoder->UpdateParams(pParams);
-	mfxStatus sts = pEncoder->ReconfigureEncoder();
 
+	pEncoder->Flush();
+	mfxStatus sts = pEncoder->ReconfigureEncoder(pParams);
 	if (sts != MFX_ERR_NONE)
 		return false;
 	return true;

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.cpp
@@ -284,6 +284,22 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams, enum qsv_codec 
 		(pParams->nKeyIntSec) ? (mfxU16)(pParams->nKeyIntSec * pParams->nFpsNum / (float)pParams->nFpsDen)
 				      : 240;
 
+	if (codec == QSV_CODEC_AVC) {
+		memset(&m_co, 0, sizeof(mfxExtCodingOption));
+		m_co.Header.BufferId = MFX_EXTBUFF_CODING_OPTION;
+		m_co.Header.BufferSz = sizeof(m_co);
+		m_co.NalHrdConformance = MFX_CODINGOPTION_ON;
+		m_co.VuiNalHrdParameters = MFX_CODINGOPTION_ON;
+		extendedBuffers.push_back((mfxExtBuffer *)&m_co);
+	} else if (codec == QSV_CODEC_HEVC) {
+		memset(&m_co, 0, sizeof(mfxExtCodingOption));
+		m_co.Header.BufferId = MFX_EXTBUFF_CODING_OPTION;
+		m_co.Header.BufferSz = sizeof(m_co);
+		m_co.NalHrdConformance = MFX_CODINGOPTION_OFF;
+		m_co.VuiNalHrdParameters = MFX_CODINGOPTION_OFF;
+		extendedBuffers.push_back((mfxExtBuffer *)&m_co);
+	}
+
 	memset(&m_co2, 0, sizeof(mfxExtCodingOption2));
 	m_co2.Header.BufferId = MFX_EXTBUFF_CODING_OPTION2;
 	m_co2.Header.BufferSz = sizeof(m_co2);
@@ -454,20 +470,49 @@ mfxStatus QSV_Encoder_Internal::InitParams(qsv_param_t *pParams, enum qsv_codec 
 	return sts;
 }
 
-bool QSV_Encoder_Internal::UpdateParams(qsv_param_t *pParams)
+mfxStatus QSV_Encoder_Internal::ReconfigureEncoder(qsv_param_t *pParams)
 {
+
+	mfxStatus sts = MFX_ERR_NONE;
+	memset(&m_parameter, 0, sizeof(m_parameter));
+	sts = m_pmfxENC->GetVideoParam(&m_parameter);
+
+	// Defining reset option for Reset function
+	memset(&m_ExtEncodeResetOption, 0, sizeof(mfxExtEncoderResetOption));
+	m_ExtEncodeResetOption.Header.BufferId = MFX_EXTBUFF_ENCODER_RESET_OPTION;
+	m_ExtEncodeResetOption.Header.BufferSz = sizeof(mfxExtEncoderResetOption);
+	m_ExtEncodeResetOption.StartNewSequence = MFX_CODINGOPTION_ON; // IDR insertion ON
+
+	bool resetFound = false;
+	for (size_t i = 0; i < extendedBuffers.size(); i++) {
+		if (extendedBuffers[i]->BufferId == MFX_EXTBUFF_ENCODER_RESET_OPTION) {
+			resetFound = true;
+		}
+	}
+
+	if (!resetFound) {
+		extendedBuffers.push_back((mfxExtBuffer *)&m_ExtEncodeResetOption);
+	}
+
+	m_mfxEncParams.ExtParam = extendedBuffers.data();
+	m_mfxEncParams.NumExtParam = (mfxU16)extendedBuffers.size();
+
+	// Change bitrate
 	switch (pParams->nRateControl) {
 	case MFX_RATECONTROL_CBR:
 		m_mfxEncParams.mfx.TargetKbps = pParams->nTargetBitRate;
+		break;
+	case MFX_RATECONTROL_VBR:
+		m_mfxEncParams.mfx.TargetKbps = pParams->nTargetBitRate;
+		m_mfxEncParams.mfx.MaxKbps = pParams->nMaxBitRate;
+		break;
 	default:
 		break;
 	}
 
-	return true;
-}
+	sts = m_pmfxENC->Query(&m_parameter, &m_parameter);
+	MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
-mfxStatus QSV_Encoder_Internal::ReconfigureEncoder()
-{
 	return m_pmfxENC->Reset(&m_mfxEncParams);
 }
 
@@ -693,8 +738,8 @@ int QSV_Encoder_Internal::GetFreeTaskIndex(Task *pTaskPool, mfxU16 nPoolSize)
 	return MFX_ERR_NOT_FOUND;
 }
 
-mfxStatus QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV, uint32_t strideY,
-				       uint32_t strideUV, mfxBitstream **pBS)
+int QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV,
+				 mfxBitstream **pBS)
 {
 	mfxStatus sts = MFX_ERR_NONE;
 	*pBS = NULL;
@@ -715,7 +760,7 @@ mfxStatus QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pD
 
 	while (MFX_ERR_NOT_FOUND == nTaskIdx || MFX_ERR_NOT_FOUND == nSurfIdx) {
 		// No more free tasks or surfaces, need to sync
-		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, 60000);
+		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, WAIT_500_MILLISECONDS);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 		mfxU8 *pTemp = m_outBitstream.Data;
@@ -767,25 +812,27 @@ mfxStatus QSV_Encoder_Internal::Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pD
 		sts = m_pmfxENC->EncodeFrameAsync(&m_ctrl, pSurface, &m_pTaskPool[nTaskIdx].mfxBS,
 						  &m_pTaskPool[nTaskIdx].syncp);
 
-		if (MFX_ERR_NONE < sts && !m_pTaskPool[nTaskIdx].syncp) {
+		if (sts == MFX_ERR_NONE) {
+			return 0;
+		} else if (sts == MFX_ERR_MORE_DATA) {
+			return 1;
+		} else if (MFX_ERR_NONE < sts && !m_pTaskPool[nTaskIdx].syncp) {
 			// Repeat the call if warning and no output
 			if (MFX_WRN_DEVICE_BUSY == sts)
 				MSDK_SLEEP(1); // Wait if device is busy, then repeat the same call
 		} else if (MFX_ERR_NONE < sts && m_pTaskPool[nTaskIdx].syncp) {
 			sts = MFX_ERR_NONE; // Ignore warnings if output is available
-			break;
+			return 0;
 		} else if (MFX_ERR_NOT_ENOUGH_BUFFER == sts) {
 			// Allocate more bitstream buffer memory here if needed...
-			break;
-		} else
-			break;
+			return -1;
+		} else {
+			return -1;
+		}
 	}
-
-	return sts;
 }
 
-mfxStatus QSV_Encoder_Internal::Encode_tex(uint64_t ts, void *tex, uint64_t lock_key, uint64_t *next_key,
-					   mfxBitstream **pBS)
+int QSV_Encoder_Internal::Encode_tex(uint64_t ts, void *tex, uint64_t lock_key, uint64_t *next_key, mfxBitstream **pBS)
 {
 	mfxStatus sts = MFX_ERR_NONE;
 	*pBS = NULL;
@@ -793,8 +840,7 @@ mfxStatus QSV_Encoder_Internal::Encode_tex(uint64_t ts, void *tex, uint64_t lock
 	int nSurfIdx = GetFreeSurfaceIndex(m_pmfxSurfaces, m_nSurfNum);
 
 	while (MFX_ERR_NOT_FOUND == nTaskIdx || MFX_ERR_NOT_FOUND == nSurfIdx) {
-		// No more free tasks or surfaces, need to sync
-		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, 60000);
+		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, WAIT_500_MILLISECONDS);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 		mfxU8 *pTemp = m_outBitstream.Data;
@@ -825,21 +871,23 @@ mfxStatus QSV_Encoder_Internal::Encode_tex(uint64_t ts, void *tex, uint64_t lock
 		sts = m_pmfxENC->EncodeFrameAsync(&m_ctrl, pSurface, &m_pTaskPool[nTaskIdx].mfxBS,
 						  &m_pTaskPool[nTaskIdx].syncp);
 
-		if (MFX_ERR_NONE < sts && !m_pTaskPool[nTaskIdx].syncp) {
+		if (sts == MFX_ERR_NONE) {
+			return 0;
+		} else if (sts == MFX_ERR_MORE_DATA) {
+			return 1;
+		} else if (MFX_ERR_NONE < sts && !m_pTaskPool[nTaskIdx].syncp) {
 			// Repeat the call if warning and no output
 			if (MFX_WRN_DEVICE_BUSY == sts)
 				MSDK_SLEEP(1); // Wait if device is busy, then repeat the same call
-		} else if (MFX_ERR_NONE < sts && m_pTaskPool[nTaskIdx].syncp) {
-			sts = MFX_ERR_NONE; // Ignore warnings if output is available
-			break;
+		} else if (MFX_ERR_NONE < sts) {
+			sts = MFX_ERR_NONE; // Ignore warnings if output
+			return 0;
 		} else if (MFX_ERR_NOT_ENOUGH_BUFFER == sts) {
 			// Allocate more bitstream buffer memory here if needed...
-			break;
+			return -1;
 		} else
-			break;
+			return -1;
 	}
-
-	return sts;
 }
 
 mfxStatus QSV_Encoder_Internal::Drain()
@@ -847,7 +895,7 @@ mfxStatus QSV_Encoder_Internal::Drain()
 	mfxStatus sts = MFX_ERR_NONE;
 
 	while (m_pTaskPool && m_pTaskPool[m_nFirstSyncTask].syncp) {
-		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, 60000);
+		sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp, WAIT_500_MILLISECONDS);
 		MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
 		m_pTaskPool[m_nFirstSyncTask].syncp = NULL;
@@ -855,6 +903,51 @@ mfxStatus QSV_Encoder_Internal::Drain()
 	}
 
 	return sts;
+}
+
+bool QSV_Encoder_Internal::Flush()
+{
+	mfxStatus sts = MFX_ERR_NONE;
+
+	for (;;) {
+		int nTaskIdx = GetFreeTaskIndex(m_pTaskPool, m_nTaskPool);
+
+		// Task queue is flushed first, it's normally in full
+		// Number of task pool is equal to AsyncDepth (4 frames in default)
+		while (m_pTaskPool[m_nFirstSyncTask].syncp) {
+			sts = MFXVideoCORE_SyncOperation(m_session, m_pTaskPool[m_nFirstSyncTask].syncp,
+							 WAIT_500_MILLISECONDS);
+			MSDK_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+			mfxU8 *pTemp = m_outBitstream.Data;
+			memcpy(&m_outBitstream, &m_pTaskPool[m_nFirstSyncTask].mfxBS, sizeof(mfxBitstream));
+			m_pTaskPool[m_nFirstSyncTask].mfxBS.Data = pTemp;
+			m_pTaskPool[m_nFirstSyncTask].mfxBS.DataLength = 0;
+			m_pTaskPool[m_nFirstSyncTask].mfxBS.DataOffset = 0;
+			m_pTaskPool[m_nFirstSyncTask].syncp = NULL;
+			nTaskIdx = m_nFirstSyncTask;
+			m_nFirstSyncTask = (m_nFirstSyncTask + 1) % m_nTaskPool;
+		}
+
+		// After flush the task queue, we need to push internal encoded frames for draining (normally 2-3 frames)
+		sts = m_pmfxENC->EncodeFrameAsync(&m_ctrl, NULL, &m_pTaskPool[nTaskIdx].mfxBS,
+						  &m_pTaskPool[nTaskIdx].syncp);
+
+		if (MFX_ERR_NONE == sts) {
+			m_nFirstSyncTask = nTaskIdx;
+			continue;
+		} else if (MFX_ERR_MORE_DATA == sts) {
+			// Flush completed.
+			for (int i = 0; i < m_nTaskPool; i++) {
+				m_pTaskPool[i].mfxBS.DataLength = 0;
+				m_pTaskPool[i].mfxBS.DataOffset = 0;
+				m_pTaskPool[i].syncp = NULL;
+			}
+			m_nFirstSyncTask = 0;
+			break;
+		}
+	}
+
+	return true;
 }
 
 mfxStatus QSV_Encoder_Internal::ClearData()

--- a/plugins/obs-qsv11/QSV_Encoder_Internal.h
+++ b/plugins/obs-qsv11/QSV_Encoder_Internal.h
@@ -62,6 +62,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 
+constexpr mfxU32 WAIT_500_MILLISECONDS = 500;
+
 class QSV_Encoder_Internal {
 public:
 	QSV_Encoder_Internal(mfxVersion &version, bool useTexAlloc);
@@ -71,13 +73,13 @@ public:
 	void GetSPSPPS(mfxU8 **pSPSBuf, mfxU8 **pPPSBuf, mfxU16 *pnSPSBuf, mfxU16 *pnPPSBuf);
 	void GetVpsSpsPps(mfxU8 **pVPSBuf, mfxU8 **pSPSBuf, mfxU8 **pPPSBuf, mfxU16 *pnVPSBuf, mfxU16 *pnSPSBuf,
 			  mfxU16 *pnPPSBuf);
-	mfxStatus Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV,
-			 mfxBitstream **pBS);
-	mfxStatus Encode_tex(uint64_t ts, void *tex, uint64_t lock_key, uint64_t *next_key, mfxBitstream **pBS);
+	int Encode(uint64_t ts, uint8_t *pDataY, uint8_t *pDataUV, uint32_t strideY, uint32_t strideUV,
+		   mfxBitstream **pBS);
+	int Encode_tex(uint64_t ts, void *tex, uint64_t lock_key, uint64_t *next_key, mfxBitstream **pBS);
 	mfxStatus ClearData();
 	mfxStatus Reset(qsv_param_t *pParams, enum qsv_codec codec);
-	mfxStatus ReconfigureEncoder();
-	bool UpdateParams(qsv_param_t *pParams);
+	bool Flush();
+	mfxStatus ReconfigureEncoder(qsv_param_t *pParams);
 	void AddROI(mfxU32 left, mfxU32 top, mfxU32 right, mfxU32 bottom, mfxI16 delta);
 	void ClearROI();
 
@@ -123,6 +125,7 @@ private:
 	mfxExtChromaLocInfo m_ExtChromaLocInfo{};
 	mfxExtMasteringDisplayColourVolume m_ExtMasteringDisplayColourVolume{};
 	mfxExtContentLightLevelInfo m_ExtContentLightLevelInfo{};
+	mfxExtEncoderResetOption m_ExtEncodeResetOption{};
 	mfxU16 m_nTaskPool;
 	Task *m_pTaskPool;
 	int m_nTaskIdx;

--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -736,6 +736,7 @@ static bool obs_qsv_update(void *data, obs_data_t *settings)
 {
 	struct obs_qsv *obsqsv = data;
 	obsqsv->params.nTargetBitRate = (mfxU16)obs_data_get_int(settings, "bitrate");
+	obsqsv->params.nMaxBitRate = (mfxU16)obs_data_get_int(settings, "max_bitrate");
 
 	if (!qsv_encoder_reconfig(obsqsv->context, &obsqsv->params)) {
 		warn("Failed to reconfigure");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Updated the qsv11 plugin to be able to reset the bitrate dynamically and added a flush function to the async pipe path.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This was changed to address the issue with Intel's A770 card on Twitch's Enhanced Broadcasting PR: https://github.com/obsproject/obs-studio/pull/12097 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Intel Core i9-12900K w/ Arc A770, with 64GB Memory
- Intel Core i9-12900 w/ UHD 770 and Arc A770, with 64GB Memory

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) --> bitrate now changes dynamically
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.