### PR TITLE
nv-filters: Guard function introduced in sdk >= 1.6.0

### DIFF
--- a/plugins/nv-filters/nvidia-audiofx-filter.c
+++ b/plugins/nv-filters/nvidia-audiofx-filter.c
@@ -130,10 +130,15 @@ static void nvidia_audio_destroy(void *data)
 {
 	struct nvidia_audio_data *ng = data;
 
+	if (!ng)
+		return;
+
 	if (ng->nvidia_sdk_dir_found)
 		pthread_mutex_lock(&ng->nvafx_mutex);
 
-	NvAFX_UninitializeLogger();
+	if (nvafx_new_sdk)
+		NvAFX_UninitializeLogger();
+
 	for (size_t i = 0; i < ng->channels; i++) {
 		if (ng->handle[0]) {
 			if (NvAFX_DestroyEffect) {


### PR DESCRIPTION
### Description
I forgot to guard NvAFX_UninitializeLogger() called in Destroy function.
This fixes a crash for people using an old sdk which does not have the function.

### Motivation and Context
Fixing a crash is good.
Such a crash was reported in Support and by @notr1ch 

### How Has This Been Tested?
Untested but the fix is obvious.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
