### PR TITLE
plugins: Set missed default bitrates to 6000 kbps

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -1375,10 +1375,10 @@ static void vt_defaults(obs_data_t *settings, void *data)
 			obs_data_set_default_string(settings, "rate_control", "CBR");
 		}
 	}
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 6000);
 	obs_data_set_default_int(settings, "quality", 60);
 	obs_data_set_default_bool(settings, "limit_bitrate", false);
-	obs_data_set_default_int(settings, "max_bitrate", 2500);
+	obs_data_set_default_int(settings, "max_bitrate", 6000);
 	obs_data_set_default_double(settings, "max_bitrate_window", 1.5f);
 	obs_data_set_default_int(settings, "keyint_sec", 2);
 	obs_data_set_default_string(settings, "profile",

--- a/plugins/obs-ffmpeg/obs-ffmpeg-openh264.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-openh264.c
@@ -193,7 +193,7 @@ static bool openh264_encode(void *data, struct encoder_frame *frame, struct enco
 
 void openh264_defaults(obs_data_t *settings)
 {
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 6000);
 	obs_data_set_default_string(settings, "profile", "main");
 }
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -861,7 +861,7 @@ static void vaapi_defaults_internal(obs_data_t *settings, enum codec_type codec)
 	else if (codec == CODEC_AV1)
 		obs_data_set_default_int(settings, "profile", AV_PROFILE_AV1_MAIN);
 	obs_data_set_default_int(settings, "level", AV_LEVEL_UNKNOWN);
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 6000);
 	obs_data_set_default_int(settings, "keyint_sec", 0);
 	obs_data_set_default_int(settings, "bf", 0);
 	obs_data_set_default_int(settings, "qp", 20);

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1383,7 +1383,7 @@ static inline void adjust_recommended_avc_defaults(amf_base *enc, obs_data_t *se
 	int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || (framerate > 60)) {
 		// Recommended base defaults
-		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "bitrate", 6000);
 		obs_data_set_default_int(settings, "cqp", 20);
 		obs_data_set_default_string(settings, "rate_control", "CBR");
 		obs_data_set_default_string(settings, "preset", "quality");
@@ -1841,7 +1841,7 @@ static inline void adjust_recommended_hevc_defaults(amf_base *enc, obs_data_t *s
 	const int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
 		// Recommended base defaults
-		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "bitrate", 6000);
 		obs_data_set_default_int(settings, "cqp", 20);
 		obs_data_set_default_string(settings, "preset", "quality");
 		info("Original base default settings were used according to resolution and framerate.");
@@ -2092,7 +2092,7 @@ try {
 static void amf_hevc_defaults(obs_data_t *settings)
 {
 	obs_data_set_default_string(settings, "rate_control", "CBR");
-	obs_data_set_default_int(settings, "bitrate", 2500);
+	obs_data_set_default_int(settings, "bitrate", 6000);
 	obs_data_set_default_int(settings, "cqp", 20);
 	obs_data_set_default_string(settings, "preset", "quality");
 }
@@ -2245,7 +2245,7 @@ static inline void adjust_recommended_av1_defaults(amf_base *enc, obs_data_t *se
 	const int64_t framerate = enc->fps_num / enc->fps_den;
 	if ((enc->cx * enc->cy > 1920 * 1088) || is10bit || (framerate > 60)) {
 		// Recommended base defaults
-		obs_data_set_default_int(settings, "bitrate", 2500);
+		obs_data_set_default_int(settings, "bitrate", 6000);
 		obs_data_set_default_int(settings, "cqp", 20);
 		obs_data_set_default_string(settings, "preset", "balanced");
 		obs_data_set_default_string(settings, "profile", "main");


### PR DESCRIPTION
### Description
#9442 efca325 already increased the default bitrate for various encoders. However, some were missed and this commit fills the gap:

* Mac-VT
* OpenH264
* Texture AMF
* VAAPI

Note I wasn't sure about the Texture AMF one because there's 4 occurrences (2 for AVC, 2 for HEVC). But I *think* one each is for new setups and one for migrating existing setups?

### Motivation and Context
Noticed in unrelated testing that VAAPI was still defaulting to 2500, fixed it and found other occurrences of the same.

### How Has This Been Tested?
Hasn't.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
