### PR TITLE
frontend: Make sure all scene item properties are copied

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -112,6 +112,14 @@ struct SourceCopyInfo {
 	obs_transform_info transform;
 	obs_blending_method blend_method;
 	obs_blending_type blend_mode;
+	obs_scale_type scale_type;
+	const char *show_transition_id;
+	const char *hide_transition_id;
+	OBSData show_transition_settings;
+	OBSData hide_transition_settings;
+	uint32_t show_transition_duration;
+	uint32_t hide_transition_duration;
+	OBSData private_settings;
 };
 
 struct OBSProfile {

--- a/frontend/widgets/OBSBasic_Clipboard.cpp
+++ b/frontend/widgets/OBSBasic_Clipboard.cpp
@@ -83,6 +83,27 @@ void OBSBasic::on_actionCopySource_triggered()
 		copyInfo.blend_method = obs_sceneitem_get_blending_method(item);
 		copyInfo.blend_mode = obs_sceneitem_get_blending_mode(item);
 		copyInfo.visible = obs_sceneitem_visible(item);
+		copyInfo.scale_type = obs_sceneitem_get_scale_filter(item);
+		copyInfo.show_transition_id = obs_source_get_id(obs_sceneitem_get_transition(item, true));
+		copyInfo.hide_transition_id = obs_source_get_id(obs_sceneitem_get_transition(item, false));
+
+		OBSDataAutoRelease newShowData = obs_data_create();
+		OBSDataAutoRelease oldShowData = obs_source_get_settings(obs_sceneitem_get_transition(item, true));
+		obs_data_apply(newShowData, oldShowData);
+		copyInfo.show_transition_settings = newShowData.Get();
+
+		OBSDataAutoRelease newHideData = obs_data_create();
+		OBSDataAutoRelease oldHideData = obs_source_get_settings(obs_sceneitem_get_transition(item, false));
+		obs_data_apply(newHideData, oldHideData);
+		copyInfo.hide_transition_settings = newHideData.Get();
+
+		copyInfo.show_transition_duration = obs_sceneitem_get_transition_duration(item, true);
+		copyInfo.hide_transition_duration = obs_sceneitem_get_transition_duration(item, false);
+
+		OBSDataAutoRelease newPrivData = obs_data_create();
+		OBSDataAutoRelease oldPrivData = obs_sceneitem_get_private_settings(item);
+		obs_data_apply(newPrivData, oldPrivData);
+		copyInfo.private_settings = newPrivData.Get();
 
 		clipboard.push_back(copyInfo);
 	}
@@ -114,6 +135,7 @@ void OBSBasic::on_actionPasteRef_triggered()
 		}
 
 		OBSBasicSourceSelect::SourcePaste(copyInfo, false);
+		RefreshSources(scene);
 	}
 
 	undo_s.pop_disabled();
@@ -135,6 +157,7 @@ void OBSBasic::on_actionPasteDup_triggered()
 	for (size_t i = clipboard.size(); i > 0; i--) {
 		SourceCopyInfo &copyInfo = clipboard[i - 1];
 		OBSBasicSourceSelect::SourcePaste(copyInfo, true);
+		RefreshSources(GetCurrentScene());
 	}
 
 	undo_s.pop_disabled();


### PR DESCRIPTION
### Description
Scale filtering, show/hide transitions and private settings (item color) were not copied when copying scene items.

### Motivation and Context
Idea from @Warchamp7 

### How Has This Been Tested?
Copied sources and made sure all properties were copied

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
