### PR TITLE
libobs: Fix for monitoring deduplication edge case

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -63,6 +63,11 @@ static inline void check_audio_output_source_is_monitoring_device(obs_source_t *
 			if (strcmp(dev_id, audio->monitoring_device_id) == 0) {
 				audio->prevent_monitoring_duplication = true;
 				audio->monitoring_duplicating_source = s;
+				if (!audio->monitoring_duplication_prevented_on_prev_tick)
+					blog(LOG_INFO,
+					     "Device for 'Audio Output Capture' source is also used for audio"
+					     " monitoring:\nDeduplication logic is being applied to all monitored"
+					     " sources.\n");
 			}
 			obs_data_release(settings);
 		}
@@ -577,6 +582,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	da_resize(audio->render_order, 0);
 	da_resize(audio->root_nodes, 0);
+	audio->monitoring_duplication_prevented_on_prev_tick = audio->prevent_monitoring_duplication;
 	audio->prevent_monitoring_duplication = false;
 	audio->monitoring_duplicating_source = NULL;
 

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -462,6 +462,7 @@ struct obs_core_audio {
 
 	volatile bool prevent_monitoring_duplication;
 	struct obs_source *monitoring_duplicating_source;
+	bool monitoring_duplication_prevented_on_prev_tick;
 };
 
 /* user sources, output channels, and displays */

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -899,6 +899,7 @@ static bool obs_init_audio(struct audio_output_info *ai)
 
 	audio->monitoring_device_name = bstrdup("Default");
 	audio->monitoring_device_id = bstrdup("default");
+	audio->monitoring_duplication_prevented_on_prev_tick = false;
 
 	errorcode = audio_output_open(&audio->audio, ai);
 	if (errorcode == AUDIO_OUTPUT_SUCCESS)


### PR DESCRIPTION
### Description
When an 'Audio Capture Source' device is also used for monitoring, the deduplication logic is applied: all monitored sources are silenced. But this should not silence the 'Audio Capture Source' if for some reason, it is being monitored (the user will get echoes, but hey, it's their choice). So we exclude the 'Audio Capture Source' from the silenced sources.
The commit also adds a log line to inform the user that deduplication is being applied.

### Motivation and Context
1. Fix an edge case. The fix was easy. What the user is doing is dubious though ...
2. Inform the user that monitoring deduplication logic is being applied to audio.

### How Has This Been Tested?
Tested that desktop audio goes to a recording even if it is being monitored.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue) 
- Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
