### PR TITLE
cmake: Fix compilation on Windows with native ARM64 Qt dependency

### DIFF
--- a/.github/scripts/Build-Windows.ps1
+++ b/.github/scripts/Build-Windows.ps1
@@ -54,14 +54,6 @@ function Build {
 
     $CmakeArgs = @('--preset', "windows-ci-${Target}")
 
-    # Required at the very least until OBS Studio updates to Qt 6.8+, pending review of Qt's build options for
-    # Windows ARM64.
-    if ( $Target -eq 'arm64' ) {
-        $QtDependencyVersion = $BuildSpec.dependencies.qt6.version
-
-        $CmakeArgs += @("-DQT_HOST_PATH=${ProjectRoot}\.deps\obs-deps-qt6-${QtDependencyVersion}-x64")
-    }
-
     $CmakeBuildArgs = @('--build')
     $CmakeInstallArgs = @()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -98,7 +98,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "architecture": "x64,version=10.0.22621",
+      "architecture": "x64,version=10.0.22621.0",
       "binaryDir": "${sourceDir}/build_x64",
       "generator": "Visual Studio 17 2022",
       "cacheVariables": {
@@ -127,7 +127,7 @@
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
-      "architecture": "ARM64,version=10.0.22621",
+      "architecture": "ARM64,version=10.0.22621.0",
       "binaryDir": "${sourceDir}/build_arm64",
       "generator": "Visual Studio 17 2022",
       "cacheVariables": {

--- a/cmake/windows/buildspec.cmake
+++ b/cmake/windows/buildspec.cmake
@@ -4,6 +4,83 @@ include_guard(GLOBAL)
 
 include(buildspec_common)
 
+# _handle_qt_cross_compile: Check for and handle cross compiled Qt dependency
+function(_handle_qt_cross_compile architecture)
+  set(options "")
+  set(oneValueArgs DIRECTORY)
+  set(multiValueArgs "")
+  cmake_parse_arguments(PARSE_ARGV 0 _HQCC "${options}" "${oneValueArgs}" "${multiValueArgs}")
+
+  file(READ "${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json" buildspec)
+
+  string(JSON dependency_data GET ${buildspec} dependencies)
+  string(JSON data GET ${dependency_data} qt6)
+  string(JSON version GET ${data} version)
+
+  set(qt_build_arch "")
+  set(qt_target_arch "")
+  set(host_arch "")
+  set(platform_name "")
+  set(config_has_buildabi FALSE)
+  set(qt_cross_compiled FALSE)
+
+  string(REPLACE "VERSION" "${version}" directory "${_HQCC_DIRECTORY}")
+  string(TOLOWER "${CMAKE_VS_PLATFORM_NAME}" platform_name)
+  string(REPLACE "ARCH" "${platform_name}" qt_arch_location "${directory}")
+
+  file(READ "${qt_arch_location}/mkspecs/qconfig.pri" qt_arch_config)
+  string(REGEX MATCH ".+QT_TARGET_BUILDABI = (.+)\n.+" config_has_buildabi "${qt_arch_config}")
+
+  if(config_has_buildabi)
+    string(
+      REGEX REPLACE
+      "host_build {\n[ \t]+QT_ARCH = (x86_64|arm64)\n.+[ \t]+QT_TARGET_ARCH = (x86_64|arm64)\n.+}.+"
+      "\\1;\\2"
+      host_build_tuple
+      "${qt_arch_config}"
+    )
+    list(GET host_build_tuple 0 qt_build_arch)
+    list(GET host_build_tuple 1 qt_target_arch)
+    set(qt_cross_compiled TRUE)
+  else()
+    string(REGEX REPLACE ".*QT_ARCH = (x86_64|arm64)\n.+" "\\1" build_arch "${qt_arch_config}")
+    set(qt_build_arch "${build_arch}")
+    set(qt_target_arch "${build_arch}")
+  endif()
+
+  if(NOT qt_build_arch MATCHES "x86_64|arm64" OR NOT qt_target_arch MATCHES "x86_64|arm64")
+    message(FATAL_ERROR "Unable to detect host or target architecture from Qt dependencies in '${qt_arch_location}'")
+  endif()
+
+  string(REPLACE "x86_64" "x64" qt_build_arch "${qt_build_arch}")
+  string(REPLACE "x86_64" "x64" qt_target_arch "${qt_target_arch}")
+  string(REPLACE "AMD64" "x64" architecture "${architecture}")
+  string(REPLACE "ARM64" "arm64" architecture "${architecture}")
+
+  if(NOT qt_cross_compiled)
+    if(architecture STREQUAL qt_target_arch OR (architecture STREQUAL arm64 AND qt_target_arch STREQUAL x64))
+      unset(QT_HOST_PATH CACHE)
+      unset(QT_REQUIRE_HOST_PATH_CHECK CACHE)
+      return()
+    endif()
+
+    set(QT_REQUIRE_HOST_PATH_CHECK TRUE CACHE STRING "Qt Host Tools Check Required" FORCE)
+  endif()
+
+  if(NOT DEFINED QT_HOST_PATH)
+    string(REPLACE "${qt_target_arch}" "${architecture}" host_tools_directory "${qt_arch_location}")
+
+    if(NOT IS_DIRECTORY "${host_tools_directory}")
+      message(
+        FATAL_ERROR
+        "Required Qt host tools for ${architecture} when building for ${qt_target_arch} not found in '${host_tools_directory}'"
+      )
+    endif()
+
+    set(QT_HOST_PATH "${host_tools_directory}" CACHE STRING "Qt Host Tools Path" FORCE)
+  endif()
+endfunction()
+
 # _check_dependencies_windows: Set up Windows slice for _check_dependencies
 function(_check_dependencies_windows)
   set(dependencies_dir "${CMAKE_CURRENT_SOURCE_DIR}/.deps")
@@ -25,19 +102,8 @@ function(_check_dependencies_windows)
 
   _check_dependencies()
 
-  if(CMAKE_VS_PLATFORM_NAME STREQUAL ARM64 AND NOT QT_HOST_PATH)
-    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/buildspec.json" buildspec)
-
-    string(JSON dependency_data GET ${buildspec} dependencies)
-    string(JSON data GET ${dependency_data} qt6)
-    string(JSON version GET ${data} version)
-    set(qt_x64_dir "${CMAKE_CURRENT_SOURCE_DIR}/.deps/obs-deps-qt6-${version}-x64")
-
-    if(IS_DIRECTORY "${qt_x64_dir}")
-      set(QT_HOST_PATH "${qt_x64_dir}" CACHE STRING "Qt Host Tools Path" FORCE)
-    else()
-      message(FATAL_ERROR "Building OBS Studio for Windows ARM64 requires x64 Qt dependencies")
-    endif()
+  if(NOT CMAKE_VS_PLATFORM_NAME STREQUAL Win32)
+    _handle_qt_cross_compile(${CMAKE_HOST_SYSTEM_PROCESSOR} DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/.deps/${qt6_destination}")
   endif()
 endfunction()
 


### PR DESCRIPTION
### Description
Adds Windows-specific code to detect differences between host architecture, build architecture, Qt target architecture and whether Qt has been cross compiled or natively compiled.

### Motivation and Context
When Qt is cross compiled the host and target architecture as well as the fact that it was cross compiled is embedded in multiple files shipped as part of the dependency.

Among these is the information whether Qt assumes that a dedicated copy of its toolchain (`moc`, `uiq`, `rcc`, et. al.) for the host architecture is required (see `Qt6Dependencies.cmake`).

When Qt6 is built for ARM64 on an X64 host, this file will set the variable `__qt_platform_requires_host_info_package` to `TRUE` by default, which leads to Qt's CMake helper scripts to complain when `QT_HOST_TOOLS` is not defined in some way.

When Qt6 is built for ARM64 on an ARM64 host, the same file will set the variable to `FALSE` by default, so Qt will not require `QT_HOST_TOOLS` to be set.

_However_ when those "native" dependencies are used to build a project on an X64 host, the toolchain will fail to execute (CMake will test this as part of project generation) because it will use the ARM64 versions provided by the natively compiled dependency.

> [!NOTE]
> ARM64 Windows hosts have no issue with the reverse situation, as they are (just like Apple Silicon machines) capable of running X64 code.

Qt did introduce the `QT_REQUIRE_HOST_PATH_CHECK` cache variable which can be used to influence the value of the internal variable, thus:

* If OBS Studio is built _for_ ARM64 on an X64 host and
* The provided Qt dependency was built natively,
* Then set `QT_REQUIRE_HOST_PATH_CHECK` to `TRUE` to introduce the requirement for `QT_HOST_TOOLS` to be set, and
* Set `QT_HOST_TOOLS` to the Qt6 dependency corresponding with the local host environment

> [!IMPORTANT]
> This change works out of the box only because the X64 dependencies are either downloaded for an actual X64 build or automatically downloaded by an ARM64 build to generate X64 variants of the graphics hook _before_ configuring the ARM64 build tree itself.
>
> It is also dependent on the format of `qconfig.pri` as it's the "simplest" file to parse for the build configuration of the dependency.

The PR also adds a fourth component to the Windows SDK version specified in the CMake presets for Windows as CMake expects four components instead of three and will internally add a fourth component (represented by the `CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION` variable) which will then not match the value provided by the preset.

### How Has This Been Tested?
Tested on CI (Windows X64 host) and Windows ARM64 host with cross-compiled Qt dependency as well as natively compiled Qt dependency.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
