### PR TITLE
obs-ffmpeg: Fix build with FFMPEG 8 and above

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -276,9 +276,9 @@ static bool vaapi_update(void *data, obs_data_t *settings)
 
 #ifdef ENABLE_HEVC
 	if (enc->codec == CODEC_HEVC) {
-		if ((profile == FF_PROFILE_HEVC_MAIN) && (info.format == VIDEO_FORMAT_P010)) {
+		if ((profile == AV_PROFILE_HEVC_MAIN) && (info.format == VIDEO_FORMAT_P010)) {
 			warn("Forcing Main10 for P010");
-			profile = FF_PROFILE_HEVC_MAIN_10;
+			profile = AV_PROFILE_HEVC_MAIN_10;
 		}
 	}
 #endif
@@ -853,14 +853,14 @@ static void vaapi_defaults_internal(obs_data_t *settings, enum codec_type codec)
 	obs_data_set_default_string(settings, "vaapi_device", device);
 #ifdef ENABLE_HEVC
 	if (codec == CODEC_HEVC)
-		obs_data_set_default_int(settings, "profile", FF_PROFILE_HEVC_MAIN);
+		obs_data_set_default_int(settings, "profile", AV_PROFILE_HEVC_MAIN);
 	else
 #endif
 		if (codec == CODEC_H264)
-		obs_data_set_default_int(settings, "profile", FF_PROFILE_H264_HIGH);
+		obs_data_set_default_int(settings, "profile", AV_PROFILE_H264_HIGH);
 	else if (codec == CODEC_AV1)
-		obs_data_set_default_int(settings, "profile", FF_PROFILE_AV1_MAIN);
-	obs_data_set_default_int(settings, "level", FF_LEVEL_UNKNOWN);
+		obs_data_set_default_int(settings, "profile", AV_PROFILE_AV1_MAIN);
+	obs_data_set_default_int(settings, "level", AV_LEVEL_UNKNOWN);
 	obs_data_set_default_int(settings, "bitrate", 2500);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "bf", 0);
@@ -914,33 +914,33 @@ static bool vaapi_device_modified(obs_properties_t *ppts, obs_property_t *p, obs
 		goto fail;
 
 	switch (profile) {
-	case FF_PROFILE_H264_CONSTRAINED_BASELINE:
+	case AV_PROFILE_H264_CONSTRAINED_BASELINE:
 		if (!vaapi_display_h264_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileH264ConstrainedBaseline;
 		break;
-	case FF_PROFILE_H264_MAIN:
+	case AV_PROFILE_H264_MAIN:
 		if (!vaapi_display_h264_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileH264Main;
 		break;
-	case FF_PROFILE_H264_HIGH:
+	case AV_PROFILE_H264_HIGH:
 		if (!vaapi_display_h264_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileH264High;
 		break;
-	case FF_PROFILE_AV1_MAIN:
+	case AV_PROFILE_AV1_MAIN:
 		if (!vaapi_display_av1_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileAV1Profile0;
 		break;
 #ifdef ENABLE_HEVC
-	case FF_PROFILE_HEVC_MAIN:
+	case AV_PROFILE_HEVC_MAIN:
 		if (!vaapi_display_hevc_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileHEVCMain;
 		break;
-	case FF_PROFILE_HEVC_MAIN_10:
+	case AV_PROFILE_HEVC_MAIN_10:
 		if (!vaapi_display_hevc_supported(va_dpy, device))
 			goto fail;
 		profile = VAProfileHEVCMain10;
@@ -1098,21 +1098,21 @@ static obs_properties_t *vaapi_properties_internal(enum codec_type codec)
 	list = obs_properties_add_list(props, "profile", obs_module_text("Profile"), OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
 	if (codec == CODEC_HEVC) {
-		obs_property_list_add_int(list, "Main", FF_PROFILE_HEVC_MAIN);
-		obs_property_list_add_int(list, "Main10", FF_PROFILE_HEVC_MAIN_10);
+		obs_property_list_add_int(list, "Main", AV_PROFILE_HEVC_MAIN);
+		obs_property_list_add_int(list, "Main10", AV_PROFILE_HEVC_MAIN_10);
 	} else if (codec == CODEC_H264) {
-		obs_property_list_add_int(list, "Constrained Baseline", FF_PROFILE_H264_CONSTRAINED_BASELINE);
-		obs_property_list_add_int(list, "Main", FF_PROFILE_H264_MAIN);
-		obs_property_list_add_int(list, "High", FF_PROFILE_H264_HIGH);
+		obs_property_list_add_int(list, "Constrained Baseline", AV_PROFILE_H264_CONSTRAINED_BASELINE);
+		obs_property_list_add_int(list, "Main", AV_PROFILE_H264_MAIN);
+		obs_property_list_add_int(list, "High", AV_PROFILE_H264_HIGH);
 	} else if (codec == CODEC_AV1) {
-		obs_property_list_add_int(list, "Main", FF_PROFILE_AV1_MAIN);
+		obs_property_list_add_int(list, "Main", AV_PROFILE_AV1_MAIN);
 	}
 
 	obs_property_set_modified_callback(list, vaapi_device_modified);
 
 	list = obs_properties_add_list(props, "level", obs_module_text("Level"), OBS_COMBO_TYPE_LIST,
 				       OBS_COMBO_FORMAT_INT);
-	obs_property_list_add_int(list, "Auto", FF_LEVEL_UNKNOWN);
+	obs_property_list_add_int(list, "Auto", AV_LEVEL_UNKNOWN);
 	if (codec == CODEC_H264) {
 		obs_property_list_add_int(list, "3.0", 30);
 		obs_property_list_add_int(list, "3.1", 31);


### PR DESCRIPTION
With commit https://github.com/FFmpeg/FFmpeg/commit/822432769868 FFMPEG
has removed almost all of the FF_API_FF_PROFILE_LEVEL related defines.
They were deprecated since 2023-09-06. This results in build failures.

This is first found on Gentoo with FFMPEG pre-release version.

Downstream-bug: https://bugs.gentoo.org/961699

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
With commit https://github.com/FFmpeg/FFmpeg/commit/822432769868 FFMPEG has removed almost all of the FF_API_FF_PROFILE_LEVEL related defines. They were deprecated since 2023-09-06. This results in build failures such as:

/var/tmp/portage/media-video/obs-studio-31.1.2/work/obs-studio-31.1.2/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c:279:33: error: ‘FF_PROFILE_HEVC_MAIN’ undeclared (first use in this function); did you mean ‘AV_PROFILE_HEVC_MAIN’?
  279 |                 if ((profile == FF_PROFILE_HEVC_MAIN) && (info.format == VIDEO_FORMAT_P010)) {
      |                                 ^~~~~~~~~~~~~~~~~~~~
      |                                 AV_PROFILE_HEVC_MAIN

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Remove usage of deprecated defines and fix build failures with newer FFMPEG

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested the patch against new and old FFMPEG, 7.1.1 and a live ebuild (i.e. latest from the source), and then ran the build binary.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Code cleanup mainly, removing usage of deprecated FFMPEG defines.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
