### PR TITLE
plugins: Ensure that graphics device type checks use graphics context

### DIFF
--- a/plugins/mac-avcapture/plugin-main.m
+++ b/plugins/mac-avcapture/plugin-main.m
@@ -35,11 +35,14 @@ static void *av_fast_capture_create(obs_data_t *settings, obs_source_t *source)
     capture_info->settings = settings;
     capture_info->source = source;
 
+    obs_enter_graphics();
     if (gs_get_device_type() == GS_DEVICE_OPENGL) {
         capture_info->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
     } else {
         capture_info->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
     }
+    obs_leave_graphics();
+
     capture_info->frameSize = CGRectZero;
 
     if (!capture_info->effect) {

--- a/plugins/mac-capture/mac-display-capture.m
+++ b/plugins/mac-capture/mac-display-capture.m
@@ -255,6 +255,8 @@ static void *display_capture_create(obs_data_t *settings, obs_source_t *source)
     dc->source = source;
     dc->hide_cursor = !obs_data_get_bool(settings, "show_cursor");
 
+    obs_enter_graphics();
+
     if (gs_get_device_type() == GS_DEVICE_OPENGL) {
         dc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
     } else {
@@ -263,8 +265,6 @@ static void *display_capture_create(obs_data_t *settings, obs_source_t *source)
 
     if (!dc->effect)
         goto fail;
-
-    obs_enter_graphics();
 
     struct gs_sampler_info info = {
         .filter = GS_FILTER_LINEAR,

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -291,11 +291,13 @@ API_AVAILABLE(macos(12.5)) static void *sck_video_capture_create(obs_data_t *set
     sc->capture_delegate = [[ScreenCaptureDelegate alloc] init];
     sc->capture_delegate.sc = sc;
 
+    obs_enter_graphics();
     if (gs_get_device_type() == GS_DEVICE_OPENGL) {
         sc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
     } else {
         sc->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
     }
+    obs_leave_graphics();
 
     if (!sc->effect)
         goto fail;
@@ -311,7 +313,6 @@ API_AVAILABLE(macos(12.5)) static void *sck_video_capture_create(obs_data_t *set
     return sc;
 
 fail:
-    obs_leave_graphics();
     sck_video_capture_destroy(sc);
     return NULL;
 }

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -312,13 +312,13 @@ static inline bool init_obs_graphics_objects(syphon_t s)
     obs_enter_graphics();
     s->sampler = gs_samplerstate_create(&info);
     s->vertbuffer = create_vertbuffer();
-    obs_leave_graphics();
 
     if (gs_get_device_type() == GS_DEVICE_OPENGL) {
         s->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT_RECT);
     } else {
         s->effect = obs_get_base_effect(OBS_EFFECT_DEFAULT);
     }
+    obs_leave_graphics();
 
     return s->sampler != NULL && s->vertbuffer != NULL && s->effect != NULL;
 }


### PR DESCRIPTION
### Description
Ensures that calls to `gs_get_device_type` take place after the current thread has acquired the graphics context.

### Motivation and Context
PR #12487 added explicit checks for the current renderer type in preparation for the Metal renderer. It was assumed that checking for a static value provided by a preprocessor `define` do not require the graphics context, the getter function does indeed require it.

Thus the checks (originally part of the Metal renderer PR) have been re-added as part of this PR.

### How Has This Been Tested?
Tested with OpenGL renderer on macOS. Affected source types like screen capture, video device capture, and display capture render as expected.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
