### PR TITLE
frontend: Remove auto remux

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -674,7 +674,6 @@ Basic.StatusBar.DelayStartingStoppingIn="Delay (stopping in %1 sec, starting in 
 Basic.StatusBar.RecordingSavedTo="Recording saved to '%1'"
 Basic.StatusBar.ReplayBufferSavedTo="Replay buffer saved to '%1'"
 Basic.StatusBar.ScreenshotSavedTo="Screenshot saved to '%1'"
-Basic.StatusBar.AutoRemuxedTo="Recording auto remuxed to '%1'"
 
 # filters window
 Basic.Filters="Filters"
@@ -1311,8 +1310,6 @@ Basic.Settings.Advanced.Hotkeys.HotkeyFocusBehavior="Hotkey Focus Behavior"
 Basic.Settings.Advanced.Hotkeys.NeverDisableHotkeys="Never disable hotkeys"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main window is in focus"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
-Basic.Settings.Advanced.AutoRemux="Automatically remux to %1"
-Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/frontend/dialogs/OBSRemux.hpp
+++ b/frontend/dialogs/OBSRemux.hpp
@@ -39,16 +39,11 @@ class OBSRemux : public QDialog {
 	virtual void closeEvent(QCloseEvent *event) override;
 	virtual void reject() override;
 
-	bool autoRemux;
-	QString autoRemuxFile;
-
 public:
-	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr, bool autoRemux = false);
+	explicit OBSRemux(const char *recPath, QWidget *parent = nullptr);
 	virtual ~OBSRemux() override;
 
 	using job_t = std::shared_ptr<struct media_remux_job>;
-
-	void AutoRemux(QString inFile, QString outFile);
 
 protected:
 	virtual void dropEvent(QDropEvent *ev) override;

--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -8203,26 +8203,6 @@
                      </property>
                     </spacer>
                    </item>
-                   <item row="2" column="1">
-                    <widget class="QCheckBox" name="autoRemux">
-                     <property name="text">
-                      <string>Basic.Settings.Advanced.AutoRemux</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item row="2" column="0">
-                    <spacer name="horizontalSpacer_16">
-                     <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                     </property>
-                     <property name="sizeHint" stdset="0">
-                      <size>
-                       <width>40</width>
-                       <height>20</height>
-                      </size>
-                     </property>
-                    </spacer>
-                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -8885,7 +8865,6 @@
   <tabstop>resetOSXVSync</tabstop>
   <tabstop>filenameFormatting</tabstop>
   <tabstop>overwriteIfExists</tabstop>
-  <tabstop>autoRemux</tabstop>
   <tabstop>simpleRBPrefix</tabstop>
   <tabstop>simpleRBSuffix</tabstop>
   <tabstop>streamDelayEnable</tabstop>

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -550,7 +550,6 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->enableNewSocketLoop,  CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->enableLowLatencyMode, CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->hotkeyFocusType,      COMBO_CHANGED,  ADV_CHANGED);
-	HookWidget(ui->autoRemux,            CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->dynBitrate,           CHECK_CHANGED,  ADV_CHANGED);
 	/* clang-format on */
 
@@ -2522,7 +2521,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	bool replayBuf = config_get_bool(main->Config(), "AdvOut", "RecRB");
 	int rbTime = config_get_int(main->Config(), "AdvOut", "RecRBTime");
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
-	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
 	const char *hotkeyFocusType = config_get_string(App()->GetUserConfig(), "General", "HotkeyFocusType");
 	bool dynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 	const char *ipFamily = config_get_string(main->Config(), "Output", "IPFamily");
@@ -2553,7 +2551,6 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	ui->streamDelaySec->setValue(delaySec);
 	ui->streamDelayPreserve->setChecked(preserveDelay);
 	ui->streamDelayEnable->setChecked(enableDelay);
-	ui->autoRemux->setChecked(autoRemux);
 	ui->dynBitrate->setChecked(dynBitrate);
 
 	SetComboByValue(ui->colorFormat, videoColorFormat);
@@ -3193,7 +3190,6 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	SaveSpinBox(ui->reconnectMaxRetries, "Output", "MaxRetries");
 	SaveComboData(ui->bindToIP, "Output", "BindIP");
 	SaveComboData(ui->ipFamily, "Output", "IPFamily");
-	SaveCheckBox(ui->autoRemux, "Video", "AutoRemux");
 	SaveCheckBox(ui->dynBitrate, "Output", "DynamicBitrate");
 
 	if (obs_audio_monitoring_available()) {
@@ -4592,10 +4588,6 @@ void OBSBasicSettings::AdvOutRecCheckWarnings()
 			warningMsg += "\n\n";
 
 		warningMsg += QTStr("OutputWarnings.MP4Recording");
-		ui->autoRemux->setText(QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4") + " " +
-				       QTStr("Basic.Settings.Advanced.AutoRemux.MP4"));
-	} else {
-		ui->autoRemux->setText(QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4"));
 	}
 
 #if defined(__APPLE__) && QT_VERSION < QT_VERSION_CHECK(6, 5, 1)
@@ -5240,10 +5232,6 @@ void OBSBasicSettings::SimpleRecordingEncoderChanged()
 		if (!warning.isEmpty())
 			warning += "\n\n";
 		warning += QTStr("OutputWarnings.MP4Recording");
-		ui->autoRemux->setText(QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4") + " " +
-				       QTStr("Basic.Settings.Advanced.AutoRemux.MP4"));
-	} else {
-		ui->autoRemux->setText(QTStr("Basic.Settings.Advanced.AutoRemux").arg("mp4"));
 	}
 
 	if (qual == "Stream") {

--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -778,8 +778,7 @@ bool AdvancedOutput::StartRecording()
 					  ffmpegRecording ? "FFFileNameWithoutSpace" : "RecFileNameWithoutSpace");
 		splitFile = config_get_bool(main->Config(), "AdvOut", "RecSplitFile");
 
