### PR TITLE
libobs: Add os_oom() to clarify out of memory crashes

### DIFF
--- a/libobs/util/bmem.c
+++ b/libobs/util/bmem.c
@@ -108,7 +108,7 @@ void *bmalloc(size_t size)
 	void *ptr = a_malloc(size);
 
 	if (!ptr) {
-		os_breakpoint();
+		os_oom();
 		bcrash("Out of memory while trying to allocate %lu bytes", (unsigned long)size);
 	}
 
@@ -129,7 +129,7 @@ void *brealloc(void *ptr, size_t size)
 	ptr = a_realloc(ptr, size);
 
 	if (!ptr) {
-		os_breakpoint();
+		os_oom();
 		bcrash("Out of memory while trying to allocate %lu bytes", (unsigned long)size);
 	}
 

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -843,6 +843,11 @@ void os_breakpoint()
 	raise(SIGTRAP);
 }
 
+void os_oom()
+{
+	raise(SIGTRAP);
+}
+
 #ifndef __APPLE__
 static int physical_cores = 0;
 static int logical_cores = 0;

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1257,6 +1257,11 @@ void os_breakpoint(void)
 	__debugbreak();
 }
 
+void os_oom(void)
+{
+	__debugbreak();
+}
+
 DWORD num_logical_cores(ULONG_PTR mask)
 {
 	DWORD left_shift = sizeof(ULONG_PTR) * 8 - 1;

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -174,6 +174,7 @@ EXPORT bool os_inhibit_sleep_set_active(os_inhibit_t *info, bool active);
 EXPORT void os_inhibit_sleep_destroy(os_inhibit_t *info);
 
 EXPORT void os_breakpoint(void);
+EXPORT void os_oom(void);
 
 EXPORT int os_get_physical_cores(void);
 EXPORT int os_get_logical_cores(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Per discussion with @notr1ch , add an `os_oom()` copy of `os_breakpoint()` to make crash stacks clearer and to make troubleshooting easier.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

When OBS crashes during `bmalloc()` or `brealloc()` calls using `os_breakpoint()` in Release/RelWithDebInfo builds, we do not get the logged line that is supposed to differentiate the crash types:
* bmalloc: Allocating 0 bytes is broken behavior, please fix your code!
* Out of memory while trying to allocate %lu bytes
* brealloc: Allocating 0 bytes is broken behavior, please fix your code!
* Out of memory while trying to allocate %lu bytes

@notr1ch suggested just duplicating `os_breakpoint()` into "nicer" variants, such as `os_oom()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Manually tested a call to `bmalloc(0)` and manually forced the null pointer check in `bmalloc()` to fail.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
