### PR TITLE
frontend: Fix transition duration not loading correctly

### DIFF
--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1003,7 +1003,7 @@ void OBSBasic::CreateDefaultScene(bool firstStart)
 	ClearSceneData();
 	InitDefaultTransitions();
 	CreateDefaultQuickTransitions();
-	transitionDuration = 300;
+	SetTransitionDuration(300);
 	SetTransition(fadeTransition);
 
 	updateRemigrationMenuItem(SceneCoordinateMode::Relative, ui->actionRemigrateSceneCollection);
@@ -1303,7 +1303,7 @@ void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
 	if (!curTransition)
 		curTransition = fadeTransition;
 
-	transitionDuration = newDuration;
+	SetTransitionDuration(newDuration);
 	SetTransition(curTransition);
 
 retryScene:


### PR DESCRIPTION
### Description
Fixes the transitions duration spinbox to be properly updated when loading data.

### Motivation and Context
When a scene collection is loaded, it contains information about the default transition and it's duration. This value was being loaded into `transitionDuration` and used but because it wasn't using the setter method, the spinbox was not getting updated.

### How Has This Been Tested?
Loaded OBS, swapped scene collections.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
