### PR TITLE
linux-capture: Make X11 display captures handle resolution changes

### DIFF
--- a/plugins/linux-capture/README
+++ b/plugins/linux-capture/README
@@ -6,7 +6,6 @@ Linux XShm capture plugin
 
 Todo:
 
- - handle resolution changes of screens
  - handle adding/removing screens while recording
  - support different depths
 

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -93,6 +93,10 @@ static void xshm_resize(struct xshm_data *data)
 	data->xshm = xshm_xcb_attach(data->xcb, data->adj_width, data->adj_height);
 	if (!data->xshm) {
 		blog(LOG_ERROR, "failed to attach shm after resize!");
+		if (data->texture) {
+			gs_texture_destroy(data->texture);
+			data->texture = NULL;
+		}
 		return;
 	}
 

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -521,7 +521,6 @@ static void xshm_video_tick(void *vptr, float seconds)
 	}
 
 	if (geo_changed > 0) {
-		blog(LOG_INFO, "resolution changed, resizing capture");
 		obs_enter_graphics();
 		xshm_resize(data);
 		obs_leave_graphics();

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -82,6 +82,26 @@ static inline void xshm_resize_texture(struct xshm_data *data)
 }
 
 /**
+ * Recreate shared memory segment and texture after geometry change
+ *
+ * @note requires to be called within the obs graphics context
+ */
+static void xshm_resize(struct xshm_data *data)
+{
+	xshm_xcb_detach(data->xshm);
+
+	data->xshm = xshm_xcb_attach(data->xcb, data->adj_width, data->adj_height);
+	if (!data->xshm) {
+		blog(LOG_ERROR, "failed to attach shm after resize!");
+		return;
+	}
+
+	xshm_resize_texture(data);
+
+	xcb_xcursor_offset(data->cursor, data->adj_x_org, data->adj_y_org);
+}
+
+/**
  * Check if the xserver supports all the extensions we need
  */
 static bool xshm_check_extensions(xcb_connection_t *xcb)
@@ -105,7 +125,7 @@ static bool xshm_check_extensions(xcb_connection_t *xcb)
 /**
  * Update the capture
  *
- * @return < 0 on error, 0 when size is unchanged, > 1 on size change
+ * @return < 0 on error, 0 when size is unchanged, > 0 on size change
  */
 static int_fast32_t xshm_update_geometry(struct xshm_data *data)
 {
@@ -161,11 +181,11 @@ static int_fast32_t xshm_update_geometry(struct xshm_data *data)
 	if (data->cut_bot != 0)
 		data->adj_height = data->adj_height - data->cut_bot;
 
-	blog(LOG_INFO, "Geometry %" PRIdFAST32 "x%" PRIdFAST32 " @ %" PRIdFAST32 ",%" PRIdFAST32, data->width,
-	     data->height, data->x_org, data->y_org);
-
 	if (prev_width == data->adj_width && prev_height == data->adj_height)
 		return 0;
+
+	blog(LOG_INFO, "Geometry %" PRIdFAST32 "x%" PRIdFAST32 " @ %" PRIdFAST32 ",%" PRIdFAST32, data->width,
+	     data->height, data->x_org, data->y_org);
 
 	return 1;
 }
@@ -489,9 +509,25 @@ static void xshm_video_tick(void *vptr, float seconds)
 	UNUSED_PARAMETER(seconds);
 	XSHM_DATA(vptr);
 
-	if (!data->texture)
+	if (!data->xcb)
 		return;
 	if (!obs_source_showing(data->source))
+		return;
+
+	int_fast32_t geo_changed = xshm_update_geometry(data);
+	if (geo_changed < 0) {
+		blog(LOG_ERROR, "failed to update geometry in video tick!");
+		return;
+	}
+
+	if (geo_changed > 0) {
+		blog(LOG_INFO, "resolution changed, resizing capture");
+		obs_enter_graphics();
+		xshm_resize(data);
+		obs_leave_graphics();
+	}
+
+	if (!data->texture || !data->xshm)
 		return;
 
 	xcb_shm_get_image_cookie_t img_c;

