### PR TITLE
frontend, captions: Fix caption dialog hang

### DIFF
--- a/plugins/frontend-tools/captions-mssapi-stream.cpp
+++ b/plugins/frontend-tools/captions-mssapi-stream.cpp
@@ -33,26 +33,20 @@ CaptionStream::CaptionStream(DWORD samplerate_, mssapi_captions *handler_)
 
 void CaptionStream::Stop()
 {
-	{
-		lock_guard<mutex> lock(m);
-		deque_free(buf);
-	}
+	lock_guard<mutex> lock(m);
+	stop = true;
+	deque_free(buf);
 
 	cv.notify_one();
 }
 
 void CaptionStream::PushAudio(const void *data, size_t frames)
 {
-	bool ready = false;
-
 	lock_guard<mutex> lock(m);
 	deque_push_back(buf, data, frames * sizeof(int16_t));
 	write_pos += frames * sizeof(int16_t);
 
 	if (wait_size && buf->size >= wait_size) {
-		ready = true;
-	}
-	if (ready) {
 		cv.notify_one();
 	}
 }
@@ -105,23 +99,18 @@ STDMETHODIMP_(ULONG) CaptionStream::Release()
 STDMETHODIMP CaptionStream::Read(void *data, ULONG bytes, ULONG *read_bytes)
 {
 	HRESULT hr = S_OK;
-	size_t cur_size;
 
 	debugfunc("data, %lu, read_bytes", bytes);
 	if (!data) {
 		return STG_E_INVALIDPOINTER;
 	}
 
-	{
-		lock_guard<mutex> lock1(m);
-		wait_size = bytes;
-		cur_size = buf->size;
-	}
-
 	unique_lock<mutex> lock(m);
 
-	if (bytes > cur_size) {
+	if (!stop && bytes > buf->size) {
+		wait_size = bytes;
 		cv.wait(lock);
+		wait_size = 0;
 	}
 
 	if (bytes > (ULONG)buf->size) {
@@ -135,7 +124,6 @@ STDMETHODIMP CaptionStream::Read(void *data, ULONG bytes, ULONG *read_bytes)
 		*read_bytes = bytes;
 	}
 
-	wait_size = 0;
 	pos.QuadPart += bytes;
 	return hr;
 }
@@ -183,11 +171,12 @@ STDMETHODIMP CaptionStream::CopyTo(IStream *stream, ULARGE_INTEGER bytes, ULARGE
 	}
 
 	ULONG written = 0;
+
+	lock_guard<mutex> lock(m);
 	if (bytes.QuadPart > (ULONGLONG)buf->size) {
 		bytes.QuadPart = (ULONGLONG)buf->size;
 	}
 
-	lock_guard<mutex> lock(m);
 	temp_buf.resize((size_t)bytes.QuadPart);
 	deque_peek_front(buf, &temp_buf[0], (size_t)bytes.QuadPart);
 

--- a/plugins/frontend-tools/captions-mssapi-stream.hpp
+++ b/plugins/frontend-tools/captions-mssapi-stream.hpp
@@ -30,6 +30,7 @@ class CaptionStream : public ISpAudio {
 	SPAUDIOSTATE state;
 	WinHandle event;
 	ULONG vol = 0;
+	volatile bool stop = false;
 
 	std::condition_variable cv;
 	std::mutex m;

--- a/plugins/frontend-tools/captions-mssapi.cpp
+++ b/plugins/frontend-tools/captions-mssapi.cpp
@@ -9,14 +9,11 @@ mssapi_captions::mssapi_captions(captions_cb callback, const std::string &lang)
 try : captions_handler(callback, AUDIO_FORMAT_16BIT, 16000) {
 	HRESULT hr;
 
-	std::wstring wlang;
-	wlang.resize(lang.size());
+	wchar_t *wlang;
+	os_utf8_to_wcs_ptr(lang.c_str(), lang.length(), &wlang);
 
-	for (size_t i = 0; i < lang.size(); i++) {
-		wlang[i] = (wchar_t)lang[i];
-	}
-
-	LCID lang_id = LocaleNameToLCID(wlang.c_str(), 0);
+	LCID lang_id = LocaleNameToLCID(wlang, 0);
+	bfree(wlang);
 
 	wchar_t lang_str[32];
 	_snwprintf(lang_str, 31, L"language=%x", (int)lang_id);

--- a/plugins/frontend-tools/captions-mssapi.cpp
+++ b/plugins/frontend-tools/captions-mssapi.cpp
@@ -123,13 +123,13 @@ try {
 		throw HRError("SetRecoState(SPRST_ACTIVE) failed", hr);
 	}
 
-	HANDLE events[] = {notify, stop};
+	HANDLE events[] = {stop, notify};
 
 	started = true;
 
 	for (;;) {
 		DWORD ret = WaitForMultipleObjects(2, events, false, INFINITE);
-		if (ret != WAIT_OBJECT_0) {
+		if (ret != WAIT_OBJECT_0 + 1) {
 			break;
 		}
 

--- a/plugins/frontend-tools/captions.cpp
+++ b/plugins/frontend-tools/captions.cpp
@@ -253,14 +253,10 @@ void obs_captions::start()
 			return;
 		}
 
-		size_t len = (size_t)wcslen(wname);
-
-		string lang_name;
-		lang_name.resize(len);
-
-		for (size_t i = 0; i < len; i++) {
-			lang_name[i] = (char)wname[i];
-		}
+		char *aname;
+		os_wcs_to_utf8_ptr(wname, 0, &aname);
+		string lang_name(aname);
+		bfree(aname);
 
 		OBSSource s = OBSGetStrongRef(source);
 		if (!s) {

--- a/plugins/frontend-tools/captions.cpp
+++ b/plugins/frontend-tools/captions.cpp
@@ -105,6 +105,7 @@ CaptionsDialog::CaptionsDialog(QWidget *parent) : QDialog(parent), ui(new Ui_Cap
 	obs_enum_sources([](void *data, obs_source_t *source) { return (*static_cast<cb_t *>(data))(source); }, &cb);
 	ui->source->blockSignals(false);
 
+	ui->provider->blockSignals(true);
 	for (auto &ht : captions->handler_types) {
 		QString name = ht.second.name().c_str();
 		QString id = ht.first.c_str();
@@ -116,6 +117,7 @@ CaptionsDialog::CaptionsDialog(QWidget *parent) : QDialog(parent), ui(new Ui_Cap
 	if (idx != -1) {
 		ui->provider->setCurrentIndex(idx);
 	}
+	ui->provider->blockSignals(false);
 
 	ui->enable->blockSignals(true);
 	ui->enable->setChecked(!!captions->handler);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
- Fix candidate for hang when opening "Captions (Experimental)" dialog from top menu.
- Fix unnecessary caption thread restart when opening caption dialog
- Tweak: Use proper char<->wchar encoding instead of simple type casting for locale names

When captions are enabled and the caption dialog is opened, the ui initialization in `CaptionsDialog::CaptionsDialog()` caused an event trigger which then restarted the caption thread. During the restart (which also happens when changing caption settings) `CaptionStream::Stop()` is supposed to notify/wake waiting reader thread, but the way mutex is handled in `CaptionStream::Read()` may cause the thread to miss the notification and then wait infinitely. Fix includes changes to mutex handling, but also adding a new `stop` flag to prevent calling `wait()` when `Stop()` has been called. 

A secondary fix is in `mssapi_captions::main_thread()` which uses `WaitForMultipleObjects()` to wait for more caption data to process and/or stop event, but the order of handles gave processing priority over stop event when both events were set. 

Additional fix for mutex handling in `CaptionStream::CopyTo()`, which acquired the buffer size to copy outside of mutex lock.

There is also one more potential issue in `mssapi_captions::main_thread()` which has a busy inner loop and the stop event is checked only in the outer loop, but this seemed more unlikely to happen in practice than the above fixes. Something to keep an eye out for though.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #12626

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Seeking testers, since I'm unable to reproduce the original issue. 
EDIT: I was able to reproduce this in current version, but not with this fix.

Note that since opening the dialog no longer restarts the caption thread, testing the fix should be done by changing the caption settings while the captions are enabled instead.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
