### PR TITLE
CI: Fix cross-compiling for Windows on Arm from an x64 host

### DIFF
--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -52,14 +52,18 @@ function Build {
     Push-Location -Stack BuildTemp
     Ensure-Location $ProjectRoot
 
+    $HostArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
     $CmakeArgs = @('--preset', "windows-ci-${Target}")
 
     # Required at the very least until OBS Studio updates to Qt 6.8+, pending review of Qt's build options for
     # Windows ARM64.
-    if ( $Target -eq 'arm64' ) {
+    if ( ( $HostArchitecture -eq "X64" ) -and ( $Target -eq 'arm64' ) ) {
         $QtDependencyVersion = $BuildSpec.dependencies.qt6.version
 
-        $CmakeArgs += @("-DQT_HOST_PATH=${ProjectRoot}\.deps\obs-deps-qt6-${QtDependencyVersion}-x64")
+        $CmakeArgs += @(
+            "-DQT_HOST_PATH:PATH=${ProjectRoot}\.deps\obs-deps-qt6-${QtDependencyVersion}-x64"
+            "-DQT_REQUIRE_HOST_PATH_CHECK:BOOL=ON"
+        )
     }
 
     $CmakeBuildArgs = @('--build')


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

When built natively, Qt defaults QT_REQUIRE_HOST_PATH_CHECK to FALSE. Cross-compiling OBS Studio with a natively built arm64 Qt6 results in the specified host tool path (QT_HOST_PATH) being ignored. Force Qt/CMake to require that the user-specified host path be checked/used to fix cross-compiling OBS Studio with a natively built arm64 Qt6 on Windows.

Also, since this should only be required when cross-compiling, only set these when on an x64 host and targeting arm64.

Ideally, we'd find a way to do this in pure CMake rather than the build script.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want to unbreak cross-compiled WoA builds in #12539.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It hasn't yet, but I will rebase #12539 on this and test that later.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- CI

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
