### PR TITLE
frontend: Fix UI deadlock

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -11,6 +11,11 @@
 
 #include "plugin-manager/PluginManager.hpp"
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
 #include "moc_SourceTreeItem.cpp"
 
 static inline OBSScene GetCurrentScene()
@@ -280,7 +285,22 @@ void SourceTreeItem::mouseDoubleClickEvent(QMouseEvent *event)
 		obs_source_t *source = obs_sceneitem_get_source(sceneitem);
 		OBSBasic *main = OBSBasic::Get();
 		if (obs_source_configurable(source)) {
+#if defined(_WIN32)
+			/* This timer works around a bug introduced around Qt 6.8.3 that causes
+			 * the application to hang when double clicking the sources list and the
+			 * Windows setting 'Snap mouse to default button in dialog boxes' is enabled.
+			 */
+			bool snapEnabled;
+			SystemParametersInfo(SPI_GETSNAPTODEFBUTTON, 0, &snapEnabled, 0);
+
+			if (snapEnabled) {
+				QTimer::singleShot(200, this, [=]() { main->CreatePropertiesWindow(source); });
+			} else {
+				main->CreatePropertiesWindow(source);
+			}
+#else
 			main->CreatePropertiesWindow(source);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
### Description
Adds a single shot timer to delay opening the properties window after double clicking a source in the sources list.

Fixes #12499
Fixes #12456

### Motivation and Context
This works around a bug on Windows seemingly introduced around Qt 6.8.

When the Windows setting 'Snap mouse to default button in dialog boxes' is enabled, OBS hangs after double clicking the sources list. This seems to be some bizarre interaction between the drag event loop and the main application loop.

A QTimer of 1ms stops the program from completely hanging, but the application does not respond to events until the mouse is moved back over the sources list to presumably "finish" the started drag event.

20ms failed in a very very small number of cases so 200ms seems like a safe value as a bandaid here.

### How Has This Been Tested?
Opened properties a **lot** of times

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
