### PR TITLE
libobs: Deprecate v1 of obs_properties_add_button

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -259,7 +259,14 @@ Property Object Functions
 ---------------------
 
 .. function:: obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name, const char *text, obs_property_clicked_t callback)
-              obs_property_t *obs_properties_add_button2(obs_properties_t *props, const char *name, const char *text, obs_property_clicked_t callback, void *priv)
+
+   Like :c:func:`obs_properties_add_button2`, except the value of the ``data`` argument in the callback is
+   determined by the caller of :c:func:`obs_property_button_clicked`, and as such unspecified by libobs.
+
+   .. deprecated:: 32.1
+   Use :c:func:`obs_properties_add_button2` instead.
+
+.. function:: obs_property_t *obs_properties_add_button2(obs_properties_t *props, const char *name, const char *text, obs_property_clicked_t callback, void *priv)
 
    Adds a button property.  This property does not actually store any
    settings; it's used to implement a button in user interface if the
@@ -270,11 +277,7 @@ Property Object Functions
 
    :param    name:        Setting identifier string
    :param    text:        Localized name shown to user
-   :param    callback:    Callback to be executed when the button is pressed. Note that if the property
-                          is created with :c:func:`obs_properties_add_button` instead of
-                          :c:func:`obs_properties_add_button2`, the value of ``data`` is determined by
-                          the caller of :c:func:`obs_property_button_clicked`, and as such unspecified
-                          by libobs.
+   :param    callback:    Callback to be executed when the button is pressed
    :param    priv:        Pointer passed back as the `data` argument of the callback
    :return:               The property
 

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -214,8 +214,8 @@ EXPORT obs_property_t *obs_properties_add_color(obs_properties_t *props, const c
 EXPORT obs_property_t *obs_properties_add_color_alpha(obs_properties_t *props, const char *name,
 						      const char *description);
 
-EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name, const char *text,
-						 obs_property_clicked_t callback);
+OBS_DEPRECATED EXPORT obs_property_t *obs_properties_add_button(obs_properties_t *props, const char *name,
+								const char *text, obs_property_clicked_t callback);
 
 EXPORT obs_property_t *obs_properties_add_button2(obs_properties_t *props, const char *name, const char *text,
 						  obs_property_clicked_t callback, void *priv);

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -565,7 +565,7 @@ static inline obs_properties_t *syphon_properties_internal(syphon_t s)
     LOAD_CROP(size.height);
 #undef LOAD_CROP
 
-    obs_properties_add_button(props, "syphon license", obs_module_text("SyphonLicense"), show_syphon_license);
+    obs_properties_add_button2(props, "syphon license", obs_module_text("SyphonLicense"), show_syphon_license, NULL);
 
     return props;
 }

--- a/plugins/obs-vst/obs-vst.cpp
+++ b/plugins/obs-vst/obs-vst.cpp
@@ -37,6 +37,8 @@ MODULE_EXPORT const char *obs_module_description(void)
 
 static bool open_editor_button_clicked(obs_properties_t *props, obs_property_t *property, void *data)
 {
+	UNUSED_PARAMETER(property);
+
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
 	if (vstPlugin && vstPlugin->vstLoaded()) {
@@ -47,15 +49,13 @@ static bool open_editor_button_clicked(obs_properties_t *props, obs_property_t *
 		obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), true);
 	}
 
