### PR TITLE
frontend: Change crash sentinel location to separate subdirectory

### DIFF
--- a/frontend/utility/CrashHandler.cpp
+++ b/frontend/utility/CrashHandler.cpp
@@ -33,8 +33,8 @@ using CrashLogUpdateResult = OBS::CrashHandler::CrashLogUpdateResult;
 
 namespace {
 
-constexpr std::string_view crashSentinelPath = "obs-studio";
-constexpr std::string_view crashSentinelPrefix = "crash_sentinel_";
+constexpr std::string_view crashSentinelPath = "obs-studio/.sentinel";
+constexpr std::string_view crashSentinelPrefix = "run_";
 constexpr std::string_view crashUploadURL = "https://obsproject.com/logs/upload";
 
 #ifndef NDEBUG
@@ -190,8 +190,14 @@ void CrashHandler::checkCrashState()
 	std::filesystem::path crashSentinelPath = crashSentinelFile_.parent_path();
 
 	if (!std::filesystem::exists(crashSentinelPath)) {
-		blog(LOG_ERROR, "Crash sentinel location '%s' does not exist", crashSentinelPath.u8string().c_str());
-		return;
+		try {
+			std::filesystem::create_directory(crashSentinelPath);
+		} catch (const std::filesystem::filesystem_error &error) {
+			blog(LOG_ERROR,
+			     "Crash sentinel location '%s' does not exist and unable to create directory:\n%s.",
+			     crashSentinelPath.u8string().c_str(), error.what());
+			return;
+		}
 	}
 
 	for (const auto &entry : std::filesystem::directory_iterator(crashSentinelPath)) {


### PR DESCRIPTION
### Description
Moves crash sentinel files into their own subdirectory inside the application configuration directory to ensure that clean-up operations will not encounter important user data.

### Motivation and Context
Putting the crash sentinel in the main "obs-studio" directory carries the risk of unwanted deletion of files in the same directory, which usually contains user configuration files like "user.ini" and "global.ini".

Even though the code will ignore any file that does not start with the crash sentinel prefix string, the code itself would allow changing the prefix to "global.ini" and thus inadvertently delete the global configuration file as well.

To further reduce the risk, this change will put the sentinels in a separate sub-directory that should only ever contain sentinel files, all of which can possibly deleted without any data loss for the user.

While the potential error case is hypothetical, application configuration data is important enough to err on the side of caution here.

### How Has This Been Tested?
Tested on macOS 15 with a clean run of OBS Studio and confirmed that the non-existing subdirectory is created on launch and the sentinel file placed, as well as removed on successful shutdown only. Also checked that any prior sentinels are correctly removed on a successful shutdown.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
