### PR TITLE
CI: Fix configuration issue with Ccache version 4.12 and above

### DIFF
--- a/.github/scripts/utils.zsh/setup_ccache
+++ b/.github/scripts/utils.zsh/setup_ccache
@@ -1,9 +1,13 @@
-autoload -Uz log_debug log_warning
+autoload -Uz is-at-least log_debug log_warning
 
 if (( ${+commands[ccache]} )) {
   log_debug "Found ccache at ${commands[ccache]}"
 
-  ccache --set-config=run_second_cpp=true
+  local ccache_version=$(ccache --version | head -1 | cut -d ' ' -f 3)
+  if ! is-at-least 4.12 ${ccache_version}; then
+    ccache --set-config=run_second_cpp=true
+  fi
+
   ccache --set-config=direct_mode=true
   ccache --set-config=inode_cache=true
   ccache --set-config=compiler_check=content

--- a/cmake/macos/resources/ccache-launcher-c.in
+++ b/cmake/macos/resources/ccache-launcher-c.in
@@ -4,7 +4,6 @@ if [[ "$1" == "${CMAKE_C_COMPILER}" ]] ; then
     shift
 fi
 
-export CCACHE_CPP2=true
 export CCACHE_DEPEND=true
 export CCACHE_DIRECT=true
 export CCACHE_FILECLONE=true

--- a/cmake/macos/resources/ccache-launcher-cxx.in
+++ b/cmake/macos/resources/ccache-launcher-cxx.in
@@ -4,7 +4,6 @@ if [[ "$1" == "${CMAKE_CXX_COMPILER}" ]] ; then
     shift
 fi
 
-export CCACHE_CPP2=true
 export CCACHE_DEPEND=true
 export CCACHE_DIRECT=true
 export CCACHE_FILECLONE=true


### PR DESCRIPTION
### Description
Removes the enforced use of a second preprocessor call by Ccache on macOS entirely and guards it behind a version check in the build script used by macOS and Linux.

### Motivation and Context
Ccache 4.12 [removed support](https://ccache.dev/releasenotes.html#_removed_features) do enable or disable the use of a second preprocessor call entirely, mainly to remove the ability to _disable_ it.

The project always enabled it explicitly, which is not necessary now, but as the flag/configuration parameter is entirely removed, Ccache will report the use of an unknown configuration parameter and break project configuration on CI.

### How Has This Been Tested?
Needs to be tested via CI runs.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
