### PR TITLE
obs-outputs: Fix chapter ts when using file splitting

### DIFF
--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -151,7 +151,7 @@ void mp4_pkt_callback(obs_output_t *output, struct encoder_packet *pkt, struct e
 
 		/* Video frames can be out of order (b-frames), so instead of using the video packet's dts_usec we need to calculate
 		 * the chapter DTS from the frame's PTS (for chapters DTS == PTS). */
-		int64_t chap_dts_usec = pkt->pts * 1000000 / pkt->timebase_den;
+		int64_t chap_dts_usec = (pkt->pts * 1000000 / pkt->timebase_den) - out->start_time;
 		int64_t chap_dts_msec = chap_dts_usec / 1000;
 		int64_t chap_dts_sec = chap_dts_msec / 1000;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Chapter timestamps are incorrect after the output file is split. Chapters take their timestamp from the total video frame time.
With file splitting enabled in recording settings, the time offset since the start of the current split was made needs to be considered before submitting chapters to the muxer.
This change subtracts the start_time (time offset since the recording was started, which is updated when the output file is changed) of the current output from the chapter timestamp so chapter timestamps are correct and appear correctly in the output files.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Without the fix, chapter timestamps are incorrect after the output file is split.

Fixes #12714.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Windows 11 Pro, 25H2, 26200.7019. Hybrid MP4 (.mp4)
- Tested adding chapters with hotkey, automatic file splitting off. Verified chapters appear at expected timestamps.
- Tested adding chapters with hotkey, automatic file splitting set to time, and 1 minute duration. Verified chapters appear at expected timestamps across split files.
- Tested adding chapters with hotkey, automatic file splitting set to size, and 20MB size. Verified chapters appear at expected timestamps across split files.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
