### PR TITLE
frontend: Prevent setting transition during transitions

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1852,6 +1852,12 @@ Transitions
 
 ---------------------
 
+.. function:: void obs_is_transition_active(obs_source_t *transition)
+
+   :return: *true* if the transition is currently transitioning, *false* otherwise.
+
+---------------------
+
 .. function:: void obs_transition_set_size(obs_source_t *transition, uint32_t cx, uint32_t cy)
               void obs_transition_get_size(const obs_source_t *transition, uint32_t *cx, uint32_t *cy)
 

--- a/frontend/widgets/OBSBasic_StudioMode.cpp
+++ b/frontend/widgets/OBSBasic_StudioMode.cpp
@@ -235,6 +235,8 @@ void OBSBasic::SetPreviewProgramMode(bool enabled)
 		ui->previewLayout->addWidget(programWidget);
 		ui->previewLayout->setAlignment(programOptions, Qt::AlignCenter);
 
+		ui->transitions->setEnabled(true);
+
 		OnEvent(OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED);
 
 		blog(LOG_INFO, "Switched to Preview/Program mode");

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -387,6 +387,10 @@ void OBSBasic::SetTransition(OBSSource transition)
 {
 	OBSSourceAutoRelease oldTransition = obs_get_output_source(0);
 
+	if (oldTransition && obs_is_transition_active(oldTransition)) {
+		return;
+	}
+
 	if (oldTransition && transition) {
 		std::string uuid = obs_source_get_uuid(transition);
 		obs_transition_swap_begin(transition, oldTransition);

--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -319,6 +319,11 @@ static inline bool transition_active(obs_source_t *transition)
 	return transition->transitioning_audio || transition->transitioning_video;
 }
 
+bool obs_is_transition_active(obs_source_t *transition)
+{
+	return transition_active(transition);
+}
+
 bool obs_transition_start(obs_source_t *transition, enum obs_transition_mode mode, uint32_t duration_ms,
 			  obs_source_t *dest)
 {

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1604,6 +1604,8 @@ EXPORT uint32_t obs_transition_get_alignment(const obs_source_t *transition);
 EXPORT void obs_transition_set_size(obs_source_t *transition, uint32_t cx, uint32_t cy);
 EXPORT void obs_transition_get_size(const obs_source_t *transition, uint32_t *cx, uint32_t *cy);
 
+EXPORT bool obs_is_transition_active(obs_source_t *transition);
+
 /* function used by transitions */
 
 /**


### PR DESCRIPTION
### Description
Adds `obs_is_transition_active` to libobs and uses it in the frontend to prevent calling SetTransition during an active transition.

### Motivation and Context
SetTransition updates the current transition source and effectively resets it back to the start. If this is called **during** a transition, it effectively interrupts it. As a result, the `transition_stop` signal never fires, since the transition that was running never actually ended.

Normally the UI dropdown itself is disabled and this cannot be done via the application window itself. However, it is possible via OBS Websockets using `SetCurrentSceneTransition`. That request calls `obs_frontend_set_current_transition` which then invokes  `OBSBasic::SetTransition`.

### How Has This Been Tested?
I used a simple OBS Websocket script that calls `SetCurrentSceneTransition`, `TriggerStudioModeTransition`, `SetCurrentSceneTransition` in succession 100ms apart.

Without these changes, the transition controls get stuck as the transition never fires the ended event.

<img width="337" height="543" alt="image" src="https://github.com/user-attachments/assets/c50a65f9-40be-4d33-8fdc-6a7d3e27e810" />


### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
