### PR TITLE
frontend: Improve FPS selector UX

### DIFF
--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -1171,7 +1171,7 @@ static QWidget *CreateRationalFPS(OBSFrameRatePropertyWidget *fpsProps, bool &se
 }
 
 static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop, bool &warning, const char *option,
-							 media_frames_per_second *current_fps,
+							 int fps_selector_mode, media_frames_per_second *current_fps,
 							 frame_rate_ranges_t &fps_ranges)
 {
 	auto widget = new OBSFrameRatePropertyWidget{};
@@ -1201,7 +1201,6 @@ static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop, b
 			continue;
 
 		option_found = true;
-		combo->setCurrentIndex(combo->count() - 1);
 	}
 
 	hlayout->addWidget(combo, 0, Qt::AlignTop);
@@ -1217,22 +1216,24 @@ static OBSFrameRatePropertyWidget *CreateFrameRateWidget(obs_property_t *prop, b
 			return;
 
 		match_found = true;
-
-		stack->setCurrentIndex(stack->count() - 1);
-		combo->setCurrentIndex(stack->count() - 1);
 	};
 
 	AddWidget(CreateSimpleFPSValues);
 	AddWidget(CreateRationalFPS);
 	stack->addWidget(new QWidget{});
 
-	if (option_found)
+	// When possible, use the previously selected FPS selector mode (typically simple or rational). If a consumer has
+	// created extra selection modes and our stored value is out of bounds, fall back to the trailing values for the mode
+	// selector and the corresponding FPS selector.
+	if (fps_selector_mode < combo->count() && fps_selector_mode < stack->count()) {
+		combo->setCurrentIndex(fps_selector_mode);
+		stack->setCurrentIndex(fps_selector_mode);
+	} else {
+		combo->setCurrentIndex(combo->count() - 1);
 		stack->setCurrentIndex(stack->count() - 1);
-	else if (!match_found) {
-		int idx = current_fps ? 1 : 0; // Rational for "unsupported"
-					       // Simple as default
-		stack->setCurrentIndex(idx);
-		combo->setCurrentIndex(idx);
+	}
+
+	if (!match_found) {
 		warning = true;
 	}
 
@@ -1367,7 +1368,9 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		fps_ranges.emplace_back(obs_property_frame_rate_fps_range_min(prop, i),
 					obs_property_frame_rate_fps_range_max(prop, i));
 
-	auto widget = CreateFrameRateWidget(prop, warning, option, valid_fps, fps_ranges);
+	int selector_mode = obs_data_get_int(settings, "fps_selector_mode");
+
+	auto widget = CreateFrameRateWidget(prop, warning, option, selector_mode, valid_fps, fps_ranges);
 	auto info = new WidgetInfo(this, prop, widget);
 
 	widget->setToolTip(QT_UTF8(obs_property_long_description(prop)));
@@ -1643,6 +1646,8 @@ static bool FrameRateChanged(QWidget *widget, const char *name, OBSData &setting
 	};
 	unique_ptr<void, decltype(StopUpdating)> signalGuard(static_cast<void *>(w), StopUpdating);
 	w->updating = true;
+
+	obs_data_set_int(w->settings, "fps_selector_mode", w->modeSelect->currentIndex());
 
 	if (!obs_data_has_user_value(settings, name))
 		obs_data_set_obj(settings, name, nullptr);

--- a/shared/properties-view/properties-view.moc.hpp
+++ b/shared/properties-view/properties-view.moc.hpp
@@ -17,7 +17,10 @@
 
 static bool operator!=(const media_frames_per_second &a, const media_frames_per_second &b)
 {
-	return a.numerator != b.numerator || a.denominator != b.denominator;
+	// Compare fractions via cross multiplication, to avoid rounding or division
+	uint64_t lhs = (uint64_t)a.numerator * (uint64_t)b.denominator;
+	uint64_t rhs = (uint64_t)b.numerator * (uint64_t)a.denominator;
+	return lhs != rhs;
 }
 
 static bool operator==(const media_frames_per_second &a, const media_frames_per_second &b)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes the effective 'autoselect' behavior of the frame rate selector's "mode" picker (i.e. "Rational" or "Simple").

The selector will now always try to retain the mode set by the user, which will be stored on the relevant settings object for the consumer using the frame rate selector.

On first use we default to the "simple" mode.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This PR represents a best effort attempt to improve the usability of the FPS selector without significantly re-architecting the underlying properties system.

Previously, the frame rate selector would aggressively revert to the Rational mode if a frame rate was selected that didn't match any Simple frame rates. This would occur for invalid framerates (such as those with a 0 in their numerator), framerates out of range for the supported frame rates on the selected format, or frame rates that were otherwise not equal to any Simple frame rates on the format (it would also spuriously switch even if a frame rate matched a Simple frame rate, due to an inferior comparator implementation that this PR corrects).

The switch to Rational mode could also be triggered inadvertently, such as when changing formats, devices, moving between simple frame rates, or even when switching to Simple mode.

All of these behaviors are now removed, and the frame rate mode selector should now remain in the same mode unless explicitly switched.

This should improve the usability of the selector overall. 

### Other

A significant drawback with this selector remains unaddressed by this PR. When interacting with the spin box for the numerator or denominator in the Rational mode as a text box, the selector will be redrawn on any update to the underlying value, i.e. not only when the text box is "done editing." This makes the rational mode very difficult to use in any reasonable way, though the UX is slightly improved by this PR. This seems to be a fundamental limitation of the basic QSpinBox that we cannot resolve without modifying the underlying implementation.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS with both capture device source types.

This PR needs testing on other platforms (Windows, Linux) to make sure that no regressions are introduced with functionality such as format autoselection on Windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
