### PR TITLE
rtmp-services: Add Nenufar.live - Multi-Streaming

### DIFF
--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -953,7 +953,8 @@ void OBSBasicSettings::on_server_currentIndexChanged(int /*index*/)
 void OBSBasicSettings::UpdateVodTrackSetting()
 {
 	bool enableForCustomServer = config_get_bool(App()->GetUserConfig(), "General", "EnableCustomServerVodTrack");
-	bool enableVodTrack = ui->service->currentText() == "Twitch";
+	QString currentService = ui->service->currentText();
+	bool enableVodTrack = currentService == "Twitch" || currentService == "Nenufar.live - Multi-Streaming";
 	bool wasEnabled = !!vodTrackCheckbox;
 
 	if (enableForCustomServer && IsCustomService())

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -136,7 +136,7 @@ const char *GetStreamOutputType(const obs_service_t *service);
 
 inline bool ServiceSupportsVodTrack(const char *service)
 {
-	static const char *vodTrackServices[] = {"Twitch"};
+	static const char *vodTrackServices[] = {"Twitch", "Nenufar.live - Multi-Streaming"};
 
 	for (const char *vodTrackService : vodTrackServices) {
 		if (astrcmpi(vodTrackService, service) == 0)

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 281,
+    "version": 282,
     "files": [
         {
             "name": "services.json",
-            "version": 281
+            "version": 282
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3593,6 +3593,77 @@
                 "max video bitrate": 8000,
                 "max audio bitrate": 192
             }
+        },
+        {
+            "name": "Nenufar.live - Multi-Streaming",
+            "more_info_link": "https://nenufar.live/docs",
+            "stream_key_link": "https://app.nenufar.live/destinations",
+            "servers": [
+                {
+                    "name": "Ingest 1",
+                    "url": "rtmp://ingest1.nenufar.live/multistream/"
+                }
+            ],
+            "supported video codecs": [
+                "h264",
+                "hevc"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "bframes": 0,
+                "max fps": 60,
+                "max video bitrate": 7000,
+                "max audio bitrate": 320,
+                "supported resolutions": [
+                    "3840x2160",
+                    "2560x1440",
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "bitrate matrix": [
+                    {
+                        "res": "1280x720",
+                        "fps": 30,
+                        "max bitrate": 5000
+                    },
+                    {
+                        "res": "1280x720",
+                        "fps": 60,
+                        "max bitrate": 6000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 30,
+                        "max bitrate": 6000
+                    },
+                    {
+                        "res": "1920x1080",
+                        "fps": 60,
+                        "max bitrate": 7000
+                    },
+                    {
+                        "res": "2560x1440",
+                        "fps": 30,
+                        "max bitrate": 9000
+                    },
+                    {
+                        "res": "2560x1440",
+                        "fps": 60,
+                        "max bitrate": 12000
+                    },
+                    {
+                        "res": "3840x2160",
+                        "fps": 30,
+                        "max bitrate": 15000
+                    },
+                    {
+                        "res": "3840x2160",
+                        "fps": 60,
+                        "max bitrate": 20000
+                    }
+                ]
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description

Add Nenufar.live - Multi-Streaming service with VOD Track support.

**Service details:**
- **Name**: Nenufar.live - Multi-Streaming
- **Website**: https://nenufar.live
- **Application**: https://app.nenufar.live
- **Documentation**: https://nenufar.live/docs
- **Protocol**: RTMP
- **Supported codecs**: H.264, HEVC (Plus subscribers)
- **Max resolution**: 4K (Plus subscribers), 1080p (standard)
- **VOD audio track**: Supported
- **General availability**: Reached
- **Proof of being an official representative**: dig TXT obs.nenufar.live

### Motivation and Context

Nenufar.live Multi-Streaming is a French/European platform that allows creators to broadcast to multiple destinations simultaneously.
This PR adds native support in OBS, including VOD Track audio support for copyright-free VOD recordings.
We figured out how to support Twitch VOD Track, but until now we had to use Twitch as a destination with our ingest URL as Custom Twitch Server URL, which is quite confusing and leads to many misunderstandings for users.
The "Multi-Streaming" precision is here to avoid confusion with other services we provide such as Nenufar "Live IRL", "Relay" and "Dispatcher", which use different URLs and don't need a specific implementation in OBS like "Multi-Streaming".

The Multi-Streaming service is brand new, version 1.0 was officially released two weeks ago (the other services are almost a year old). Our public communication campaign is scheduled to begin on January 5th, but we already have active users who have been using it daily since pre-release.

This is our first contribution to OBS Studio. We're open to feedback and happy to discuss the VOD Track implementation approach if there's a preferred or cleaner way to integrate it.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This was tested locally on OBS 32.0.4 on Fedora 43 and Windows 25H4 (dual boot).
AMD Ryzen 9 5950x - Nvidia RTX 3090 - 128Gb RAM

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
