### PR TITLE
frontend/api: Remove obs_frontend_get_global_config from internal code

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -419,13 +419,6 @@ config_t *OBSStudioAPI::obs_frontend_get_profile_config()
 	return main->activeConfiguration;
 }
 
-config_t *OBSStudioAPI::obs_frontend_get_global_config()
-{
-	blog(LOG_WARNING,
-	     "DEPRECATION: obs_frontend_get_global_config is deprecated. Read from global or user configuration explicitly instead.");
-	return App()->GetAppConfig();
-}
-
 config_t *OBSStudioAPI::obs_frontend_get_app_config()
 {
 	return App()->GetAppConfig();

--- a/frontend/OBSStudioAPI.hpp
+++ b/frontend/OBSStudioAPI.hpp
@@ -138,8 +138,6 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 
 	config_t *obs_frontend_get_profile_config(void) override;
 
-	config_t *obs_frontend_get_global_config(void) override;
-
 	config_t *obs_frontend_get_app_config(void) override;
 
 	config_t *obs_frontend_get_user_config(void) override;

--- a/frontend/api/obs-frontend-internal.hpp
+++ b/frontend/api/obs-frontend-internal.hpp
@@ -70,7 +70,6 @@ struct obs_frontend_callbacks {
 	virtual obs_output_t *obs_frontend_get_replay_buffer_output(void) = 0;
 
 	virtual config_t *obs_frontend_get_profile_config(void) = 0;
-	OBS_DEPRECATED virtual config_t *obs_frontend_get_global_config(void) = 0;
 
 	virtual config_t *obs_frontend_get_app_config(void) = 0;
 	virtual config_t *obs_frontend_get_user_config(void) = 0;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR removes `obs_frontend_callbacks::obs_frontend_get_global_config()`.

The structure `obs_frontend_callbacks` is for internal use only. Hence, we can remove the member function without considering the API compatibility.

Since the exported API `obs_frontend_get_global_config()` calls `obs_frontend_callbacks::obs_frontend_get_app_config()`, this member function was never called.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

RytoEX noticed this.
- https://github.com/obsproject/obs-studio/pull/12527#issuecomment-3255950750

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedora 41

Built and ran OBS Studio.
Check the message `DEPRECATION: obs_frontend_get_global_config is deprecated.  Use obs_frontend_get_app_config or ...` is displayed in the log, which ensure `obs_frontend_get_global_config()` is still called from obs-websocket plugin.

Also confirmed obs-websocket configuration is same as previous (the websocket server is enabled, where the default is disabled).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
