### PR TITLE
linux-pipewire: Fix PipeWire IPU6 camera broken in 32.0.1

### DIFF
--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -675,7 +675,7 @@ static void framerate_list(struct camera_device *dev, uint32_t pixelformat, cons
 		if (!obs_pw_video_format_from_spa_format(format, &obs_pw_video_format))
 			continue;
 
-		if (obs_pw_video_format.video_format != pixelformat)
+		if (obs_pw_video_format.spa_format != pixelformat)
 			continue;
 
 		if (spa_pod_parse_object(p->param, SPA_TYPE_OBJECT_Format, NULL, SPA_FORMAT_VIDEO_size,

--- a/plugins/linux-pipewire/formats.c
+++ b/plugins/linux-pipewire/formats.c
@@ -55,9 +55,9 @@ static const struct obs_pw_video_format supported_formats[] = {
 	{
 		SPA_VIDEO_FORMAT_RGBx,
 		DRM_FORMAT_XBGR8888,
-		GS_BGRX,
-		VIDEO_FORMAT_NONE,
-		true,
+		GS_RGBA,
+		VIDEO_FORMAT_RGBA,
+		false,
 		4,
 		"XBGR8888",
 	},


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fix PipeWire IPU6 camera broken in 32.0.1, Use RGBA to support RGBX.
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Revise the following PR：#12718

See issue: #12700

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I have tested in my complute.
### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Bug fix (non-breaking change which fixes an issue)
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
