### PR TITLE
Remove Qt 5 module checks

### DIFF
--- a/libobs/CMakeLists.txt
+++ b/libobs/CMakeLists.txt
@@ -15,10 +15,6 @@ find_package(FFmpeg 6.1 REQUIRED avformat avutil swscale swresample OPTIONAL_COM
 find_package(ZLIB REQUIRED)
 find_package(Uthash REQUIRED)
 
-if(ENABLE_UI)
-  find_package(Qt6 REQUIRED Core)
-endif()
-
 find_package(jansson REQUIRED)
 if(NOT TARGET OBS::caption)
   add_subdirectory("${CMAKE_SOURCE_DIR}/deps/libcaption" "${CMAKE_BINARY_DIR}/deps/libcaption")

--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -442,7 +442,7 @@ void obs_add_disabled_module(const char *name)
 	da_push_back(obs->disabled_modules, &item);
 }
 
-extern void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load);
+extern void get_plugin_info(const char *path, bool *is_obs_plugin);
 
 struct fail_info {
 	struct dstr fail_modules;
@@ -497,9 +497,8 @@ static void load_all_callback(void *param, const struct obs_module_info2 *info)
 	obs_module_t *disabled_module;
 
 	bool is_obs_plugin;
-	bool can_load_obs_plugin;
 
-	get_plugin_info(info->bin_path, &is_obs_plugin, &can_load_obs_plugin);
+	get_plugin_info(info->bin_path, &is_obs_plugin);
 
 	if (!is_obs_plugin) {
 		blog(LOG_WARNING, "Skipping module '%s', not an OBS plugin", info->bin_path);
@@ -516,14 +515,6 @@ static void load_all_callback(void *param, const struct obs_module_info2 *info)
 		obs_create_disabled_module(&disabled_module, info->bin_path, info->data_path, OBS_MODULE_DISABLED);
 		blog(LOG_WARNING, "Skipping module '%s', is disabled", info->name);
 		return;
-	}
-
-	if (!can_load_obs_plugin) {
-		blog(LOG_WARNING,
-		     "Skipping module '%s' due to possible "
-		     "import conflicts",
-		     info->bin_path);
-		goto load_failure;
 	}
 
 	int code = obs_open_module(&module, info->bin_path, info->data_path);

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -16,7 +16,7 @@
 
 #include "obsconfig.h"
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && OBS_QT_VERSION == 6
 #define _GNU_SOURCE
 #include <link.h>
 #include <stdlib.h>
@@ -110,7 +110,7 @@ void os_dlclose(void *module)
 		dlclose(module);
 }
 
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && OBS_QT_VERSION == 6
 int module_has_qt5_check(const char *path)
 {
 	void *mod = dlopen(path, RTLD_LAZY);
@@ -151,7 +151,7 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 {
 	*is_obs_plugin = true;
 	*can_load = true;
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && OBS_QT_VERSION == 6
 	*can_load = !has_qt5_dependency(path);
 #endif
 	UNUSED_PARAMETER(path);

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -134,7 +134,6 @@ bool has_qt5_dependency(const char *path)
 {
 	pid_t pid = fork();
 	if (pid == 0) {
-		base_set_log_handler(NULL, NULL);
 		_exit(module_has_qt5_check(path));
 	}
 	if (pid < 0) {

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -14,14 +14,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#include "obsconfig.h"
-
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
-#define _GNU_SOURCE
-#include <link.h>
-#include <stdlib.h>
-#endif
-
 #include <stdio.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -36,6 +28,8 @@
 #include <time.h>
 #include <signal.h>
 #include <uuid/uuid.h>
+
+#include "obsconfig.h"
 
 #if !defined(__APPLE__)
 #include <sys/times.h>
@@ -110,50 +104,10 @@ void os_dlclose(void *module)
 		dlclose(module);
 }
 
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
-int module_has_qt5_check(const char *path)
-{
-	void *mod = dlopen(path, RTLD_LAZY);
-	if (mod == NULL) {
-		return 1;
-	}
-
-	struct link_map *list = NULL;
-	if (dlinfo(mod, RTLD_DI_LINKMAP, &list) == 0) {
-		for (struct link_map *ptr = list; ptr; ptr = ptr->l_next) {
-			if (strstr(ptr->l_name, "libQt5") != NULL) {
-				return 0;
-			}
-		}
-	}
-
-	return 1;
-}
-
-bool has_qt5_dependency(const char *path)
-{
-	pid_t pid = fork();
-	if (pid == 0) {
-		_exit(module_has_qt5_check(path));
-	}
-	if (pid < 0) {
-		return false;
-	}
-	int status;
-	if (waitpid(pid, &status, 0) < 0) {
-		return false;
-	}
-	return WIFEXITED(status) && WEXITSTATUS(status) == 0;
-}
-#endif
-
 void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 {
 	*is_obs_plugin = true;
 	*can_load = true;
-#if !defined(__APPLE__) && OBS_QT_VERSION == 6
-	*can_load = !has_qt5_dependency(path);
-#endif
 	UNUSED_PARAMETER(path);
 }
 

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -104,10 +104,9 @@ void os_dlclose(void *module)
 		dlclose(module);
 }
 
-void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
+void get_plugin_info(const char *path, bool *is_obs_plugin)
 {
 	*is_obs_plugin = true;
-	*can_load = true;
 	UNUSED_PARAMETER(path);
 }
 

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -27,7 +27,6 @@
 #include "platform.h"
 #include "darray.h"
 #include "dstr.h"
-#include "obsconfig.h"
 #include "util_uint64.h"
 #include "windows/win-registry.h"
 #include "windows/win-version.h"
@@ -134,65 +133,6 @@ void os_dlclose(void *module)
 	FreeLibrary(module);
 }
 
-#if OBS_QT_VERSION == 6
-static bool has_qt5_import(VOID *base, PIMAGE_NT_HEADERS nt_headers)
-{
-	__try {
-		PIMAGE_DATA_DIRECTORY data_dir;
-		data_dir = &nt_headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
-
-		if (data_dir->Size == 0)
-			return false;
-
-		PIMAGE_SECTION_HEADER section, last_section;
-		section = IMAGE_FIRST_SECTION(nt_headers);
-		last_section = section;
-
-		/* find the section that contains the export directory */
-		int i;
-		for (i = 0; i < nt_headers->FileHeader.NumberOfSections; i++) {
-			if (section->VirtualAddress <= data_dir->VirtualAddress) {
-				last_section = section;
-				section++;
-				continue;
-			} else {
-				break;
-			}
-		}
-
-		/* double check in case we exited early */
-		if (last_section->VirtualAddress > data_dir->VirtualAddress ||
-		    section->VirtualAddress <= data_dir->VirtualAddress)
-			return false;
-
-		section = last_section;
-
-		/* get a pointer to the import directory */
-		PIMAGE_IMPORT_DESCRIPTOR import;
-		import = (PIMAGE_IMPORT_DESCRIPTOR)((byte *)base + data_dir->VirtualAddress - section->VirtualAddress +
-						    section->PointerToRawData);
-
-		while (import->Name != 0) {
-			char *name = (char *)((byte *)base + import->Name - section->VirtualAddress +
-					      section->PointerToRawData);
-
-			/* qt5? bingo, reject this library */
-			if (astrcmpi_n(name, "qt5", 3) == 0) {
-				return true;
-			}
-
-			import++;
-		}
-
-	} __except (EXCEPTION_EXECUTE_HANDLER) {
-		/* we failed somehow, for compatibility assume no qt5 import */
-		return false;
-	}
-
-	return false;
-}
-#endif
-
 static bool has_obs_export(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 {
 	__try {
@@ -258,7 +198,7 @@ static bool has_obs_export(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 	return false;
 }
 
-void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
+void get_plugin_info(const char *path, bool *is_obs_plugin)
 {
 	struct dstr dll_name;
 	wchar_t *wpath;
@@ -271,7 +211,6 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 	PIMAGE_NT_HEADERS nt_headers;
 
 	*is_obs_plugin = false;
-	*can_load = false;
 
 	if (!path)
 		return;
@@ -314,19 +253,10 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 
 		*is_obs_plugin = has_obs_export(base, nt_headers);
 
-#if OBS_QT_VERSION == 6
-		if (*is_obs_plugin) {
-			*can_load = !has_qt5_import(base, nt_headers);
-		}
-#else
-		*can_load = true;
-#endif
-
 	} __except (EXCEPTION_EXECUTE_HANDLER) {
 		/* we failed somehow, for compatibility let's assume it
 		 * was a valid plugin and let the loader deal with it */
 		*is_obs_plugin = true;
-		*can_load = true;
 		goto cleanup;
 	}
 
@@ -344,11 +274,10 @@ cleanup:
 bool os_is_obs_plugin(const char *path)
 {
 	bool is_obs_plugin;
-	bool can_load;
 
-	get_plugin_info(path, &is_obs_plugin, &can_load);
+	get_plugin_info(path, &is_obs_plugin);
 
-	return is_obs_plugin && can_load;
+	return is_obs_plugin;
 }
 
 union time_data {

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -134,6 +134,7 @@ void os_dlclose(void *module)
 	FreeLibrary(module);
 }
 
+#if OBS_QT_VERSION == 6
 static bool has_qt5_import(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 {
 	__try {
@@ -190,6 +191,7 @@ static bool has_qt5_import(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 
 	return false;
 }
+#endif
 
 static bool has_obs_export(VOID *base, PIMAGE_NT_HEADERS nt_headers)
 {
@@ -312,9 +314,13 @@ void get_plugin_info(const char *path, bool *is_obs_plugin, bool *can_load)
 
 		*is_obs_plugin = has_obs_export(base, nt_headers);
 
+#if OBS_QT_VERSION == 6
 		if (*is_obs_plugin) {
 			*can_load = !has_qt5_import(base, nt_headers);
 		}
+#else
+		*can_load = true;
+#endif
 
 	} __except (EXCEPTION_EXECUTE_HANDLER) {
 		/* we failed somehow, for compatibility let's assume it


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Remove the Qt 5 module checks.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The Qt 5 module checks were added in OBS Studio 28 about three years ago to help smooth the transition from Qt 5 to Qt 6. These checks have served their purpose, and we had previously decided to remove them for OBS Studio 32, particularly because they slow down initialization.

Alternatively, we could split this to only handle the removal in `platform-nix` and deal with `platform-windows` separately, and/or we could do manual reverts instead of `git reverts`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

It compiled on my fork's CI:
https://github.com/RytoEX/obs-studio/actions/runs/17448529710

I haven't done any runtime tests.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
