### PR TITLE
frontend: Enable multitrack RTMP option for custom RTMP services

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -5591,8 +5591,6 @@ void OBSBasicSettings::UpdateAdvNetworkGroup()
 #endif
 }
 
-extern bool MultitrackVideoDeveloperModeEnabled();
-
 void OBSBasicSettings::UpdateMultitrackVideo()
 {
 	// Technically, it should currently be safe to toggle multitrackVideo
@@ -5615,15 +5613,6 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 			ui->enableMultitrackVideo->setChecked(false);
 	}
 
-	// Enhanced Broadcasting works on Windows, Apple Silicon Macs, and Linux.
-	// For other OS variants, only enable the GUI controls if developer mode was invoked.
-#if !defined(_WIN32) && !(defined(__APPLE__) && defined(__aarch64__)) && !defined(__linux__)
-	available = available && MultitrackVideoDeveloperModeEnabled();
-#endif
-
-	if (IsCustomService())
-		available = available && MultitrackVideoDeveloperModeEnabled();
-
 	ui->multitrackVideoGroupBox->setVisible(available);
 
 	ui->enableMultitrackVideo->setEnabled(toggle_available);
@@ -5644,10 +5633,10 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 							  !ui->multitrackVideoMaximumVideoTracksAuto->isChecked());
 	ui->multitrackVideoAdditionalCanvas->setEnabled(toggle_available && ui->enableMultitrackVideo->isChecked());
 
-	ui->multitrackVideoStreamDumpEnable->setVisible(available && MultitrackVideoDeveloperModeEnabled());
-	ui->multitrackVideoConfigOverrideEnable->setVisible(available && MultitrackVideoDeveloperModeEnabled());
-	ui->multitrackVideoConfigOverrideLabel->setVisible(available && MultitrackVideoDeveloperModeEnabled());
-	ui->multitrackVideoConfigOverride->setVisible(available && MultitrackVideoDeveloperModeEnabled());
+	ui->multitrackVideoStreamDumpEnable->setVisible(available && IsCustomService());
+	ui->multitrackVideoConfigOverrideEnable->setVisible(available && IsCustomService());
+	ui->multitrackVideoConfigOverrideLabel->setVisible(available && IsCustomService());
+	ui->multitrackVideoConfigOverride->setVisible(available && IsCustomService());
 
 	ui->multitrackVideoStreamDumpEnable->setEnabled(toggle_available && ui->enableMultitrackVideo->isChecked());
 	ui->multitrackVideoConfigOverrideEnable->setEnabled(toggle_available && ui->enableMultitrackVideo->isChecked());

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -231,7 +231,8 @@ BasicOutputHandler::BasicOutputHandler(OBSBasic *main_) : main(main_)
 	auto service = main_->GetService();
 	OBSDataAutoRelease settings = obs_service_get_settings(service);
 	auto multitrack_enabled = config_get_bool(main->Config(), "Stream1", "EnableMultitrackVideo") &&
-				  obs_data_has_user_value(settings, "multitrack_video_configuration_url");
+				  (obs_data_has_user_value(settings, "multitrack_video_configuration_url") ||
+				   strcmp(obs_service_get_id(service), "rtmp_custom") == 0);
 
 	if (multitrack_enabled)
 		multitrackVideo = make_unique<MultitrackVideoOutput>();

--- a/frontend/utility/MultitrackVideoOutput.cpp
+++ b/frontend/utility/MultitrackVideoOutput.cpp
@@ -410,8 +410,7 @@ void MultitrackVideoOutput::PrepareStreaming(
 	     rtmp_url.has_value() ? rtmp_url->c_str() : "",
 	     vod_track_info_storage->array ? vod_track_info_storage->array : "No", canvasNames.c_str());
 
-	const bool custom_config_only = auto_config_url.isEmpty() && MultitrackVideoDeveloperModeEnabled() &&
-					custom_config.has_value() &&
+	const bool custom_config_only = auto_config_url.isEmpty() && custom_config.has_value() &&
 					strcmp(obs_service_get_id(service), "rtmp_custom") == 0;
 
 	if (!custom_config_only) {


### PR DESCRIPTION
### Description
Removes the checks for an undocumented launch argument to enable multitrack functionality for custom RTMP services and the display of associated UI to add a custom multitrack configuration.

### Motivation and Context

Prior PR #12425 fixed an existing issue that made multitrack "available" to all services once one service had it enabled, but in turn removed the ability to "force-enable" it via a hidden command-line argument.

There should be no need for the use of hidden arguments to use a custom RTMP service that also happens to support multitrack, so the functionality as well as the associated UI should be available for custom RTMP configurations by default.

This change will consider multitrack to be enabled _if_:

* The multitrack stream setting is enabled,
* AND
    * The service has a multitrack video configuration URL setting
    * OR
    * The service is the "custom RTMP" service

The user interface for custom multitrack configuration is now visible _if_:
* Multitrack is available, which is the case _if_:
    * The current service is the "custom RTMP" service
    * OR
        * The current service is _not_ the "custom RTMP" service
        * AND
        * The current service has a multitrack video configuration URL setting

Finally, in the preparation stage for multitrack streaming only the custom config is used _if_:
* No automatic video configuration URL is provided
* AND
* The checkbox to use a custom config is set
* AND
* The service is the "custom RTMP" service

Multitrack streaming will effectively fail if those three conditions are not met, appropriate error messages (that no config URL was provided or the config JSON was not correct) are shown to the user.

Supersedes #12646.

### How Has This Been Tested?
- [x] Twitch has no custom UI, but multitrack toggle when service is connected
- [x] Amazon IVS has no custom UI, but multitrack toggle
- [x] Youtube HLS has no custom UI or toggle
- [x] Youtube RTMP has no custom UI or toggle
- [x] Custom RTMP has custom UI and toggle

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
