### PR TITLE
libobs: Do not wait for audio of removed sources

### DIFF
--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -928,6 +928,12 @@ bool obs_transition_audio_render(obs_source_t *transition, uint64_t *ts_out, str
 	sources[0] = transition->transition_sources[0];
 	sources[1] = transition->transition_sources[1];
 
+	if (sources[0] && obs_source_removed(sources[0]))
+		sources[0] = NULL;
+
+	if (sources[1] && obs_source_removed(sources[1]))
+		sources[1] = NULL;
+
 	min_ts = calc_min_ts(sources);
 
 	if (min_ts) {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -5420,6 +5420,9 @@ bool obs_source_audio_pending(const obs_source_t *source)
 	if (!obs_source_valid(source, "obs_source_audio_pending"))
 		return true;
 
+	if (obs_source_removed(source))
+		return true;
+
 	return (is_composite_source(source) || is_audio_source(source)) ? source->audio_pending : true;
 }
 


### PR DESCRIPTION
### Description
Do not wait for audio of removed sources

### Motivation and Context
Fix #12880
Without this PR `obs_transition_stop` is not called because `transitioning_audio` stays true, because the removed scene won't process any more audio the `transitioning_audio` will never get to false.
`obs_transition_stop` would call `obs_source_remove_active_child` which deactivates the sources on the deleted scene
The `VolControl` keeps a reference as that UI element is removed on the deactivate signal which does not come
The transition keeps a reference as it does not stop, when switching scenes after that it tries to transition from the removed scene every time.

### How Has This Been Tested?
On Windows by removing a scene with an audio source and checking if that audio source removes from the mixer when the transition is done.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
