### PR TITLE
Add user setting to allow hotkeys with extra modifier keys

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -339,6 +339,7 @@ void OBSApp::InitUserConfigDefaults()
 	config_set_default_bool(userConfig, "General", "ConfirmOnExit", true);
 
 	config_set_default_string(userConfig, "General", "HotkeyFocusType", "NeverDisableHotkeys");
+	config_set_default_bool(userConfig, "General", "HotkeyIgnoreModifiers", false);
 
 	config_set_default_bool(userConfig, "BasicWindow", "PreviewEnabled", true);
 	config_set_default_bool(userConfig, "BasicWindow", "PreviewProgramMode", false);
@@ -1122,6 +1123,9 @@ void OBSApp::UpdateHotkeyFocusSetting(bool resetState)
 	} else if (astrcmpi(hotkeyFocusType, "DisableHotkeysOutOfFocus") == 0) {
 		enableHotkeysOutOfFocus = false;
 	}
+
+	bool ignoreModifiers = config_get_bool(userConfig, "General", "HotkeyIgnoreModifiers");
+	obs_hotkey_enable_strict_modifiers(!ignoreModifiers);
 
 	if (resetState)
 		ResetHotkeyState(applicationState() == Qt::ApplicationActive);

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1324,6 +1324,8 @@ Basic.Settings.Advanced.Hotkeys.HotkeyFocusBehavior="Hotkey Focus Behavior"
 Basic.Settings.Advanced.Hotkeys.NeverDisableHotkeys="Never disable hotkeys"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysInFocus="Disable hotkeys when main window is in focus"
 Basic.Settings.Advanced.Hotkeys.DisableHotkeysOutOfFocus="Disable hotkeys when main window is not in focus"
+Basic.Settings.Advanced.Hotkeys.IgnoreModifiers="Ignore additional modifier keys"
+Basic.Settings.Advanced.Hotkeys.IgnoreModifiers.Tooltip="When enabled, hotkeys will trigger even when extra modifier keys are pressed.\nExample: 'K' will trigger for K, Shift+K, Ctrl+K, Alt+K, etc."
 Basic.Settings.Advanced.AutoRemux="Automatically remux to %1"
 Basic.Settings.Advanced.AutoRemux.MP4="(record as mkv)"
 

--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -8603,7 +8603,17 @@
                    <item row="0" column="1">
                     <widget class="QComboBox" name="hotkeyFocusType"/>
                    </item>
-                   <item row="1" column="0">
+                   <item row="1" column="0" colspan="2">
+                    <widget class="QCheckBox" name="hotkeyIgnoreModifiers">
+                     <property name="text">
+                      <string>Basic.Settings.Advanced.Hotkeys.IgnoreModifiers</string>
+                     </property>
+                     <property name="toolTip">
+                      <string>Basic.Settings.Advanced.Hotkeys.IgnoreModifiers.Tooltip</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0">
                     <spacer name="horizontalSpacer_14">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -550,6 +550,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 	HookWidget(ui->enableNewSocketLoop,  CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->enableLowLatencyMode, CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->hotkeyFocusType,      COMBO_CHANGED,  ADV_CHANGED);
+	HookWidget(ui->hotkeyIgnoreModifiers, CHECK_CHANGED, ADV_CHANGED);
 	HookWidget(ui->autoRemux,            CHECK_CHANGED,  ADV_CHANGED);
 	HookWidget(ui->dynBitrate,           CHECK_CHANGED,  ADV_CHANGED);
 	/* clang-format on */
@@ -2540,6 +2541,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 	int rbSize = config_get_int(main->Config(), "AdvOut", "RecRBSize");
 	bool autoRemux = config_get_bool(main->Config(), "Video", "AutoRemux");
 	const char *hotkeyFocusType = config_get_string(App()->GetUserConfig(), "General", "HotkeyFocusType");
+	bool hotkeyIgnoreModifiers = config_get_bool(App()->GetUserConfig(), "General", "HotkeyIgnoreModifiers");
 	bool dynBitrate = config_get_bool(main->Config(), "Output", "DynamicBitrate");
 	const char *ipFamily = config_get_string(main->Config(), "Output", "IPFamily");
 	bool confirmOnExit = config_get_bool(App()->GetUserConfig(), "General", "ConfirmOnExit");
@@ -2616,6 +2618,7 @@ void OBSBasicSettings::LoadAdvancedSettings()
 #endif
 
 	SetComboByValue(ui->hotkeyFocusType, hotkeyFocusType);
