### PR TITLE
rtmp-services: Add Streamplace

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 278,
+    "version": 279,
     "files": [
         {
             "name": "services.json",
-            "version": 278
+            "version": 279
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3541,6 +3541,27 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Streamplace",
+            "more_info_link": "https://stream.place/about",
+            "stream_key_link": "https://stream.place/live",
+            "common": false,
+            "servers": [
+                {
+                    "name": "Global",
+                    "url": "rtmps://rtmp.stream.place:1935/live"
+                }
+            ],
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 1,
+                "profile": "high",
+                "bframes": 0,
+                "max video bitrate": 20000
+            }
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

* Added Streamplace as a service in OBS.

### Motivation and Context
We're making [Streamplace](https://stream.place/), live video on Bluesky's [AT Protocol](https://atproto.com/)! [We've applied once before](https://github.com/obsproject/obs-studio/pull/12032) so I wanted to be totally sure we're meeting the requirements this time:

> If your service is available to the public, some adoption should be visible to warrant the inclusion in OBS

Usage of the service has been trending upward, we're hitting 10+ streamers during peak hours. Please feel free to check out our usage yourselves on our [public Grafana dashboard](https://grafana.streamplace.team/public-dashboards/b14002510c96412b9da8b4f275484426).

> Your service must be released and have documentation available.

Streamplace is open-source and available for download at [https://stream.place/download](https://stream.place/download). Our documentation is at [https://stream.place/docs/](https://stream.place/docs/).  We're soon going to be releasing syndication, so that Streamplace users may replicate each others' streams and support each other by sharing bandwidth: [more details on our blog](https://blog.stream.place/3lvjz5qno7k26).

> Exemptions may be made at the OBS Project's discretion. You may submit a PR in draft stage before release for review and to accelerate merge once your service becomes available

Not being on the list on OBS has been a huge pain point for us because we're using WebRTC output and things are very broken if the user has B-Frames enabled. So we've been having to instruct our users to turn on advanced options and manually type `bframes=0` into the x264 advanced options field -- not fun. Please let me know if there's anything else I can do to have this go smoothly!

### How Has This Been Tested?

Replaced my local `services.json` file with this one and streamed into Streamplace successfully.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
