### PR TITLE
libobs: Fix canvas private duplicated scenes

### DIFF
--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1022,6 +1022,8 @@ extern void audio_monitor_destroy(struct audio_monitor *monitor);
 
 extern obs_source_t *obs_source_create_canvas(obs_canvas_t *canvas, const char *id, const char *name,
 					      obs_data_t *settings, obs_data_t *hotkey_data);
+extern obs_source_t *obs_source_create_canvas_private(obs_canvas_t *canvas, const char *id, const char *name,
+						      obs_data_t *settings);
 extern obs_source_t *obs_source_create_set_last_ver(obs_canvas_t *canvas, const char *id, const char *name,
 						    const char *uuid, obs_data_t *settings, obs_data_t *hotkey_data,
 						    uint32_t last_obs_ver, bool is_private);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -1785,9 +1785,9 @@ static inline obs_scene_t *create_id(obs_canvas_t *canvas, const char *id, const
 	return source->context.data;
 }
 
-static inline obs_scene_t *create_private_id(const char *id, const char *name)
+static inline obs_scene_t *create_private_id(obs_canvas_t *canvas, const char *id, const char *name)
 {
-	struct obs_source *source = obs_source_create_private(id, name, NULL);
+	struct obs_source *source = obs_source_create_canvas_private(canvas, id, name, NULL);
 	return source->context.data;
 }
 
@@ -1798,7 +1798,7 @@ obs_scene_t *obs_scene_create(const char *name)
 
 obs_scene_t *obs_scene_create_private(const char *name)
 {
-	return create_private_id("scene", name);
+	return create_private_id(obs->data.main_canvas, "scene", name);
 }
 
 static obs_source_t *get_child_at_idx(obs_scene_t *scene, size_t idx)
@@ -1939,7 +1939,7 @@ obs_scene_t *obs_scene_duplicate(obs_scene_t *scene, const char *name, enum obs_
 	/* --------------------------------- */
 
 	obs_canvas_t *canvas = obs_weak_canvas_get_canvas(scene->source->canvas);
-	new_scene = make_private ? create_private_id(scene->source->info.id, name)
+	new_scene = make_private ? create_private_id(canvas, scene->source->info.id, name)
 				 : create_id(canvas, scene->source->info.id, name);
 	obs_canvas_release(canvas);
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -284,6 +284,8 @@ static void obs_source_init_finalize(struct obs_source *source, obs_canvas_t *ca
 			obs_context_data_insert_name(&source->context, &obs->data.sources_mutex,
 						     &obs->data.public_sources);
 		}
+	} else if (requires_canvas(source)) {
+		source->canvas = obs_canvas_get_weak_canvas(canvas);
 	}
 	obs_context_data_insert_uuid(&source->context, &obs->data.sources_mutex, &obs->data.sources);
 }
@@ -466,6 +468,12 @@ obs_source_t *obs_source_create_canvas(obs_canvas_t *canvas, const char *id, con
 				       obs_data_t *hotkey_data)
 {
 	return obs_source_create_internal(id, name, NULL, settings, hotkey_data, false, LIBOBS_API_VER, canvas);
+}
+
+obs_source_t *obs_source_create_canvas_private(obs_canvas_t *canvas, const char *id, const char *name,
+					       obs_data_t *settings)
+{
+	return obs_source_create_internal(id, name, NULL, settings, NULL, true, LIBOBS_API_VER, canvas);
 }
 
 obs_source_t *obs_source_create_set_last_ver(obs_canvas_t *canvas, const char *id, const char *name, const char *uuid,


### PR DESCRIPTION
### Description
Fix calling obs_scene_duplicate with OBS_SCENE_DUP_PRIVATE_REFS not setting canvas

### Motivation and Context
When you use studio mode with duplicate scene you get this warning in the OBS log file:
`Attempted to add Scene without specifying a canvas! Using default canvas instead.`


### How Has This Been Tested?
On windows by enabling studio mode

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
