### PR TITLE
obs-text: Fix changing fonts for Qt 6.7+

### DIFF
--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -226,6 +226,7 @@ struct TextSource {
 
 	wstring text;
 	wstring face;
+	wstring style;
 	int face_size = 0;
 	uint32_t color = 0xFFFFFF;
 	uint32_t color2 = 0xFFFFFF;
@@ -727,6 +728,7 @@ inline void TextSource::Update(obs_data_t *s)
 	bool new_antialiasing = obs_data_get_bool(s, S_ANTIALIASING);
 
 	const char *font_face = obs_data_get_string(font_obj, "face");
+	const char *font_style = obs_data_get_string(font_obj, "style");
 	int font_size = (int)obs_data_get_int(font_obj, "size");
 	int64_t font_flags = obs_data_get_int(font_obj, "flags");
 	bool new_bold = (font_flags & OBS_FONT_BOLD) != 0;
@@ -740,9 +742,10 @@ inline void TextSource::Update(obs_data_t *s)
 	/* ----------------------------- */
 
 	wstring new_face = to_wide(font_face);
+	wstring new_style = to_wide(font_style);
 
-	if (new_face != face || face_size != font_size || new_bold != bold || new_italic != italic ||
-	    new_underline != underline || new_strikeout != strikeout) {
+	if (new_face != face || new_style != style || face_size != font_size || new_bold != bold ||
+	    new_italic != italic || new_underline != underline || new_strikeout != strikeout) {
 
 		face = new_face;
 		face_size = font_size;

--- a/plugins/obs-text/gdiplus/obs-text.cpp
+++ b/plugins/obs-text/gdiplus/obs-text.cpp
@@ -227,6 +227,7 @@ struct TextSource {
 	wstring text;
 	wstring face;
 	wstring style;
+	int weight = 0;
 	int face_size = 0;
 	uint32_t color = 0xFFFFFF;
 	uint32_t color2 = 0xFFFFFF;
@@ -313,7 +314,7 @@ void TextSource::UpdateFont()
 
 	LOGFONT lf = {};
 	lf.lfHeight = face_size;
-	lf.lfWeight = bold ? FW_BOLD : FW_DONTCARE;
+	lf.lfWeight = weight;
 	lf.lfItalic = italic;
 	lf.lfUnderline = underline;
 	lf.lfStrikeOut = strikeout;
@@ -729,6 +730,7 @@ inline void TextSource::Update(obs_data_t *s)
 
 	const char *font_face = obs_data_get_string(font_obj, "face");
 	const char *font_style = obs_data_get_string(font_obj, "style");
+	int font_weight = (int)obs_data_get_int(font_obj, "weight");
 	int font_size = (int)obs_data_get_int(font_obj, "size");
 	int64_t font_flags = obs_data_get_int(font_obj, "flags");
 	bool new_bold = (font_flags & OBS_FONT_BOLD) != 0;
@@ -744,11 +746,13 @@ inline void TextSource::Update(obs_data_t *s)
 	wstring new_face = to_wide(font_face);
 	wstring new_style = to_wide(font_style);
 
-	if (new_face != face || new_style != style || face_size != font_size || new_bold != bold ||
-	    new_italic != italic || new_underline != underline || new_strikeout != strikeout) {
+	if (new_face != face || new_style != style || font_weight != weight || font_size != face_size ||
+	    new_bold != bold || new_italic != italic || new_underline != underline || new_strikeout != strikeout) {
 
 		face = new_face;
+		style = new_style;
 		face_size = font_size;
+		weight = font_weight;
 		bold = new_bold;
 		italic = new_italic;
 		underline = new_underline;

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -833,12 +833,14 @@ void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
 {
 	const char *face = obs_data_get_string(font_obj, "face");
 	const char *style = obs_data_get_string(font_obj, "style");
+	int weight = (int)obs_data_get_int(font_obj, "weight");
 	int size = (int)obs_data_get_int(font_obj, "size");
 	uint32_t flags = (uint32_t)obs_data_get_int(font_obj, "flags");
 
 	if (face) {
 		font.setFamily(face);
 		font.setStyleName(style);
+		font.setWeight(static_cast<QFont::Weight>(weight));
 	}
 
 	if (size) {
@@ -1881,6 +1883,7 @@ bool WidgetInfo::FontChanged(const char *setting)
 
 	obs_data_set_string(font_obj, "face", QT_TO_UTF8(font.family()));
 	obs_data_set_string(font_obj, "style", QT_TO_UTF8(font.styleName()));
+	obs_data_set_int(font_obj, "weight", font.weight());
 	obs_data_set_int(font_obj, "size", font.pointSize());
 	flags = font.bold() ? OBS_FONT_BOLD : 0;
 	flags |= font.italic() ? OBS_FONT_ITALIC : 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Add support for variable font weights to obs-text (the GDI+ Text Source).

Instead of simply checking if a font is bold or not (which in Qt is equivalent to `font.weight() > Medium` / `font.weight() > 500`), 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #12393

https://doc.qt.io/qt-6.8/qfont.html#Weight-enum
https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-logfontw


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on Windows 11.

For the most part, this improves user experience when using variable fonts. Some changes, such as between Regular and Medium styles, still do not seem to show a difference, even if the code does not actually call `UpdateFont()`.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
