### PR TITLE
libobs: Restore only canvases that have video info

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -296,6 +296,9 @@ void obs_free_canvas_mixes(void)
 
 bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
+	if (!ovi && !canvas->mix)
+		return true;
+
 	obs_canvas_clear_mix(canvas);
 
 	if (ovi)


### PR DESCRIPTION
### Description
Restore only canvases that have video info

### Motivation and Context
When you have an extra canvas from a plugin that is disabled or removed and you change the resolution of the main canvas it will stop the graphics thread completely. The log lines look like this:
```
17:26:03.069: Invalid video parameters specified
17:26:03.069: Failed restoring video mix for canvas 'Aitum Vertical'
```
`obs_canvas_reset_video_internal` will fail because internal video info is not set
`restore_canvases` will return `false`
[`obs_init_video`](https://github.com/obsproject/obs-studio/blob/407944a27c15830c2b22c3c723ef89fb97cc98a5/libobs/obs.c#L707) will not start the graphics thread

### How Has This Been Tested?
On windows 11 by installing Aitum Vertical and disabling it after it created a canvas. Changing the size of the main resolution stops the graphics thread.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
