### PR TITLE
cmake: Find Qt6 GuiPrivate for Qt 6.10 compatibility

### DIFF
--- a/frontend/plugins/frontend-tools/CMakeLists.txt
+++ b/frontend/plugins/frontend-tools/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.28...3.30)
 find_package(Qt6 REQUIRED Widgets)
 
 if(OS_LINUX OR OS_FREEBSD OR OS_OPENBSD)
-  find_package(Qt6 REQUIRED Gui)
+  find_package(Qt6 REQUIRED GuiPrivate)
   find_package(X11 REQUIRED)
 endif()
 


### PR DESCRIPTION
### Motivation and Context
The build was failing on Linux/FreeBSD/OpenBSD with the following CMake error:

`CMake Error at frontend/plugins/frontend-tools/CMakeLists.txt:57 (target_link_libraries):
  Target "frontend-tools" links to:

    Qt::GuiPrivate

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.`

This occurred because the code was attempting to link against Qt::GuiPrivate on lines 57+ without first calling find_package to make the target available.  Starting from Qt 6.10, the GuiPrivate component must be explicitly listed in find_package() calls. Update frontend-tools CMakeLists.txt to properly find Qt6 GuiPrivate instead of just Gui for Linux, FreeBSD, and OpenBSD platforms.

There seems to be a bug in the documentation.

See: 

Original: [https://doc.qt.io/qt-6/qtguiprivate-module.html#details](url)
Snapshot: [https://doc-snapshots.qt.io/qt6-6.10/qtguiprivate-module.html#details](url)

### How Has This Been Tested?
Environment: Linux x86_64
OBS Version: Tested against tag 32.0.2
Testing performed:
Verified CMake configuration completes without errors
Confirmed successful compilation of obs-studio-32.0.2
Verified no regressions on functionality
Build completes end-to-end successfully

### Types of changes
Bug fix (non-breaking change which fixes an issue)