### PR TITLE
frontend: More adjustments to shutdown logic 

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1238,8 +1238,6 @@ bool OBSApp::OBSInit()
 	mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 
 	connect(QApplication::instance(), &QApplication::aboutToQuit, this, [this]() {
-		crashHandler_->applicationShutdownHandler();
-
 		/* Ensure OBSMainWindow gets closed */
 		if (mainWindow) {
 			mainWindow->close();
@@ -1252,6 +1250,9 @@ bool OBSApp::OBSInit()
 	});
 
 	mainWindow->OBSInit();
+
+	connect(OBSBasic::Get(), &OBSBasic::mainWindowClosed, crashHandler_.get(),
+		&OBS::CrashHandler::applicationShutdownHandler);
 
 	connect(this, &QGuiApplication::applicationStateChanged,
 		[this](Qt::ApplicationState state) { ResetHotkeyState(state == Qt::ApplicationActive); });

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -397,8 +397,8 @@ ConfirmBWTest.Title="Start Bandwidth Test?"
 ConfirmBWTest.Text="You have OBS configured in bandwidth test mode. This mode allows for network testing without your channel going live. Once you are done testing, you will need to disable it in order for viewers to be able to see your stream.\n\nDo you want to continue?"
 
 # confirm exit dialog box
-ConfirmExit.Title="Exit OBS?"
-ConfirmExit.Text="OBS is currently active. All streams/recordings will be shut down. Are you sure you wish to exit?"
+ConfirmExit.Title="Active Outputs"
+ConfirmExit.Text="OBS is still currently active. All streams/recordings will be shut down."
 
 # confirm delete dialog box
 ConfirmRemove.Title="Confirm Remove"

--- a/frontend/utility/NativeEventFilter_Windows.cpp
+++ b/frontend/utility/NativeEventFilter_Windows.cpp
@@ -43,7 +43,10 @@ bool NativeEventFilter::nativeEventFilter(const QByteArray &eventType, void *mes
 			}
 
 			if (main->shouldPromptForClose()) {
-				*result = FALSE;
+				if (result) {
+					*result = FALSE;
+				}
+				QTimer::singleShot(1, main, &OBSBasic::close);
 				return true;
 			}
 
@@ -52,13 +55,6 @@ bool NativeEventFilter::nativeEventFilter(const QByteArray &eventType, void *mes
 			if (msg->wParam == TRUE) {
 				// Session is ending, start closing the main window now with no checks or prompts.
 				main->closeWindow();
-			} else {
-				/* Session is no longer ending. If OBS is still open, odds are it is what held
-				 * up the session end due to its higher than default priority. We call the
-				 * close method to trigger the confirmation window flow. We do this after the fact
-				 * to avoid blocking the main window event loop prior to this message.
-				 * Otherwise, OBS is already gone and invoking this does nothing. */
-				main->close();
 			}
 
 			return true;

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1894,9 +1894,10 @@ bool OBSBasic::promptToClose()
 
 	SetShowing(true);
 	QMessageBox::StandardButton button =
-		OBSMessageBox::question(this, QTStr("ConfirmExit.Title"), QTStr("ConfirmExit.Text"));
+		OBSMessageBox::question(this, QTStr("ConfirmExit.Title"), QTStr("ConfirmExit.Text"),
+					QMessageBox::StandardButtons(QMessageBox::Ok | QMessageBox::Cancel));
 
-	if (button == QMessageBox::No) {
+	if (button == QMessageBox::Cancel) {
 		isClosePromptOpen_ = false;
 		return false;
 	}
@@ -1970,6 +1971,8 @@ void OBSBasic::closeWindow()
 
 	applicationShutdown();
 	deleteLater();
+
+	emit mainWindowClosed();
 
 	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
 }

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -341,6 +341,9 @@ protected:
 	virtual bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;
 	virtual void changeEvent(QEvent *event) override;
 
+signals:
+	void mainWindowClosed();
+
 	/* -------------------------------------
 	 * MARK: - OAuth
 	 * -------------------------------------


### PR DESCRIPTION
### Description
Windows will send WM_ENDSESSION for every application window and this was causing multiple prompts on logout when the logout process was cancelled.

When the app should prompt for closing, immediately attempt to close the main window on the Qt event loop and trigger the prompt, rather than waiting for the WM_ENDSESSION follow-up.

Additionally, the main window now emits a signal after doing all of it's cleanup for the CrashHandler to connect to instead of removing it in response to aboutToQuit. aboutToQuit is not reached on Windows when the session is being forcefully ended, which leads to an Unclean Shutdown prompt next launch.

Qt mentions this in their documentation in regards to aboutToQuit.
https://doc.qt.io/qt-6/qcoreapplication.html#exec
> For example, on Windows when the user logs off, the system terminates the process after Qt closes all top-level windows.

It is worth noting that in this same paragraph Qt suggests connecting clean-up code to the aboutToQuit signal. However in our case because OBSBasic is a load-bearing window, aboutToQuit is fired after it's closed, rather than the main window closing in response to it.

### Motivation and Context
The changes in #12668 do not appear to be fully solving the problem on Windows

### How Has This Been Tested?
Logged off with outputs active and inactive.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
