### PR TITLE
libobs-winrt: Prevent hard cap of 60 fps for WGC capture

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -1,5 +1,9 @@
 #include "winrt-capture.h"
 
+#if defined(WDK_NTDDI_VERSION) && (WDK_NTDDI_VERSION >= 0x0A000010)
+#define WINRT_MIN_UPDATE_INTERVAL
+#endif
+
 extern "C" EXPORT BOOL winrt_capture_supported()
 try {
 	/* no contract for IGraphicsCaptureItemInterop, verify 10.0.18362.0 */
@@ -26,6 +30,18 @@ try {
 	blog(LOG_ERROR, "winrt_capture_cursor_toggle_supported (0x%08X)", winrt::to_hresult().value);
 	return false;
 }
+
+#ifdef WINRT_MIN_UPDATE_INTERVAL
+static inline winrt::Windows::Foundation::TimeSpan calculate_min_interval()
+{
+	obs_video_info ovi{};
+	if (!obs_get_video_info(&ovi) || !ovi.fps_num)
+		return winrt::Windows::Foundation::TimeSpan{0};
+
+	const uint64_t frame_interval_hns = util_mul_div64(ovi.fps_den, 10000000ULL, ovi.fps_num);
+	return winrt::Windows::Foundation::TimeSpan{static_cast<int64_t>(frame_interval_hns / 2)};
+}
+#endif
 
 template<typename T>
 static winrt::com_ptr<T> GetDXGIInterfaceFromObject(winrt::Windows::Foundation::IInspectable const &object)
@@ -313,6 +329,18 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 			capture->last_size);
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session = frame_pool.CreateCaptureSession(item);
 
+#ifdef WINRT_MIN_UPDATE_INTERVAL
+	if (winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+		    L"Windows.Graphics.Capture.GraphicsCaptureSession", L"MinUpdateInterval")) {
+		try {
+			session.MinUpdateInterval(calculate_min_interval());
+		} catch (const winrt::hresult_error &err) {
+			blog(LOG_WARNING, "GraphicsCaptureSession::MinUpdateInterval (0x%08X): %s", err.code().value,
+			     winrt::to_string(err.message()).c_str());
+		}
+	}
+#endif
+
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::RequestAccessAsync(
 			winrt::Windows::Graphics::Capture::GraphicsCaptureAccessKind::Borderless)
@@ -378,6 +406,18 @@ try {
 		winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::Create(
 			device, static_cast<winrt::Windows::Graphics::DirectX::DirectXPixelFormat>(format), 2, size);
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session = frame_pool.CreateCaptureSession(item);
+
+#ifdef WINRT_MIN_UPDATE_INTERVAL
+	if (winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+		    L"Windows.Graphics.Capture.GraphicsCaptureSession", L"MinUpdateInterval")) {
+		try {
+			session.MinUpdateInterval(calculate_min_interval());
+		} catch (const winrt::hresult_error &err) {
+			blog(LOG_WARNING, "GraphicsCaptureSession::MinUpdateInterval (0x%08X): %s", err.code().value,
+			     winrt::to_string(err.message()).c_str());
+		}
+	}
+#endif
 
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::RequestAccessAsync(


### PR DESCRIPTION
### Description
By overriding WGC’s default pacing with 'MinUpdateInterval' (introduced in Windows build 26100), OBS avoids the compositor’s conservative frame-delivery interval and unlocks higher capture rates, aligning frame arrival frequency with the framerate we request via OBS settings.

### Motivation and Context
Windows 10 capture helps with recording stuff that is not compatible with regular Game Capture method, but currently is limited to 60 fps, which is really inconvenient for people who might wanna use higher framerates.

### How Has This Been Tested?
By checking video footage frame-by-frame
RTX 4060, Windows 11 24H2

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.