### PR TITLE
rtmp-services: add Odysee as a service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -5,7 +5,7 @@
     "files": [
         {
             "name": "services.json",
-            "version": 272
+            "version": 273
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3552,7 +3552,6 @@
             ],
             "recommended": {
                 "keyint": 2,
-                "x264opts": "tune=zerolatency",
                 "profile": "high",
                 "max video bitrate": 7000
             }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3537,6 +3537,25 @@
                 "keyint": 1,
                 "max video bitrate": 6000
             }
+        },
+        {
+            "name": "Odysee",
+            "more_info_link": "https://odysee.com",
+            "servers": [
+                {
+                    "name": "Primary RTMP",
+                    "url": "rtmp://stream.odysee.com/live"
+                }
+            ],
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "x264opts": "tune=zerolatency",
+                "profile": "high",
+                "max video bitrate": 7000
+            }
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added **Odysee** as a streaming service option in the RTMP dropdown.  
Also incremented the `rtmp-services` package.json version accordingly.  

### Motivation and Context
Odysee serves over 10 million monthly active users, with many creators using OBS as their primary encoder.  
Creators often encounter issues with incorrect manual RTMP settings, so adding Odysee as a preset simplifies the process, reduces errors, and improves their streaming experience.  

### How Has This Been Tested?
- Verified that Odysee appears as an option in the RTMP service dropdown.  
- Confirmed correct RTMP ingest URL and stream key handling.  
- Tested stream initiation and stability using OBS on Ubuntu 24.04. 
- Ensured no issues with other streaming destinations.  

### Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (not applicable, only json edits)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
