### PR TITLE
obs-scripting: Replace deprecated PySys_SetArgv

### DIFF
--- a/shared/obs-scripting/obs-scripting-python.c
+++ b/shared/obs-scripting/obs-scripting-python.c
@@ -1637,23 +1637,28 @@ bool obs_scripting_load_python(const char *python_path)
 		return false;
 #endif
 
-	/* ---------------------------------------------- */
-	/* Must set arguments for guis to work            */
-
-	wchar_t *argv[] = {L"", NULL};
-	int argc = sizeof(argv) / sizeof(wchar_t *) - 1;
-
-	//PySys_SetArgvEx(argc, argv, 0);
+//PySys_SetArgv is deprecated in 3.8+, so use the new initialization API if detected
+#if PY_VERSION_HEX >= 0x03080000
 	PyConfig config;
 	PyConfig_InitPythonConfig(&config);
-	config.parse_argv = 1;
 
-	PyStatus status = PyConfig_SetArgv(&config, argc, argv);
+	config.parse_argv = 0;
+	config.safe_path = 1;
+
+	PyWideStringList_Append(&config.argv, L"");
+
+	PyStatus status = Py_InitializeFromConfig(&config);
+	PyConfig_Clear(&config); //critical!
+
 	if (PyStatus_Exception(status)) {
+		Py_ExitStatusException(status);
 	}
-
-	Py_InitializeFromConfig(&config);
-	PyConfig_Clear(&config);
+#else
+	// Classic 3.6/3.7 path
+	Py_Initialize();
+	wchar_t *argv[] = {L"", NULL};
+	PySys_SetArgv(0, argv); // or PySys_SetArgvEx if you have 3.7+
+#endif
 
 #ifdef __APPLE__
 	PyRun_SimpleString("import sys");


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Updated the `PySys_SetArgv(argc, argv);` line to have a more modern way of setting the arguments.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`PySys_SetArgv` is depreciated and has [already been removed in Python 3.13](https://github.com/python/cpython/issues/88279)
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran in Visual Studio code
Operating System: Kubuntu 25.10
KDE Plasma Version: 6.5.4
KDE Frameworks Version: 6.20.0
Qt Version: 6.9.2
Kernel Version: 6.18.1-061801-generic (64-bit)
Graphics Platform: Wayland
Processors: 16 × AMD Ryzen 7 5800X3D 8-Core Processor
Memory: 32 GiB of RAM (31.2 GiB usable)
Graphics Processor: AMD Radeon Graphics
Manufacturer: ASUS

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
