### PR TITLE
docs: Fix Rendering Graphics documentation

### DIFF
--- a/docs/sphinx/graphics.rst
+++ b/docs/sphinx/graphics.rst
@@ -265,8 +265,8 @@ would be used:
    uniform texture2d image;
 
    struct VertInOut {
-           float4 my_position : POSITION;
-           float2 my_texcoord : TEXCOORD0;
+           float4 pos : POSITION;
+           float2 uv : TEXCOORD0;
    };
 
    VertInOut MyVertexShaderFunc(VertInOut vert_in)


### PR DESCRIPTION
### Description
Fixed variable naming inconsistency in an example given in the Rendering Graphics documentation.

### Motivation and Context
The correct use of semantics prevents confusion about possible hidden mechanisms.

### How Has This Been Tested?
Referred to the specification of HLSL concerning Types and references to undeclared members. (3.1.3-6 of the HLSL spec: https://microsoft.github.io/hlsl-specs/specs/hlsl.pdf)

### Types of changes
Documentation

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
