### PR TITLE
linux-pipewire: Support enumerated camera sizes

### DIFF
--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -317,6 +317,28 @@ static struct dstr aspect_ratio_from_spa_rectangle(struct spa_rectangle rect)
 	return str;
 }
 
+static const void *get_values_from_pod(const struct spa_pod *p, uint32_t type, uint32_t size, uint32_t *cnt)
+{
+	uint32_t choice;
+	const struct spa_pod *vals = spa_pod_get_values(p, cnt, &choice);
+	if (!vals || vals->type != type || vals->size != size || *cnt <= 0)
+		return NULL;
+
+	const void *body = SPA_POD_BODY_CONST(vals);
+
+	switch (choice) {
+	case SPA_CHOICE_Enum:
+		/* skip the first one, the default value */
+		*cnt -= 1;
+		body = SPA_PTROFF(body, size, const void);
+		SPA_FALLTHROUGH;
+	case SPA_CHOICE_None:
+		return body;
+	default:
+		return NULL;
+	}
+}
+
 static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 {
 	struct param *p;
@@ -332,8 +354,6 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 		uint32_t format = 0;
 		const char *format_name;
 		struct spa_rectangle resolution;
-
-		const struct spa_pod_prop *framerate_prop = NULL;
 
 		if (p->id != SPA_PARAM_EnumFormat || p->param == NULL)
 			continue;
@@ -380,49 +400,22 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 			dstr_free(&aspect_ratio);
 		}
 
