### PR TITLE
frontend: Add logging for not default audio tracks

### DIFF
--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1078,10 +1078,27 @@ static bool LogSceneItem(obs_scene_t *, obs_sceneitem_t *item, void *v_val)
 
 	blog(LOG_INFO, "%s- source: '%s' (%s)", indent.c_str(), name, id);
 
-	bool monitoring = obs_source_get_monitoring_enabled(source);
+	if (obs_source_get_output_flags(source) & OBS_SOURCE_AUDIO) {
+		const uint32_t all_mixers = (1 << MAX_AUDIO_MIXES) - 1;
+		uint32_t mixers = obs_source_get_audio_mixers(source);
+		if (mixers == 0) {
+			blog(LOG_INFO, "    %s- audio tracks: none", indent.c_str());
+		} else if ((mixers & all_mixers) != all_mixers) {
+			std::string tracks;
+			for (uint32_t i = 0; i < MAX_AUDIO_MIXES; i++) {
+				if (mixers & (1 << i)) {
+					tracks += " ";
+					tracks += std::to_string(i + 1);
+				}
+			}
+			blog(LOG_INFO, "    %s- audio tracks:%s", indent.c_str(), tracks.c_str());
+		}
 
-	if (monitoring) {
-		blog(LOG_INFO, "    %s- monitoring: enabled", indent.c_str());
+		bool monitoring = obs_source_get_monitoring_enabled(source);
+
+		if (monitoring) {
+			blog(LOG_INFO, "    %s- monitoring: enabled", indent.c_str());
+		}
 	}
 	int child_indent = 1 + indent_count;
 	obs_source_enum_filters(source, LogFilter, (void *)(intptr_t)child_indent);


### PR DESCRIPTION
### Description
Add logging for not default audio tracks

### Motivation and Context
Want to be able to diagnose audio issues from the OBS log file
example:
```
10:50:33.820: - scene 'Scene':
10:50:33.820:     - source: 'Video Capture Device' (dshow_input)
10:50:33.821:         - audio tracks: 1 2 4 5 6
```


### How Has This Been Tested?
On windows by having sources in the advanced audio properties set to none tracks and some tracks

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
