### PR TITLE
libobs: Monitoring deduplication fix for 'Desktop Audio' on monitor_only

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -517,6 +517,9 @@ static inline bool should_silence_monitored_source(obs_source_t *source, struct 
 	if (!dup_src || !obs_source_active(dup_src))
 		return false;
 
+	if (dup_src->monitoring_type == OBS_MONITORING_TYPE_MONITOR_ONLY)
+		return false;
+
 	bool fader_muted = close_float(audio->monitoring_duplicating_source->volume, 0.0f, 0.0001f);
 	bool output_capture_unmuted = !audio->monitoring_duplicating_source->muted && !fader_muted;
 


### PR DESCRIPTION
### Description
When an Audio Output Capture source (AOC) like 'Desktop Audio' has monitoring_type == OBS_MONITORING_TYPE_MONITOR_ONLY, deduplication should not be triggered. this is an edge case which may not cover a reasonable use case, but for the sake of completeness, we deal with it.

### Motivation and Context
Fix bug reported by @Penwy 

Fixes #13241

### How Has This Been Tested?
Bug is fixed on windows 11 25 H2.
Deduplication is not triggered if AOC is monitor_only.
Tested on a sine signal: the level stays nominal.

### Types of changes
 - Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
