### PR TITLE
cmake: Sort target_sources alphabetically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,9 @@
 !/docs/sphinx/_build/.gitignore
 !/docs/sphinx/Makefile
 
-# Exclude modified Flatpak files
+# Exclude modified Flatpak and gersemi files
 build-aux/flatpak-github-action-modified-*
+build-aux/__pycache__
 
 # Exclude macOS legacy resource forks
 .DS_Store

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -111,7 +111,7 @@ invoke_formatter() {
         local -i num_failures=0
         local -a source_files=($@)
         local file
-        local -a command=(${formatter} -c --no-cache ${source_files})
+        local -a command=(${formatter} -c --no-cache ${source_files} --extensions ./build-aux/gersemi-sort.py)
 
         if (( ${#source_files} )) {
           while read -r line; do
@@ -136,7 +136,7 @@ invoke_formatter() {
         local -a source_files=($@)
 
         if (( ${#source_files} )) {
-          "${formatter}" -i ${source_files}
+          "${formatter}" -i ${source_files} --extensions ./build-aux/gersemi-sort.py
         }
       }
       ;;

--- a/build-aux/gersemi-sort.py
+++ b/build-aux/gersemi-sort.py
@@ -1,0 +1,12 @@
+# Adapted from https://github.com/BlankSpruce/gersemi/blob/2b5f154fb069e0b97f481f4ad0c282d52fcee89e/extension-example/as_module/gersemi_extension_example/__init__.py
+
+from gersemi.builtin_commands import builtin_commands
+
+target_sources = builtin_commands["target_sources"]
+target_sources["keyword_preprocessors"] = {
+    key: "sort+unique" for key in target_sources["multi_value_keywords"]
+}
+
+command_definitions = {
+    "target_sources": target_sources,
+}

--- a/deps/glad/CMakeLists.txt
+++ b/deps/glad/CMakeLists.txt
@@ -8,14 +8,14 @@ add_library(OBS::glad ALIAS obsglad)
 target_sources(
   obsglad
   PRIVATE
-    src/glad.c
     $<$<PLATFORM_ID:Windows>:src/glad_wgl.c>
-    $<$<TARGET_EXISTS:OpenGL::EGL>:src/glad_egl.c>
     $<$<TARGET_EXISTS:OpenGL::EGL>:include/EGL/eglplatform.h>
+    $<$<TARGET_EXISTS:OpenGL::EGL>:src/glad_egl.c>
+    src/glad.c
   PUBLIC
-    include/glad/glad.h
     "$<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/include/glad/glad_wgl.h>"
     "$<$<TARGET_EXISTS:OpenGL::EGL>:${CMAKE_CURRENT_SOURCE_DIR}/include/glad/glad_egl.h>"
+    include/glad/glad.h
 )
 
 target_compile_options(obsglad PRIVATE $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang>:-Wno-strict-prototypes>)

--- a/frontend/cmake/ui-qt.cmake
+++ b/frontend/cmake/ui-qt.cmake
@@ -25,7 +25,6 @@ target_sources(
   PRIVATE
     forms/AutoConfigFinishPage.ui
     forms/AutoConfigStartPage.ui
-    forms/AutoConfigStartPage.ui
     forms/AutoConfigStreamPage.ui
     forms/AutoConfigTestPage.ui
     forms/AutoConfigVideoPage.ui
@@ -45,8 +44,8 @@ target_sources(
     forms/OBSImporter.ui
     forms/OBSMissingFiles.ui
     forms/OBSRemux.ui
-    forms/StatusBarWidget.ui
     forms/PluginManagerWindow.ui
+    forms/StatusBarWidget.ui
     forms/obs.qrc
     forms/source-toolbar/browser-source-toolbar.ui
     forms/source-toolbar/color-source-toolbar.ui

--- a/frontend/cmake/ui-settings.cmake
+++ b/frontend/cmake/ui-settings.cmake
@@ -1,11 +1,11 @@
 target_sources(
   obs-studio
   PRIVATE
+    settings/OBSBasicSettings.cpp
+    settings/OBSBasicSettings.hpp
     settings/OBSBasicSettings_A11y.cpp
     settings/OBSBasicSettings_Appearance.cpp
     settings/OBSBasicSettings_Stream.cpp
-    settings/OBSBasicSettings.cpp
-    settings/OBSBasicSettings.hpp
     settings/OBSHotkeyEdit.cpp
     settings/OBSHotkeyEdit.hpp
     settings/OBSHotkeyLabel.cpp

--- a/frontend/cmake/ui-widgets.cmake
+++ b/frontend/cmake/ui-widgets.cmake
@@ -14,6 +14,14 @@ target_sources(
     widgets/ColorSelect.hpp
     widgets/OBSBasic.cpp
     widgets/OBSBasic.hpp
+    widgets/OBSBasicControls.cpp
+    widgets/OBSBasicControls.hpp
+    widgets/OBSBasicPreview.cpp
+    widgets/OBSBasicPreview.hpp
+    widgets/OBSBasicStats.cpp
+    widgets/OBSBasicStats.hpp
+    widgets/OBSBasicStatusBar.cpp
+    widgets/OBSBasicStatusBar.hpp
     widgets/OBSBasic_Browser.cpp
     widgets/OBSBasic_Canvases.cpp
     widgets/OBSBasic_Clipboard.cpp
@@ -43,14 +51,6 @@ target_sources(
     widgets/OBSBasic_VirtualCam.cpp
     widgets/OBSBasic_VolControl.cpp
     widgets/OBSBasic_YouTube.cpp
-    widgets/OBSBasicControls.cpp
-    widgets/OBSBasicControls.hpp
-    widgets/OBSBasicPreview.cpp
-    widgets/OBSBasicPreview.hpp
-    widgets/OBSBasicStats.cpp
-    widgets/OBSBasicStats.hpp
-    widgets/OBSBasicStatusBar.cpp
-    widgets/OBSBasicStatusBar.hpp
     widgets/OBSMainWindow.hpp
     widgets/OBSProjector.cpp
     widgets/OBSProjector.hpp

--- a/libobs/cmake/os-windows.cmake
+++ b/libobs/cmake/os-windows.cmake
@@ -51,9 +51,9 @@ target_sources(
     util/threading-windows.c
     util/threading-windows.h
     util/windows/CoTaskMemPtr.hpp
+    util/windows/HRError.hpp
     util/windows/device-enum.c
     util/windows/device-enum.h
-    util/windows/HRError.hpp
     util/windows/win-registry.h
     util/windows/win-version.h
     util/windows/window-helpers.c

--- a/plugins/decklink/CMakeLists.txt
+++ b/plugins/decklink/CMakeLists.txt
@@ -42,6 +42,14 @@ target_sources(
     $<$<PLATFORM_ID:Darwin>:mac/platform.cpp>
     $<$<PLATFORM_ID:Linux,FreeBSD,OpenBSD>:linux/platform.cpp>
     $<$<PLATFORM_ID:Windows>:win/platform.cpp>
+    DecklinkBase.cpp
+    DecklinkBase.h
+    DecklinkInput.cpp
+    DecklinkInput.hpp
+    DecklinkOutput.cpp
+    DecklinkOutput.hpp
+    OBSVideoFrame.cpp
+    OBSVideoFrame.h
     audio-repack.c
     audio-repack.h
     audio-repack.hpp
@@ -58,14 +66,6 @@ target_sources(
     decklink-devices.hpp
     decklink-output.cpp
     decklink-source.cpp
-    DecklinkBase.cpp
-    DecklinkBase.h
-    DecklinkInput.cpp
-    DecklinkInput.hpp
-    DecklinkOutput.cpp
-    DecklinkOutput.hpp
-    OBSVideoFrame.cpp
-    OBSVideoFrame.h
     platform.hpp
     plugin-main.cpp
     util.cpp

--- a/plugins/mac-avcapture/CMakeLists.txt
+++ b/plugins/mac-avcapture/CMakeLists.txt
@@ -33,16 +33,16 @@ add_library(OBS::avcapture ALIAS mac-avcapture)
 target_sources(
   mac-avcapture
   PRIVATE
-    AVCaptureDeviceFormat+OBSListable.m
     AVCaptureDeviceFormat+OBSListable.h
-    plugin-main.m
-    plugin-main.h
-    plugin-properties.m
-    plugin-properties.h
-    OBSAVCapture.m
+    AVCaptureDeviceFormat+OBSListable.m
     OBSAVCapture.h
-    OBSAVCapturePresetInfo.m
+    OBSAVCapture.m
     OBSAVCapturePresetInfo.h
+    OBSAVCapturePresetInfo.m
+    plugin-main.h
+    plugin-main.m
+    plugin-properties.h
+    plugin-properties.m
 )
 
 target_link_libraries(mac-avcapture PRIVATE OBS::libobs)

--- a/plugins/mac-virtualcam/src/camera-extension/CMakeLists.txt
+++ b/plugins/mac-virtualcam/src/camera-extension/CMakeLists.txt
@@ -27,11 +27,11 @@ target_sources(
   mac-camera-extension
   PRIVATE
     "${_placeholder_location}"
-    main.swift
     OBSCameraDeviceSource.swift
     OBSCameraProviderSource.swift
     OBSCameraStreamSink.swift
     OBSCameraStreamSource.swift
+    main.swift
 )
 
 set_property(SOURCE "${_placeholder_location}" PROPERTY MACOSX_PACKAGE_LOCATION "Resources")

--- a/plugins/obs-ffmpeg/CMakeLists.txt
+++ b/plugins/obs-ffmpeg/CMakeLists.txt
@@ -30,10 +30,10 @@ target_sources(
     obs-ffmpeg-av1.c
     obs-ffmpeg-compat.h
     obs-ffmpeg-formats.h
-    obs-ffmpeg-openh264.c
     obs-ffmpeg-hls-mux.c
     obs-ffmpeg-mux.c
     obs-ffmpeg-mux.h
+    obs-ffmpeg-openh264.c
     obs-ffmpeg-output.c
     obs-ffmpeg-output.h
     obs-ffmpeg-source.c

--- a/plugins/obs-qsv11/CMakeLists.txt
+++ b/plugins/obs-qsv11/CMakeLists.txt
@@ -23,14 +23,14 @@ target_sources(
     $<$<PLATFORM_ID:Windows>:common_directx11.cpp>
     $<$<PLATFORM_ID:Windows>:common_directx11.h>
     $<$<PLATFORM_ID:Windows>:common_utils_windows.cpp>
-    common_utils.cpp
-    common_utils.h
-    obs-qsv11-plugin-main.c
-    obs-qsv11.c
     QSV_Encoder.cpp
     QSV_Encoder.h
     QSV_Encoder_Internal.cpp
     QSV_Encoder_Internal.h
+    common_utils.cpp
+    common_utils.h
+    obs-qsv11-plugin-main.c
+    obs-qsv11.c
 )
 
 target_compile_options(

--- a/plugins/obs-vst/CMakeLists.txt
+++ b/plugins/obs-vst/CMakeLists.txt
@@ -22,12 +22,12 @@ target_sources(
     $<$<PLATFORM_ID:Windows>:win/EditorWidget-win.cpp>
     $<$<PLATFORM_ID:Windows>:win/VSTPlugin-win.cpp>
     EditorWidget.cpp
+    VSTPlugin.cpp
     headers/EditorWidget.h
-    headers/vst-plugin-callbacks.hpp
     headers/VSTPlugin.h
+    headers/vst-plugin-callbacks.hpp
     obs-vst.cpp
     vst_header/aeffectx.h
-    VSTPlugin.cpp
 )
 
 target_include_directories(obs-vst PRIVATE vst_header)

--- a/plugins/win-dshow/cmake/libdshowcapture.cmake
+++ b/plugins/win-dshow/cmake/libdshowcapture.cmake
@@ -5,6 +5,10 @@ target_sources(
   libdshowcapture
   INTERFACE
     libdshowcapture/dshowcapture.hpp
+    libdshowcapture/external/capture-device-support/Library/EGAVResult.cpp
+    libdshowcapture/external/capture-device-support/Library/ElgatoUVCDevice.cpp
+    libdshowcapture/external/capture-device-support/Library/win/EGAVHIDImplementation.cpp
+    libdshowcapture/external/capture-device-support/SampleCode/DriverInterface.cpp
     libdshowcapture/source/capture-filter.cpp
     libdshowcapture/source/capture-filter.hpp
     libdshowcapture/source/device-vendor.cpp
@@ -31,10 +35,6 @@ target_sources(
     libdshowcapture/source/log.hpp
     libdshowcapture/source/output-filter.cpp
     libdshowcapture/source/output-filter.hpp
-    libdshowcapture/external/capture-device-support/Library/EGAVResult.cpp
-    libdshowcapture/external/capture-device-support/Library/ElgatoUVCDevice.cpp
-    libdshowcapture/external/capture-device-support/Library/win/EGAVHIDImplementation.cpp
-    libdshowcapture/external/capture-device-support/SampleCode/DriverInterface.cpp
 )
 
 target_include_directories(

--- a/shared/ipc-util/CMakeLists.txt
+++ b/shared/ipc-util/CMakeLists.txt
@@ -7,8 +7,8 @@ target_sources(
   ipc-util
   INTERFACE
     "$<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/ipc-util/pipe-windows.c>"
-    ipc-util/pipe.h
     "$<$<PLATFORM_ID:Windows>:${CMAKE_CURRENT_SOURCE_DIR}/ipc-util/pipe-windows.h>"
+    ipc-util/pipe.h
 )
 
 target_include_directories(ipc-util INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Creates a gersemi extension that sorts the elements in `target_sources` alphabetically (and also removes duplicates). This uses case-sensitive sorting as bd2024eb814ea0380b2e1c4828b4307eacb5b458 does.
The minimum version of gersemi for these extensions is 0.20 as per BlankSpruce/gersemi@4b21bf5b009d0ae9a3962224786708a18c8f1340, which is below our current minimum of 0.21.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Sorting of these lists comes up every so often in PR reviews (see e.g. https://github.com/obsproject/obs-studio/commit/bd2024eb814ea0380b2e1c4828b4307eacb5b458 or https://github.com/obsproject/obs-studio/pull/12735#discussion_r2590182700). Having it get sorted automatically (and enforced by CI) should make things easier.

In theory, this could be extended to other lists like `target_link_libraries` as well, but from what it looks like, those are usually sorted manually based on other criteria (internal `OBS::` libraries first, etc)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran the check (`./build-aux/run-gersemi -c`) and saw many badly formatted files. Ran the formatter (`./build-aux/run-gersemi`) and the files changed (to what is in this PR). Ran the check again and had no more badly formatted files.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
