### PR TITLE
libobs: Remove "using namespace std" from headers

### DIFF
--- a/libobs-d3d11/d3d11-shaderprocessor.hpp
+++ b/libobs-d3d11/d3d11-shaderprocessor.hpp
@@ -28,10 +28,10 @@ struct ShaderProcessor {
 	gs_device_t *device;
 	ShaderParser parser;
 
-	void BuildInputLayout(vector<D3D11_INPUT_ELEMENT_DESC> &inputs);
-	void BuildParams(vector<gs_shader_param> &params);
-	void BuildSamplers(vector<unique_ptr<ShaderSampler>> &samplers);
-	void BuildString(string &outputString);
+	void BuildInputLayout(std::vector<D3D11_INPUT_ELEMENT_DESC> &inputs);
+	void BuildParams(std::vector<gs_shader_param> &params);
+	void BuildSamplers(std::vector<std::unique_ptr<ShaderSampler>> &samplers);
+	void BuildString(std::string &outputString);
 	void Process(const char *shader_string, const char *file);
 
 	inline ShaderProcessor(gs_device_t *device) : device(device) {}

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -479,9 +479,9 @@ struct HagsStatus {
 		}
 	}
 
-	string ToString() const
+	std::string ToString() const
 	{
-		string status = enabled ? "Enabled" : "Disabled";
+		std::string status = enabled ? "Enabled" : "Disabled";
 		status += " (Default: ";
 		status += enabled_by_default ? "Yes" : "No";
 		status += ", Driver status: ";
@@ -509,9 +509,9 @@ private:
 	}
 };
 
