### PR TITLE
libobs: Various fixes for monitoring deduplication

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -553,7 +553,8 @@ static inline bool should_silence_monitored_source(obs_source_t *source, struct 
 	if (!audio->monitoring_duplicating_source)
 		return false;
 
-	bool output_capture_unmuted = !audio->monitoring_duplicating_source->user_muted;
+	bool fader_muted = close_float(audio->monitoring_duplicating_source->volume, 0.0f, 0.0001f);
+	bool output_capture_unmuted = !audio->monitoring_duplicating_source->user_muted && !fader_muted;
 
 	if (audio->prevent_monitoring_duplication && output_capture_unmuted) {
 		if (source->monitoring_type == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT &&


### PR DESCRIPTION
### Description
This fixes several bugs reported in audio-support and dev channels of our Discord server.

1. Monitoring deduplication must be applied only to tracks for which the monitored source and the 'Audio Output Capture' (AOC) source are both enabled. This adds such checks.
2. On linux, pulse device ids can have a '.monitor' suffix, so we need to take that into account.
3. When the Desktop Audio has its fader to minimum, we should not deduplicate anymore.

### Motivation and Context
Fixes 3 bugs.
Bugs reported by @Penwy & @prgmitchell 
Bug 1 fix:
If the AOC has, say, tracks 1 2 3 enabled but not 4 5 6, and the monitored source has tracks 2 & 5 enabled,
the duplication occurs only on track 2.
So the silencing should occur on track 2 but not the others (track 5 in the example).
The bug fix checks then which tracks are common to AOC and monitored source and silences only them.

Bug 2 fix:
we allow for a looser device id match on linux by strncmp in addition to strcmp.

Bug3 fix:
~~we add a fader_muted member of obs_source; it is set to false unless the fader cur_db is below min_db.
The deduplication logic is now bypassed whenever the Desktop Audio is either user_muted or fader_muted.~~
We check against source->volume for the AOC; if it is detected to be 0 , we treat it as 'muted' and bypass deduplication logic.

### How Has This Been Tested?
Bug 1: Checked by breakpointing that the silencing did not occur any more for tracks which are not common to both AOC
and monitored source.
Bug 2 : not checked. Waiting for linux testers.
Bug 3: Checked by making a recording. The monitored source set to monitor_and_and_output was still heard in the recording even though the desktop audio fader was at minimum.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
