### PR TITLE
libobs: Fix signal callback removal during signaling

### DIFF
--- a/libobs/callback/signal.c
+++ b/libobs/callback/signal.c
@@ -31,7 +31,7 @@ struct signal_info {
 	struct decl_info func;
 	DARRAY(struct signal_callback) callbacks;
 	pthread_mutex_t mutex;
-	bool signalling;
+	long signaling;
 
 	struct signal_info *next;
 };
@@ -41,7 +41,7 @@ static inline struct signal_info *signal_info_create(struct decl_info *info)
 	struct signal_info *si = bmalloc(sizeof(struct signal_info));
 	si->func = *info;
 	si->next = NULL;
-	si->signalling = false;
+	si->signaling = 0;
 	da_init(si->callbacks);
 
 	if (pthread_mutex_init_recursive(&si->mutex) != 0) {
@@ -70,7 +70,7 @@ static inline size_t signal_get_callback_idx(struct signal_info *si, signal_call
 	for (size_t i = 0; i < si->callbacks.num; i++) {
 		struct signal_callback *sc = si->callbacks.array + i;
 
-		if (sc->callback == callback && sc->data == data)
+		if (sc->callback == callback && sc->data == data && sc->remove == false)
 			return i;
 	}
 
@@ -80,7 +80,6 @@ static inline size_t signal_get_callback_idx(struct signal_info *si, signal_call
 struct global_callback_info {
 	global_signal_callback_t callback;
 	void *data;
-	long signaling;
 	bool remove;
 };
 
@@ -88,6 +87,7 @@ struct signal_handler {
 	struct signal_info *first;
 	pthread_mutex_t mutex;
 	volatile long refs;
+	long global_signaling;
 
 	DARRAY(struct global_callback_info) global_callbacks;
 	pthread_mutex_t global_callbacks_mutex;
@@ -261,7 +261,7 @@ void signal_handler_disconnect(signal_handler_t *handler, const char *signal, si
 
 	idx = signal_get_callback_idx(sig, callback, data);
 	if (idx != DARRAY_INVALID) {
-		if (sig->signalling) {
+		if (sig->signaling) {
 			sig->callbacks.array[idx].remove = true;
 		} else {
 			keep_ref = sig->callbacks.array[idx].keep_ref;
@@ -291,55 +291,66 @@ void signal_handler_signal(signal_handler_t *handler, const char *signal, callda
 {
 	struct signal_info *sig = getsignal_locked(handler, signal);
 	long remove_refs = 0;
+	struct signal_callback *last_signal_cb = NULL;
+	struct global_callback_info *last_global_cb = NULL;
 
 	if (!sig)
 		return;
 
 	pthread_mutex_lock(&sig->mutex);
-	sig->signalling = true;
+	sig->signaling++;
 
 	for (size_t i = 0; i < sig->callbacks.num; i++) {
 		struct signal_callback *cb = sig->callbacks.array + i;
 		if (!cb->remove) {
+			last_signal_cb = current_signal_cb;
 			current_signal_cb = cb;
 			cb->callback(cb->data, params);
-			current_signal_cb = NULL;
+			current_signal_cb = last_signal_cb;
+		}
+	}
+	sig->signaling--;
+
+	// Only remove callbacks when recursion level is 0
+	if (!sig->signaling) {
+		for (size_t i = sig->callbacks.num; i > 0; i--) {
+			struct signal_callback *cb = sig->callbacks.array + i - 1;
+			if (cb->remove) {
+				if (cb->keep_ref)
+					remove_refs++;
+
+				da_erase(sig->callbacks, i - 1);
+			}
 		}
 	}
 
-	for (size_t i = sig->callbacks.num; i > 0; i--) {
-		struct signal_callback *cb = sig->callbacks.array + i - 1;
-		if (cb->remove) {
-			if (cb->keep_ref)
-				remove_refs++;
-
-			da_erase(sig->callbacks, i - 1);
-		}
-	}
-
-	sig->signalling = false;
 	pthread_mutex_unlock(&sig->mutex);
 
 	pthread_mutex_lock(&handler->global_callbacks_mutex);
 
 	if (handler->global_callbacks.num) {
+
+		handler->global_signaling++;
 		for (size_t i = 0; i < handler->global_callbacks.num; i++) {
 			struct global_callback_info *cb = handler->global_callbacks.array + i;
 
 			if (!cb->remove) {
-				cb->signaling++;
+				last_global_cb = current_global_cb;
 				current_global_cb = cb;
 				cb->callback(cb->data, signal, params);
-				current_global_cb = NULL;
-				cb->signaling--;
+				current_global_cb = last_global_cb;
 			}
 		}
+		handler->global_signaling--;
 
-		for (size_t i = handler->global_callbacks.num; i > 0; i--) {
-			struct global_callback_info *cb = handler->global_callbacks.array + (i - 1);
+		// Only remove callbacks when recursion level is 0
+		if (!handler->global_signaling) {
+			for (size_t i = handler->global_callbacks.num; i > 0; i--) {
+				struct global_callback_info *cb = handler->global_callbacks.array + (i - 1);
 
-			if (cb->remove && !cb->signaling)
-				da_erase(handler->global_callbacks, i - 1);
+				if (cb->remove)
+					da_erase(handler->global_callbacks, i - 1);
+			}
 		}
 	}
 
@@ -358,7 +369,7 @@ void signal_handler_signal(signal_handler_t *handler, const char *signal, callda
 
 void signal_handler_connect_global(signal_handler_t *handler, global_signal_callback_t callback, void *data)
 {
-	struct global_callback_info cb_data = {callback, data, 0, false};
+	struct global_callback_info cb_data = {callback, data, false};
 	size_t idx;
 
 	if (!handler || !callback)
@@ -375,7 +386,7 @@ void signal_handler_connect_global(signal_handler_t *handler, global_signal_call
 
 void signal_handler_disconnect_global(signal_handler_t *handler, global_signal_callback_t callback, void *data)
 {
-	struct global_callback_info cb_data = {callback, data, 0, false};
+	struct global_callback_info cb_data = {callback, data, false};
 	size_t idx;
 
 	if (!handler || !callback)
@@ -387,7 +398,7 @@ void signal_handler_disconnect_global(signal_handler_t *handler, global_signal_c
 	if (idx != DARRAY_INVALID) {
 		struct global_callback_info *cb = handler->global_callbacks.array + idx;
 
-		if (cb->signaling)
+		if (handler->global_signaling)
 			cb->remove = true;
 		else
 			da_erase(handler->global_callbacks, idx);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

- Fix atomic subtraction of signal callback references, which may cause signal handler to be freed prematurely or not at all
- Free the signal handler if reference count reaches zero during signaling.
  - This may happen if `signal_handler_destroy()` is called before all reference counted callbacks have been disconnected and such callback is disconnected during signaling process. `signal_handler_destroy()` doesn't actually destroy the handler if reference count is not yet zero.
 
- `signal_handler_connect_global()` 
   - Fix being possible to make duplicate callbacks from within callbacks
- `signal_handler_disconnect_global()` 
  - Fix not being able to disconnect own callback from within the callback
  - Fix being able to directly erase (instead of queuing erase) other callbacks while array is iterated in signaling , causing the signal to not be delivered to all recipients (index skipped)
- Fix `signal_handler_connect()` from within callback not being able to add a callback if one with same parameters is removed previously in the same (probably nested) callback
- Fix `signal_handler_disconnect()` being able to erase (instead of queuing) callback array items while being iterated, if called from nested callback, because nesting caused signaling status to be lost, causing signal to not be delivered to all recipients (index skipped)
- Fix `signal_handler_remove_current()` not being able to remove anything if callback calls `signal_handler_signal()` before (current item lost)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
These are just findings browsing the source. 

Reference count for signal handler is subtracted in a non-atomic way, which may cause the handler to be freed prematurely or never. 
Nested calls to `signal_handler_signal()` are not being handled in correct manner. There was some effort with re-entrant mutexes and recursion counting, but it's incomplete. 
`signal_handler_connect_global()` and `signal_handler_disconnect_global()` use `da_find()` to find existing callback, but fail to account for recursion counter `signaling` not being 0 in the struct.
 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Monitored signal handlers reference counter during app startup, adding/removing some sources and app shutdown.
More testing for disconnect/connect calls from signal callbacks would be appreciated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
