### PR TITLE
Revert "UI: Restore XDG config path update for FreeBSD"

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -304,35 +304,6 @@ static uint64_t convert_log_name(bool has_prefix, const char *name)
 	return std::stoull(timestring.str());
 }
 
-/* If upgrading from an older (non-XDG) build of OBS, move config files to XDG directory. */
-/* TODO: Remove after version 32.0. */
-#if defined(__FreeBSD__)
-static void move_to_xdg(void)
-{
-	char old_path[512];
-	char new_path[512];
-	char *home = getenv("HOME");
-	if (!home)
-		return;
-
-	if (snprintf(old_path, sizeof(old_path), "%s/.obs-studio", home) <= 0)
-		return;
-
-	/* make base xdg path if it doesn't already exist */
-	if (GetAppConfigPath(new_path, sizeof(new_path), "") <= 0)
-		return;
-	if (os_mkdirs(new_path) == MKDIR_ERROR)
-		return;
-
-	if (GetAppConfigPath(new_path, sizeof(new_path), "obs-studio") <= 0)
-		return;
-
-	if (os_file_exists(old_path) && !os_file_exists(new_path)) {
-		rename(old_path, new_path);
-	}
-}
-#endif
-
 static void delete_oldest_file(bool has_prefix, const char *location)
 {
 	BPtr<char> logDir(GetAppConfigPathPtr(location));
@@ -919,10 +890,6 @@ int main(int argc, char *argv[])
 #endif
 
 	base_get_log_handler(&def_log_handler, nullptr);
-
-#if defined(__FreeBSD__)
-	move_to_xdg();
-#endif
 
 	obs_set_cmdline_args(argc, argv);
 


### PR DESCRIPTION
### Description
To support upgrades from older versions move_to_xdg was reintroduced for FreeBSD.  This has now been available since release 31.0, so users have likely upgraded across this version and it is no longer needed.

### Motivation and Context
Clean up no longer needed code.

This reverts commit 39b91d88752699f3f8328b45529f93b511f19c01.
It is essentially c0532168243b78a7f880b3ef0c1b20cfe9be51ca reapplied.

### How Has This Been Tested?
Verified that obs still uses expected XDG path (~/.config/obs-studio/) with this change applied.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
