### PR TITLE
frontend: Don't store `QT_TO_UTF8` to `std::string`

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -370,7 +370,7 @@ void SourceTreeItem::ExitEditModeInternal(bool save)
 	OBSBasic *main = OBSBasic::Get();
 	OBSScene scene = main->GetCurrentScene();
 
-	newName = QT_TO_UTF8(editor->text());
+	newName = editor->text().toStdString();
 
 	setFocusProxy(nullptr);
 	int index = boxLayout->indexOf(editor);

--- a/frontend/components/TextSourceToolbar.cpp
+++ b/frontend/components/TextSourceToolbar.cpp
@@ -137,7 +137,7 @@ void TextSourceToolbar::on_text_textChanged()
 	if (!source) {
 		return;
 	}
-	std::string newText = QT_TO_UTF8(ui->text->text());
+	std::string newText = ui->text->text().toStdString();
 	OBSDataAutoRelease settings = obs_source_get_settings(source);
 	if (newText == obs_data_get_string(settings, "text")) {
 		return;

--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -947,7 +947,7 @@ void OBSBasicFilters::FilterNameEdited(QWidget *editor, QListWidget *list)
 	QListWidgetItem *listItem = list->currentItem();
 	OBSSource filter = listItem->data(Qt::UserRole).value<OBSSource>();
 	QLineEdit *edit = qobject_cast<QLineEdit *>(editor);
-	string name = QT_TO_UTF8(edit->text().trimmed());
+	string name = edit->text().trimmed().toStdString();
 
 	const char *prevName = obs_source_get_name(filter);
 	bool sameName = (name == prevName);

--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -527,14 +527,14 @@ void OBSYoutubeActions::InitBroadcast()
 			} else {
 				// Stream now usecase.
 				blog(LOG_DEBUG, "New valid stream: %s", QT_TO_UTF8(stream.name));
-				emit ok(QT_TO_UTF8(broadcast.id), QT_TO_UTF8(stream.id), QT_TO_UTF8(stream.name), true,
-					true, true);
+				emit ok(broadcast.id.toStdString(), stream.id.toStdString(), stream.name.toStdString(),
+					true, true, true);
 				Accept();
 			}
 		} else {
 			// Stream to precreated broadcast usecase.
-			emit ok(QT_TO_UTF8(broadcast.id), QT_TO_UTF8(stream.id), QT_TO_UTF8(stream.name), autostart,
-				autostop, true);
+			emit ok(broadcast.id.toStdString(), stream.id.toStdString(), stream.name.toStdString(),
+				autostart, autostop, true);
 			Accept();
 		}
 	} else {
@@ -577,8 +577,8 @@ void OBSYoutubeActions::ReadyBroadcast()
 	thread->wait();
 
 	if (success) {
-		emit ok(QT_TO_UTF8(broadcast.id), QT_TO_UTF8(stream.id), QT_TO_UTF8(stream.name), autostart, autostop,
-			false);
+		emit ok(broadcast.id.toStdString(), stream.id.toStdString(), stream.name.toStdString(), autostart,
+			autostop, false);
 		Accept();
 	} else {
 		// Fail.

--- a/frontend/dialogs/OBSYoutubeActions.hpp
+++ b/frontend/dialogs/OBSYoutubeActions.hpp
@@ -33,8 +33,8 @@ class OBSYoutubeActions : public QDialog {
 	std::unique_ptr<Ui::OBSYoutubeActions> ui;
 
 signals:
-	void ok(const QString &broadcast_id, const QString &stream_id, const QString &key, bool autostart,
-		bool autostop, bool start_now);
+	void ok(const std::string &broadcast_id, const std::string &stream_id, const std::string &key, bool autostart,
+		bool autostop, bool startNow);
 
 protected:
 	void showEvent(QShowEvent *event) override;

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -3153,7 +3153,7 @@ void OBSBasicSettings::SaveAdvancedSettings()
 #endif
 
 #ifdef _WIN32
-	std::string priority = QT_TO_UTF8(ui->processPriority->currentData().toString());
+	std::string priority = ui->processPriority->currentData().toString().toStdString();
 	config_set_string(App()->GetAppConfig(), "General", "ProcessPriority", priority.c_str());
 	if (main->Active())
 		SetProcessPriority(priority.c_str());
@@ -4168,9 +4168,8 @@ void OBSBasicSettings::ReloadAudioSources()
 
 void OBSBasicSettings::SpeakerLayoutChanged(int idx)
 {
-	QString speakerLayoutQstr = ui->channelSetup->itemText(idx);
-	std::string speakerLayout = QT_TO_UTF8(speakerLayoutQstr);
-	bool surround = IsSurround(speakerLayout.c_str());
+	QByteArray speakerLayout = ui->channelSetup->itemText(idx).toUtf8();
+	bool surround = IsSurround(speakerLayout.constData());
 	bool isOpus = ui->simpleOutStrAEncoder->currentData().toString() == "opus";
 
 	if (surround) {

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -621,7 +621,7 @@ void OBSBasicSettings::on_customServer_textChanged(const QString &)
 
 void OBSBasicSettings::ServiceChanged(bool resetFields)
 {
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 	bool custom = IsCustomService();
 	bool whip = IsWHIP();
 
@@ -838,7 +838,7 @@ void OBSBasicSettings::OnOAuthStreamKeyConnected()
 
 void OBSBasicSettings::OnAuthConnected()
 {
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 	Auth::Type type = Auth::AuthType(service);
 
 	if (type == Auth::Type::OAuth_StreamKey || type == Auth::Type::OAuth_LinkedAccount) {
@@ -853,7 +853,7 @@ void OBSBasicSettings::OnAuthConnected()
 
 void OBSBasicSettings::on_connectAccount_clicked()
 {
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 
 	OAuth::DeleteCookies(service);
 
@@ -890,7 +890,7 @@ void OBSBasicSettings::on_disconnectAccount_clicked()
 	auth.reset();
 	main->SetBroadcastFlowEnabled(false);
 
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 
 #ifdef BROWSER_AVAILABLE
 	OAuth::DeleteCookies(service);
@@ -1154,7 +1154,7 @@ bool OBSBasicSettings::ResFPSValid(obs_service_resolution *res_list, size_t res_
 		if (fpsType != 0)
 			return false;
 
-		std::string fps_str = QT_TO_UTF8(ui->fpsCommon->currentText());
+		std::string fps_str = ui->fpsCommon->currentText().toStdString();
 		float fps;
 		sscanf(fps_str.c_str(), "%f", &fps);
 		if (fps > (float)max_fps)

--- a/frontend/utility/CrashHandler.cpp
+++ b/frontend/utility/CrashHandler.cpp
@@ -324,14 +324,14 @@ void CrashHandler::handleExistingCrashLogUpload()
 	}
 }
 
-void CrashHandler::crashLogUploadResultHandler(const QString &uploadResult, const QString &error)
+void CrashHandler::crashLogUploadResultHandler(const std::string &uploadResult, const std::string &error)
 {
-	if (uploadResult.isEmpty()) {
-		emit crashLogUploadFailed(error);
+	if (uploadResult.empty()) {
+		emit crashLogUploadFailed(QString::fromStdString(error));
 		return;
 	}
 
-	json uploadResultData = json::parse(uploadResult.toStdString());
+	json uploadResultData = json::parse(uploadResult);
 
 	try {
 		std::string crashLogUrl = uploadResultData["url"];

--- a/frontend/utility/CrashHandler.hpp
+++ b/frontend/utility/CrashHandler.hpp
@@ -83,7 +83,7 @@ private:
 	PlatformType getPlatformType() const;
 
 private slots:
-	void crashLogUploadResultHandler(const QString &uploadResult, const QString &error);
+	void crashLogUploadResultHandler(const std::string &uploadResult, const std::string &error);
 
 	// FIXME: Turn into private slot once OBSBasic does not handle application shutdown duties anymore.
 public slots:

--- a/frontend/utility/RemoteTextThread.cpp
+++ b/frontend/utility/RemoteTextThread.cpp
@@ -89,9 +89,9 @@ void RemoteTextThread::run()
 		if (code != CURLE_OK) {
 			blog(LOG_WARNING, "RemoteTextThread: HTTP request failed. %s",
 			     strlen(error) ? error : curl_easy_strerror(code));
-			emit Result(QString(), QT_UTF8(error));
+			emit Result(std::string{}, std::string{error});
 		} else {
-			emit Result(QT_UTF8(str.c_str()), QString());
+			emit Result(str, std::string{});
 		}
 
 		curl_slist_free_all(header);

--- a/frontend/utility/RemoteTextThread.hpp
+++ b/frontend/utility/RemoteTextThread.hpp
@@ -33,7 +33,7 @@ class RemoteTextThread : public QThread {
 	void run() override;
 
 signals:
-	void Result(const QString &text, const QString &error);
+	void Result(const std::string &text, const std::string &error);
 
 public:
 	inline RemoteTextThread(std::string url_, std::string contentType_ = std::string(),

--- a/frontend/utility/WhatsNewInfoThread.cpp
+++ b/frontend/utility/WhatsNewInfoThread.cpp
@@ -268,7 +268,7 @@ try {
 	std::string text;
 
 	if (FetchAndVerifyFile("whatsnew", "obs-studio/updates/whatsnew.json", WHATSNEW_URL, &text)) {
-		emit Result(QString::fromStdString(text));
+		emit Result(text);
 	}
 } catch (std::string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());

--- a/frontend/utility/WhatsNewInfoThread.hpp
+++ b/frontend/utility/WhatsNewInfoThread.hpp
@@ -11,7 +11,7 @@ class WhatsNewInfoThread : public QThread {
 	virtual void run() override;
 
 signals:
-	void Result(const QString &text);
+	void Result(const std::string &text);
 
 public:
 	inline WhatsNewInfoThread() {}

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -2085,12 +2085,12 @@ OBSBasic *OBSBasic::Get()
 	return reinterpret_cast<OBSBasic *>(App()->GetMainWindow());
 }
 
-void OBSBasic::UpdatePatronJson(const QString &text, const QString &error)
+void OBSBasic::UpdatePatronJson(const std::string &text, const std::string &error)
 {
-	if (!error.isEmpty())
+	if (!error.empty())
 		return;
 
-	patronJson = QT_TO_UTF8(text);
+	patronJson = text;
 }
 
 void OBSBasic::SetDisplayAffinity(QWindow *window)

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -302,7 +302,7 @@ private:
 
 public slots:
 	void close();
-	void UpdatePatronJson(const QString &text, const QString &error);
+	void UpdatePatronJson(const std::string &text, const std::string &error);
 	void UpdateEditMenu();
 	void applicationShutdown() noexcept;
 
@@ -647,7 +647,7 @@ private slots:
 
 	void on_resetUI_triggered();
 
-	void logUploadFinished(const QString &text, const QString &error, OBS::LogFileType uploadType);
+	void logUploadFinished(const std::string &text, const std::string &error, OBS::LogFileType uploadType);
 
 	void updateCheckFinished();
 
@@ -1615,7 +1615,7 @@ private:
 	void CheckForUpdates(bool manualUpdate);
 
 	void MacBranchesFetched(const QString &branch, bool manualUpdate);
-	void ReceivedIntroJson(const QString &text);
+	void ReceivedIntroJson(const std::string &text);
 	void ShowWhatsNew(const QString &url);
 
 	/* -------------------------------------

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1705,8 +1705,8 @@ private:
 
 	void YoutubeStreamCheck(const std::string &key);
 	void ShowYouTubeAutoStartWarning();
-	void YouTubeActionDialogOk(const QString &broadcast_id, const QString &stream_id, const QString &key,
-				   bool autostart, bool autostop, bool start_now);
+	void YouTubeActionDialogOk(const std::string &broadcastId, const std::string &streamId, const std::string &key,
+				   bool autostart, bool autostop, bool startNow);
 #endif
 
 	void BroadcastButtonClicked();

--- a/frontend/widgets/OBSBasic_Browser.cpp
+++ b/frontend/widgets/OBSBasic_Browser.cpp
@@ -132,7 +132,7 @@ void OBSBasic::AddExtraBrowserDock(const QString &title, const QString &url, con
 			std::string script;
 			script = "Object.defineProperty(document, 'referrer', { get: () => '";
 			script += "https://twitch.tv/";
-			script += QT_TO_UTF8(username);
+			script += username.toStdString();
 			script += "/dashboard/live";
 			script += "'});";
 			browser->setStartupScript(script);

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -47,6 +47,7 @@
 
 #include <qt-wrappers.hpp>
 
+#include <nlohmann/json.hpp>
 #include <QDesktopServices>
 
 #ifdef _WIN32
@@ -285,9 +286,10 @@ void OBSBasic::UploadLog(const char *subdir, const char *file, const LogUploadTy
 
 	logUploadThread.reset(thread);
 
-	connect(thread, &RemoteTextThread::Result, this, [this, uploadType](const QString &text, const QString &error) {
-		logUploadFinished(text, error, uploadType);
-	});
+	connect(thread, &RemoteTextThread::Result, this,
+		[this, uploadType](const std::string &text, const std::string &error) {
+			logUploadFinished(text, error, uploadType);
+		});
 
 	logUploadThread->start();
 }
@@ -382,18 +384,17 @@ void OBSBasic::on_actionRestartSafe_triggered()
 	}
 }
 
-void OBSBasic::logUploadFinished(const QString &text, const QString &error, LogUploadType uploadType)
+void OBSBasic::logUploadFinished(const std::string &text, const std::string &error, LogUploadType uploadType)
 {
 	OBSApp *app = App();
 
-	if (text.isEmpty()) {
-		emit app->logUploadFailed(uploadType, error);
+	if (text.empty()) {
+		emit app->logUploadFailed(uploadType, QString::fromStdString(error));
 	} else {
-		OBSDataAutoRelease returnData = obs_data_create_from_json(QT_TO_UTF8(text));
-		string resURL = obs_data_get_string(returnData, "url");
-		QString logURL = resURL.c_str();
+		nlohmann::json parsed = nlohmann::json::parse(text);
+		std::string logURL = parsed["url"];
 
-		emit app->logUploadFinished(uploadType, logURL);
+		emit app->logUploadFinished(uploadType, QString::fromStdString(logURL));
 	}
 }
 

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -899,7 +899,7 @@ void OBSBasic::SceneNameEdited(QWidget *editor)
 {
 	OBSScene scene = GetCurrentScene();
 	QLineEdit *edit = qobject_cast<QLineEdit *>(editor);
-	string text = QT_TO_UTF8(edit->text().trimmed());
+	string text = edit->text().trimmed().toStdString();
 
 	if (!scene)
 		return;

--- a/frontend/widgets/OBSBasic_Updater.cpp
+++ b/frontend/widgets/OBSBasic_Updater.cpp
@@ -60,7 +60,7 @@ template<typename OBSRef> struct SignalContainer {
 };
 } // namespace
 
-void OBSBasic::ReceivedIntroJson(const QString &text)
+void OBSBasic::ReceivedIntroJson(const std::string &text)
 {
 #ifdef WHATSNEW_ENABLED
 	if (isClosing()) {
@@ -69,7 +69,7 @@ void OBSBasic::ReceivedIntroJson(const QString &text)
 
 	WhatsNewList items;
 	try {
-		nlohmann::json json = nlohmann::json::parse(text.toStdString());
+		nlohmann::json json = nlohmann::json::parse(text);
 		items = json.get<WhatsNewList>();
 	} catch (nlohmann::json::exception &e) {
 		blog(LOG_WARNING, "Parsing whatsnew data failed: %s", e.what());

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -32,21 +32,15 @@ using namespace std;
 extern bool cef_js_avail;
 
 #ifdef YOUTUBE_ENABLED
-void OBSBasic::YouTubeActionDialogOk(const QString &broadcast_id, const QString &stream_id, const QString &key,
-				     bool autostart, bool autostop, bool start_now)
+void OBSBasic::YouTubeActionDialogOk(const std::string &broadcastId, const std::string &streamId,
+				     const std::string &key, bool autostart, bool autostop, bool startNow)
 {
-	//blog(LOG_DEBUG, "Stream key: %s", QT_TO_UTF8(key));
 	obs_service_t *service_obj = GetService();
 	OBSDataAutoRelease settings = obs_service_get_settings(service_obj);
 
-	const std::string a_key = QT_TO_UTF8(key);
-	obs_data_set_string(settings, "key", a_key.c_str());
-
-	const std::string b_id = QT_TO_UTF8(broadcast_id);
-	obs_data_set_string(settings, "broadcast_id", b_id.c_str());
-
-	const std::string s_id = QT_TO_UTF8(stream_id);
-	obs_data_set_string(settings, "stream_id", s_id.c_str());
+	obs_data_set_string(settings, "key", key.c_str());
+	obs_data_set_string(settings, "broadcast_id", broadcastId.c_str());
+	obs_data_set_string(settings, "stream_id", streamId.c_str());
 
 	obs_service_update(service_obj, settings);
 	autoStartBroadcast = autostart;
@@ -55,7 +49,7 @@ void OBSBasic::YouTubeActionDialogOk(const QString &broadcast_id, const QString 
 
 	emit BroadcastStreamReady(broadcastReady);
 
-	if (start_now)
+	if (startNow)
 		QMetaObject::invokeMethod(this, "StartStreaming");
 }
 

--- a/frontend/wizards/AutoConfigStreamPage.cpp
+++ b/frontend/wizards/AutoConfigStreamPage.cpp
@@ -136,10 +136,12 @@ bool AutoConfigStreamPage::validatePage()
 
 	if (wiz->customServer) {
 		QString server = ui->customServer->text().trimmed();
-		wiz->server = wiz->serverName = QT_TO_UTF8(server);
+		const std::string name = server.toStdString();
+		wiz->server = name;
+		wiz->serverName = name;
 	} else {
-		wiz->serverName = QT_TO_UTF8(ui->server->currentText());
-		wiz->server = QT_TO_UTF8(ui->server->currentData().toString());
+		wiz->serverName = ui->server->currentText().toStdString();
+		wiz->server = ui->server->currentData().toString().toStdString();
 	}
 
 	wiz->bandwidthTest = ui->doBandwidthTest->isChecked();
@@ -149,10 +151,10 @@ bool AutoConfigStreamPage::validatePage()
 	wiz->regionEU = ui->regionEU->isChecked();
 	wiz->regionAsia = ui->regionAsia->isChecked();
 	wiz->regionOther = ui->regionOther->isChecked();
-	wiz->serviceName = QT_TO_UTF8(ui->service->currentText());
+	wiz->serviceName = ui->service->currentText().toStdString();
 	if (ui->preferHardware)
 		wiz->preferHardware = ui->preferHardware->isChecked();
-	wiz->key = QT_TO_UTF8(ui->key->text());
+	wiz->key = ui->key->text().toStdString();
 
 	if (!wiz->customServer) {
 		if (wiz->serviceName == "Twitch")
@@ -302,7 +304,7 @@ void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 
 void AutoConfigStreamPage::OnAuthConnected()
 {
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 	Auth::Type type = Auth::AuthType(service);
 
 	if (type == Auth::Type::OAuth_StreamKey || type == Auth::Type::OAuth_LinkedAccount) {
@@ -312,7 +314,7 @@ void AutoConfigStreamPage::OnAuthConnected()
 
 void AutoConfigStreamPage::on_connectAccount_clicked()
 {
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 
 	OAuth::DeleteCookies(service);
 
@@ -342,7 +344,7 @@ void AutoConfigStreamPage::on_disconnectAccount_clicked()
 	main->auth.reset();
 	auth.reset();
 
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 
 #ifdef BROWSER_AVAILABLE
 	OAuth::DeleteCookies(service);
@@ -438,7 +440,7 @@ void AutoConfigStreamPage::ServiceChanged()
 	if (showMore)
 		return;
 
-	std::string service = QT_TO_UTF8(ui->service->currentText());
+	std::string service = ui->service->currentText().toStdString();
 	bool regionBased = service == "Twitch";
 	bool testBandwidth = ui->doBandwidthTest->isChecked();
 	bool custom = IsCustomService();


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
`QT_TO_UTF8` returns a `const char *` that, in general, shouldn't be stored.
This is because `QT_TO_UTF8(str)` expands to `str.toUtf8().constData()`: `toUtf8()` returns a `QByteArray`, and `constData()` the pointer to its data which is only valid until the `QByteArray` goes out of scope, which is immediately after the call.
The original code that is changed here only works because in all of the situations, the object that is stored to is actually a `std::string` that gets constructed implicitly, so the `constData()` pointer is valid long enough for the `std::string` constructor to copy the data.

The issue is that any `... = QT_TO_UTF8` code *looks* unsafe, and may lead new or unfamiliar contributors to assume that they can also use it, only to do `const char *... = QT_TO_UTF8(...)` which is dangerous. Additionally, it introduces an unnecessary round of implicit conversions and copies when `QString::toStdString()` already exists and copies into the string buffer directly.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
There was a PR a while back that contained a `const c1har *... = QT_TO_UTF8(...)`. Luckily that was caught, but made me look into if there's anywhere else where we're storing `QT_TO_UTF8`.
Also, imo we should look at reducing (potentially even completely removing) these Qt-magic macros (`QT_TO_UTF8`, `QT_UTF8`) anyways, in favor of explicit function calls (that would probably lead to less back and for conversions overall, like the ones found in the first two commits on this PR).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested in the debugger that the resulting `std::string`s have the same value before and after that PR.
Made sure the YouTube functionality still works.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
