### PR TITLE
frontend: Fix groups not being saved to collection

### DIFF
--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -849,7 +849,7 @@ void OBSBasic::Save(SceneCollection &collection)
 
 	// Saving groups separately ensures they won't be loaded in older versions.
 	// TODO: Get rid of this at some point. Groups were introduced in 22.0
-	OBSDataArrayAutoRelease groupsArray;
+	OBSDataArrayAutoRelease groupsArray = obs_data_array_create();
 
 	auto sourcesAndGroups = std::make_pair(sourcesArray.Get(), groupsArray.Get());
 	using sourcesAndGroups_t = decltype(sourcesAndGroups);


### PR DESCRIPTION
### Description

Fixes groups not being saved due to the array not being created.

### Motivation and Context

Fix groups not being saved.

### How Has This Been Tested?

Loaded a scene collection, groups are back!

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
