### PR TITLE
libobs: Add devices_match to null monitor

### DIFF
--- a/libobs/audio-monitoring/null/null-audio-monitoring.c
+++ b/libobs/audio-monitoring/null/null-audio-monitoring.c
@@ -26,3 +26,10 @@ void audio_monitor_destroy(struct audio_monitor *monitor)
 {
 	UNUSED_PARAMETER(monitor);
 }
+
+bool devices_match(const char *id1, const char *id2)
+{
+	UNUSED_PARAMETER(id1);
+	UNUSED_PARAMETER(id2);
+	return false;
+}


### PR DESCRIPTION
### Description
Fixes https://github.com/obsproject/obs-studio/issues/12810 where compilation fails for null monitor due to
devices_match symbol not found.
This adds the devices_match function to null monitor to fix linking issues on linux when pulse audio is disabled.
### Motivation and Context
Fixes a bug.

### How Has This Been Tested?
Untested. I'll leave it to the OP of the issue to check the fix works.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
