### PR TITLE
frontend: Auto-discovery of registered services

### DIFF
--- a/frontend/settings/OBSBasicSettings.hpp
+++ b/frontend/settings/OBSBasicSettings.hpp
@@ -37,6 +37,39 @@ struct OBSTheme;
 
 std::string DeserializeConfigText(const char *value);
 
+// Structured data for service dropdown items
+struct ServiceItemData {
+	enum class Type {
+		Custom,           // rtmp_custom service
+		ShowAll,          // "Show All" option in dropdown
+		RtmpCommon,       // Standard rtmp_common service (Twitch, YouTube, etc.)
+		CustomServiceType // Custom service types (WHIP, MoQ, etc.)
+	};
+
+	Type type;
+	QString serviceId;   // Service ID: for RtmpCommon this is the service name,
+			     // for CustomServiceType this is the service type ID (e.g., "whip_custom")
+	QString displayName; // Human-readable display name
+
+	ServiceItemData() : type(Type::Custom) {}
+
+	ServiceItemData(Type t, const QString &id = QString(), const QString &name = QString())
+		: type(t),
+		  serviceId(id),
+		  displayName(name)
+	{
+	}
+
+	// Helper methods for easy type checking
+	bool isCustom() const { return type == Type::Custom; }
+	bool isShowAll() const { return type == Type::ShowAll; }
+	bool isRtmpCommon() const { return type == Type::RtmpCommon; }
+	bool isCustomServiceType() const { return type == Type::CustomServiceType; }
+};
+
+// Register with Qt's meta-type system so it can be stored in QVariant
+Q_DECLARE_METATYPE(ServiceItemData)
+
 class OBSBasicSettings : public QDialog {
 	Q_OBJECT
 	Q_PROPERTY(QIcon generalIcon READ GetGeneralIcon WRITE SetGeneralIcon DESIGNABLE true)
@@ -204,6 +237,8 @@ private:
 	/* stream */
 	void InitStreamPage();
 	bool IsCustomService() const;
+	inline bool IsCustomServiceType() const;
+	inline QString GetCustomServiceTypeId() const;
 	inline bool IsWHIP() const;
 	void LoadServices(bool showAll);
 	void OnOAuthStreamKeyConnected();

--- a/frontend/settings/OBSBasicSettings.hpp
+++ b/frontend/settings/OBSBasicSettings.hpp
@@ -237,9 +237,10 @@ private:
 	/* stream */
 	void InitStreamPage();
 	bool IsCustomService() const;
-	inline bool IsCustomServiceType() const;
-	inline QString GetCustomServiceTypeId() const;
+	bool IsCustomServiceType() const;
+	QString GetCustomServiceTypeId() const;
 	inline bool IsWHIP() const;
+	int FindService(const std::function<bool(const ServiceItemData &)> &predicate);
 	void LoadServices(bool showAll);
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -39,12 +39,45 @@ enum class Section : int {
 
 bool OBSBasicSettings::IsCustomService() const
 {
-	return ui->service->currentData().toInt() == (int)ListOpt::Custom;
+	QVariant data = ui->service->currentData();
+	if (data.canConvert<ServiceItemData>()) {
+		ServiceItemData serviceData = data.value<ServiceItemData>();
+		return serviceData.isCustom();
+	}
+	// Fallback for backward compatibility during migration
+	return data.toInt() == (int)ListOpt::Custom;
+}
+
+inline bool OBSBasicSettings::IsCustomServiceType() const
+{
+	QVariant data = ui->service->currentData();
+	if (data.canConvert<ServiceItemData>()) {
+		ServiceItemData serviceData = data.value<ServiceItemData>();
+		return serviceData.isCustomServiceType();
+	}
+	// Fallback for backward compatibility during migration
+	return data.canConvert<QString>() && !data.toString().isEmpty();
+}
+
+inline QString OBSBasicSettings::GetCustomServiceTypeId() const
+{
+	QVariant data = ui->service->currentData();
+	if (data.canConvert<ServiceItemData>()) {
+		ServiceItemData serviceData = data.value<ServiceItemData>();
+		if (serviceData.isCustomServiceType()) {
+			return serviceData.serviceId;
+		}
+	}
+	// Fallback for backward compatibility during migration
+	if (data.canConvert<QString>()) {
+		return data.toString();
+	}
+	return QString();
 }
 
 inline bool OBSBasicSettings::IsWHIP() const
 {
-	return ui->service->currentData().toInt() == (int)ListOpt::WHIP;
+	return GetCustomServiceTypeId() == "whip_custom";
 }
 
 void OBSBasicSettings::InitStreamPage()
@@ -114,13 +147,28 @@ void OBSBasicSettings::LoadStream1Settings()
 	protocol = QT_UTF8(obs_service_get_protocol(service_obj));
 	const char *bearer_token = obs_data_get_string(settings, "bearer_token");
 
-	if (is_rtmp_custom || is_whip) {
+	if (!is_rtmp_common) {
 		ui->customServer->setText(server);
 	}
 
 	if (is_rtmp_custom) {
-		ui->service->setCurrentIndex(0);
-		lastServiceIdx = 0;
+		// Find the "Custom" option by looking for ServiceItemData with Type::Custom
+		int idx = -1;
+		for (int i = 0; i < ui->service->count(); i++) {
+			QVariant data = ui->service->itemData(i);
+			if (data.canConvert<ServiceItemData>()) {
+				ServiceItemData serviceData = data.value<ServiceItemData>();
+				if (serviceData.isCustom()) {
+					idx = i;
+					break;
+				}
+			}
+		}
+		if (idx == -1) {
+			idx = 0;
+		}
+		ui->service->setCurrentIndex(idx);
+		lastServiceIdx = idx;
 		lastCustomServer = ui->customServer->text();
 
 		bool use_auth = obs_data_get_bool(settings, "use_auth");
@@ -129,11 +177,25 @@ void OBSBasicSettings::LoadStream1Settings()
 		ui->authUsername->setText(QT_UTF8(username));
 		ui->authPw->setText(QT_UTF8(password));
 		ui->useAuth->setChecked(use_auth);
-	} else {
-		int idx = ui->service->findText(service);
+	} else if (is_rtmp_common) {
+		// For rtmp_common services, find by service ID in ServiceItemData
+		int idx = -1;
+		for (int i = 0; i < ui->service->count(); i++) {
+			QVariant data = ui->service->itemData(i);
+			if (data.canConvert<ServiceItemData>()) {
+				ServiceItemData serviceData = data.value<ServiceItemData>();
+				if (serviceData.isRtmpCommon() && serviceData.serviceId == service) {
+					idx = i;
+					break;
+				}
+			}
+		}
+
 		if (idx == -1) {
+			// Service not found, add it
 			if (service && *service) {
-				ui->service->insertItem(1, service);
+				ServiceItemData newService(ServiceItemData::Type::RtmpCommon, service, service);
+				ui->service->insertItem(1, service, QVariant::fromValue(newService));
 			}
 			idx = 1;
 		}
@@ -145,6 +207,34 @@ void OBSBasicSettings::LoadStream1Settings()
 
 		idx = config_get_int(main->Config(), "Twitch", "AddonChoice");
 		ui->twitchAddonDropdown->setCurrentIndex(idx);
+	} else {
+		// For custom service types (WHIP, MoQ, etc.), find by service type ID in ServiceItemData
+		int idx = -1;
+		for (int i = 0; i < ui->service->count(); i++) {
+			QVariant data = ui->service->itemData(i);
+			if (data.canConvert<ServiceItemData>()) {
+				ServiceItemData serviceData = data.value<ServiceItemData>();
+				if (serviceData.isCustomServiceType() && serviceData.serviceId == type) {
+					idx = i;
+					break;
+				}
+			}
+		}
+
+		if (idx == -1) {
+			// Service type not found in dropdown, try to add it
+			const char *display_name = obs_service_get_display_name(type);
+			if (!display_name) {
+				display_name = type;
+			}
+			ServiceItemData newService(ServiceItemData::Type::CustomServiceType, QString(type),
+						   QT_UTF8(display_name));
+			ui->service->insertItem(1, QT_UTF8(display_name), QVariant::fromValue(newService));
+			idx = 1;
+		}
+
+		ui->service->setCurrentIndex(idx);
+		lastServiceIdx = idx;
 	}
 
 	ui->enableMultitrackVideo->setChecked(config_get_bool(main->Config(), "Stream1", "EnableMultitrackVideo"));
@@ -267,13 +357,15 @@ void OBSBasicSettings::SwapMultiTrack(const char *protocol)
 void OBSBasicSettings::SaveStream1Settings()
 {
 	bool customServer = IsCustomService();
-	bool whip = IsWHIP();
+	QString customServiceTypeId = GetCustomServiceTypeId();
 	const char *service_id = "rtmp_common";
+	QByteArray serviceIdUtf8;
 
 	if (customServer) {
 		service_id = "rtmp_custom";
-	} else if (whip) {
-		service_id = "whip_custom";
+	} else if (!customServiceTypeId.isEmpty()) {
+		serviceIdUtf8 = customServiceTypeId.toUtf8();
+		service_id = serviceIdUtf8.constData();
 	}
 
 	obs_service_t *oldService = main->GetService();
@@ -281,7 +373,7 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	OBSDataAutoRelease settings = obs_data_create();
 
-	if (!customServer && !whip) {
+	if (!customServer && customServiceTypeId.isEmpty()) {
 		obs_data_set_string(settings, "service", QT_TO_UTF8(ui->service->currentText()));
 		obs_data_set_string(settings, "protocol", QT_TO_UTF8(protocol));
 		if (ui->server->currentData() == CustomServerUUID()) {
@@ -316,8 +408,7 @@ void OBSBasicSettings::SaveStream1Settings()
 		obs_data_set_bool(settings, "bwtest", false);
 	}
 
-	if (whip) {
-		obs_data_set_string(settings, "service", "WHIP");
+	if (IsWHIP()) {
 		obs_data_set_string(settings, "bearer_token", QT_TO_UTF8(ui->key->text()));
 	} else {
 		obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
@@ -382,7 +473,7 @@ void OBSBasicSettings::SaveStream1Settings()
 
 void OBSBasicSettings::UpdateMoreInfoLink()
 {
-	if (IsCustomService() || IsWHIP()) {
+	if (IsCustomService() || IsCustomServiceType()) {
 		ui->moreInfoButton->hide();
 		return;
 	}
@@ -487,20 +578,49 @@ void OBSBasicSettings::LoadServices(bool showAll)
 		names.sort(Qt::CaseInsensitive);
 	}
 
+	// Add rtmp_common services with ServiceItemData
 	for (QString &name : names) {
-		ui->service->addItem(name);
+		ServiceItemData data(ServiceItemData::Type::RtmpCommon, name, name);
+		ui->service->addItem(name, QVariant::fromValue(data));
 	}
 
-	if (obs_is_output_protocol_registered("WHIP")) {
-		ui->service->addItem(QTStr("WHIP"), QVariant((int)ListOpt::WHIP));
+	// Enumerate all available service types loaded in OBS
+	size_t idx = 0;
+	const char *service_id;
+	while (obs_enum_service_types(idx++, &service_id)) {
+		// Skip rtmp_common and rtmp_custom as they're handled separately
+		if (strcmp(service_id, "rtmp_common") == 0 || strcmp(service_id, "rtmp_custom") == 0) {
+			continue;
+		}
+
+		// Get the display name for the service
+		const char *display_name = obs_service_get_display_name(service_id);
+		if (!display_name) {
+			display_name = service_id;
+		}
+
+		// Check if the service has a registered protocol
+		OBSServiceAutoRelease temp_service = obs_service_create(service_id, "temp", nullptr, nullptr);
+		if (temp_service) {
+			const char *protocol = obs_service_get_protocol(temp_service);
+			if (protocol && obs_is_output_protocol_registered(protocol)) {
+				// Add the service to the dropdown with ServiceItemData
+				ServiceItemData data(ServiceItemData::Type::CustomServiceType, QString(service_id),
+						     QT_UTF8(display_name));
+				ui->service->addItem(QT_UTF8(display_name), QVariant::fromValue(data));
+			}
+		}
 	}
 
 	if (!showAll) {
+		ServiceItemData showAllData(ServiceItemData::Type::ShowAll);
 		ui->service->addItem(QTStr("Basic.AutoConfig.StreamPage.Service.ShowAll"),
-				     QVariant((int)ListOpt::ShowAll));
+				     QVariant::fromValue(showAllData));
 	}
 
-	ui->service->insertItem(0, QTStr("Basic.AutoConfig.StreamPage.Service.Custom"), QVariant((int)ListOpt::Custom));
+	ServiceItemData customData(ServiceItemData::Type::Custom);
+	ui->service->insertItem(0, QTStr("Basic.AutoConfig.StreamPage.Service.Custom"),
+				QVariant::fromValue(customData));
 
 	if (!lastService.isEmpty()) {
 		int idx = ui->service->findText(lastService);
@@ -576,7 +696,17 @@ void OBSBasicSettings::UseStreamKeyAdvClicked()
 
 void OBSBasicSettings::on_service_currentIndexChanged(int idx)
 {
-	if (ui->service->currentData().toInt() == (int)ListOpt::ShowAll) {
+	// Check if "Show All" was selected
+	QVariant data = ui->service->currentData();
+	if (data.canConvert<ServiceItemData>()) {
+		ServiceItemData serviceData = data.value<ServiceItemData>();
+		if (serviceData.isShowAll()) {
+			LoadServices(true);
+			ui->service->showPopup();
+			return;
+		}
+	} else if (data.toInt() == (int)ListOpt::ShowAll) {
+		// Fallback for backward compatibility
 		LoadServices(true);
 		ui->service->showPopup();
 		return;
@@ -634,7 +764,7 @@ void OBSBasicSettings::ServiceChanged(bool resetFields)
 {
 	std::string service = ui->service->currentText().toStdString();
 	bool custom = IsCustomService();
-	bool whip = IsWHIP();
+	bool customServiceType = IsCustomServiceType();
 
 	ui->disconnectAccount->setVisible(false);
 	ui->bandwidthTestEnable->setVisible(false);
@@ -655,7 +785,7 @@ void OBSBasicSettings::ServiceChanged(bool resetFields)
 	ui->authPwLabel->setVisible(custom);
 	ui->authPwWidget->setVisible(custom);
 
-	if (custom || whip) {
+	if (custom || customServiceType) {
 		ui->destinationLayout->insertRow(1, ui->serverLabel, ui->serverStackedWidget);
 
 		ui->serverStackedWidget->setCurrentIndex(1);
@@ -778,25 +908,27 @@ void OBSBasicSettings::on_authPwShow_clicked()
 OBSService OBSBasicSettings::SpawnTempService()
 {
 	bool custom = IsCustomService();
-	bool whip = IsWHIP();
+	QString customServiceTypeId = GetCustomServiceTypeId();
 	const char *service_id = "rtmp_common";
+	QByteArray serviceIdUtf8;
 
 	if (custom) {
 		service_id = "rtmp_custom";
-	} else if (whip) {
-		service_id = "whip_custom";
+	} else if (!customServiceTypeId.isEmpty()) {
+		serviceIdUtf8 = customServiceTypeId.toUtf8();
+		service_id = serviceIdUtf8.constData();
 	}
 
 	OBSDataAutoRelease settings = obs_data_create();
 
-	if (!custom && !whip) {
+	if (!custom && customServiceTypeId.isEmpty()) {
 		obs_data_set_string(settings, "service", QT_TO_UTF8(ui->service->currentText()));
 		obs_data_set_string(settings, "server", QT_TO_UTF8(ui->server->currentData().toString()));
 	} else {
 		obs_data_set_string(settings, "server", QT_TO_UTF8(ui->customServer->text().trimmed()));
 	}
 
-	if (whip) {
+	if (IsWHIP()) {
 		obs_data_set_string(settings, "bearer_token", QT_TO_UTF8(ui->key->text()));
 	} else {
 		obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -26,12 +26,6 @@ extern QCef *cef;
 extern QCefCookieManager *panel_cookies;
 extern bool cef_js_avail;
 
-enum class ListOpt : int {
-	ShowAll = 1,
-	Custom,
-	WHIP,
-};
-
 enum class Section : int {
 	Connect,
 	StreamKey,
@@ -40,37 +34,23 @@ enum class Section : int {
 bool OBSBasicSettings::IsCustomService() const
 {
 	QVariant data = ui->service->currentData();
-	if (data.canConvert<ServiceItemData>()) {
-		ServiceItemData serviceData = data.value<ServiceItemData>();
-		return serviceData.isCustom();
-	}
-	// Fallback for backward compatibility during migration
-	return data.toInt() == (int)ListOpt::Custom;
+	ServiceItemData serviceData = data.value<ServiceItemData>();
+	return serviceData.isCustom();
 }
 
-inline bool OBSBasicSettings::IsCustomServiceType() const
+bool OBSBasicSettings::IsCustomServiceType() const
 {
 	QVariant data = ui->service->currentData();
-	if (data.canConvert<ServiceItemData>()) {
-		ServiceItemData serviceData = data.value<ServiceItemData>();
-		return serviceData.isCustomServiceType();
-	}
-	// Fallback for backward compatibility during migration
-	return data.canConvert<QString>() && !data.toString().isEmpty();
+	ServiceItemData serviceData = data.value<ServiceItemData>();
+	return serviceData.isCustomServiceType();
 }
 
-inline QString OBSBasicSettings::GetCustomServiceTypeId() const
+QString OBSBasicSettings::GetCustomServiceTypeId() const
 {
 	QVariant data = ui->service->currentData();
-	if (data.canConvert<ServiceItemData>()) {
-		ServiceItemData serviceData = data.value<ServiceItemData>();
-		if (serviceData.isCustomServiceType()) {
-			return serviceData.serviceId;
-		}
-	}
-	// Fallback for backward compatibility during migration
-	if (data.canConvert<QString>()) {
-		return data.toString();
+	ServiceItemData serviceData = data.value<ServiceItemData>();
+	if (serviceData.isCustomServiceType()) {
+		return serviceData.serviceId;
 	}
 	return QString();
 }
@@ -78,6 +58,20 @@ inline QString OBSBasicSettings::GetCustomServiceTypeId() const
 inline bool OBSBasicSettings::IsWHIP() const
 {
 	return GetCustomServiceTypeId() == "whip_custom";
+}
+
+int OBSBasicSettings::FindService(const std::function<bool(const ServiceItemData &)> &predicate)
+{
+	for (int i = 0; i < ui->service->count(); i++) {
+		QVariant data = ui->service->itemData(i);
+		if (data.canConvert<ServiceItemData>()) {
+			ServiceItemData serviceData = data.value<ServiceItemData>();
+			if (predicate(serviceData)) {
+				return i;
+			}
+		}
+	}
+	return -1;
 }
 
 void OBSBasicSettings::InitStreamPage()
@@ -152,18 +146,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	}
 
 	if (is_rtmp_custom) {
-		// Find the "Custom" option by looking for ServiceItemData with Type::Custom
-		int idx = -1;
-		for (int i = 0; i < ui->service->count(); i++) {
-			QVariant data = ui->service->itemData(i);
-			if (data.canConvert<ServiceItemData>()) {
-				ServiceItemData serviceData = data.value<ServiceItemData>();
-				if (serviceData.isCustom()) {
-					idx = i;
-					break;
-				}
-			}
-		}
+		auto idx = FindService([](const ServiceItemData &serviceData) { return serviceData.isCustom(); });
 		if (idx == -1) {
 			idx = 0;
 		}
@@ -178,21 +161,11 @@ void OBSBasicSettings::LoadStream1Settings()
 		ui->authPw->setText(QT_UTF8(password));
 		ui->useAuth->setChecked(use_auth);
 	} else if (is_rtmp_common) {
-		// For rtmp_common services, find by service ID in ServiceItemData
-		int idx = -1;
-		for (int i = 0; i < ui->service->count(); i++) {
-			QVariant data = ui->service->itemData(i);
-			if (data.canConvert<ServiceItemData>()) {
-				ServiceItemData serviceData = data.value<ServiceItemData>();
-				if (serviceData.isRtmpCommon() && serviceData.serviceId == service) {
-					idx = i;
-					break;
-				}
-			}
-		}
+		auto idx = FindService([&](const ServiceItemData &serviceData) {
+			return serviceData.isRtmpCommon() && serviceData.serviceId == service;
+		});
 
 		if (idx == -1) {
-			// Service not found, add it
 			if (service && *service) {
 				ServiceItemData newService(ServiceItemData::Type::RtmpCommon, service, service);
 				ui->service->insertItem(1, service, QVariant::fromValue(newService));
@@ -208,21 +181,11 @@ void OBSBasicSettings::LoadStream1Settings()
 		idx = config_get_int(main->Config(), "Twitch", "AddonChoice");
 		ui->twitchAddonDropdown->setCurrentIndex(idx);
 	} else {
-		// For custom service types (WHIP, MoQ, etc.), find by service type ID in ServiceItemData
-		int idx = -1;
-		for (int i = 0; i < ui->service->count(); i++) {
-			QVariant data = ui->service->itemData(i);
-			if (data.canConvert<ServiceItemData>()) {
-				ServiceItemData serviceData = data.value<ServiceItemData>();
-				if (serviceData.isCustomServiceType() && serviceData.serviceId == type) {
-					idx = i;
-					break;
-				}
-			}
-		}
+		auto idx = FindService([&](const ServiceItemData &serviceData) {
+			return serviceData.isCustomServiceType() && serviceData.serviceId == type;
+		});
 
 		if (idx == -1) {
-			// Service type not found in dropdown, try to add it
 			const char *display_name = obs_service_get_display_name(type);
 			if (!display_name) {
 				display_name = type;
@@ -698,15 +661,8 @@ void OBSBasicSettings::on_service_currentIndexChanged(int idx)
 {
 	// Check if "Show All" was selected
 	QVariant data = ui->service->currentData();
-	if (data.canConvert<ServiceItemData>()) {
-		ServiceItemData serviceData = data.value<ServiceItemData>();
-		if (serviceData.isShowAll()) {
-			LoadServices(true);
-			ui->service->showPopup();
-			return;
-		}
-	} else if (data.toInt() == (int)ListOpt::ShowAll) {
-		// Fallback for backward compatibility
+	ServiceItemData serviceData = data.value<ServiceItemData>();
+	if (serviceData.isShowAll()) {
 		LoadServices(true);
 		ui->service->showPopup();
 		return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
This PR refactors `LoadServices` in `OBSBasicSettings_Stream.cpp` to dynamically discover and populate the stream services dropdown. 

Instead of hardcoding check for specific service types (like the existing WHIP check), the code now:
1. Iterates through all registered service types using `obs_enum_service_types`.
2. Checks if the service type has a corresponding registered output protocol.
3. Automatically adds valid services to the dropdown.

To support this cleaner logic, a `ServiceItemData` struct (registered with `Q_DECLARE_METATYPE`) was introduced to replace the mixed usage of `ListOpt` enums and strings in the dropdown's `QVariant` data. This unifies how service metadata (type, ID, display name) is stored and retrieved.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, plugins that introduce new service types (e.g., a new streaming protocol) do not automatically appear in the Stream Settings service dropdown. Developers typically have to modify the core `OBSBasicSettings_Stream.cpp` file to hardcode their service into the list.

This change allows any plugin to register a service and have it automatically discovered and listed in the UI, provided the underlying output protocol is registered. This decouples the frontend UI from specific service implementations and significantly improves extensibility for protocol plugins.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS.
- Verified that standard RTMP services (Twitch, YouTube, etc.) load and work effectively as before.
- Verified that the "Custom..." option functions correctly.
- Verified that "Show All" correctly expands the list.
- Verified that a custom plugin registering a new service type (and protocol) automatically appears in the list without further code changes.
- Checked that saving and loading settings persists the correct service type.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Tweak (non-breaking change to improve existing functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.