### PR TITLE
frontend: Change renderer combo box to use custom data

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1089,7 +1089,7 @@ const char *OBSApp::GetRenderModule() const
 #elif defined(__APPLE__) && defined(__aarch64__)
 	const char *renderer = config_get_string(appConfig, "Video", "Renderer");
 
-	return (astrcmpi(renderer, "Metal (Experimental)") == 0) ? DL_METAL : DL_OPENGL;
+	return (astrcmpi(renderer, "Metal") == 0) ? DL_METAL : DL_OPENGL;
 #else
 	return DL_OPENGL;
 #endif

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -1396,15 +1396,15 @@ void OBSBasicSettings::LoadRendererList()
 #if defined(_WIN32) || (defined(__APPLE__) && defined(__aarch64__))
 	const char *renderer = config_get_string(App()->GetAppConfig(), "Video", "Renderer");
 #ifdef _WIN32
-	ui->renderer->addItem(QT_UTF8("Direct3D 11"));
+	ui->renderer->addItem(QString("Direct3D 11"), QString("Direct3D 11"));
 	if (opt_allow_opengl || strcmp(renderer, "OpenGL") == 0) {
-		ui->renderer->addItem(QT_UTF8("OpenGL"));
+		ui->renderer->addItem(QString("OpenGL"), QString("OpenGL"));
 	}
 #else
-	ui->renderer->addItem(QT_UTF8("OpenGL"));
-	ui->renderer->addItem(QT_UTF8("Metal (Experimental)"));
+	ui->renderer->addItem(QString("OpenGL"), QString("OpenGL"));
+	ui->renderer->addItem(QString("Metal (Experimental)"), QString("Metal"));
 #endif
-	int index = ui->renderer->findText(QT_UTF8(renderer));
+	int index = ui->renderer->findData(QString(renderer));
 	if (index == -1) {
 		index = 0;
 	}
@@ -3146,7 +3146,8 @@ void OBSBasicSettings::SaveAdvancedSettings()
 
 #if defined(_WIN32) || (defined(__APPLE__) && defined(__aarch64__))
 	if (WidgetChanged(ui->renderer)) {
-		config_set_string(App()->GetAppConfig(), "Video", "Renderer", QT_TO_UTF8(ui->renderer->currentText()));
+		config_set_string(App()->GetAppConfig(), "Video", "Renderer",
+				  QT_TO_UTF8(ui->renderer->currentData().toString()));
 	}
 #endif
 


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes the combo box for the renderer selection to use custom data. There, we can store just "Metal" and save that to the config.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Storing the "Experimental" tag in the config would mean that once the tag is removed, anyone who previously had it selected would have it unselected.
Presumably the people who have the Metal renderer selected while it's experimental would also be the people who would want it once it's stable.

I actually noticed this when scrolling through the Metal PR a while back, but forgot to comment on it. Sorry about that.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
macOS 26
App config file (`global.ini`) now contains
```
[Video]
Renderer=Metal
```
while the UI still shows "Metal (Experimental)".

Switching back and forth between Metal and OpenGL still selects the correct renderer.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
