### PR TITLE
frontend: Add MediaControls to source properties

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -499,6 +499,10 @@
 
 /* Media icons */
 
+MediaControls QPushButton {
+    min-height: var(--input_height);
+}
+
 .icon-media-play {
     qproperty-icon: url(theme:Dark/media/media_play.svg);
 }

--- a/frontend/dialogs/OBSBasicProperties.cpp
+++ b/frontend/dialogs/OBSBasicProperties.cpp
@@ -17,6 +17,8 @@
 
 #include "OBSBasicProperties.hpp"
 
+#include <components/MediaControls.hpp>
+#include <Idian/Utils.hpp>
 #include <utility/display-helpers.hpp>
 #include <widgets/OBSBasic.hpp>
 
@@ -39,6 +41,19 @@ using namespace std;
 
 static void CreateTransitionScene(OBSSource scene, const char *text, uint32_t color);
 
+namespace {
+bool is_network_media_source(obs_source_t *source, const char *id)
+{
+	if (strcmp(id, "ffmpeg_source") != 0)
+		return false;
+
+	OBSDataAutoRelease s = obs_source_get_settings(source);
+	bool is_local_file = obs_data_get_bool(s, "is_local_file");
+
+	return !is_local_file;
+}
+} // namespace
+
 OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	: QDialog(parent),
 	  ui(new Ui::OBSBasicProperties),
@@ -53,11 +68,17 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 	int cy = (int)config_get_int(App()->GetAppConfig(), "PropertiesWindow", "cy");
 
 	enum obs_source_type type = obs_source_get_type(source);
+	uint32_t caps = obs_source_get_output_flags(source);
 
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
+	idian::Utils utils(this);
+
 	ui->setupUi(this);
 	ui->buttonBox->button(QDialogButtonBox::Ok)->setFocus();
+
+	ui->controlsFrame->hide();
+	utils.addClass(ui->controlsFrame, "dialog-frame");
 
 	if (cx > 400 && cy > 400)
 		resize(cx, cy);
@@ -83,6 +104,15 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		ui->transitionButton->setVisible(false);
 	}
 
+	if ((caps & OBS_SOURCE_CONTROLLABLE_MEDIA) != 0) {
+		MediaControls *mediaControls = new MediaControls(this);
+		mediaControls->SetSource(source);
+
+		ui->controlsFrame->layout()->addWidget(mediaControls);
+
+		connect(view, &OBSPropertiesView::PropertiesRefreshed, this, &OBSBasicProperties::refreshControls);
+	}
+
 	view->show();
 	installEventFilter(CreateShortcutFilter());
 
@@ -101,7 +131,7 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		obs_display_add_draw_callback(ui->preview->GetDisplay(), OBSBasicProperties::DrawTransitionPreview,
 					      this);
 	};
-	uint32_t caps = obs_source_get_output_flags(source);
+
 	bool drawable_type = type == OBS_SOURCE_TYPE_INPUT || type == OBS_SOURCE_TYPE_SCENE;
 	bool drawable_preview = (caps & OBS_SOURCE_VIDEO) != 0;
 
@@ -404,6 +434,21 @@ void OBSBasicProperties::DrawTransitionPreview(void *data, uint32_t cx, uint32_t
 
 	gs_projection_pop();
 	gs_viewport_pop();
+}
+
+void OBSBasicProperties::refreshControls()
+{
+	uint32_t caps = obs_source_get_output_flags(source);
+
+	if ((caps & OBS_SOURCE_CONTROLLABLE_MEDIA) != 0) {
+		const char *id = obs_source_get_unversioned_id(source);
+
+		if (!is_network_media_source(source, id)) {
+			ui->controlsFrame->show();
+		} else {
+			ui->controlsFrame->hide();
+		}
+	}
 }
 
 void OBSBasicProperties::Cleanup()

--- a/frontend/dialogs/OBSBasicProperties.hpp
+++ b/frontend/dialogs/OBSBasicProperties.hpp
@@ -51,10 +51,13 @@ private:
 	static void UpdateProperties(void *data, calldata_t *params);
 	static void DrawPreview(void *data, uint32_t cx, uint32_t cy);
 	static void DrawTransitionPreview(void *data, uint32_t cx, uint32_t cy);
+
+	void refreshControls();
 	void UpdateCallback(void *obj, obs_data_t *settings);
 	bool ConfirmQuit();
 	int CheckSettings();
 	void Cleanup();
+	void addTransitionPreviewButton();
 
 private slots:
 	void on_buttonBox_clicked(QAbstractButton *button);

--- a/frontend/forms/OBSBasicProperties.ui
+++ b/frontend/forms/OBSBasicProperties.ui
@@ -44,7 +44,10 @@
       <property name="frameShadow">
        <enum>QFrame::Plain</enum>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <property name="lineWidth">
+       <number>0</number>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
        <property name="spacing">
         <number>0</number>
        </property>
@@ -74,6 +77,42 @@
            <height>150</height>
           </size>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="controlsFrame">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="frameShape">
+          <enum>QFrame::Shape::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Shadow::Plain</enum>
+         </property>
+         <property name="lineWidth">
+          <number>0</number>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+         </layout>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
### Description
Depends on #8041 which I recently rebased.

Adds the MediaControls component to the source properties window for sources with the OBS_SOURCE_CONTROLLABLE_MEDIA flag.

<img width="869" height="952" alt="image" src="https://github.com/user-attachments/assets/821ca98a-4f4f-4311-81db-92940c0c385e" />


### Motivation and Context
More ways to control media playback besides the context bar.

### How Has This Been Tested?
Tested with Media Sources using a local file and an Image Slideshow source.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
