### PR TITLE
libobs,libobs-d3d11,libobs-opengl,libobs-metal: Rename gs_begin_frame to gs_reset_duplicators

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2181,7 +2181,7 @@ void device_stage_texture(gs_device_t *device, gs_stagesurf_t *dst, gs_texture_t
 
 extern "C" void reset_duplicators(void);
 
-void device_begin_frame(gs_device_t *device)
+void device_reset_duplicators(gs_device_t *device)
 {
 	/* does nothing in D3D11 */
 	UNUSED_PARAMETER(device);

--- a/libobs-metal/metal-subsystem.swift
+++ b/libobs-metal/metal-subsystem.swift
@@ -263,28 +263,6 @@ public func device_get_color_space(device: UnsafeRawPointer) -> gs_color_space {
     return device.renderState.gsColorSpace
 }
 
-/// Signals the beginning of a new render loop iteration by `libobs` renderer.
-/// - Parameter device: Opaque pointer to ``MetalDevice`` instance shared with `libobs`
-///
-/// This function is the first graphics API-specific function called by `libobs` render loop and can be used as a
-/// signal to reset any lingering state of the prior loop iteration.
-///
-/// For the Metal renderer this ensures that the current render target, current swap chain, as well as the list of
-/// active swap chains is reset. As the Metal renderer also needs to keep track of whether `libobs` is rendering any
-/// "displays", the associated state variable is also reset here.
-@_cdecl("device_begin_frame")
-public func device_begin_frame(device: UnsafeRawPointer) {
-    let device: MetalDevice = unretained(device)
-
-    device.renderState.useSRGBGamma = false
-    device.renderState.renderTarget = nil
-
-    device.renderState.swapChain = nil
-    device.renderState.isInDisplaysRenderStage = false
-
-    return
-}
-
 /// Gets a pointer to the current render target
 /// - Parameter device: Opaque pointer to ``MetalDevice`` instance shared with `libobs`
 /// - Returns: Opaque pointer to ``MetalTexture`` object representing the render target

--- a/libobs-opengl/gl-subsystem.c
+++ b/libobs-opengl/gl-subsystem.c
@@ -1009,12 +1009,6 @@ void device_copy_texture(gs_device_t *device, gs_texture_t *dst, gs_texture_t *s
 	device_copy_texture_region(device, dst, 0, 0, src, 0, 0, 0, 0);
 }
 
-void device_begin_frame(gs_device_t *device)
-{
-	/* does nothing */
-	UNUSED_PARAMETER(device);
-}
-
 void device_begin_scene(gs_device_t *device)
 {
 	clear_textures(device);

--- a/libobs/graphics/graphics-imports.c
+++ b/libobs/graphics/graphics-imports.c
@@ -93,7 +93,6 @@ bool load_graphics_imports(struct gs_exports *exports, void *module, const char 
 	GRAPHICS_IMPORT(device_copy_texture_region);
 	GRAPHICS_IMPORT(device_copy_texture);
 	GRAPHICS_IMPORT(device_stage_texture);
-	GRAPHICS_IMPORT(device_begin_frame);
 	GRAPHICS_IMPORT(device_begin_scene);
 	GRAPHICS_IMPORT(device_draw);
 	GRAPHICS_IMPORT(device_load_swapchain);
@@ -217,6 +216,7 @@ bool load_graphics_imports(struct gs_exports *exports, void *module, const char 
 
 	/* win32 specific functions */
 #elif _WIN32
+	GRAPHICS_IMPORT(device_reset_duplicators);
 	GRAPHICS_IMPORT(device_gdi_texture_available);
 	GRAPHICS_IMPORT(device_shared_texture_available);
 	GRAPHICS_IMPORT_OPTIONAL(device_get_duplicator_monitor_info);

--- a/libobs/graphics/graphics-internal.h
+++ b/libobs/graphics/graphics-internal.h
@@ -95,7 +95,6 @@ struct gs_exports {
 					   gs_texture_t *src, uint32_t src_x, uint32_t src_y, uint32_t src_w,
 					   uint32_t src_h);
 	void (*device_stage_texture)(gs_device_t *device, gs_stagesurf_t *dst, gs_texture_t *src);
-	void (*device_begin_frame)(gs_device_t *device);
 	void (*device_begin_scene)(gs_device_t *device);
 	void (*device_draw)(gs_device_t *device, enum gs_draw_mode draw_mode, uint32_t start_vert, uint32_t num_verts);
 	void (*device_end_scene)(gs_device_t *device);
@@ -226,6 +225,7 @@ struct gs_exports {
 	bool (*device_shared_texture_available)(void);
 
 #elif _WIN32
+	void (*device_reset_duplicators)(gs_device_t *device);
 	bool (*device_gdi_texture_available)(void);
 	bool (*device_shared_texture_available)(void);
 

--- a/libobs/graphics/graphics.c
+++ b/libobs/graphics/graphics.c
@@ -1909,16 +1909,6 @@ void gs_stage_texture(gs_stagesurf_t *dst, gs_texture_t *src)
 	graphics->exports.device_stage_texture(graphics->device, dst, src);
 }
 
-void gs_begin_frame(void)
-{
-	graphics_t *graphics = thread_graphics;
-
-	if (!gs_valid("gs_begin_frame"))
-		return;
-
-	graphics->exports.device_begin_frame(graphics->device);
-}
-
 void gs_begin_scene(void)
 {
 	graphics_t *graphics = thread_graphics;
@@ -3041,6 +3031,16 @@ gs_texture_t *gs_texture_open_shared(uint32_t handle)
 }
 
 #elif _WIN32
+
+void gs_reset_duplicators(void)
+{
+	graphics_t *graphics = thread_graphics;
+
+	if (!gs_valid("gs_begin_frame"))
+		return;
+
+	graphics->exports.device_reset_duplicators(graphics->device);
+}
 
 bool gs_gdi_texture_available(void)
 {

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -679,7 +679,6 @@ EXPORT void gs_copy_texture_region(gs_texture_t *dst, uint32_t dst_x, uint32_t d
 				   uint32_t src_y, uint32_t src_w, uint32_t src_h);
 EXPORT void gs_stage_texture(gs_stagesurf_t *dst, gs_texture_t *src);
 
-EXPORT void gs_begin_frame(void);
 EXPORT void gs_begin_scene(void);
 EXPORT void gs_draw(enum gs_draw_mode draw_mode, uint32_t start_vert, uint32_t num_verts);
 EXPORT void gs_end_scene(void);
@@ -826,7 +825,7 @@ EXPORT gs_texture_t *gs_texture_open_shared(uint32_t handle);
 EXPORT bool gs_shared_texture_available(void);
 
 #elif _WIN32
-
+EXPORT void gs_reset_duplicators(void);
 EXPORT bool gs_gdi_texture_available(void);
 EXPORT bool gs_shared_texture_available(void);
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -1105,7 +1105,9 @@ bool obs_graphics_thread_loop(struct obs_graphics_context *context)
 	source_profiler_frame_begin();
 
 	gs_enter_context(obs->video.graphics);
-	gs_begin_frame();
+#ifdef _WIN32
+	gs_reset_duplicators();
+#endif
 	gs_leave_context();
 
 	profile_start(tick_sources_name);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Rename gs_begin_frame to gs_reset_duplicators
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
gs_begin_frame is only used for windows dxgi  screen capture with duplicator, and gs_begin_frame does not have a corresponding gs_end_frame definition.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have tested it in my computor.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Code cleanup (non-breaking change which makes code smaller or more readable) 
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
