### PR TITLE
mac-avcapture: Use fallback frame rate by default for new devices

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -417,6 +417,23 @@ static const UInt32 kMaxFrameRateRangesInDescription = 10;
     OBSAVCaptureMediaFPS fps;
     if (!obs_data_get_frames_per_second(self.captureInfo->settings, "frame_rate", &fps, NULL)) {
         [self AVCaptureLog:LOG_DEBUG withFormat:@"No valid framerate found in settings"];
+
+        AVCaptureDeviceFormat *lastFormat = [self.deviceInput.device.formats lastObject];
+
+        fps = [OBSAVCapture fallbackFrameRateForFormat:lastFormat];
+
+        if (lastFormat.videoSupportedFrameRateRanges.count == 0) {
+            return NO;
+        }
+
+        obs_data_set_obj(self.captureInfo->settings, "frame_rate", NULL);
+
+        obs_data_item_t *frameRateSetting = obs_data_item_byname(self.captureInfo->settings, "frame_rate");
+
+        obs_data_item_set_frames_per_second(&frameRateSetting, fps, NULL);
+
+        obs_source_update(self.captureInfo->source, self.captureInfo->settings);
+
         return NO;
     }
 


### PR DESCRIPTION
### Description
Enables the video capture and capture card sources to automatically select an initial fallback framerate when a device is selected.

### Motivation and Context
When a new device is selected, a best-possible frame rate is chosen for the initial configuration of the device. This has to be set in the source settings, as those are the "source of truth" for the properties and the device configuration.

The object has to be created explicitly first before setting the frame rate value. The source then has to be updated explicitly as well to ensure that the change will be picked up by the next iteration of the render thread to "tick" the source and thus make it configure a capture session with the fallback framerate set.

Ensures that a "good-enough" setup is used immediately and users can see that their chosen capture device is actually "working".

> [!NOTE]
> Due to a bug with the frame rate property code, this will also make the property widget automatically switch the frame rate selection to "rational" mode.
>
> The root cause for this is that the specific values for numerator and denominator used by CoreMedia do not match the values used by OBS (even though they effectively both represent the same frame interval), and it only does a naive numerical comparison of both values.
>
> This will have to be fixed separately in the associated shared property UI code.

### How Has This Been Tested?
Tested on macOS 26 with capture card source and video capture source:

* Initial setup always chose best-possible fallback for a new source
* Capture device was correctly initialised with the fallback frame rate

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
