### PR TITLE
Revert "UI: Work around Qt dock restore crash"

### DIFF
--- a/frontend/oauth/RestreamAuth.cpp
+++ b/frontend/oauth/RestreamAuth.cpp
@@ -203,9 +203,7 @@ void RestreamAuth::LoadUI()
 	} else {
 		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
-
-		if (main->isVisible() || !main->isMaximized())
-			main->restoreState(dockState);
+		main->restoreState(dockState);
 	}
 
 	uiLoaded = true;

--- a/frontend/oauth/TwitchAuth.cpp
+++ b/frontend/oauth/TwitchAuth.cpp
@@ -273,9 +273,7 @@ void TwitchAuth::LoadUI()
 	} else {
 		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
-
-		if (main->isVisible() || !main->isMaximized())
-			main->restoreState(dockState);
+		main->restoreState(dockState);
 	}
 
 	TryLoadSecondaryUIPanes();

--- a/frontend/oauth/YoutubeAuth.cpp
+++ b/frontend/oauth/YoutubeAuth.cpp
@@ -148,9 +148,7 @@ void YoutubeAuth::LoadUI()
 	if (!firstLoad) {
 		const char *dockStateStr = config_get_string(main->Config(), service(), "DockState");
 		QByteArray dockState = QByteArray::fromBase64(QByteArray(dockStateStr));
-
-		if (main->isVisible() || !main->isMaximized())
-			main->restoreState(dockState);
+		main->restoreState(dockState);
 	}
 
 	uiLoaded = true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This reverts commit 3dcf68f8ed500a23154f502a85caa109afd04d81.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The bug that this was meant to work around was most likely QTBUG-102718, which was fixed in Qt 6.2.5, 6.3.1, and 6.4.0. The minimum version of Qt we currently support is Qt 6.4.2 because it is what is available on Ubuntu 24.04. Thus, we should not need this workaround now.

This should restore service dock restoration if the main window is "not visible but maximized". See:
* https://github.com/obsproject/obs-studio/pull/8135
* https://github.com/obsproject/obs-studio/issues/7348

https://bugreports.qt.io/browse/QTBUG-102718

Want to get rid of code targeting Qt versions older than Qt 6.4.2.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It hasn't yet. Testing appreciated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
