### PR TITLE
docs: Clarify some aspects of OBS_PROPERTY_BUTTON

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -270,7 +270,11 @@ Property Object Functions
 
    :param    name:        Setting identifier string
    :param    text:        Localized name shown to user
-   :param    callback:    Callback to be executed when the button is pressed
+   :param    callback:    Callback to be executed when the button is pressed. Note that if the property
+                          is created with :c:func:`obs_properties_add_button` instead of
+                          :c:func:`obs_properties_add_button2`, the value of ``data`` is determined by
+                          the caller of :c:func:`obs_property_button_clicked`, and as such unspecified
+                          by libobs.
    :param    priv:        Pointer passed back as the `data` argument of the callback
    :return:               The property
 
@@ -642,6 +646,16 @@ Property Modification Functions
 
 .. function:: bool obs_property_button_clicked(obs_property_t *p, void *obj)
 
+   Calls the ``callback`` of the button.
+
+   :param p: The property
+   :param obj: Must be a pointer to an object of type ``obs_canvas_t``, ``obs_source_t``,
+               ``obs_output_t``, ``obs_encoder_t``, or ``obs_service_t``.
+               If the property was created with :c:func:`obs_properties_add_button`, that
+               object's context will be passed as the ``obj`` parameter.
+               If the property was created with :c:func:`obs_properties_add_button2`, it
+               will be ignored.
+
 ---------------------
 
 .. function:: void obs_property_set_visible(obs_property_t *p, bool visible)
@@ -813,6 +827,8 @@ Property Modification Functions
 
 .. function:: void obs_property_button_set_type(obs_property_t *p, enum obs_button_type type)
 
+   Sets the type of the button. The button's ``callback`` will be called regardless of type.
+
    :param   type: Can be one of the following values:
 
                   - **OBS_BUTTON_DEFAULT** - Standard button
@@ -822,3 +838,6 @@ Property Modification Functions
 ---------------------
 
 .. function:: void obs_property_button_set_url(obs_property_t *p, char *url)
+
+   :param p:   The property
+   :param url: The URL to be opened if the button is of type ``OBS_BUTTON_URL``


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The important point here is that "data" from the callback isn't defined by libobs, but rather by the API consumer.
Additionally, it's not entirely clear from the documentation whether the callback would still be called for button of type OBS_BUTTON_URL. There should be no negatives to always calling it and the OBS Studio frontend already behaves that way, so let's document that in libobs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Spent a bit of time with `obs-properties.h` and noticed some things weren't specified/documented anywhere, specifically what the `data` pointer of the callback is.

I actually want to create a follow-up PR to deprecate v1 of `obs_properties_add_button` and replace `obs_property_button_clicked` with a version that doesn't take a second argument, because this `data` callback implicitly links the entire `obs_properties_t` object to some kind of object, which is both really annoying and also not needed with the existence of v2, anyone can just pass their own context.
However this follow-up PR requires a change in obs-browser first, and these documentation changes are correct either way.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Had CI build the docs. Here are screenshots of the modified parts:


<img width="793" height="774" alt="image" src="https://github.com/user-attachments/assets/86a889a6-fea1-45a4-920b-7173aa552d14" />

<img width="801" height="360" alt="image" src="https://github.com/user-attachments/assets/4e073fac-7d36-4ed7-a799-3e14159c9d71" />

<img width="712" height="435" alt="image" src="https://github.com/user-attachments/assets/b3c000c1-2de4-4599-adeb-84940bd56665" />

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
