### PR TITLE
frontend: fix leaving FE canvases in bad state

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -664,8 +664,8 @@ void OBSStudioAPI::obs_frontend_add_undo_redo_action(const char *name, const und
 
 void OBSStudioAPI::obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_list)
 {
-	for (const auto &canvas : main->canvases) {
-		obs_canvas_t *ref = obs_canvas_get_ref(canvas);
+	for (const auto &kv : main->canvases) {
+		obs_canvas_t *ref = obs_canvas_get_ref(kv.first);
 		if (ref)
 			da_push_back(canvas_list->canvases, &ref);
 	}
@@ -674,7 +674,7 @@ void OBSStudioAPI::obs_frontend_get_canvases(obs_frontend_canvas_list *canvas_li
 obs_canvas_t *OBSStudioAPI::obs_frontend_add_canvas(const char *name, obs_video_info *ovi, int flags)
 {
 	auto &canvas = main->AddCanvas(std::string(name), ovi, flags);
-	return obs_canvas_get_ref(canvas);
+	return obs_canvas_get_ref(canvas->canvas);
 }
 
 bool OBSStudioAPI::obs_frontend_remove_canvas(obs_canvas_t *canvas)

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -173,10 +173,11 @@ void OBSBasicSettings::LoadStream1Settings()
 	ui->multitrackVideoAdditionalCanvas->clear();
 	ui->multitrackVideoAdditionalCanvas->addItem(QTStr("None"));
 	for (const auto &canvas : main->GetCanvases()) {
-		if (obs_canvas_get_flags(canvas) & EPHEMERAL)
+		if (obs_canvas_get_flags(canvas.first) & EPHEMERAL)
 			continue;
 
-		ui->multitrackVideoAdditionalCanvas->addItem(obs_canvas_get_name(canvas), obs_canvas_get_uuid(canvas));
+		ui->multitrackVideoAdditionalCanvas->addItem(obs_canvas_get_name(canvas.first),
+							     obs_canvas_get_uuid(canvas.first));
 	}
 
 	if (config_has_user_value(main->Config(), "Stream1", "MultitrackExtraCanvas")) {

--- a/frontend/utility/OBSCanvas.hpp
+++ b/frontend/utility/OBSCanvas.hpp
@@ -20,6 +20,7 @@
 #include <memory>
 #include <optional>
 #include <vector>
+#include <map>
 
 #include "obs.h"
 #include "obs.hpp"
@@ -37,16 +38,16 @@ public:
 	Canvas() = delete;
 	Canvas(Canvas &other) = delete;
 
-	Canvas &operator=(Canvas &&other) noexcept;
+	Canvas &operator=(Canvas &&other) = delete;
 
 	operator obs_canvas_t *() const { return canvas; }
 
 	[[nodiscard]] std::optional<OBSDataAutoRelease> Save() const;
-	static std::unique_ptr<Canvas> Load(obs_data_t *data);
-	static std::vector<Canvas> LoadCanvases(obs_data_array_t *canvases);
-	static OBSDataArrayAutoRelease SaveCanvases(const std::vector<Canvas> &canvases);
+	static std::shared_ptr<Canvas> Load(obs_data_t *data);
+	static std::map<obs_canvas_t *, std::shared_ptr<Canvas>> LoadCanvases(obs_data_array_t *canvases);
+	static OBSDataArrayAutoRelease SaveCanvases(const std::map<obs_canvas_t *, std::shared_ptr<Canvas>> &canvases);
 
-private:
+public:
 	obs_canvas_t *canvas = nullptr;
 };
 } // namespace OBS

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1120,14 +1120,15 @@ public:
 	 * -------------------------------------
 	 */
 private:
-	std::vector<OBS::Canvas> canvases;
+	std::map<obs_canvas_t *, std::shared_ptr<OBS::Canvas>> canvases;
 
 	static void CanvasRemoved(void *data, calldata_t *params);
 
 public:
-	const std::vector<OBS::Canvas> &GetCanvases() const noexcept { return canvases; }
+	const std::map<obs_canvas_t *, std::shared_ptr<OBS::Canvas>> &GetCanvases() const noexcept { return canvases; }
 
-	const OBS::Canvas &AddCanvas(const std::string &name, obs_video_info *ovi = nullptr, int flags = 0);
+	const std::shared_ptr<OBS::Canvas> AddCanvas(const std::string &name, obs_video_info *ovi = nullptr,
+						     int flags = 0);
 
 public slots:
 	bool RemoveCanvas(OBSCanvas canvas);

--- a/frontend/widgets/OBSBasic_Canvases.cpp
+++ b/frontend/widgets/OBSBasic_Canvases.cpp
@@ -23,12 +23,13 @@ void OBSBasic::CanvasRemoved(void *data, calldata_t *params)
 	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveCanvas", Q_ARG(OBSCanvas, OBSCanvas(canvas)));
 }
 
-const OBS::Canvas &OBSBasic::AddCanvas(const std::string &name, obs_video_info *ovi, int flags)
+const std::shared_ptr<OBS::Canvas> OBSBasic::AddCanvas(const std::string &name, obs_video_info *ovi, int flags)
 {
 	OBSCanvas canvas = obs_canvas_create(name.c_str(), ovi, flags);
-	auto &it = canvases.emplace_back(canvas);
+	canvases[canvas] = std::make_shared<OBS::Canvas>(canvas);
+
 	OnEvent(OBS_FRONTEND_EVENT_CANVAS_ADDED);
-	return it;
+	return canvases[canvas];
 }
 
 bool OBSBasic::RemoveCanvas(OBSCanvas canvas)
@@ -36,9 +37,8 @@ bool OBSBasic::RemoveCanvas(OBSCanvas canvas)
 	if (!canvas)
 		return false;
 
-	auto canvas_it = std::find(std::begin(canvases), std::end(canvases), canvas);
-	if (canvas_it != std::end(canvases)) {
-		canvases.erase(canvas_it);
+	if (canvases.count(canvas)) {
+		canvases.erase(canvas);
 		OnEvent(OBS_FRONTEND_EVENT_CANVAS_REMOVED);
 		return true;
 	}

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1535,8 +1535,8 @@ void OBSBasic::ClearSceneData()
 	obs_enum_scenes(cb, nullptr);
 	obs_enum_sources(cb, nullptr);
 
-	for (const auto &canvas : canvases) {
-		obs_canvas_enum_scenes(canvas, cb, nullptr);
+	for (const auto &kv : canvases) {
+		obs_canvas_enum_scenes(kv.first, cb, nullptr);
 	}
 
 	canvases.clear();


### PR DESCRIPTION
### Description

This PR modifies the canvases vector to be
represented as a map of obs_canvas_t* to a
shared pointer to OBS::Canvas.

This will preserve both the OBS::Canvas manager
instance, and pointer to obs_canvas_t* for
reference by obs_frontend_canvas_remove(),
ensuring that the right objects will be used
when called upon.

### Motivation and Context

When the `obs_frontend_remove_canvas` is called,
the destructor of OBS::Canvas calls
obs_canvas_release() on an object which is
both allocated on the heap and added as reference
to the canvases vector causing a double deallocation.

This causes the `canvases` collection on the main
window to become corrupt, and crash the next time
you try to add another frontend canvas.

This effectively prevents the canvases collection
from being managed properly by plug-ins.

### How Has This Been Tested?
Ran obs_frontend_add_canvas() followed by obs_frontend_remove_canvas() followed by obs_frontend_add_canvas() before and after the change.

Before change: crash
After change: smooth operation

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
