### PR TITLE
frontend: Use palette for Light theme audio mixer

### DIFF
--- a/frontend/data/themes/Yami_Light.ovt
+++ b/frontend/data/themes/Yami_Light.ovt
@@ -45,15 +45,15 @@
 }
 
 VolumeMeter {
-    qproperty-backgroundNominalColor: rgb(66,112,24);
-    qproperty-backgroundWarningColor: rgb(112,91,28);
-    qproperty-backgroundErrorColor: rgb(112,39,53);
-    qproperty-foregroundNominalColor: rgb(115,189,49);
-    qproperty-foregroundWarningColor: rgb(189,144,9);
-    qproperty-foregroundErrorColor: rgb(189,47,73);
+    qproperty-backgroundNominalColor: var(--green4);
+    qproperty-backgroundWarningColor: var(--yellow4);
+    qproperty-backgroundErrorColor: var(--red4);
+    qproperty-foregroundNominalColor: var(--green1);
+    qproperty-foregroundWarningColor: var(--yellow1);
+    qproperty-foregroundErrorColor: var(--red1);
     qproperty-magnitudeColor: rgb(0,0,0);
-    qproperty-majorTickColor: palette(text);
-    qproperty-minorTickColor: palette(light);
+    qproperty-majorTickColor: var(--black1);
+    qproperty-minorTickColor: var(--black5);
 }
 
 QMenu::right-arrow {


### PR DESCRIPTION
### Description
Uses OBS palette colors for Light theme mixer

**Before**
<img width="371" height="365" alt="image" src="https://github.com/user-attachments/assets/9f9964b4-d6ca-4b1c-af82-9ea9c97e6bf2" />

**After**
<img width="341" height="378" alt="image" src="https://github.com/user-attachments/assets/bc2a081c-8cda-4a03-8a69-5256155fb3c0" />


### Motivation and Context
Theme consistency.

### How Has This Been Tested?
👁

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
