### PR TITLE
frontend: Change overflow texture rendering to be sRGB-aware

### DIFF
--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -1841,7 +1841,7 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *, obs_sceneitem_t *item,
 	vec2_set(&s, boxTransform.x.x / 96, boxTransform.y.y / 96);
 
 	gs_effect_set_vec2(scale, &s);
-	gs_effect_set_texture(image, prev->overflow);
+	gs_effect_set_texture_srgb(image, prev->overflow);
 
 	gs_matrix_push();
 	gs_matrix_mul(&boxTransform);
@@ -1849,10 +1849,14 @@ bool OBSBasicPreview::DrawSelectedOverflow(obs_scene_t *, obs_sceneitem_t *item,
 	obs_sceneitem_crop crop;
 	obs_sceneitem_get_crop(item, &crop);
 
+	const bool currentFramebufferSrgbState = gs_framebuffer_srgb_enabled();
+	gs_enable_framebuffer_srgb(true);
+
 	while (gs_effect_loop(solid, "Draw")) {
 		gs_draw_sprite(prev->overflow, 0, 1, 1);
 	}
 
+	gs_enable_framebuffer_srgb(currentFramebufferSrgbState);
 	gs_matrix_pop();
 
 	GS_DEBUG_MARKER_END();


### PR DESCRIPTION
### Description
Changes the code to render the overflow texture in the main preview to support linear blending and automatic sRGB to linear gamma en- and decoding for the overflow texture render pass.

### Motivation and Context
Current code assumes that the overflow texture and the render target always share the same colour format including transfer function.

This assumption is incorrect however as OBS might use a 16-bit floating point texture with a linear transfer function when a high-bitrate format is selected. On top of that OBS Studio wants rendering code to ensure that linear colour blending is used throughout the application.

The `DrawOverflow` function had not been updated to reflect this. This change brings it in line with other functions involved in preview rendering, which enable automatic sRGB conversion for the render target and the texture used in the fragment shader.

> [!NOTE]
> As a bonus this also fixes a very specific issue with OpenGL on Apple Silicon Macs:
>
>Apple Silicon GPUs have no actual OpenGL driver, instead Apple provides an OpenGL API implemented in Metal. In my tests it seems that a call to `glClear` is not immediately executed, but is potentially deferred to the first actual render command sent to the GPU.
>
> Automatic sRGB _encoding_ is currently not enabled for the render target by the overflow rendering function, thus the clear colour (using linear gamma in preparation for the Metal renderer) is not encoded into sRGB gamma and appears too dark.
>
> When no overflow is rendered, a function like `obs_render_main_texture_src_color_only` becomes the first render command, which is sRGB-aware and ensures a linear rendering path already, thus the deferred clear is rendered correctly.

### How Has This Been Tested?
Tested with OpenGL renderer on macOS 15 on an Apple Silicon machine and on Windows 11 with Direct3D11 renderer to check if both the clear colour and the overflow texture still appear correct.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
