### PR TITLE
libobs: Fix scene and group load state

### DIFF
--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -3963,9 +3963,19 @@ bool obs_source_is_group(const obs_source_t *source)
 	return source && strcmp(source->info.id, group_info.id) == 0;
 }
 
+bool obs_source_type_is_group(const char *id)
+{
+	return id && strcmp(id, group_info.id) == 0;
+}
+
 bool obs_source_is_scene(const obs_source_t *source)
 {
 	return source && strcmp(source->info.id, scene_info.id) == 0;
+}
+
+bool obs_source_type_is_scene(const char *id)
+{
+	return id && strcmp(id, scene_info.id) == 0;
 }
 
 bool obs_scene_is_group(const obs_scene_t *scene)

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -157,6 +157,12 @@ obs_module_t *obs_source_get_module(const char *id)
 
 enum obs_module_load_state obs_source_load_state(const char *id)
 {
+	if (!id)
+		return OBS_MODULE_INVALID;
+
+	if (obs_source_type_is_scene(id) || obs_source_type_is_group(id))
+		return OBS_MODULE_ENABLED;
+
 	obs_module_t *module = obs_source_get_module(id);
 	if (!module) {
 		return OBS_MODULE_MISSING;

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -2258,7 +2258,7 @@ static obs_source_t *obs_load_source_type(obs_data_t *source_data, bool is_priva
 	if (!*v_id)
 		v_id = id;
 
-	if (strcmp(id, scene_info.id) == 0 || strcmp(id, group_info.id) == 0) {
+	if (obs_source_type_is_scene(id) || obs_source_type_is_group(id)) {
 		const char *canvas_uuid = obs_data_get_string(source_data, "canvas_uuid");
 		canvas = obs_get_canvas_by_uuid(canvas_uuid);
 		/* Fall back to main canvas if canvas cannot be found. */

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1710,6 +1710,7 @@ EXPORT bool obs_scene_reorder_items2(obs_scene_t *scene, struct obs_sceneitem_or
 				     size_t item_order_size);
 
 EXPORT bool obs_source_is_scene(const obs_source_t *source);
+EXPORT bool obs_source_type_is_scene(const char *id);
 
 /** Adds/creates a new scene item for a source */
 EXPORT obs_sceneitem_t *obs_scene_add(obs_scene_t *scene, obs_source_t *source);
@@ -1839,6 +1840,7 @@ EXPORT void obs_sceneitem_group_remove_item(obs_sceneitem_t *group, obs_sceneite
 EXPORT obs_sceneitem_t *obs_sceneitem_get_group(obs_scene_t *scene, obs_sceneitem_t *item);
 
 EXPORT bool obs_source_is_group(const obs_source_t *source);
+EXPORT bool obs_source_type_is_group(const char *id);
 EXPORT bool obs_scene_is_group(const obs_scene_t *scene);
 
 EXPORT void obs_sceneitem_group_enum_items(obs_sceneitem_t *group,


### PR DESCRIPTION
### Description
Fix scene and group load state

### Motivation and Context
Scenes and groups are now shown as missing/invalid sources in OBS
<img width="230" height="280" alt="image" src="https://github.com/user-attachments/assets/de254c44-5087-48ee-a135-f12850adaadf" />
scenes and groups are not loaded in a module

### How Has This Been Tested?
On windows looking at the sources dock with scenes and groups in it.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
