### PR TITLE
libobs-metal: Add preparations for Metal renderer to current codebase

### DIFF
--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -34,7 +34,12 @@ static void *av_fast_capture_create(obs_data_t *settings, obs_source_t *source)
     capture_info->isFastPath = true;
     capture_info->settings = settings;
     capture_info->source = source;
-    capture_info->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+
+    if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+        capture_info->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    } else {
+        capture_info->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+    }
     capture_info->frameSize = CGRectZero;
 
     if (!capture_info->effect) {

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -255,7 +255,12 @@ static void *display_capture_create(obs_data_t *settings, obs_source_t *source)
     dc->source = source;
     dc->hide_cursor = !obs_data_get_bool(settings, "show_cursor");
 
-    dc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+        dc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    } else {
+        dc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+    }
+
     if (!dc->effect)
         goto fail;
 

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -281,7 +281,12 @@ API_AVAILABLE(macos(12.5)) static void *sck_video_capture_create(obs_data_t *set
     sc->capture_delegate = [[ScreenCaptureDelegate alloc] init];
     sc->capture_delegate.sc = sc;
 
-    sc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+        sc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    } else {
+        sc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+    }
+
     if (!sc->effect)
         goto fail;
 

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -314,7 +314,11 @@ static inline bool init_obs_graphics_objects(syphon_t s)
     s->vertbuffer = create_vertbuffer();
     obs_leave_graphics();
 
-    s->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    if (gs_get_device_type() == GS_DEVICE_OPENGL) {
+        s->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
+    } else {
+        s->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
+    }
 
     return s->sampler != NULL && s->vertbuffer != NULL && s->effect != NULL;
 }

--- a/plugins/obs-filters/data/sharpness.effect
+++ b/plugins/obs-filters/data/sharpness.effect
@@ -61,7 +61,7 @@ float4 PSDrawBare(VertOut vert_in) : TARGET
 	color -= H;
 	color -= image.Sample(def_sampler, vert_in.t3.zw);
 
-	color = ((E!=F && E!=D) || (E!=B && E!=H)) ? saturate(E + color*sharpness) : E;
+	color = ( (distance(E,F) != 0.0 && distance(E,D) != 0.0) || (distance(E,B) != 0.0 && distance(E,H) != 0.0) ) ? saturate(E + color * sharpness) : E;
 
 	return color;
 }


### PR DESCRIPTION
### Description
This PR contains changes required to the existing codebase for the Metal renderer to function properly:

* It disables the clear workaround enabled unconditionally on macOS and instead uses the _linear gamma_ variant of the clear color to match the way `glClear` is apparently implemented in the Metal-based OpenGL driver for Apple Silicon Macs (which also matches how a clear has to be simulated in Metal proper)
* It adds a conditional branch to any plugin that uses the `OBS_EFFECT_DEFAULT_RECT` (required for OpenGL on macOS) to use it _explicitly_ only when OpenGL is selected as the current renderer
* Changes a ternary expression in the `sharpness` shader to explicitly convert a vector of booleans into a scalar boolean value, as the Metal Shader Language does not allow implicit type changes

### Motivation and Context
These changes affect users on all platforms (using the sharpness effect) and macOS users who will continue to use the existing OpenGL renderer. As such it is beneficial to merge them "early" and thus have them tested at scale to ensure they have no negative side-effects.

### How Has This Been Tested?
Tested locally on macOS 15, ensuring that the clear colour is still correct (most easily checked by confirming that the dark blue padding of the preview window isn't much too bright or barely visible).

Additional testing on Windows 11, comparing the visual output of an image with and without the "sharpness" shader to confirm that edges are indeed sharpened.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
