### PR TITLE
libobs: Raise out of memory exception manually when out of memory

### DIFF
--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -1194,7 +1194,11 @@ void os_breakpoint(void)
 
 void os_oom(void)
 {
+#ifdef DEBUG
 	__debugbreak();
+#else
+	RaiseException(ERROR_OUTOFMEMORY, EXCEPTION_NONCONTINUABLE, 0, NULL);
+#endif
 }
 
 DWORD num_logical_cores(ULONG_PTR mask)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Make `os_oom()` specifically raise an out of memory exception instead of just calling `_debugbreak()`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The previous attempt to clarify an out of memory exception/crash resulted in the compiler optimizing os_breakpoint() and os_oom() into the same result, which meant that crash stacks in the wild were still not specific enough to be helpful. Forcefully differentiating the functions in Release configuration by having os_breakpoint() only call __debugbreak() and having os_oom() call RaiseException() should give us clearer crash stacks.

Amends 94a736f1795c21afd0baa10c0692543b70c17dc5.

Want clearer crash stacks to differentiate memory allocation failures.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally. The crash stack still seems to optimize out in a different way, where the crash stack omits the bmalloc/brealloc calls and `os_oom()` and ends at `kernelbase.dll` instead. Unhandled exception is denoted as "e". Maybe this will be unique enough.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
