### PR TITLE
mac-capture: Relocate static vars into coreaudio struct

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -57,6 +57,8 @@ struct coreaudio_data {
 	unsigned long retry_time;
 
 	obs_source_t *source;
+	double factor;
+	mach_timebase_info_data_t info;
 };
 
 static bool get_default_output_device(struct coreaudio_data *ca)
@@ -438,14 +440,12 @@ static OSStatus input_callback(void *data, AudioUnitRenderActionFlags *action_fl
 									     : ca->buf_list->mNumberBuffers;
 	audio.format = ca->format;
 	audio.samples_per_sec = ca->sample_rate;
-	static double factor = 0.;
-	static mach_timebase_info_data_t info = {0, 0};
-	if (info.numer == 0 && info.denom == 0) {
-		mach_timebase_info(&info);
-		factor = ((double)info.numer) / info.denom;
+	if (ca->info.numer == 0 && ca->info.denom == 0) {
+		mach_timebase_info(&ca->info);
+		ca->factor = ((double)ca->info.numer) / ca->info.denom;
 	}
-	if (info.numer != info.denom)
-		audio.timestamp = (uint64_t)(factor * ts_data->mHostTime);
+	if (ca->info.numer != ca->info.denom)
+		audio.timestamp = (uint64_t)(ca->factor * ts_data->mHostTime);
 	else
 		audio.timestamp = ts_data->mHostTime;
 
@@ -856,6 +856,9 @@ static void *coreaudio_create(obs_data_t *settings, obs_source_t *source, bool i
 	ca->source = source;
 	ca->input = input;
 	ca->enable_downmix = obs_data_get_bool(settings, "enable_downmix");
+	ca->factor = 0;
+	ca->info.denom = 0;
+	ca->info.numer = 0;
 
 	if (!ca->enable_downmix) {
 		coreaudio_set_channels(ca, settings);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Relocating static variables into the instanced `coreaudio` struct that is passed into the thread to avoid a potential race condition? Granted, in this case, the variable seems to be initialized just fine so wasn't sure was this intended by the author? So not quite a 'bug'. Perhaps optional code cleanup
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
The `input_callback` function is invoked by the Apple audio thread. We were setting up static variables here which is shared between both coreaudio input/output threads. I am not sure if that is intended or not? But cannot hurt to relocate this into the thread's coreaudio struct?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified in the debugger each thread has its' own `factor` and `info` variables.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!---- Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
