### PR TITLE
frontend, obs-filters: Add missing file support for filters

### DIFF
--- a/plugins/obs-filters/color-grade-filter.c
+++ b/plugins/obs-filters/color-grade-filter.c
@@ -465,6 +465,34 @@ static enum gs_color_space color_grade_filter_get_color_space(void *data, size_t
 	return source_space;
 }
 
+static void missing_file_callback(void *src, const char *new_path, void *data)
+{
+	struct lut_filter_data *filter = src;
+
+	obs_source_t *source = filter->context;
+	obs_data_t *settings = obs_source_get_settings(source);
+	obs_data_set_string(settings, SETTING_IMAGE_PATH, new_path);
+	obs_source_update(source, settings);
+	obs_data_release(settings);
+
+	UNUSED_PARAMETER(data);
+}
+
+static obs_missing_files_t *color_grade_filter_missing_files(void *data)
+{
+	struct lut_filter_data *filter = data;
+	obs_missing_files_t *files = obs_missing_files_create();
+
+	if (filter->file && strcmp(filter->file, "") != 0 && !os_file_exists(filter->file)) {
+		obs_missing_file_t *file = obs_missing_file_create(filter->file, missing_file_callback,
+								   OBS_MISSING_FILE_SOURCE, filter->context, NULL);
+
+		obs_missing_files_add_file(files, file);
+	}
+
+	return files;
+}
+
 struct obs_source_info color_grade_filter = {
 	.id = "clut_filter",
 	.type = OBS_SOURCE_TYPE_FILTER,
@@ -477,4 +505,5 @@ struct obs_source_info color_grade_filter = {
 	.get_properties = color_grade_filter_properties,
 	.video_render = color_grade_filter_render,
 	.video_get_color_space = color_grade_filter_get_color_space,
+	.missing_files = color_grade_filter_missing_files,
 };


### PR DESCRIPTION
### Description
Add missing file support for filters

### Motivation and Context
When importing a scene collection you get a popup with missing files which does not contain all missing files.

### How Has This Been Tested?
On windows 11 with a mask filter and remove the mask from disk

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