--- a/plugins/linux-capture/xshm-input.c
+++ b/plugins/linux-capture/xshm-input.c
@@ -65,6 +65,9 @@ struct xshm_data {
 	bool use_xinerama;
 	bool use_randr;
 	bool advanced;
+
+	uint8_t randr_first_event;
+	bool geo_event_pending;
 };
 
 /**
@@ -279,6 +282,20 @@ static void xshm_capture_start(struct xshm_data *data)
 
 	data->cursor = xcb_xcursor_init(data->xcb);
 	xcb_xcursor_offset(data->cursor, data->adj_x_org, data->adj_y_org);
+
+	/* Always subscribe to ConfigureNotify on the root window.
+	 * According to WebRTC's source code comments, adding/removing monitors
+	 * can generate ConfigureNotify without any RRScreenChangeNotify. */
+	const uint32_t mask = XCB_EVENT_MASK_STRUCTURE_NOTIFY;
+	xcb_change_window_attributes(data->xcb, data->xcb_screen->root, XCB_CW_EVENT_MASK, &mask);
+
+	if (data->use_randr) {
+		const xcb_query_extension_reply_t *ext = xcb_get_extension_data(data->xcb, &xcb_randr_id);
+		data->randr_first_event = ext->first_event;
+		xcb_randr_select_input(data->xcb, data->xcb_screen->root,
+				       XCB_RANDR_NOTIFY_MASK_SCREEN_CHANGE | XCB_RANDR_NOTIFY_MASK_CRTC_CHANGE);
+	}
+	xcb_flush(data->xcb);
 
 	obs_enter_graphics();
 
@@ -506,6 +523,24 @@ static void *xshm_create(obs_data_t *settings, obs_source_t *source)
 }
 
 /**
+ * Drain pending X events to detect screen geometry changes
+ */
+static void xshm_process_events(struct xshm_data *data)
+{
+	xcb_generic_event_t *event;
+	while ((event = xcb_poll_for_event(data->xcb))) {
+		uint8_t type = event->response_type & ~0x80; /* Strip out "sent event" flag */
+		if (type == XCB_CONFIGURE_NOTIFY) {
+			data->geo_event_pending = true;
+		} else if (data->use_randr && (type == data->randr_first_event + XCB_RANDR_SCREEN_CHANGE_NOTIFY ||
+					       type == data->randr_first_event + XCB_RANDR_NOTIFY)) {
+			data->geo_event_pending = true;
+		}
+		free(event);
+	}
+}
+
+/**
  * Prepare the capture data
  */
 static void xshm_video_tick(void *vptr, float seconds)
@@ -518,16 +553,22 @@ static void xshm_video_tick(void *vptr, float seconds)
 	if (!obs_source_showing(data->source))
 		return;
 
-	int_fast32_t geo_changed = xshm_update_geometry(data);
-	if (geo_changed < 0) {
-		blog(LOG_ERROR, "failed to update geometry in video tick!");
-		return;
-	}
+	xshm_process_events(data);
 
-	if (geo_changed > 0) {
-		obs_enter_graphics();
-		xshm_resize(data);
-		obs_leave_graphics();
+	if (data->geo_event_pending) {
+		data->geo_event_pending = false;
+
+		int_fast32_t geo_changed = xshm_update_geometry(data);
+		if (geo_changed < 0) {
+			blog(LOG_ERROR, "failed to update geometry in video tick!");
+			return;
+		}
+
+		if (geo_changed > 0) {
+			obs_enter_graphics();
+			xshm_resize(data);
+			obs_leave_graphics();
+		}
 	}
 
 	if (!data->texture || !data->xshm)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Motivation and Context

The XSHM display source has been unable to handle screen resolution changes on the fly for over 11 years (see commit [`76d2bf2`](https://github.com/obsproject/obs-studio/commit/76d2bf2c29cfd34ed89ac1fad03b1596612b45ca)): when screen resolution changes while such a source is active, the source fails to resize accordingly, resulting in incorrect output.

While this rarely affects the most typical workflows, as users seldom change physical display resolutions while recording, it becomes a more significant issue with virtual displays and multi-monitor setups. For example, virtual screens created by remote desktop servers like xrdp may be frequently resized during client window drag and resize operations.

I have identified and tried several workarounds, but none are ideal:

- The third-party [`obs-gstreamer` plugin](https://github.com/fzwoch/obs-gstreamer) can delegate screen capturing to [GStreamer's `ximagesrc` element](https://gstreamer.freedesktop.org/documentation/ximagesrc/index.html). However, this incurs higher CPU usage than the native XSHM source.
- Manually changing any source configuration parameter triggers `xshm_update`, restarting the capture with the new screen geometry. But manual solutions are inconvenient, and may cause visible artifacts while being applied.
- A custom OBS plugin or WebSocket client could listen for resolution changes and automate the above workaround, but this solution is inelegant and beyond most users' reach.

### Description

These changes fix the problem described above at its root by following an approach inspired by other sources and GStreamer's `ximagesrc`: checking for screen geometry changes on each video tick. When a change is detected, the OBS and XSHM textures are resized to match, avoiding unnecessary reinitialization steps for better performance. I didn't observe any material performance impact in the happy path of a constant screen resolution.

### How Has This Been Tested?

I've built OBS 32.0.4 from source on a Debian Unstable X11 environment, both with and without this patch. Then I manually tested the two builds side by side, and confirmed that this patch fixes the intended issue without introducing any regressions. I conducted my tests under the xorgxrdp X server.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.