### PR TITLE
libobs: Disallow overwriting the crash handler

### DIFF
--- a/docs/sphinx/reference-libobs-util-base.rst
+++ b/docs/sphinx/reference-libobs-util-base.rst
@@ -55,6 +55,7 @@ Logging Functions
 .. function:: void base_set_crash_handler(void (*handler)(const char *, va_list, void *), void *param)
 
    Sets the current crash handler.
+   This may only be set once.
 
 ---------------------
 

--- a/libobs/util/base.c
+++ b/libobs/util/base.c
@@ -19,6 +19,7 @@
 
 #include "c99defs.h"
 #include "base.h"
+#include "threading.h"
 
 static int crashing = 0;
 static void *log_param = NULL;
@@ -83,6 +84,13 @@ void base_set_log_handler(log_handler_t handler, void *param)
 
 void base_set_crash_handler(void (*handler)(const char *, va_list, void *), void *param)
 {
+	static bool non_default_handler_set = false;
+
+	if (os_atomic_exchange_bool(&non_default_handler_set, true)) {
+		blog(LOG_WARNING, "Tried to set a crash handler when one already exists.");
+		return;
+	}
+
 	crash_param = param;
 	crash_handler = handler;
 }


### PR DESCRIPTION
Setting a new crash handler overwrites the existing one. This is not desirable.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Makes it illegal (and impossible*) to overwrite the existing crash handler.
If a crash handler is set already, calling this method will now be no-op.

*Nothing is impossible if you have access to the application's memory, but... :P

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
We set a crash handler in OBS Studio, and we'd like to keep it.
Sometimes OBS doesn't generate a crash log, and I suspect this could be the reason why.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
On Windows: Hasn't, because no Windows.
On macOS: Tested that the first call to `base_set_crash_handler` works, and any following call gets rejected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
