### PR TITLE
obs-nvenc: Fix GPU selector visibility on dual-GPU systems

### DIFF
--- a/plugins/obs-nvenc/nvenc-properties.c
+++ b/plugins/obs-nvenc/nvenc-properties.c
@@ -202,7 +202,7 @@ obs_properties_t *nvenc_properties_internal(enum codec_type codec)
 	p = obs_properties_add_bool(props, "adaptive_quantization", obs_module_text("AdaptiveQuantization"));
 	obs_property_set_long_description(p, obs_module_text("AdaptiveQuantization.ToolTip"));
 
-	if (num_encoder_devices() > 1) {
+	if (num_encoder_devices() > 0) {
 		obs_properties_add_int(props, "device", obs_module_text("GPU"), -1, num_encoder_devices(), 1);
 	}
 


### PR DESCRIPTION
### Description
This change ensures the GPU (encoder device) selector is visible whenever at least one compatible device is detected, rather than requiring two or more devices.

### Motivation and Context
Problem: On systems where a previously saved GPU encoder device has been removed or disabled, OBS returns a CUDA_ERROR_INVALID_DEVICE error when attempting to stream or record. In dual-GPU configurations, the device selector dropdown not appear, leaving users unable to select the remaining valid GPU through the UI.

### How Has This Been Tested?
Not a breaking change, but tested the build on a dual-GPU setup with Windows 11 Professional (x64) Build 26100.7171 (24H2)

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.