### PR TITLE
CI: Pin patch generation workflows to Windows 2022

### DIFF
--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -139,7 +139,7 @@ jobs:
   windows-patches:
     name: Create Windows Patches 🩹
     if: github.repository_owner == 'obsproject' && inputs.job == 'patches'
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/windows-patches

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -202,7 +202,7 @@ jobs:
     name: Create Windows Patches 🩹
     needs: check-tag
     if: github.repository_owner == 'obsproject' && fromJSON(needs.check-tag.outputs.validTag)
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/windows-patches


### PR DESCRIPTION
### Description

Pin patch generation workflows to `windows-2022`

### Motivation and Context

`windows-latest` is now Windows Server 2025, which does not have `pdbcopy` in the old path, TBD where it is or if there are other differences.

### How Has This Been Tested?

Amazon Private Repo.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) -->

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
