### PR TITLE
libobs/util: Fix memory leak at failure condition

### DIFF
--- a/libobs/util/buffered-file-serializer.c
+++ b/libobs/util/buffered-file-serializer.c
@@ -333,8 +333,11 @@ bool buffered_file_serializer_init(struct serializer *s, const char *path, size_
 	dstr_init_copy(&out->filename, path);
 
 	out->io.output_file = os_fopen(path, "wb");
-	if (!out->io.output_file)
+	if (!out->io.output_file) {
+		dstr_free(&out->filename);
+		bfree(out);
 		return false;
+	}
 
 	out->io.buffer_size = max_bufsize ? max_bufsize : DEFAULT_BUF_SIZE;
 	out->io.chunk_size = chunk_size ? chunk_size : DEFAULT_CHUNK_SIZE;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix a memory leak on `buffered_file_serializer_init` when the file cannot be opened.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I'm playing with GCC analyzer with applying `malloc` attribute to `bmalloc`. Then, the analyzer found the memory leak.

Note: The analyzer shows too many false errors. I haven't checked all the errors yet. I don't assure there are no more errors.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

OS: Fedor 41

1. Create the directory `/dev/shm/a`.
2. Set MP4 output
3. Set the output file directory to a directory `/dev/shm/a`.
5. Remove access permission to the directory `chmod -x /dev/shm/a`.
6. Start and stop recording. --> Expected error.
7. Exit OBS Studio

With this modification, there is no memory leak.

Without this modification, there are 2 memory leaks.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
