### PR TITLE
frontend: Condense duplicated grid logic in SceneTree

### DIFF
--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -12,6 +12,22 @@ SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 	setMovement(QListView::Snap);
 }
 
+int SceneTree::ComputeGridWidth(int &scrollWid)
+{
+	scrollWid = verticalScrollBar()->sizeHint().width();
+	const QRect lastItem = visualItemRect(item(count() - 1));
+	const int h = lastItem.y() + lastItem.height();
+
+	if (h < height()) {
+		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+		scrollWid = 0;
+	} else {
+		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+	}
+
+	return contentsRect().width() - scrollWid - 1;
+}
+
 void SceneTree::SetGridMode(bool grid)
 {
 	parent()->setProperty("class", grid ? "list-grid" : "");
@@ -65,18 +81,9 @@ bool SceneTree::eventFilter(QObject *obj, QEvent *event)
 void SceneTree::resizeEvent(QResizeEvent *event)
 {
 	if (gridMode) {
-		int scrollWid = verticalScrollBar()->sizeHint().width();
-		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
+		int scrollWid = 0;
+		int wid = ComputeGridWidth(scrollWid);
 
-		if (h < height()) {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
-		} else {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-		}
-
-		int wid = contentsRect().width() - scrollWid - 1;
 		int items = (int)std::ceil((float)wid / maxWidth);
 		int itemWidth = wid / items;
 
@@ -108,20 +115,11 @@ void SceneTree::dropEvent(QDropEvent *event)
 	}
 
 	if (gridMode) {
-		int scrollWid = verticalScrollBar()->sizeHint().width();
+		int scrollWid = 0;
 		const QRect firstItem = visualItemRect(item(0));
-		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
 		const int firstItemY = abs(firstItem.y());
 
-		if (h < height()) {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
-		} else {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-		}
-
-		float wid = contentsRect().width() - scrollWid - 1;
+		float wid = static_cast<float>(ComputeGridWidth(scrollWid));
 
 		QPoint point = event->position().toPoint();
 
@@ -148,20 +146,11 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
 {
-	int scrollWid = verticalScrollBar()->sizeHint().width();
+	int scrollWid = 0;
 	const QRect firstItem = visualItemRect(item(0));
-	const QRect lastItem = visualItemRect(item(count() - 1));
-	const int h = lastItem.y() + lastItem.height();
-	const int firstItemY = abs(firstItem.y());
+	const int firstItemY = std::abs(firstItem.y());
 
-	if (h < height()) {
-		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-		scrollWid = 0;
-	} else {
-		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-	}
-
-	float wid = contentsRect().width() - scrollWid - 1;
+	float wid = static_cast<float>(ComputeGridWidth(scrollWid));
 
 	if (event) {
 		QPoint point = event->position().toPoint();

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -27,6 +27,7 @@ public:
 
 private:
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
+	int ComputeGridWidth(int &scrollWid);
 
 protected:
 	virtual bool eventFilter(QObject *obj, QEvent *event) override;


### PR DESCRIPTION

### Description

The same scrollbar visibility and grid width logic was duplicated in a few different functions and could cause possible inconsistencies in future updates. Condensing the code into a helper function reduces modification effort and aids its scalability.

Directory: frontend/components/SceneTree.cpp
Functions: resizeEvent, dropEvent, and RepositionGrid

### Motivation and Context

I noticed this during a code review and at first posted it as an issue where I was advised proposed code clean-ups should be brought up as PR requests. While not tied to an existing open issue, this change improves overall code quality and error prevention.

### How Has This Been Tested?

- Built OBS Studio from source on Windows 10 x64 using Visual Studio 2022.
- Verified successful compilation and linking.
- Manually tested:
  - Scene grid resizing
  - Drag-and-drop scene reordering
  - Scrollbar behavior with overflowing scene lists

<img width="251" height="378" alt="Functioning1" src="https://github.com/user-attachments/assets/f65ccc7b-4d63-41a4-aabe-e5c798561782" />
<img width="253" height="386" alt="Functioning2" src="https://github.com/user-attachments/assets/79bbee1f-18ee-4e5c-9233-c4fd5290fadf" />
<img width="244" height="375" alt="Functioning3" src="https://github.com/user-attachments/assets/83deddc3-d58f-4903-a7dc-b2a8a5e988f5" />

### Types of changes

- Tweak (non-breaking change to improve existing functionality)
- Code cleanup (non-breaking change which makes code smaller or more readable) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
