### PR TITLE
rtmp-services: Add Sportify

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 283,
+    "version": 284,
     "files": [
         {
             "name": "services.json",
-            "version": 283
+            "version": 284
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3581,6 +3581,29 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Sportify",
+            "more_info_link": "https://www.homegroundapp.com",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://stream.homegroundapp.com/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 3500,
+                "max audio bitrate": 192,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "max fps": 30
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION


### Description
I have added a new service in services.json for my Homeground TV user to be able to push directly through OBS without using cutom URL

### Motivation and Context
1. My users always need to add stream url in the stream section, now by adding this service they only need to enter stream key
2. In case of changes i had trouble to communicate with all the users to change the url, using this i can change in OBS and it will reflect automatically

### How Has This Been Tested?
1. I have tested it locally on my macbook and windows laptop both with intel i7 16gb ram

### Types of changes
- New feature (non-breaking change which adds functionality)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
