### PR TITLE
frontend: Fix plugin manager config loading crash

### DIFF
--- a/frontend/plugin-manager/PluginManager.cpp
+++ b/frontend/plugin-manager/PluginManager.cpp
@@ -94,7 +94,15 @@ void PluginManager::loadModules_()
 	auto modulesFile = getConfigFilePath_();
 	if (std::filesystem::exists(modulesFile)) {
 		std::ifstream jsonFile(modulesFile);
-		nlohmann::json data = nlohmann::json::parse(jsonFile);
+		nlohmann::json data;
+		try {
+			data = nlohmann::json::parse(jsonFile);
+		} catch (const nlohmann::json::parse_error &error) {
+			modules_.clear();
+			blog(LOG_ERROR, "Error loading modules config file: %s", error.what());
+			blog(LOG_ERROR, "Generating new config file.");
+			return;
+		}
 		modules_.clear();
 		for (auto it : data) {
 			ModuleInfo obsModule;


### PR DESCRIPTION
Issue found testing 32.0.0 Beta 1.  Current code isn't catching a parse error exception if an invalid config file is loaded by the plugin manager. This change wraps the plugin manager config json parse call with a try/catch, and handles invalid config files by creating a new config file, and logs an error that the existing config file is invalid.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Plugin manager initialization code has been modified to wrap the `nlohmann::json` parse function with a `try/catch` to catch any parsing errors that might occur if the plugin manager config file is corrupted or empty. If an invalid config file is found, a new default config file is created and used, and an error is logged to the OBS log.

### Motivation and Context
Currently, if the plugin manager config file is corrupted or empty, OBS will crash on load. This change fixes the crashing behavior and instead creates a new default config file.

### How Has This Been Tested?
This is quite a simple change.  It has been tested by manually editing the config file to invalid json when OBS is not running, then re-launching OBS, and seeing that a new config file is created, and the error is logged.  It has been tested using a windows build.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