-static optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
+static std::optional<HagsStatus> GetAdapterHagsStatus(const DXGI_ADAPTER_DESC *desc)
 {
-	optional<HagsStatus> ret;
+	std::optional<HagsStatus> ret;
 	D3DKMT_OPENADAPTERFROMLUID d3dkmt_openluid{};
 	d3dkmt_openluid.AdapterLuid = desc->AdapterLuid;
 
@@ -586,7 +586,7 @@ static bool FastClearSupported(UINT vendorId, uint64_t version)
 
 void gs_device::InitDevice(uint32_t adapterIdx)
 {
-	wstring adapterName;
+	std::wstring adapterName;
 	DXGI_ADAPTER_DESC desc;
 	D3D_FEATURE_LEVEL levelUsed = D3D_FEATURE_LEVEL_10_0;
 	LARGE_INTEGER umd;

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -43,8 +43,6 @@ struct shader_var;
 struct shader_sampler;
 struct gs_vertex_shader;
 
-using namespace std;
-
 /*
  * Just to clarify, all structs, and all public.  These are exporting only
  * via encapsulated C bindings, not C++ bindings, so the whole concept of
@@ -376,12 +374,12 @@ struct gs_vertex_buffer : gs_obj {
 	ComPtr<ID3D11Buffer> normalBuffer;
 	ComPtr<ID3D11Buffer> colorBuffer;
 	ComPtr<ID3D11Buffer> tangentBuffer;
-	vector<ComPtr<ID3D11Buffer>> uvBuffers;
+	std::vector<ComPtr<ID3D11Buffer>> uvBuffers;
 
 	bool dynamic;
 	VBDataPtr vbd;
 	size_t numVerts;
-	vector<size_t> uvSizes;
+	std::vector<size_t> uvSizes;
 
 	void FlushBuffer(ID3D11Buffer *buffer, void *array, size_t elementSize);
 
@@ -516,11 +514,11 @@ struct gs_texture_2d : gs_texture {
 	bool chroma = false;
 	bool acquired = false;
 
-	vector<vector<uint8_t>> data;
-	vector<D3D11_SUBRESOURCE_DATA> srd;
+	std::vector<std::vector<uint8_t>> data;
+	std::vector<D3D11_SUBRESOURCE_DATA> srd;
 	D3D11_TEXTURE2D_DESC td = {};
 
-	void InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd);
+	void InitSRD(std::vector<D3D11_SUBRESOURCE_DATA> &srd);
 	void InitTexture(const uint8_t *const *data);
 	void InitResourceView();
 	void InitRenderTargets();
@@ -571,11 +569,11 @@ struct gs_texture_3d : gs_texture {
 	bool chroma = false;
 	bool acquired = false;
 
-	vector<vector<uint8_t>> data;
-	vector<D3D11_SUBRESOURCE_DATA> srd;
+	std::vector<std::vector<uint8_t>> data;
+	std::vector<D3D11_SUBRESOURCE_DATA> srd;
 	D3D11_TEXTURE3D_DESC td = {};
 
-	void InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd);
+	void InitSRD(std::vector<D3D11_SUBRESOURCE_DATA> &srd);
 	void InitTexture(const uint8_t *const *data);
 	void InitResourceView();
 	void BackupTexture(const uint8_t *const *data);
@@ -655,7 +653,7 @@ struct gs_sampler_state : gs_obj {
 };
 
 struct gs_shader_param {
-	string name;
+	std::string name;
 	gs_shader_param_type type;
 
 	uint32_t textureID;
@@ -665,8 +663,8 @@ struct gs_shader_param {
 
 	size_t pos;
 
-	vector<uint8_t> curValue;
-	vector<uint8_t> defaultValue;
+	std::vector<uint8_t> curValue;
+	std::vector<uint8_t> defaultValue;
 	bool changed;
 
 	gs_shader_param(shader_var &var, uint32_t &texCounter);
@@ -681,14 +679,14 @@ struct ShaderError {
 
 struct gs_shader : gs_obj {
 	gs_shader_type type;
-	vector<gs_shader_param> params;
+	std::vector<gs_shader_param> params;
 	ComPtr<ID3D11Buffer> constants;
 	size_t constantSize;
 
 	D3D11_BUFFER_DESC bd = {};
-	vector<uint8_t> data;
+	std::vector<uint8_t> data;
 
-	inline void UpdateParam(vector<uint8_t> &constData, gs_shader_param &param, bool &upload);
+	inline void UpdateParam(std::vector<uint8_t> &constData, gs_shader_param &param, bool &upload);
 	void UploadParams();
 
 	void BuildConstantBuffer();
@@ -705,7 +703,7 @@ struct gs_shader : gs_obj {
 };
 
 struct ShaderSampler {
-	string name;
+	std::string name;
 	gs_sampler_state sampler;
 
 	inline ShaderSampler(const char *name, gs_device_t *device, gs_sampler_info *info)
@@ -721,7 +719,7 @@ struct gs_vertex_shader : gs_shader {
 
 	gs_shader_param *world, *viewProj;
 
-	vector<D3D11_INPUT_ELEMENT_DESC> layoutData;
+	std::vector<D3D11_INPUT_ELEMENT_DESC> layoutData;
 
 	bool hasNormals;
 	bool hasColors;
@@ -750,7 +748,7 @@ struct gs_vertex_shader : gs_shader {
 		return count;
 	}
 
-	void GetBuffersExpected(const vector<D3D11_INPUT_ELEMENT_DESC> &inputs);
+	void GetBuffersExpected(const std::vector<D3D11_INPUT_ELEMENT_DESC> &inputs);
 
 	gs_vertex_shader(gs_device_t *device, const char *file, const char *shaderString);
 };
@@ -775,7 +773,7 @@ struct gs_duplicator : gs_obj {
 
 struct gs_pixel_shader : gs_shader {
 	ComPtr<ID3D11PixelShader> shader;
-	vector<unique_ptr<ShaderSampler>> samplers;
+	std::vector<std::unique_ptr<ShaderSampler>> samplers;
 
 	void Rebuild(ID3D11Device *dev);
 
@@ -987,9 +985,9 @@ struct gs_device {
 	ZStencilState zstencilState;
 	RasterState rasterState;
 	BlendState blendState;
-	vector<SavedZStencilState> zstencilStates;
-	vector<SavedRasterState> rasterStates;
-	vector<SavedBlendState> blendStates;
+	std::vector<SavedZStencilState> zstencilStates;
+	std::vector<SavedRasterState> rasterStates;
+	std::vector<SavedBlendState> blendStates;
 	ID3D11DepthStencilState *curDepthStencilState = nullptr;
 	ID3D11RasterizerState *curRasterState = nullptr;
 	ID3D11BlendState *curBlendState = nullptr;
@@ -997,16 +995,16 @@ struct gs_device {
 
 	gs_rect viewport;
 
-	vector<mat4float> projStack;
+	std::vector<mat4float> projStack;
 
 	matrix4 curProjMatrix;
 	matrix4 curViewMatrix;
 	matrix4 curViewProjMatrix;
 
-	vector<gs_device_loss> loss_callbacks;
+	std::vector<gs_device_loss> loss_callbacks;
 	gs_obj *first_obj = nullptr;
 
-	vector<std::pair<HMONITOR, gs_monitor_color_info>> monitor_to_hdr;
+	std::vector<std::pair<HMONITOR, gs_monitor_color_info>> monitor_to_hdr;
 
 	void InitFactory();
 	void InitAdapter(uint32_t adapterIdx);

--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -18,7 +18,7 @@
 #include <util/base.h>
 #include "d3d11-subsystem.hpp"
 
-void gs_texture_2d::InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd)
+void gs_texture_2d::InitSRD(std::vector<D3D11_SUBRESOURCE_DATA> &srd)
 {
 	uint32_t rowSizeBytes = width * gs_get_format_bpp(format);
 	uint32_t texSizeBytes = height * rowSizeBytes / 8;
@@ -66,7 +66,7 @@ void gs_texture_2d::BackupTexture(const uint8_t *const *data)
 
 			uint32_t texSize = bbp * w * h / 8;
 
-			vector<uint8_t> &subData = this->data[i];
+			std::vector<uint8_t> &subData = this->data[i];
 			subData.resize(texSize);
 			memcpy(&subData[0], data[i], texSize);
 

--- a/libobs-d3d11/d3d11-texture3d.cpp
+++ b/libobs-d3d11/d3d11-texture3d.cpp
@@ -18,7 +18,7 @@
 #include <util/base.h>
 #include "d3d11-subsystem.hpp"
 
-void gs_texture_3d::InitSRD(vector<D3D11_SUBRESOURCE_DATA> &srd)
+void gs_texture_3d::InitSRD(std::vector<D3D11_SUBRESOURCE_DATA> &srd)
 {
 	uint32_t rowSizeBits = width * gs_get_format_bpp(format);
 	uint32_t sliceSizeBytes = height * rowSizeBits / 8;
@@ -58,7 +58,7 @@ void gs_texture_3d::BackupTexture(const uint8_t *const *data)
 		const uint32_t texSize = bbp * w * h * d / 8;
 		this->data[i].resize(texSize);
 
-		vector<uint8_t> &subData = this->data[i];
+		std::vector<uint8_t> &subData = this->data[i];
 		memcpy(&subData[0], data[i], texSize);
 
 		if (w > 1)


### PR DESCRIPTION
### Description
Following up #12683 to also remove this from Windows-only headers for the D3D11 subsystem. There are also submodules utilizing `using namespace std` that also need it removed in a separate PR.

### Motivation and Context
This is bad practice.

### How Has This Been Tested?
Windows 10, still compiles.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
