### PR TITLE
mac-capture: Avoid inadvertent capture of screen content

### DIFF
--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -83,6 +83,10 @@ bool build_display_list(struct screen_capture *sc, obs_properties_t *props)
     obs_property_t *display_list = obs_properties_get(props, "display_uuid");
     obs_property_list_clear(display_list);
 
+    // Add null entry to the top of the content list, to avoid inadvertent capture of the first enumerated display
+    // when opening the source's properties window
+    obs_property_list_add_string(display_list, " ", NULL);
+
     for (SCDisplay *display in sc->shareable_content.displays) {
         NSScreen *display_screen = nil;
         for (NSScreen *screen in NSScreen.screens) {
@@ -126,6 +130,10 @@ bool build_window_list(struct screen_capture *sc, obs_properties_t *props)
 
     obs_property_t *window_list = obs_properties_get(props, "window");
     obs_property_list_clear(window_list);
+
+    // Add null entry to the top of the content list, to avoid inadvertent capture of the first enumerated window
+    // when opening the source's properties window
+    obs_property_list_add_int(window_list, " ", kCGNullWindowID);
 
     NSPredicate *filteredWindowPredicate =
         [NSPredicate predicateWithBlock:^BOOL(SCWindow *window, NSDictionary *bindings __unused) {
@@ -172,6 +180,10 @@ bool build_application_list(struct screen_capture *sc, obs_properties_t *props)
 
     obs_property_t *application_list = obs_properties_get(props, "application");
     obs_property_list_clear(application_list);
+
+    // Add null entry to the top of the content list, to avoid inadvertent capture of the first enumerated application
+    // when opening the source's properties window
+    obs_property_list_add_string(application_list, " ", 0);
 
     NSArray<SCRunningApplication *> *filteredApplications;
     filteredApplications = [sc->shareable_content.applications

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -392,24 +392,8 @@ API_AVAILABLE(macos(12.5)) static uint32_t sck_video_capture_getheight(void *dat
 
 static void sck_video_capture_defaults(obs_data_t *settings)
 {
-    CGDirectDisplayID initial_display = 0;
-    {
-        NSScreen *mainScreen = [NSScreen mainScreen];
-        if (mainScreen) {
-            NSNumber *screen_num = mainScreen.deviceDescription[@"NSScreenNumber"];
-            if (screen_num) {
-                initial_display = (CGDirectDisplayID) (uintptr_t) screen_num.pointerValue;
-            }
-        }
-    }
-
-    CFUUIDRef display_uuid = CGDisplayCreateUUIDFromDisplayID(initial_display);
-    CFStringRef uuid_string = CFUUIDCreateString(kCFAllocatorDefault, display_uuid);
-    obs_data_set_default_string(settings, "display_uuid", CFStringGetCStringPtr(uuid_string, kCFStringEncodingUTF8));
-    CFRelease(uuid_string);
-    CFRelease(display_uuid);
-
     obs_data_set_default_string(settings, "application", NULL);
+    obs_data_set_default_string(settings, "display_uuid", NULL);
     obs_data_set_default_int(settings, "type", ScreenCaptureDisplayStream);
     obs_data_set_default_int(settings, "window", kCGNullWindowID);
     obs_data_set_default_bool(settings, "show_cursor", true);

--- a/plugins/mac-capture/window-utils.m
+++ b/plugins/mac-capture/window-utils.m
@@ -267,7 +267,7 @@ CGDirectDisplayID get_display_migrate_settings(obs_data_t *settings)
     }
 
     const char *display_uuid = obs_data_get_string(settings, "display_uuid");
-    if (display_uuid) {
+    if (display_uuid && *display_uuid) {
         CFStringRef uuid_string = CFStringCreateWithCString(kCFAllocatorDefault, display_uuid, kCFStringEncodingUTF8);
         CFUUIDRef uuid_ref = CFUUIDCreateFromString(kCFAllocatorDefault, uuid_string);
         CGDirectDisplayID display = CGDisplayGetDisplayIDFromUUID(uuid_ref);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds null or placeholder values as the first elements of macOS Screen Capture content lists, and removes the automatic selection of the user's primary display for capture.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This change is designed to end any inadvertent capture of the user's screen content which was not expressly selected for capture by the user.

When opening a source properties window in OBS, property lists by default typically select the first element. If the source is an SCK source and the list represents running applications, windows, or displays, the first enumerated content in the list would be selected on opening the properties window, causing that content to immediately begin streaming. This could be a significant privacy concern.

Related: https://github.com/obsproject/obs-studio/pull/11233

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Apple Silicon, macOS 15.7.1.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
