### PR TITLE
obs-ffmpeg: Null-check url query parameters

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -863,8 +863,8 @@ static bool fetch_service_info(struct ffmpeg_output *stream, struct ffmpeg_cfg *
 	const char *p;
 	char buf[1024];
 	p = strchr(config->url, '?');
-	if (av_find_info_tag(buf, sizeof(buf), "payload_size", p) ||
-	    av_find_info_tag(buf, sizeof(buf), "pkt_size", p)) {
+	if (p && (av_find_info_tag(buf, sizeof(buf), "payload_size", p) ||
+		  av_find_info_tag(buf, sizeof(buf), "pkt_size", p))) {
 		config->srt_pkt_size = strtol(buf, NULL, 10);
 	}
 	return true;


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes a crash if someone streams to a URL that does not have any query parameters, e.g. `srt://127.0.0.1:9000` (or invalid URLs like `srt://asdfasdfasdfasdfasdf`).

Amends 55c4ca9e63379fb0629b424318e06dc8105b6874.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Crash reported on Discord: https://discord.com/channels/348973006581923840/1411186848528728146/1411300355387691111

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Successfully streamed to `srt://127.0.0.1:9000` without crashing. (to a media source listening to `srt://127.0.0.1:9000?mode=listener`).
Trying to stream to `srt://asdfasdfasdfasdfasdf` now shows the appropriate error message instead of crashing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
