### PR TITLE
frontend: Round theme variables with "px" units

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -646,6 +646,12 @@ static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBST
 		val = d1 < d2 ? d1 : d2;
 	}
 
+	// Round any values with a px suffix. Qt does this anyway for some properties,
+	// but then will flat out break with decimals for others.
+	if (val1.suffix == "px" || val2.suffix == "px") {
+		val = std::roundf(val);
+	}
+
 	bool isInteger = ceill(val) == val;
 	QString result = QString::number(val, 'f', isInteger ? 0 : -1);
 


### PR DESCRIPTION
### Description
When a theme variable is of type `Size` and has a units suffix of `px`, this rounds the value.

### Motivation and Context
Qt does this anyway for some certain styling properties, but others (Such as `icon-size`) will flat out break with a decimal value.

Fixes #13071

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
