### PR TITLE
frontend: Add minimum width to spinboxes

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -173,6 +173,7 @@
     --input_text_padding: max(calc(6px + var(--padding_base)), 8px);
     --input_height: calc(var(--input_height_base) - calc(var(--input_padding) * 2px));
     --input_height_half: calc(var(--input_height_base) / 2);
+    --spinbox_width: calc(var(--input_height_base) + calc(var(--input_padding) * 2px));
 
     --input_bg: var(--grey4);
     --input_bg_hover: var(--grey7);
@@ -1278,6 +1279,7 @@ QDoubleSpinBox {
     border-radius: var(--border_radius);
     padding: var(--input_padding) var(--input_text_padding);
     height: var(--input_height);
+    min-width: var(--spinbox_width);
     max-height: var(--input_height);
 }
 


### PR DESCRIPTION
### Description
Adds a minimum width for spinboxes to the stylesheet to work around [QTBUG-141916](https://bugreports.qt.io/browse/QTBUG-141916)

Fixes #12476
Fixes #12502
Fixes #12503

### Motivation and Context
Text in many spinboxes gets clipped due to a bug in how Qt calculates the widget size when the up/down buttons have their size changed by the stylesheet.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
