### PR TITLE
frontend: Remove unneeded argument from log upload privacy notice

### DIFF
--- a/frontend/dialogs/LogUploadDialog.cpp
+++ b/frontend/dialogs/LogUploadDialog.cpp
@@ -45,8 +45,7 @@ LogUploadDialog::LogUploadDialog(QWidget *parent, LogFileType uploadType)
 
 	ui->stackedWidget->setCurrentIndex(DialogPage::Start);
 
-	ui->privacyNotice->setText(
-		QTStr("LogUploadDialog.Labels.PrivacyNotice").arg(QTStr("LogUploadDialog.Buttons.ConfirmUpload")));
+	ui->privacyNotice->setText(QTStr("LogUploadDialog.Labels.PrivacyNotice"));
 
 	if (uploadType_ == LogFileType::CrashLog) {
 		ui->analyzeURL->hide();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes an unneeded `.arg` call on the log upload text.
The string doesn't have (or need) any arguments, the text put into the `.arg` call is in the button.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Wanted to upload a log and got a warning in the console:
```
warning: QString::arg: Argument missing: "Please read the <a href='https://obsproject.com/privacy-policy'>Privacy Policy</a> and its section regarding file uploads before uploading any files.", "Upload"
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Uploaded a log. Dialog still looks correct:
<img width="576" height="205" alt="image" src="https://github.com/user-attachments/assets/4174c7e1-b827-4216-a97a-b93743879b22" />

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