+	ui->hotkeyIgnoreModifiers->setChecked(hotkeyIgnoreModifiers);
 
 	loading = false;
 }
@@ -3168,6 +3171,11 @@ void OBSBasicSettings::SaveAdvancedSettings()
 	if (WidgetChanged(ui->hotkeyFocusType)) {
 		QString str = GetComboData(ui->hotkeyFocusType);
 		config_set_string(App()->GetUserConfig(), "General", "HotkeyFocusType", QT_TO_UTF8(str));
+	}
+
+	if (WidgetChanged(ui->hotkeyIgnoreModifiers)) {
+		bool ignoreModifiers = ui->hotkeyIgnoreModifiers->isChecked();
+		config_set_bool(App()->GetUserConfig(), "General", "HotkeyIgnoreModifiers", ignoreModifiers);
 	}
 
 #ifdef __APPLE__

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1217,6 +1217,15 @@ void obs_hotkey_enable_callback_rerouting(bool enable)
 	unlock();
 }
 
+void obs_hotkey_enable_strict_modifiers(bool enable)
+{
+	if (!lock())
+		return;
+
+	obs->hotkeys.strict_modifiers = enable;
+	unlock();
+}
+
 static void obs_set_key_translation(obs_key_t key, const char *translation)
 {
 	bfree(obs->hotkeys.translations[key]);

--- a/libobs/obs-hotkey.h
+++ b/libobs/obs-hotkey.h
@@ -246,6 +246,9 @@ EXPORT void obs_hotkey_trigger_routed_callback(obs_hotkey_id id, bool pressed);
  * router func is set */
 EXPORT void obs_hotkey_enable_callback_rerouting(bool enable);
 
+/* Allow hotkeys to match even with extra modifiers pressed (e.g., 'k' matches 'Shift+k') */
+EXPORT void obs_hotkey_enable_strict_modifiers(bool enable);
+
 /* misc */
 
 typedef void (*obs_hotkey_atomic_update_func)(void *);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1140,7 +1140,7 @@ static inline bool obs_init_hotkeys(void)
 	if (pthread_create(&hotkeys->hotkey_thread, NULL, obs_hotkey_thread, NULL))
 		goto fail;
 
-	hotkeys->strict_modifiers = true;
+	hotkeys->strict_modifiers = false;
 	hotkeys->hotkey_thread_initialized = true;
 
 	success = true;


### PR DESCRIPTION
### Description
- libobs: Added `obs_hotkey_enable_strict_modifiers()` API to control modifier matching behavior. Changed default `strict_modifiers` from `true` to `false` (now set by frontend).
- frontend: Added "Ignore additional modifier keys" checkbox in Settings → Advanced → Hotkeys section. Loads/saves the `HotkeyIgnoreModifiers` config value and applies it to libobs on startup, leading to the following behavior:
  - Unchecked (default): Preserves current exact-match behavior. 'K' only triggers with K alone.
  - Checked: Allows fuzzy matching. 'K' triggers with K, Shift+K, Ctrl+K, Alt+K, etc.


### Motivation and Context
Hotkeys currently require exact modifier matches. For example, if you bind 'K' to start recording, it only works when pressing K alone—pressing Shift+K or Ctrl+K won't trigger it. This is frustrating when typing or using other shortcuts, as you need to ensure no extra modifiers are held down.

This adds a checkbox in Advanced → Hotkeys to allow hotkeys to match even with additional modifiers pressed, making them more forgiving in real-world use.


### How Has This Been Tested?
Testing Environment:
- Windows 11 x64
- Visual Studio 2022 (17.x)
- CMake 3.30
- Built using windows-x64 preset with default options

Tests Performed:
1. Basic functionality: Set 'K' as Start Recording hotkey. Verified it triggers with K alone (checkbox unchecked), then enabled the setting and confirmed it triggers with Shift+K, Ctrl+K, Alt+K combinations.
2. Existing hotkeys: Tested that existing hotkey bindings (Ctrl+K, Alt+K) still work correctly with the setting both enabled and disabled.
3. Settings persistence: Verified the checkbox state is saved/loaded correctly across OBS restarts.
4. Modifier-only hotkeys: Confirmed that binding only 'Alt' still triggers with Alt+W regardless of setting (expected behavior).

No issues observed. Changes are isolated to hotkey matching logic in libobs and the Advanced settings UI - no impact on recording, streaming, or other functionality.


### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