-		framerate_prop = spa_pod_find_prop(p->param, NULL, SPA_FORMAT_VIDEO_framerate);
-		if (framerate_prop) {
-			struct spa_pod *framerate_pod;
-			uint32_t n_framerates;
-			enum spa_choice_type framerate_choice;
-			const struct spa_fraction *framerate_values;
-			g_autoptr(GArray) framerates = NULL;
+		const struct spa_fraction *framerate_values = NULL;
+		uint32_t n_framerates;
 
-			framerate_pod = spa_pod_get_values(&framerate_prop->value, &n_framerates, &framerate_choice);
-			if (framerate_pod->type != SPA_TYPE_Fraction) {
-				blog(LOG_WARNING, "Framerate is not a fraction");
-				continue;
-			}
+		const struct spa_pod_prop *framerate_prop =
+			spa_pod_find_prop(p->param, NULL, SPA_FORMAT_VIDEO_framerate);
+		if (framerate_prop)
+			framerate_values = get_values_from_pod(&framerate_prop->value, SPA_TYPE_Fraction,
+							       sizeof(*framerate_values), &n_framerates);
 
-			framerate_values = SPA_POD_BODY(framerate_pod);
-			framerates = g_array_new(FALSE, FALSE, sizeof(struct spa_fraction));
-
-			switch (framerate_choice) {
-			case SPA_CHOICE_None:
-				g_array_append_val(framerates, framerate_values[0]);
-				break;
-			case SPA_CHOICE_Range:
-				blog(LOG_WARNING, "Ranged framerates not supported");
-				continue;
-			case SPA_CHOICE_Step:
-				blog(LOG_WARNING, "Stepped framerates not supported");
-				continue;
-			case SPA_CHOICE_Enum:
-				/* i=0 is the default framerate, skip it */
-				for (uint32_t i = 1; i < n_framerates; i++)
-					g_array_append_val(framerates, framerate_values[i]);
-				break;
-			default:
-				continue;
-			}
-
+		if (framerate_values) {
 			dstr_cat(&str, " - ");
 
-			for (int i = framerates->len - 1; i >= 0; i--) {
-				const struct spa_fraction *framerate =
-					&g_array_index(framerates, struct spa_fraction, i);
+			for (uint32_t i = n_framerates; i > 0; i--) {
+				const struct spa_fraction *framerate = &framerate_values[i - 1];
 
-				if (i != (int)framerates->len - 1)
+				if (i != n_framerates)
 					dstr_cat(&str, ", ");
 
 				if (framerate->denom == 1)
@@ -649,10 +642,8 @@ static bool framerate_list(struct camera_device *dev, uint32_t pixelformat, cons
 	spa_list_for_each(p, &dev->param_list, link)
 	{
 		const struct spa_fraction *framerate_values;
-		enum spa_choice_type choice;
 		const struct spa_pod_prop *prop;
 		struct spa_rectangle this_resolution;
-		struct spa_pod *framerate_pod;
 		uint32_t media_subtype;
 		uint32_t media_type;
 		uint32_t n_framerates;
@@ -687,32 +678,13 @@ static bool framerate_list(struct camera_device *dev, uint32_t pixelformat, cons
 		if (!prop)
 			continue;
 
-		framerate_pod = spa_pod_get_values(&prop->value, &n_framerates, &choice);
-		if (framerate_pod->type != SPA_TYPE_Fraction) {
-			blog(LOG_WARNING, "Framerate is not a fraction - something is wrong");
+		framerate_values =
+			get_values_from_pod(&prop->value, SPA_TYPE_Fraction, sizeof(*framerate_values), &n_framerates);
+		if (!framerate_values)
 			continue;
-		}
 
-		framerate_values = SPA_POD_BODY(framerate_pod);
-
-		switch (choice) {
-		case SPA_CHOICE_None:
-			g_array_append_val(framerates, framerate_values[0]);
-			break;
-		case SPA_CHOICE_Range:
-			blog(LOG_WARNING, "Ranged framerates not supported");
-			break;
-		case SPA_CHOICE_Step:
-			blog(LOG_WARNING, "Stepped framerates not supported");
-			break;
-		case SPA_CHOICE_Enum:
-			/* i=0 is the default framerate, skip it */
-			for (uint32_t i = 1; i < n_framerates; i++)
-				g_array_append_val(framerates, framerate_values[i]);
-			break;
-		default:
-			break;
-		}
+		for (uint32_t i = 0; i < n_framerates; i++)
+			g_array_append_val(framerates, framerate_values[i]);
 	}
 
 	g_array_sort(framerates, compare_framerates);

--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -343,17 +343,14 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 {
 	struct param *p;
 	obs_data_t *data = NULL;
-	struct dstr str = {};
 
 	obs_property_list_clear(prop);
 
 	spa_list_for_each(p, &dev->param_list, link)
 	{
-		struct dstr aspect_ratio;
 		uint32_t media_type, media_subtype;
 		uint32_t format = 0;
 		const char *format_name;
-		struct spa_rectangle resolution;
 
 		if (p->id != SPA_PARAM_EnumFormat || p->param == NULL)
 			continue;
@@ -385,20 +382,20 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 			continue;
 		}
 
-		if (spa_pod_parse_object(p->param, SPA_TYPE_OBJECT_Format, format ? &format : NULL,
-					 SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&resolution)) < 0)
+		if (spa_pod_parse_object(p->param, SPA_TYPE_OBJECT_Format, format ? &format : NULL) < 0)
 			continue;
 
-		obs_data_set_int(data, "width", resolution.width);
-		obs_data_set_int(data, "height", resolution.height);
+		const struct spa_pod_prop *resolution_prop = spa_pod_find_prop(p->param, NULL, SPA_FORMAT_VIDEO_size);
+		if (!resolution_prop)
+			continue;
 
-		dstr_printf(&str, "%ux%u", resolution.width, resolution.height);
+		const struct spa_rectangle *resolution_values;
+		uint32_t n_resolutions;
 
-		aspect_ratio = aspect_ratio_from_spa_rectangle(resolution);
-		if (aspect_ratio.len != 0) {
-			dstr_catf(&str, " (%s)", aspect_ratio.array);
-			dstr_free(&aspect_ratio);
-		}
+		resolution_values = get_values_from_pod(&resolution_prop->value, SPA_TYPE_Rectangle,
+							sizeof(*resolution_values), &n_resolutions);
+		if (!resolution_values)
+			continue;
 
 		const struct spa_fraction *framerate_values = NULL;
 		uint32_t n_framerates;
@@ -409,30 +406,47 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 			framerate_values = get_values_from_pod(&framerate_prop->value, SPA_TYPE_Fraction,
 							       sizeof(*framerate_values), &n_framerates);
 
-		if (framerate_values) {
-			dstr_cat(&str, " - ");
+		for (uint32_t i = 0; i < n_resolutions; i++) {
+			const struct spa_rectangle *resolution = &resolution_values[i];
+			struct dstr aspect_ratio;
+			struct dstr str = {};
 
-			for (uint32_t i = n_framerates; i > 0; i--) {
-				const struct spa_fraction *framerate = &framerate_values[i - 1];
+			obs_data_set_int(data, "width", resolution->width);
+			obs_data_set_int(data, "height", resolution->height);
 
-				if (i != n_framerates)
-					dstr_cat(&str, ", ");
+			dstr_printf(&str, "%ux%u", resolution->width, resolution->height);
 
-				if (framerate->denom == 1)
-					dstr_catf(&str, "%u", framerate->num);
-				else
-					dstr_catf(&str, "%.2f", framerate->num / (double)framerate->denom);
+			aspect_ratio = aspect_ratio_from_spa_rectangle(*resolution);
+			if (aspect_ratio.len != 0) {
+				dstr_catf(&str, " (%s)", aspect_ratio.array);
+				dstr_free(&aspect_ratio);
 			}
 
-			dstr_cat(&str, " FPS");
-		}
+			if (framerate_values) {
+				dstr_cat(&str, " - ");
 
-		dstr_catf(&str, " - %s", format_name);
-		obs_property_list_add_string(prop, str.array, obs_data_get_json(data));
+				for (uint32_t i = n_framerates; i > 0; i--) {
+					const struct spa_fraction *framerate = &framerate_values[i - 1];
+
+					if (i != n_framerates)
+						dstr_cat(&str, ", ");
+
+					if (framerate->denom == 1)
+						dstr_catf(&str, "%u", framerate->num);
+					else
+						dstr_catf(&str, "%.2f", framerate->num / (double)framerate->denom);
+				}
+
+				dstr_cat(&str, " FPS");
+			}
+
+			dstr_catf(&str, " - %s", format_name);
+			obs_property_list_add_string(prop, str.array, obs_data_get_json(data));
+			dstr_free(&str);
+		}
 	}
 
 	g_clear_pointer(&data, obs_data_release);
-	dstr_free(&str);
 }
 
 static bool control_changed(void *data, obs_properties_t *props, obs_property_t *prop, obs_data_t *settings)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description + Motivation and Context

A node might choose to use an enumerated choice pod to report the set of
supported sizes. Currently that is not supported. And what's worse, since
`SPA_POD_OPT_Rectangle()` is used, if the node uses an enum choice, then
`{,this_}resolution` stays uninitialized but `spa_pod_parse_object()` will
not report errors because the field is considered optional.

Fix this by using `spa_pod_get_values()`, which can be used for concrete
values, and both `SPA_CHOICE_{None,Enum}`.

Since the resolutions are parsed in two separate places, and since the
frame rates require essentially the same treatment a new function is
introduced to handle the common parts.

### How Has This Been Tested?

With the current pipewire master branch, with a video node that uses enumerated choice for size, as well as nodes that don't use enumerated choices.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
