### PR TITLE
frontend: Add more source undo/redo actions

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -362,6 +362,11 @@ Undo.MoveToBottom="Move '%1' to bottom in '%2'"
 Undo.PasteSource="Paste Source(s) in '%1'"
 Undo.PasteSourceRef="Paste Source Reference(s) in '%1'"
 Undo.GroupItems="Group Items into '%1'"
+Undo.ScaleFiltering="Scale Filtering on '%1' in '%2'"
+Undo.BlendingMode="Blending Mode on '%1' in '%2'"
+Undo.BlendingMethod="Blending Method on '%1' in '%2'"
+Undo.DeinterlacingMode="Deinterlacing Mode on '%1'"
+Undo.DeinterlacingOrder="Deinterlacing Field Order on '%1'"
 
 # transition name dialog
 TransitionNameDlg.Text="Please enter the name of the transition"


### PR DESCRIPTION
### Description
This adds undo/redo actions for scale filtering, blending mode, blending method, deinterlacing mode and deinterlacing field order.

### Motivation and Context
Suggestion from @Warchamp7 

### How Has This Been Tested?
Used undo/redo for these actions and made sure that they worked properly.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
