### PR TITLE
frontend: Switch off deleted scenes immediately

### DIFF
--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -492,16 +492,21 @@ void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current, QListWidge
 {
 	OBSSource source;
 
+	bool forceSceneChange = false;
+
 	if (current) {
 		OBSScene scene = GetOBSRef<OBSScene>(current);
 		source = obs_scene_get_source(scene);
+
+		bool oldSceneIsRemoved = obs_source_removed(obs_scene_get_source(currentScene));
+		forceSceneChange = oldSceneIsRemoved;
 
 		currentScene = scene;
 	} else {
 		currentScene = NULL;
 	}
 
-	SetCurrentScene(source);
+	SetCurrentScene(source, forceSceneChange);
 
 	if (vcamEnabled && vcamConfig.type == VCamOutputType::PreviewOutput)
 		outputHandler->UpdateVirtualCamOutputSource();


### PR DESCRIPTION
### Description
Companion PR to #12882. When a scene has been removed and it was the previously active scene, switch immediately off of it.

### Motivation and Context
Fixes #12880 on the frontend side whereas #12882 fixes it on the libobs side. Both solutions are good: `libobs` should immediately cease using any source marked as removed and the frontend should avoid putting `libobs` in a state where it needs to.

### How Has This Been Tested?
Deleted multiple scenes that contained Audio Input/Output captures. Performed transitions after deleting the scene and confirmed no "ghost" transitions happened caused by the scene still being held by the current transition.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