-	UNUSED_PARAMETER(props);
-	UNUSED_PARAMETER(property);
-	UNUSED_PARAMETER(data);
-
 	return true;
 }
 
 static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t *property, void *data)
 {
+	UNUSED_PARAMETER(property);
+
 	VSTPlugin *vstPlugin = (VSTPlugin *)data;
 
 	if (vstPlugin && vstPlugin->vstLoaded() && vstPlugin->isEditorOpen()) {
@@ -65,8 +65,6 @@ static bool close_editor_button_clicked(obs_properties_t *props, obs_property_t 
 		obs_property_set_visible(obs_properties_get(props, OPEN_VST_SETTINGS), true);
 		obs_property_set_visible(obs_properties_get(props, CLOSE_VST_SETTINGS), false);
 	}
-
-	UNUSED_PARAMETER(property);
 
 	return true;
 }
@@ -302,8 +300,8 @@ static obs_properties_t *vst_properties(void *data)
 
 	fill_out_plugins(list);
 
-	obs_properties_add_button(props, OPEN_VST_SETTINGS, OPEN_VST_TEXT, open_editor_button_clicked);
-	obs_properties_add_button(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT, close_editor_button_clicked);
+	obs_properties_add_button2(props, OPEN_VST_SETTINGS, OPEN_VST_TEXT, open_editor_button_clicked, data);
+	obs_properties_add_button2(props, CLOSE_VST_SETTINGS, CLOSE_VST_TEXT, close_editor_button_clicked, data);
 
 	bool open_settings_vis = true;
 	bool close_settings_vis = false;

--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -1879,9 +1879,9 @@ static obs_properties_t *GetDShowProperties(void *obj)
 			activateText = TEXT_DEACTIVATE;
 	}
 
-	obs_properties_add_button(ppts, "activate", activateText, ActivateClicked);
-	obs_properties_add_button(ppts, "video_config", TEXT_CONFIG_VIDEO, VideoConfigClicked);
-	obs_properties_add_button(ppts, "xbar_config", TEXT_CONFIG_XBAR, CrossbarConfigClicked);
+	obs_properties_add_button2(ppts, "activate", activateText, ActivateClicked, input);
+	obs_properties_add_button2(ppts, "video_config", TEXT_CONFIG_VIDEO, VideoConfigClicked, input);
+	obs_properties_add_button2(ppts, "xbar_config", TEXT_CONFIG_XBAR, CrossbarConfigClicked, input);
 
 	obs_properties_add_bool(ppts, DEACTIVATE_WNS, TEXT_DWNS);
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
With v1 of this function, it's unclear where exactly the data pointer comes from or what it is. In fact, this is not determined by libobs, but the consumer. libobs assumes that the caller of `obs_property_button_clicked` passes an `obs_context_data` pointer, and then passes the data pointer of that `obs_context_data` (which, btw, is an internal implementation detail!) as the data pointer to the callback.
In OBS Studio, this is always the private data of the associated object. However, this assumes that there even is such an object (source/encoder/etc), even though properties are meant to be free-standing. This is not just philosophical, because with `obs_get_source_properties` you can actually get an `obs_properties_t` that isn't associated with any specific source, at which point you have no idea what the data pointer will be.

For this reason, `obs_properties_add_button` v1 needs to go. `obs_properties_add_button2` can be used as a drop-in replacement. With v2, it's well-defined that the pointer you're passing as priv is the pointer you get back in the callback as data. If you don't care about it, simply pass NULL/nullptr.

Once v1 is removed in the future, `obs_property_button_clicked` could be replaced with a variant that doesn't take a second argument, as that argument will no longer be used anywhere (although the existing second argument could also just be marked as unused, that would avoid an arguably unneeded breakage).


Contains https://github.com/obsproject/obs-studio/pull/12528 to avoid conflicts (I assume that that PR will be merged before this one, but otherwise it's fine for this to be merged first and the other one to be closed).
Depends on https://github.com/obsproject/obs-browser/pull/496.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This method is problematic as described above. `obs_properties_add_button` is basically a drop-in replacement that doesn't have those issues.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 26.
Tested that the "Syphon License" button of the syphon source still works.
Tested that the "Open Plug-in Interface" / "Close Plug-in Interface" buttons of the VST filter properties still work.

Screenshot of the docs:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/adb0bc62-8a5c-4f37-a5e6-a3091d4ed258" />

CI will fail until https://github.com/obsproject/obs-browser/pull/496 is merged and the submodule is updated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
