### PR TITLE
graphics-hook: Fix D3D9 memory capture regression

### DIFF
--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -348,7 +348,7 @@ void d3d10_capture(void *swap_ptr, void *backbuffer_ptr)
 	if (capture_should_init()) {
 		d3d10_init(swap);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		ID3D10Resource *backbuffer;
 
 		hr = dxgi_backbuffer->QueryInterface(__uuidof(ID3D10Resource), (void **)&backbuffer);

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -306,7 +306,7 @@ void d3d11_capture(void *swap_ptr, void *backbuffer_ptr)
 	if (capture_should_init()) {
 		d3d11_init(swap);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		ID3D11Resource *backbuffer;
 
 		hr = dxgi_backbuffer->QueryInterface(__uuidof(ID3D11Resource), (void **)&backbuffer);

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -552,7 +552,7 @@ static void d3d9_capture(IDirect3DDevice9 *device, IDirect3DSurface9 *backbuffer
 	if (capture_should_init()) {
 		d3d9_init(device);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		if (data.device != device) {
 			d3d9_free();
 			return;


### PR DESCRIPTION
Commit 0b87f53 added a conditional check on the shared texture handle, preventing memory capture in D3D9.

D3D10 and D3D11 use a capture struct with a union whose variants overlap in memory, so the check still accessed the union member, which worked in practice but is undefined behavior.

Fix the capture detection for D3D9 memory capture, and update the D3D10/D3D11 checks to evaluate only the active union variant to remove the undefined behavior.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix D3D9 memory capture.
Fix C++ UB.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested D3D9, D3D10 and D3D11 game capture with both memory and shared texture capture.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
