### PR TITLE
frontend: Only saved scene sources from frontend-managed canvases

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -67,12 +67,12 @@ struct Rect;
 enum class LogFileType;
 } // namespace OBS
 
-#define DESKTOP_AUDIO_1 Str("DesktopAudioDevice1")
-#define DESKTOP_AUDIO_2 Str("DesktopAudioDevice2")
-#define AUX_AUDIO_1 Str("AuxAudioDevice1")
-#define AUX_AUDIO_2 Str("AuxAudioDevice2")
-#define AUX_AUDIO_3 Str("AuxAudioDevice3")
-#define AUX_AUDIO_4 Str("AuxAudioDevice4")
+#define DESKTOP_AUDIO_1 "DesktopAudioDevice1"
+#define DESKTOP_AUDIO_2 "DesktopAudioDevice2"
+#define AUX_AUDIO_1 "AuxAudioDevice1"
+#define AUX_AUDIO_2 "AuxAudioDevice2"
+#define AUX_AUDIO_3 "AuxAudioDevice3"
+#define AUX_AUDIO_4 "AuxAudioDevice4"
 
 #define SIMPLE_ENCODER_X264 "x264"
 #define SIMPLE_ENCODER_X264_LOWCPU "x264_lowcpu"


### PR DESCRIPTION
### Description

Changes the saving logic a bit so that scenes from canvases not managed by the frontend won't get saved.

Also refactors the saving a bit since the separate `GenerateSaveData()` seems unnecessary.

### Motivation and Context

The intention was that the frontend should only save and load canvases it manages (i.e. created via the frontend API). Likewise it shouldn't save any scenes on canvases that aren't frontend-managed or ephemeral.

This problem was reported on Discord.

### How Has This Been Tested?

Saved and loaded some scene collections.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
