### PR TITLE
rtmp-services: Added HomeGround TV

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -5,7 +5,7 @@
     "files": [
         {
             "name": "services.json",
-            "version": 281
+            "version": 282
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3593,6 +3593,28 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "HomeGround TV",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://ticker.homegroundapp.com:8100/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 2500,
+                "max audio bitrate": 192,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "max fps": 30
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
I have added a new service in services.json for my Homeground TV user to be able to push directly through OBS without using cutom URL

### Motivation and Context
1. My users always need to add stream url in the stream section, now by adding this service they only need to enter stream key
2. In case of changes i had trouble to communicate with all the users to change the url, using this i can change in OBS and it will reflect automatically

### How Has This Been Tested?
1. I have tested it locally on my macbook and windows laptop both with intel i7 16gb ram

### Types of changes

New feature (non-breaking change which adds functionality)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
