### PR TITLE
frontend: Add supported_encoders to GoLiveAPI

### DIFF
--- a/frontend/utility/GoLiveAPI_PostData.cpp
+++ b/frontend/utility/GoLiveAPI_PostData.cpp
@@ -36,6 +36,7 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 		} else if (qstricmp(codec, "av1") == 0) {
 			client.supported_codecs.emplace("av1");
 		}
+		client.supported_encoders.emplace(encoder_id);
 	}
 
 	auto &preferences = post_data.preferences;

--- a/frontend/utility/GoLiveAPI_PostData.cpp
+++ b/frontend/utility/GoLiveAPI_PostData.cpp
@@ -36,7 +36,9 @@ GoLiveApi::PostData constructGoLivePost(QString streamKey, const std::optional<u
 		} else if (qstricmp(codec, "av1") == 0) {
 			client.supported_codecs.emplace("av1");
 		}
-		client.supported_encoders.emplace(encoder_id);
+		auto encoder_caps = obs_get_encoder_caps(encoder_id);
+		if ((encoder_caps & OBS_ENCODER_CAP_DEPRECATED) == 0)
+			client.supported_encoders.emplace(encoder_id);
 	}
 
 	auto &preferences = post_data.preferences;

--- a/frontend/utility/models/multitrack-video.hpp
+++ b/frontend/utility/models/multitrack-video.hpp
@@ -96,8 +96,9 @@ struct Client {
 	string name = "obs-studio";
 	string version;
 	std::unordered_set<std::string> supported_codecs;
+	std::unordered_set<std::string> supported_encoders;
 
-	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Client, name, version, supported_codecs)
+	NLOHMANN_DEFINE_TYPE_INTRUSIVE(Client, name, version, supported_codecs, supported_encoders)
 };
 
 struct Cpu {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adding `supported_encoders` to the GoLiveAPI for Multi-track config

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When implementing a custom stream server with multi-track support, its impossible to accurately return the correct encoder type with only the list of supported codecs

Example Values:
```
"supported_encoders":["obs_qsv11_hevc_soft","obs_qsv11_hevc","obs_qsv11_soft","obs_qsv11_soft_v2","ffmpeg_opus","ffmpeg_pcm_s16le","ffmpeg_pcm_s24le","ffmpeg_vaapi_tex","ffmpeg_aac","ffmpeg_pcm_f32le","ffmpeg_alac","obs_qsv11","ffmpeg_flac","obs_x264","ffmpeg_vaapi","hevc_ffmpeg_vaapi_tex","hevc_ffmpeg_vaapi","obs_qsv11_v2"]
```

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested the request/response flow for GoLiveApi

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
 - New feature (non-breaking change which adds functionality) 
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
