### PR TITLE
docs: Add API disclaimer to canvases

### DIFF
--- a/docs/sphinx/reference-canvases.rst
+++ b/docs/sphinx/reference-canvases.rst
@@ -1,6 +1,16 @@
 Canvas API Reference (obs_canvas_t)
 ===================================
 
+.. danger::
+
+   Canvases are still in their early stages of implementation and the API will evolve as they are gradually integrated
+   across OBS Studio.
+
+   The Canvas API should be considered **unstable** and may be changed without warning. This documentation serves to aid
+   in their iterative development within OBS Studio.
+
+   **If you are developing a plugin that utilizes canvases, proceed with great caution.**
+
 Canvases are reference-counted objects that contain scenes and define how those are rendered.
 They provide a video object which can be used with encoders or raw outputs.
 


### PR DESCRIPTION
### Description
Adds a disclaimer to the docs regarding Canvases and their current in-progress state
<img width="784" height="467" alt="image" src="https://github.com/user-attachments/assets/59beff6a-bd55-4225-97c4-c1faafeafc00" />


### Motivation and Context
I want to make sure we have a sign to tap when these APIs change and evolve as we use them.

In a perfect world Canvases would have been added to libobs, implemented across all of OBS Studio, and in a more or less final state. That is sadly unrealistic with the resources we have available, and it was decided it was better to implement canvases gradually as both project and volunteer contributors have time to do so. Due to the architecture of libobs and OBS there is no way currently for us to have private APIs that are available to OBS and not plugins. An unstable API is the lesser of two evils here and so we disclose as such.

### How Has This Been Tested?
Built the docs locally.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
