### PR TITLE
Remove Linux soversion workarounds

### DIFF
--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -19,7 +19,6 @@ function(set_target_properties_obs target)
   endwhile()
 
   get_target_property(target_type ${target} TYPE)
-  set(OBS_SOVERSION 30)
 
   if(target_type STREQUAL EXECUTABLE)
     install(TARGETS ${target} RUNTIME DESTINATION "${OBS_EXECUTABLE_DESTINATION}" COMPONENT Runtime)
@@ -60,8 +59,8 @@ function(set_target_properties_obs target)
     set_target_properties(
       ${target}
       PROPERTIES
-        VERSION ${OBS_SOVERSION}
-        SOVERSION ${OBS_SOVERSION}
+        VERSION 30
+        SOVERSION 30
         BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
         INSTALL_RPATH "${OBS_LIBRARY_RPATH}"
     )
@@ -97,7 +96,7 @@ function(set_target_properties_obs target)
         POST_BUILD
         COMMAND
           "${CMAKE_COMMAND}" -E create_symlink
-          "$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.${OBS_SOVERSION}"
+          "$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.${OBS_VERSION_MAJOR}"
           "$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.0"
         COMMAND
           "${CMAKE_COMMAND}" -E copy_if_different
@@ -108,13 +107,13 @@ function(set_target_properties_obs target)
     endif()
   elseif(target_type STREQUAL MODULE_LIBRARY)
     if(target STREQUAL obs-browser)
-      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION ${OBS_SOVERSION})
+      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION 30)
     else()
       set_target_properties(
         ${target}
         PROPERTIES
           VERSION 0
-          SOVERSION ${OBS_SOVERSION}
+          SOVERSION 30
           BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
           INSTALL_RPATH "${OBS_MODULE_RPATH}"
       )

--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -59,8 +59,8 @@ function(set_target_properties_obs target)
     set_target_properties(
       ${target}
       PROPERTIES
-        VERSION 30
-        SOVERSION 30
+        VERSION ${OBS_VERSION_CANONICAL}
+        SOVERSION ${OBS_VERSION_MAJOR}
         BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
         INSTALL_RPATH "${OBS_LIBRARY_RPATH}"
     )
@@ -107,13 +107,13 @@ function(set_target_properties_obs target)
     endif()
   elseif(target_type STREQUAL MODULE_LIBRARY)
     if(target STREQUAL obs-browser)
-      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION 30)
+      set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION ${OBS_VERSION_MAJOR})
     else()
       set_target_properties(
         ${target}
         PROPERTIES
           VERSION 0
-          SOVERSION 30
+          SOVERSION ${OBS_VERSION_MAJOR}
           BUILD_RPATH "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
           INSTALL_RPATH "${OBS_MODULE_RPATH}"
       )

--- a/cmake/linux/helpers.cmake
+++ b/cmake/linux/helpers.cmake
@@ -84,27 +84,6 @@ function(set_target_properties_obs target)
       COMMENT "Copy ${target} to library directory (${OBS_LIBRARY_DESTINATION})"
       VERBATIM
     )
-
-    if(target STREQUAL libobs OR target STREQUAL obs-frontend-api)
-      install(
-        FILES "$<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.0"
-        DESTINATION "${OBS_LIBRARY_DESTINATION}"
-      )
-
-      add_custom_command(
-        TARGET ${target}
-        POST_BUILD
-        COMMAND
-          "${CMAKE_COMMAND}" -E create_symlink
-          "$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.${OBS_VERSION_MAJOR}"
-          "$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.0"
-        COMMAND
-          "${CMAKE_COMMAND}" -E copy_if_different
-          "$<TARGET_FILE_DIR:${target}>/$<TARGET_FILE_PREFIX:${target}>$<TARGET_FILE_BASE_NAME:${target}>.so.0"
-          "${OBS_OUTPUT_DIR}/$<CONFIG>/${OBS_LIBRARY_DESTINATION}"
-        COMMENT "Create symlink for legacy ${target}"
-      )
-    endif()
   elseif(target_type STREQUAL MODULE_LIBRARY)
     if(target STREQUAL obs-browser)
       set_target_properties(${target} PROPERTIES VERSION 0 SOVERSION ${OBS_VERSION_MAJOR})


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Never had time to make it for 32 (and I don't plan to push for it during the beta), so plan for 33.

This PR removes any tweak made to soversion to avoid ABI break on Linux before enforcing that major version do a break.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

We need to break on ABI break even if dlopen on Linux would find missing symbols and properly fail.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Untested, I need CI builds.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
