### PR TITLE
frontend: Remove help text for shutdown check

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -991,7 +991,6 @@ int main(int argc, char *argv[])
 				"--multi, -m: Don't warn when launching multiple instances.\n\n"
 				"--safe-mode: Run in Safe Mode (disables third-party plugins, scripting, and WebSockets).\n"
 				"--only-bundled-plugins: Only load included (first-party) plugins\n"
-				"--disable-shutdown-check: Disable unclean shutdown detection.\n"
 				"--verbose: Make log more verbose.\n"
 				"--always-on-top: Start in 'always on top' mode.\n\n"
 				"--unfiltered_log: Make log unfiltered.\n\n"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Removes the text from the help flag showing the shutdown check disable option which no longer exists.

### Motivation and Context
Cleanup for function that was removed.

### How Has This Been Tested?
👁️ 👁️ help flag no longer showed the text

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
