### PR TITLE
frontend-tools: Add lua registered source to module

### DIFF
--- a/frontend/plugins/frontend-tools/scripts.cpp
+++ b/frontend/plugins/frontend-tools/scripts.cpp
@@ -630,6 +630,7 @@ extern "C" void InitScripts()
 {
 	scriptLogWindow = new ScriptLogWindow();
 
+	obs_scripting_set_module(obs_current_module());
 	obs_scripting_load();
 	obs_scripting_set_log_callback(script_log, nullptr);
 

--- a/shared/obs-scripting/obs-scripting-lua-source.c
+++ b/shared/obs-scripting/obs-scripting-lua-source.c
@@ -632,6 +632,7 @@ static int obs_lua_register_source(lua_State *script)
 		info.get_name = obs_lua_source_get_name;
 		info.get_defaults2 = obs_lua_source_get_defaults;
 		obs_register_source(&info);
+		obs_module_add_source(obs_current_module(), info.id);
 
 		pthread_mutex_lock(&lua_source_def_mutex);
 		v = info.type_data;

--- a/shared/obs-scripting/obs-scripting.c
+++ b/shared/obs-scripting/obs-scripting.c
@@ -24,6 +24,18 @@
 #include "obs-scripting-internal.h"
 #include "obs-scripting-callback.h"
 
+static obs_module_t *obs_module_pointer;
+
+void obs_scripting_set_module(obs_module_t *module)
+{
+	obs_module_pointer = module;
+}
+
+obs_module_t *obs_current_module(void)
+{
+	return obs_module_pointer;
+}
+
 #if defined(LUAJIT_FOUND)
 extern obs_script_t *obs_lua_script_create(const char *path, obs_data_t *settings);
 extern bool obs_lua_script_load(obs_script_t *s);

--- a/shared/obs-scripting/obs-scripting.h
+++ b/shared/obs-scripting/obs-scripting.h
@@ -20,6 +20,7 @@
 #include <stdarg.h>
 #include <util/c99defs.h>
 #include <obs-data.h>
+#include <obs.h>
 #include <obs-properties.h>
 
 #ifdef __cplusplus
@@ -31,6 +32,7 @@ typedef struct obs_script obs_script_t;
 
 enum obs_script_lang { OBS_SCRIPT_LANG_UNKNOWN, OBS_SCRIPT_LANG_LUA, OBS_SCRIPT_LANG_PYTHON };
 
+EXPORT void obs_scripting_set_module(obs_module_t *module);
 EXPORT bool obs_scripting_load(void);
 EXPORT void obs_scripting_unload(void);
 EXPORT const char **obs_scripting_supported_formats(void);


### PR DESCRIPTION
### Description
Add lua registered source to module

### Motivation and Context
Sources registered by a lua script are displayed red in the source tree, because the source had no loaded module
Fixes #12966

### How Has This Been Tested?
On windows 11 with the lua clock script that comes with OBS

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
