### PR TITLE
frontend/api: Fix deprecation warning message in obs_frontend_get_global_config

### DIFF
--- a/frontend/api/obs-frontend-api.cpp
+++ b/frontend/api/obs-frontend-api.cpp
@@ -371,8 +371,8 @@ config_t *obs_frontend_get_user_config(void)
 
 config_t *obs_frontend_get_global_config(void)
 {
-	blog(LOG_WARNING,
-	     "DEPRECATION: obs_frontend_get_global_config is deprecated. Read from global or user configuration explicitly instead.");
+	blog(LOG_WARNING, "DEPRECATION: obs_frontend_get_global_config is deprecated. "
+			  "Use obs_frontend_get_app_config or obs_frontend_get_user_config explicitly instead.");
 	return !!callbacks_valid() ? c->obs_frontend_get_app_config() : nullptr;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR revised the deprecation log message in `obs_frontend_get_global_config`.

Instead of suggesting "global or user configuration", let's use the API names so that there is no confusion.

Also replaced the verb "read" with "use" because the usage of the API is actually not only reading the configuration but also set the configuration.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The message suggested to use "global configuration", which is deprecated.

The new API `obs_frontend_get_app_config` or `obs_frontend_get_user_config` should be called instead.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 42

Called the API from a plugin and checked the message in the log file.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
