### PR TITLE
frontend: Fix canvas removal causing crashes due to recursive remove calls

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1123,6 +1123,7 @@ private:
 	std::vector<OBS::Canvas> canvases;
 
 	static void CanvasRemoved(void *data, calldata_t *params);
+	void ClearCanvases();
 
 public:
 	const std::vector<OBS::Canvas> &GetCanvases() const noexcept { return canvases; }

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1539,7 +1539,7 @@ void OBSBasic::ClearSceneData()
 		obs_canvas_enum_scenes(canvas, cb, nullptr);
 	}
 
-	canvases.clear();
+	ClearCanvases();
 
 	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CLEANUP);
 


### PR DESCRIPTION
### Description

Makes some changes to how canvas removal is handled to avoid recursion in the middle of an `erase()` operation on the vector holding frontend-managed canvases.

Also prevents a similar issue when clearing scene data by replacing `.clear()` with a dedicated method that also ensures the canvas removal signal is properly fired for each removed canvas.

### Motivation and Context

See #12728, which this PR superseedes.

### How Has This Been Tested?

Reproduced using the following snipped (just added to the end of the `OBSBasicSettings::OBSBasicSettings()` constructor):
```c++
	obs_video_info ovi;
	obs_get_video_info(&ovi);
	OBSCanvasAutoRelease cv = obs_frontend_add_canvas("test", &ovi, PROGRAM);
	obs_frontend_remove_canvas(cv);
	OBSCanvasAutoRelease cv2 = obs_frontend_add_canvas("test2", &ovi, PROGRAM);
```
Note that the crash only happens in release builds, not debug.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
