### PR TITLE
frontend: Use system locale with UTF-8 instead of 'C' 

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -282,7 +282,7 @@ string CurrentDateTimeString()
 	struct tm tstruct;
 	char buf[80];
 	tstruct = *localtime(&now);
-	strftime(buf, sizeof(buf), "%Y-%m-%d, %X", &tstruct);
+	strftime(buf, sizeof(buf), "%Y-%m-%d, %H:%M:%S", &tstruct);
 	return buf;
 }
 

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -724,11 +724,6 @@ bool OBSApp::InitLocale()
 
 	locale = lang;
 
-	// set basic default application locale
-	if (!locale.empty()) {
-		QLocale::setDefault(QLocale(QString::fromStdString(locale).replace('-', '_')));
-	}
-
 	string englishPath;
 	if (!GetDataFilePath("locale/" DEFAULT_LANG ".ini", englishPath)) {
 		OBSErrorBox(NULL, "Failed to find locale/" DEFAULT_LANG ".ini");
@@ -767,11 +762,6 @@ bool OBSApp::InitLocale()
 
 			blog(LOG_INFO, "Using preferred locale '%s'", locale_.c_str());
 			locale = locale_;
-
-			// set application default locale to the new chosen one
-			if (!locale.empty()) {
-				QLocale::setDefault(QLocale(QString::fromStdString(locale).replace('-', '_')));
-			}
 
 			return true;
 		}
