### PR TITLE
CI: Add Xcode compile cache to scheduled cleanup

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -69,7 +69,7 @@ jobs:
             fi
           done <<< \
           "$(gh api repos/${GITHUB_REPOSITORY}/actions/caches \
-            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".*-ccache-*")) | {id, key} | join(";")')"
+            --jq '.actions_caches.[] | select(.ref|test("refs/heads/master")) | select(.key|test(".*-(ccache|xcode)-*")) | {id, key} | join(";")')"
           echo '::endgroup::'
 
 


### PR DESCRIPTION
### Description
Extends the regular expression used in the `gh` call to fetch possible cache entries to delete to also include caches create for the Xcode compile cache.

### Motivation and Context
Compile caches are refreshed daily using the scheduled workflow, with downstream jobs using an available cache with the purpose of providing a "baseline" of cacheable source files so that only changed files will result in a full recompilation.

This requires that the cache is kept reasonably fresh and doesn't diverge too far from the root commit used for branches.

### How Has This Been Tested?
Tested the `gh` call locally and confirmed that the `ccache` entry used by Ubuntu was provided as well as both Xcode cache entries.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
