### PR TITLE
libobs-metal: Explicitly enable Swift language support if ENABLE_PLUGINS is OFF

### DIFF
--- a/libobs-metal/CMakeLists.txt
+++ b/libobs-metal/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.28...3.30)
 
+# Enable support for the Swift language.
+enable_language(Swift)
+
 add_library(libobs-metal SHARED)
 add_library(OBS::libobs-metal ALIAS libobs-metal)
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes a mistake in the libobs-metal CMake file that was likely missed due to unexpected CMake behavior. When ENABLE_PLUGINS is set to OFF we don't actually ever enable Swift support and CMake delays the error for this until after the configure stage. This behavior is hidden by mac-virtualcam which does call the proper functions.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
When ENABLE_PLUGINS (since 32.0.0) is set to OFF strange CMake errors are reported and the build fails. These patches fix the mistake in the CMake code and allowed us to keep libobs as a dependency.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
We've been able to successfully build libOBS with ENABLE_PLUGINS=OFF locally and on Github Actions with these patches applied.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

I did not check any of the ones that don't apply here.