-		string strPath = GetRecordingFilename(path, recFormat, noSpace, overwriteIfExists, filenameFormat,
-						      ffmpegRecording);
+		string strPath = GetRecordingFilename(path, recFormat, noSpace, overwriteIfExists, filenameFormat);
 
 		OBSDataAutoRelease settings = obs_data_create();
 		obs_data_set_string(settings, ffmpegRecording ? "url" : "path", strPath.c_str());

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -412,19 +412,9 @@ void clear_archive_encoder(obs_output_t *output, const char *expected_name)
 		obs_output_set_audio_encoder(output, nullptr, 1);
 }
 
-void BasicOutputHandler::SetupAutoRemux(const char *&container)
-{
-	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
-	if (autoRemux && strcmp(container, "mp4") == 0)
-		container = "mkv";
-}
-
 std::string BasicOutputHandler::GetRecordingFilename(const char *path, const char *container, bool noSpace,
-						     bool overwrite, const char *format, bool ffmpeg)
+						     bool overwrite, const char *format)
 {
-	if (!ffmpeg)
-		SetupAutoRemux(container);
-
 	string dst = GetOutputFilename(path, container, noSpace, overwrite, format);
 	lastRecordingPath = dst;
 	return dst;
@@ -567,9 +557,7 @@ OBSDataAutoRelease BasicOutputHandler::GenerateMultitrackVideoStreamDumpConfig()
 
 	OBSDataAutoRelease settings = obs_data_create();
 	f = GetFormatString(filenameFormat, nullptr, nullptr);
-	string strPath = GetRecordingFilename(path, useMP4 ? "mp4" : "flv", noSpace, overwriteIfExists, f.c_str(),
-					      // never remux stream dump
-					      false);
+	string strPath = GetRecordingFilename(path, useMP4 ? "mp4" : "flv", noSpace, overwriteIfExists, f.c_str());
 	obs_data_set_string(settings, "path", strPath.c_str());
 
 	if (useMP4) {

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -96,9 +96,8 @@ struct BasicOutputHandler {
 	}
 
 protected:
-	void SetupAutoRemux(const char *&container);
 	std::string GetRecordingFilename(const char *path, const char *container, bool noSpace, bool overwrite,
-					 const char *format, bool ffmpeg);
+					 const char *format);
 
 	std::shared_future<void> SetupMultitrackVideo(obs_service_t *service, std::string audio_encoder_id,
 						      size_t main_audio_mixer, std::optional<size_t> vod_track_mixer,

--- a/frontend/utility/RemuxQueueModel.cpp
+++ b/frontend/utility/RemuxQueueModel.cpp
@@ -330,10 +330,8 @@ void RemuxQueueModel::endProcessing()
 
 	// Signal that the insertion point exists again.
 	isProcessing = false;
-	if (!autoRemux) {
-		beginInsertRows(QModelIndex(), queue.length(), queue.length());
-		endInsertRows();
-	}
+	beginInsertRows(QModelIndex(), queue.length(), queue.length());
+	endInsertRows();
 
 	emit dataChanged(index(0, RemuxEntryColumn::State), index(queue.length(), RemuxEntryColumn::State));
 }

--- a/frontend/utility/RemuxQueueModel.hpp
+++ b/frontend/utility/RemuxQueueModel.hpp
@@ -59,8 +59,6 @@ public:
 	void clearFinished();
 	void clearAll();
 
-	bool autoRemux = false;
-
 private:
 	struct RemuxQueueEntry {
 		RemuxEntryState state;

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -810,7 +810,7 @@ bool SimpleOutput::ConfigureRecording(bool updateReplayBuffer)
 	} else {
 		f = GetFormatString(filenameFormat, nullptr, nullptr);
 		string strPath = GetRecordingFilename(path, ffmpegOutput ? "avi" : format, noSpace, overwriteIfExists,
-						      f.c_str(), ffmpegOutput);
+						      f.c_str());
 		obs_data_set_string(settings, ffmpegOutput ? "url" : "path", strPath.c_str());
 		if (ffmpegOutput)
 			obs_output_set_mixers(fileOutput, tracks);

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -964,7 +964,6 @@ private:
 	bool isRecordingPausable = false;
 	bool recordingPaused = false;
 
-	void AutoRemux(QString input, bool no_show = false);
 	void UpdateIsRecordingPausable();
 
 	bool LowDiskSpace();

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -170,8 +170,6 @@ void OBSBasic::ReplayBufferSaved()
 	calldata_free(&cd);
 
 	OnEvent(OBS_FRONTEND_EVENT_REPLAY_BUFFER_SAVED);
-
-	AutoRemux(QT_UTF8(path.c_str()));
 }
 
 void OBSBasic::ReplayBufferStop(int code)


### PR DESCRIPTION
### Description
This feature was intended for when mp4 could be corrupted, so a user would record to mkv and it would auto remux to mp4. With hybrid/fragmented mp4, this is no longer the case.

### Motivation and Context
This feature is not necessarily needed anymore.

### How Has This Been Tested?
Ran OBS and made sure it was correctly removed.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
