### PR TITLE
libobs,frontend: Plugin manager API cleanup, minor fixes

### DIFF
--- a/frontend/plugin-manager/PluginManager.cpp
+++ b/frontend/plugin-manager/PluginManager.cpp
@@ -191,7 +191,7 @@ void PluginManager::addModuleTypes_()
 	i = 0;
 	while (obs_enum_output_types(i, &output_id)) {
 		i += 1;
-		obs_module_t *obsModule = obs_source_get_module(output_id);
+		obs_module_t *obsModule = obs_output_get_module(output_id);
 		if (!obsModule) {
 			continue;
 		}
@@ -208,7 +208,7 @@ void PluginManager::addModuleTypes_()
 	i = 0;
 	while (obs_enum_encoder_types(i, &encoder_id)) {
 		i += 1;
-		obs_module_t *obsModule = obs_source_get_module(encoder_id);
+		obs_module_t *obsModule = obs_encoder_get_module(encoder_id);
 		if (!obsModule) {
 			continue;
 		}
@@ -225,7 +225,7 @@ void PluginManager::addModuleTypes_()
 	i = 0;
 	while (obs_enum_service_types(i, &service_id)) {
 		i += 1;
-		obs_module_t *obsModule = obs_source_get_module(service_id);
+		obs_module_t *obsModule = obs_service_get_module(service_id);
 		if (!obsModule) {
 			continue;
 		}

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -344,9 +344,6 @@ struct obs_encoder_info {
 
 	bool (*encode_texture2)(void *data, struct encoder_texture *texture, int64_t pts, uint64_t lock_key,
 				uint64_t *next_key, struct encoder_packet *packet, bool *received_packet);
-
-	/** Pointer to module that generated this encoder **/
-	obs_module_t *module;
 };
 
 EXPORT void obs_register_encoder_s(const struct obs_encoder_info *info, size_t size);

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -1116,6 +1116,11 @@ void obs_register_output_s(const struct obs_output_info *info, size_t size)
 		strlist_free(protocols);
 	}
 
+	if (loadingModule) {
+		char *output_id = bstrdup(info->id);
+		da_push_back(loadingModule->outputs, &output_id);
+	}
+
 	return;
 
 error:

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -990,7 +990,6 @@ void obs_register_source_s(const struct obs_source_info *info, size_t size)
 
 	/* NOTE: The assignment of data.module must occur before memcpy! */
 	if (loadingModule) {
-		data.module = loadingModule;
 		char *source_id = bstrdup(info->id);
 		da_push_back(loadingModule->sources, &source_id);
 	}

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -180,8 +180,8 @@ MODULE_EXPORT const char *obs_module_name(void);
 /** Optional: Returns a description of the module */
 MODULE_EXPORT const char *obs_module_description(void);
 
-/** Returns the module's unique ID, or null if it doesn't have one */
+/** Returns the module's unique ID, or NULL if it doesn't have one */
 MODULE_EXPORT const char *obs_get_module_id(obs_module_t *module);
 
-/** Returns the module's semver verison number or null if it doesn't have one */
+/** Returns the module's semver version number or NULL if it doesn't have one */
 MODULE_EXPORT const char *obs_get_module_version(obs_module_t *module);

--- a/libobs/obs-output.h
+++ b/libobs/obs-output.h
@@ -85,9 +85,6 @@ struct obs_output_info {
 
 	/* required if OBS_OUTPUT_SERVICE */
 	const char *protocols;
-
-	/* Pointer to module that generated this output */
-	obs_module_t *module;
 };
 
 EXPORT void obs_register_output_s(const struct obs_output_info *info, size_t size);

--- a/libobs/obs-service.h
+++ b/libobs/obs-service.h
@@ -104,9 +104,6 @@ struct obs_service_info {
 	const char *(*get_connect_info)(void *data, uint32_t type);
 
 	bool (*can_try_to_connect)(void *data);
-
-	/* Pointer to module that generated this service */
-	obs_module_t *module;
 };
 
 EXPORT void obs_register_service_s(const struct obs_service_info *info, size_t size);

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -551,9 +551,6 @@ struct obs_source_info {
 	 * @param  source  Source that the filter is being added to
 	 */
 	void (*filter_add)(void *data, obs_source_t *source);
-
-	/** Pointer to module that generated this source **/
-	obs_module_t *module;
 };
 
 EXPORT void obs_register_source_s(const struct obs_source_info *info, size_t size);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the `module` pointer from the `obs_*_info` structs, as it's unused (and was not even implemented for anything except `obs_source_info`). Generally `obs_*_info` are only* set by the caller of `obs_register_*`, not internally, so having the module there wouldn't make much sense (which is probably why another route was chosen, and this was just forgotten).
(* with the exception of `unversioned_id` for `obs_source_info`)

Sets the module for outputs that are registered, this seemed to have been forgotten.

Changes `obs_source_get_module` calls in the frontend to the calls that were probably intended originally.

cc @FiniteSingularity 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was looking at the [32.0 public API changes](https://github.com/obsproject/obs-studio/compare/31.1.2...gxalpha:obs-studio:32.0-api-change-review) and got confused by the `module` additions to `obs_*_info`, and then saw that it wasn't used anywhere. This should be removed before stable (as doing so afterwards would be an API break).
While addressing this, I noticed that for outputs the code where the output was added to the module was missing.
While then addressing that, I noticed the `obs_source_get_module` in places where they seemingly made no sense.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- First commit (`libobs: Remove unused obs_*_info module pointer`): Checked that it still compiled, and that there were no usages of this.
- Second commit (`libobs: Set module for outputs`): Tested that `obs_output_get_module("virtualcam_output")` previously returned `NULL`, and now returns the correct `obs_module_t *`.
- Third commit: I have no idea what that does or how to test it, but it was obviously wrong.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