@@ -913,13 +903,6 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 	  appLaunchUUID_(QUuid::createUuid())
 {
 	installNativeEventFilter(new OBS::NativeEventFilter);
-
-	/* fix float handling */
-#if defined(Q_OS_UNIX)
-	if (!setlocale(LC_NUMERIC, "C")) {
-		blog(LOG_WARNING, "Failed to set LC_NUMERIC to C locale");
-	}
-#endif
 
 #ifndef _WIN32
 	// Add POSIX signal handlers:

--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -384,7 +384,7 @@ static vector<OBSThemeVariable> ParseThemeVariables(const char *themeData)
 
 			/* Look for a suffix and mark variable as size if it exists */
 			while (ch < end) {
-				if (!isdigit(*ch) && !isspace(*ch) && *ch != '.') {
+				if (!isdigit((unsigned char)*ch) && !isspace((unsigned char)*ch) && *ch != '.') {
 					var.suffix = QString::fromUtf8(ch, end - ch);
 					var.type = OBSThemeVariable::Size;
 					break;
@@ -581,14 +581,14 @@ static OBSThemeVariable ParseMathVariable(const QHash<QString, OBSThemeVariable>
 	const QByteArray utf8 = value.toUtf8();
 	const char *data = utf8.constData();
 
-	if (isdigit(*data)) {
+	if (isdigit((unsigned char)*data)) {
 		double f = os_strtod(data);
 		var.type = OBSThemeVariable::Number;
 		var.value = f;
 
 		const char *dataEnd = data + utf8.size();
 		while (data < dataEnd) {
-			if (*data && !isdigit(*data) && *data != '.') {
+			if (*data && !isdigit((unsigned char)*data) && *data != '.') {
 				var.suffix = QString::fromUtf8(data, dataEnd - data);
 				var.type = OBSThemeVariable::Size;
 				break;

--- a/frontend/cmake/windows/obs.manifest
+++ b/frontend/cmake/windows/obs.manifest
@@ -11,6 +11,11 @@
             </requestedPrivileges>
         </security>
     </trustInfo>
+    <application>
+	<windowsSettings>
+	    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+        </windowsSettings>
+    </application>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>
             <!-- Windows 10 and Windows 11 -->

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -45,6 +45,7 @@
 #include <shellapi.h>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <mbctype.h>
 #else
 #include <signal.h>
 #endif
@@ -77,6 +78,7 @@ bool opt_disable_missing_files_check = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
+bool using_utf8 = false;
 
 bool restart = false;
 bool restart_safe = false;
@@ -416,6 +418,42 @@ static void create_log_file(fstream &logFile)
 	}
 }
 
+static bool set_utf8_locale(void)
+{
+	// Use system locale with UTF-8 codepage (available from Windows 10 version 1803)
+	bool usingUTF8 = !!setlocale(LC_ALL, ".UTF-8");
+
+	/*
+	Fallback to minimal C locale
+	Could use "" for system defaults, but the Windows default ANSI codepages (such as .125x or .9xx)
+	mismatch with UTF-8 that is assumed by many parts of the codebase. "C" only covers ASCII, so no mismatches.
+	*/
+	usingUTF8 = usingUTF8 || !!setlocale(LC_ALL, "C.UTF-8");
+
+#ifdef _WIN32
+	usingUTF8 = usingUTF8 && (_setmbcp(CP_UTF8) == 0);
+#endif
+	if (!usingUTF8) {
+		setlocale(LC_ALL, "C");
+	}
+
+	// fix float handling
+	setlocale(LC_NUMERIC, "C");
+
+	// Copy C runtime locale for C++
+	std::locale defaultLocale(setlocale(LC_ALL, nullptr));
+	std::locale::global(defaultLocale);
+
+	/*
+	system() is already the QLocale default, but just to be explicit about the intention.
+	Unlike CRT and C++ locales above, QLocale doesn't support customization of locale categories and codepages.
+	Ie. We can't enforce decimal point to be a dot and at the same time use user's preferred locale.
+	*/
+	QLocale::setDefault(QLocale::system());
+
+	return usingUTF8;
+}
+
 static auto ProfilerNameStoreRelease = [](profiler_name_store_t *store) {
 	profiler_name_store_free(store);
 };
@@ -533,6 +571,12 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 	qputenv("QT_NO_SUBTRACTOPAQUESIBLINGS", "1");
 
 	OBSApp program(argc, argv, profilerNameStore.get());
+
+#if defined(Q_OS_UNIX)
+	// OBSApp (QApplication) constructor overwrote the locale for unix, so set it again
+	set_utf8_locale();
+#endif
+
 	try {
 		QAccessible::installFactory(accessibleFactory);
 		QFontDatabase::addApplicationFont(":/fonts/OpenSans-Regular.ttf");
@@ -682,6 +726,15 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 			}
 			blog(LOG_INFO, "Command Line Arguments: %s", stor.str().c_str());
 		}
+
+		if (!using_utf8) {
+			blog(LOG_DEBUG, "UTF-8 locale is not available on this OS version. "
+					"Skipping regional formatting and sorting.");
+		}
+
+		// Use collation (sorting rules) as indicator of regional settings
+		blog(LOG_DEBUG, "Locale: %s", setlocale(LC_COLLATE, nullptr));
+		blog(LOG_DEBUG, "App language: %s", program.GetLocale());
 
 		if (!program.OBSInit()) {
 			return 0;
@@ -903,6 +956,7 @@ static void set_process_mitigation_policies()
 
 int main(int argc, char *argv[])
 {
+	using_utf8 = set_utf8_locale();
 #ifndef _WIN32
 	using SignalHandlerCallback = decltype(OBSApp::sigIntSignalHandler);
 

--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -245,7 +245,7 @@ static inline void write_header(struct exception_handler_data *data)
 	time_t now = time(0);
 	struct tm ts;
 	ts = *localtime(&now);
-	strftime(date_time, sizeof(date_time), "%Y-%m-%d, %X", &ts);
+	strftime(date_time, sizeof(date_time), "%Y-%m-%d, %H:%M:%S", &ts);
 
 	const char *obs_bitness;
 	if (sizeof(void *) == 8)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -382,8 +382,11 @@ EXPORT const char *obs_get_version_string(void);
  * and safely copies argv/argc from main(). Subsequent calls do nothing.
  *
  * @param  argc  The count of command line arguments, from main()
- * @param  argv  An array of command line arguments, copied from main() and ends
+ * @param  argv  An array of command line arguments in UTF-8, copied from main() and ends
  *               with NULL.
+ * 
+ *		 On Windows this requires that active code page is UTF-8.
+ *		 For example as a declaration in obs.manifest.
  */
 EXPORT void obs_set_cmdline_args(int argc, const char *const *argv);
 

--- a/libobs/util/cf-lexer.c
+++ b/libobs/util/cf-lexer.c
@@ -71,7 +71,7 @@ static inline void cf_convert_from_escape_literal(char **p_dst, const char **p_s
 
 	/* oct */
 	default:
-		if (isdigit(*src)) {
+		if (isdigit((unsigned char)*src)) {
 			*(dst++) = (char)strtoul(src, NULL, 8);
 			src += 3;
 		}

--- a/libobs/util/dstr.c
+++ b/libobs/util/dstr.c
@@ -43,8 +43,8 @@ int astrcmpi(const char *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1 = (char)toupper(*str1);
-		char ch2 = (char)toupper(*str2);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*str1);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;
@@ -85,8 +85,8 @@ int astrcmp_n(const char *str1, const char *str2, size_t n)
 		str2 = astrblank;
 
 	do {
-		char ch1 = *str1;
-		char ch2 = *str2;
+		unsigned char ch1 = (unsigned char)*str1;
+		unsigned char ch2 = (unsigned char)*str2;
 
 		if (ch1 < ch2)
 			return -1;
@@ -129,8 +129,8 @@ int astrcmpi_n(const char *str1, const char *str2, size_t n)
 		str2 = astrblank;
 
 	do {
-		char ch1 = (char)toupper(*str1);
-		char ch2 = (char)toupper(*str2);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*str1);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;

--- a/libobs/util/lexer.c
+++ b/libobs/util/lexer.c
@@ -29,7 +29,8 @@ int strref_cmp(const struct strref *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
 		ch1 = (i < str1->len) ? str1->array[i] : 0;
 		ch2 = *str2;
@@ -53,10 +54,11 @@ int strref_cmpi(const struct strref *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
-		ch1 = (i < str1->len) ? (char)toupper(str1->array[i]) : 0;
-		ch2 = (char)toupper(*str2);
+		ch1 = (i < str1->len) ? (unsigned char)toupper((unsigned char)str1->array[i]) : 0;
+		ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;
@@ -77,7 +79,8 @@ int strref_cmp_strref(const struct strref *str1, const struct strref *str2)
 		return -1;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
 		ch1 = (i < str1->len) ? str1->array[i] : 0;
 		ch2 = (i < str2->len) ? str2->array[i] : 0;
@@ -103,10 +106,11 @@ int strref_cmpi_strref(const struct strref *str1, const struct strref *str2)
 		return -1;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
-		ch1 = (i < str1->len) ? (char)toupper(str1->array[i]) : 0;
-		ch2 = (i < str2->len) ? (char)toupper(str2->array[i]) : 0;
+		ch1 = (i < str1->len) ? (unsigned char)toupper((unsigned char)str1->array[i]) : 0;
+		ch2 = (i < str2->len) ? (unsigned char)toupper((unsigned char)str2->array[i]) : 0;
 
 		if (ch1 < ch2)
 			return -1;

--- a/plugins/text-freetype2/find-font.c
+++ b/plugins/text-freetype2/find-font.c
@@ -333,8 +333,8 @@ static inline size_t get_rating(struct font_path_info *info, struct dstr *cmp)
 	size_t num = 0;
 
 	do {
-		char ch1 = (char)toupper(*src);
-		char ch2 = (char)toupper(*dst);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*src);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*dst);
 
 		if (ch1 != ch2)
 			break;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

The changes here are based on PR #13097 that was split from this issue and does some preliminary work to support changes introduced here.

- Sets C runtime locale to system locale with UTF-8 codepage on Windows.
This has always been [default behavior on unix](https://github.com/qt/qtbase/blob/dev/src/corelib/kernel/qcoreapplication.cpp#L569), but Windows defaults to minimal 'C' locale.
  - `LC_NUMERIC` is still set to `"C"`. Now on all platforms instead of just unix. 
This is so decimal point is a dot (not a comma) for string <-> float conversions.

- The configured CRT locale is copied to be the default `std::locale` for C++. 
All platforms have been using minimal `"C"` until now. This change affects new `facet` and `ios_base` instances without a specified locale or `imbue()` call.

- OBS Studio language setting no longer changes `QLocale`'s default locale and instead always uses system locale.
This gives conformity with non Qt functions, but most importantly is likely what user wants as well. Ie. sorting and formatting functions should follow OS locale rules instead of OBS Studio translations language. (Reverts c4840ddba05a8c2d01568445645097704595ea47)

- `obs_get_locale()` still returns OBS language locale, which is used for Python and LUA apis, GDI+ text widget transformations, and HTTP accepted languages header. 

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context

Locale-aware operations like sorting and time formatting in C are not available on Windows, but are on unix, as pointed out in PR #12577. 
Fixes #11133, fixes #12953

The C++ locale and QLocale changes make the locale-aware functions of all layers work in similiar fashion. 

For example: On unix currently the used locales are: OS locale for CRT, minimal `"C"` for C++ and OBS language for QLocale.
A weekday name can be in three different languages depending if you used `strftime()`, `std::time_get` facet or `QLocale`.
This makes string transformations between C, C++ and Qt very tricky.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?

An important point is that the CRT locale settings introduced here have always been this way for unix, which suggests there aren't any insurmountable problems with the new locales. Windows specific functions should be tested for CRT locale. Changes for C++ and QLocale defaults affect all platforms.

Searched the codebase for affected areas and addressed as necessary:
- [x] CRT:  [_ctype.h_](https://en.cppreference.com/w/c/header/ctype.html) character classification function parameters and expected return values
- [x] CRT: `strftime()` formatting with `%` placeholders
- [x] CRT: `scanf()` and `printf()` formatting with `%` placeholders
- [x] CRT: `FILE` operations
- [x] C++: `fstream` operations
- [x] C++: `facet` locale usage
- [x] QLocale: Expected return values of formatting functions
- [x] QLocale: `QString` locale-aware methods


Some general testing with Japanese characters
- Edited recording path with %A (weekday) variable and some Japanese characters. Recorded a video. Weekday name was localized and recording worked fine.
- Remuxed said file. Worked fine.
- Renamed some sources with Japanese characters and exported the scene collection, removed it from OBS and re-imported it. No problems.
- Wrote names of those sources to logFile with blog()


I'm on Windows 11 English US version, but with Finnish locale settings (fi_FI). OBS language is English.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!-- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
  -  3rd party Python, LUA and rtmp that have been using `_mbs_` conversion functions directly or via file io operations have to input text in utf-8 and expect utf-8 output (except for `wchar`/`_wcs_` which is OS defined). 

<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
