### PR TITLE
libobs: Fix crash with non-ASCII characters in formatted filenames

### DIFF
--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -166,6 +166,8 @@ EXPORT int os_safe_replace(const char *target_path, const char *from_path, const
 
 EXPORT char *os_generate_formatted_filename(const char *extension, bool space, const char *format);
 
+EXPORT size_t os_strftime_utf8(char *dst, size_t dst_size, const char *format, const struct tm *tm);
+
 struct os_inhibit_info;
 typedef struct os_inhibit_info os_inhibit_t;
 


### PR DESCRIPTION
**Description**
Added os_strftime_utf8() to handle strftime correctly on Windows. The existing strftime() calls in os_generate_formatted_filename() now use this new function.

On Windows, strftime() returns strings in the system's ANSI codepage rather than UTF-8. The new function uses wcsftime() and converts to UTF-8 properly.

**Motivation and Context**
Fixes #12953

Using %Z (timezone name) in the filename format crashes OBS on German Windows because the timezone "Mitteleuropäische Zeit" contains an umlaut. The ANSI-encoded string gets passed to os_fopen() which expects UTF-8, causing MultiByteToWideChar to fail.

Same issue would happen with any locale that has non-ASCII characters in timezone names or other strftime output.

**How Has This Been Tested?**
I don't have a German Windows installation to test directly. The fix follows the same pattern OBS already uses elsewhere for Windows string handling (wcs functions + os_wcs_to_utf8).

Would appreciate if someone with a German Windows setup could verify.

**Types of changes**
- Bug fix (non-breaking change which fixes an issue)

**Checklist:**
- [ ] My code has been run through clang-format (https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the contributing document (https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.