### PR TITLE
obs-webrtc: Enable ice-tcp

### DIFF
--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -279,6 +279,10 @@ bool WHIPOutput::Setup()
 	cfg.disableAutoGathering = true;
 #endif
 
+#if RTC_VERSION_MAJOR == 0 && RTC_VERSION_MINOR > 23 || RTC_VERSION_MAJOR > 0
+	cfg.enableIceTcp = true;
+#endif
+
 	peer_connection = std::make_shared<rtc::PeerConnection>(cfg);
 
 	peer_connection->onStateChange([this](rtc::PeerConnection::State state) {


### PR DESCRIPTION
### Description
Enable ice-tcp support in libdatachannel which is used for the WHIP/WebRTC output.

### Motivation and Context
This allows streamers to publish video over UDP or TCP.

UDP is preferred for WebRTC because it gives the lowest latency. TCP is a fallback
for networks that don't allow UDP or in situations where you need 0 loss.

### How Has This Been Tested?
I implemented ice-tcp against Pion. After builds are generated will ask other WebRTC
providers to test.

### Types of changes
 - New feature (non-breaking change which adds functionality)


### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.


Requires: https://github.com/obsproject/obs-deps/pull/305