### PR TITLE
rtmp-services: Add Streamrun

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 275,
+    "version": 276,
     "files": [
         {
             "name": "services.json",
-            "version": 275
+            "version": 276
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3498,6 +3498,27 @@
                 "keyint": 1,
                 "max video bitrate": 6000
             }
+        },
+        {
+            "name": "Streamrun",
+            "common": false,
+            "more_info_link": "https://streamrun.com",
+            "stream_key_link": "https://streamrun.com/apps",
+            "servers": [
+                {
+                    "name": "Automatic",
+                    "url": "rtmp://ingest.streamrun.io"
+                }
+            ],
+            "supported video codecs": [
+                "h264",
+                "hevc",
+                "av1"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 20000
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Added Streamrun as a streaming service option and incremented the package.json versions.

### Motivation and Context
Helps Streamrun users set up OBS more easily and with fewer mistakes.

### How Has This Been Tested?
Tested locally on macOS 14.6.1 with the latest version of OBS.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.