### PR TITLE
libobs: Restore original video_t for encoders when GPU scaling is used

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -262,6 +262,10 @@ static void maybe_set_up_gpu_rescale(struct obs_encoder *encoder)
 	if (!current_mix)
 		return;
 
+	/* Store original video_t so it can be restored if scaling is disabled. */
+	if (!current_mix->encoder_only_mix)
+		encoder->original_video = encoder->media;
+
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *current = obs->video.mixes.array[i];
@@ -687,7 +691,7 @@ static void maybe_clear_encoder_core_video_mix(obs_encoder_t *encoder)
 		if (!mix->encoder_only_mix)
 			break;
 
-		encoder_set_video(encoder, obs_get_video());
+		encoder_set_video(encoder, encoder->original_video);
 		mix->encoder_refs -= 1;
 		if (mix->encoder_refs == 0) {
 			da_erase(obs->video.mixes, i);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -1427,6 +1427,8 @@ struct obs_encoder {
 
 	/* stores the video/audio media output pointer.  video_t *or audio_t **/
 	void *media;
+	/* Stores the original video if GPU scaling is enabled and `media` can be overwritten. */
+	video_t *original_video;
 
 	pthread_mutex_t callbacks_mutex;
 	DARRAY(struct encoder_callback) callbacks;


### PR DESCRIPTION
### Description

Stores and restores original `video_t` object when GPU scaling is enabled.

### Motivation and Context

GPU scaling utilises "encoder only" mixes to create a new, scaled version of the original `video_t` object set for the encoder. When an encoder gets stopped, this mix gets cleared.

However, when the encoder is configured for a non-default `video_t`, e.g. in multi-canvas scenarios, then `maybe_clear_encoder_core_video_mix()` would reset `media` to the main canvas's video object obtained from `obs_get_video()` rather than the actual video that was set. This would result in incorrect output if the encoder is restarted as part of the reconnection process.

To avoid this, this change simply stores the pointer to the original `video_t` that was set when the encoder was configured, and restores it when an encoder-only mix gets deleted.

### How Has This Been Tested?

Locally by yanking the ethernet cable to simulate a connection drop and trigger a reconnect.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
