### PR TITLE
rtmp-services: Add Streamvi service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 281,
+    "version": 282,
     "files": [
         {
             "name": "services.json",
-            "version": 281
+            "version": 282
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3593,6 +3593,18 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "StreamVi",
+            "common": false,
+            "more_info_link": "https://streamvi.io/ru/docs/info",
+            "stream_key_link": "https://streamvi.io/cabinet/my/settings/stream",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://ingest.live-default.streamvi.ru/live"
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Added Streamvi to streaming services drop down.

### Motivation and Context
Popular restreaming service

### Types of changes
New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

