### PR TITLE
libobs: Don't use removed sources

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -84,6 +84,9 @@ static inline void check_audio_output_source_is_monitoring_device(obs_source_t *
  */
 static void push_audio_tree2(obs_source_t *parent, obs_source_t *source, void *p)
 {
+	if (obs_source_removed(source))
+		return;
+
 	struct obs_core_audio *audio = p;
 	size_t idx = da_find(audio->render_order, &source, 0);
 
@@ -614,6 +617,8 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 				continue;
 			if (!obs_source_active(source))
 				continue;
+			if (obs_source_removed(source))
+				continue;
 
 			/* first, add top - level sources as root_nodes */
 			if (obs->video.mixes.array[j]->mix_audio)
@@ -636,7 +641,9 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	source = data->first_audio_source;
 	while (source) {
-		push_audio_tree(NULL, source, audio);
+		if (!obs_source_removed(source)) {
+			push_audio_tree(NULL, source, audio);
+		}
 		source = (struct obs_source *)source->next_audio_source;
 	}
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -64,7 +64,7 @@ static uint64_t tick_sources(uint64_t cur_time, uint64_t last_time)
 
 	source = data->sources;
 	while (source) {
-		obs_source_t *s = obs_source_get_ref(source);
+		obs_source_t *s = obs_source_removed(source) ? NULL : obs_source_get_ref(source);
 		if (s)
 			da_push_back(data->sources_to_tick, &s);
 		source = (struct obs_source *)source->context.hh_uuid.next;
@@ -77,9 +77,11 @@ static uint64_t tick_sources(uint64_t cur_time, uint64_t last_time)
 
 	for (size_t i = 0; i < data->sources_to_tick.num; i++) {
 		obs_source_t *s = data->sources_to_tick.array[i];
-		const uint64_t start = source_profiler_source_tick_start();
-		obs_source_video_tick(s, seconds);
-		source_profiler_source_tick_end(s, start);
+		if (!obs_source_removed(s)) {
+			const uint64_t start = source_profiler_source_tick_start();
+			obs_source_video_tick(s, seconds);
+			source_profiler_source_tick_end(s, start);
+		}
 		obs_source_release(s);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Don't use removed sources in the audio and graphics thread

### Motivation and Context
In OBSBasic::ClearSceneData() obs_source_remove is called on all sources, but the sources are still being used and referenced in the graphics and audio thread making the it possible that the reference counter does not reach 0 and the source is not destroyed, giving the user the error
<img width="744" height="395" alt="image" src="https://github.com/user-attachments/assets/cce1b1a3-476e-47ea-bbe5-8e1bd5835d96" />

### How Has This Been Tested?
On windows with a scene collection that would not close correctly

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
