### PR TITLE
frontend: Fix Audio Mixer toolbar tooltips

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1366,6 +1366,8 @@ Basic.AudioMixer.Category.Inactive="Inactive"
 Basic.AudioMixer.Category.Preview="Preview"
 Basic.AudioMixer.Category.Hidden="Hidden"
 Basic.AudioMixer.Category.Unassigned="Unassigned"
+Basic.AudioMixer.Layout.Horizontal="Horizontal"
+Basic.AudioMixer.Layout.Vertical="Vertical"
 
 # advanced audio properties
 Basic.AdvAudio="Advanced Audio Properties"

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -145,8 +145,8 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 	mainLayout->addWidget(mixerToolbar);
 
 	advAudio = new QAction(this);
-	advAudio->setText(QTStr("AdvAudioProps"));
-	advAudio->setToolTip(QTStr("AdvAudioProps"));
+	advAudio->setText(QTStr("Basic.AdvAudio"));
+	advAudio->setToolTip(QTStr("Basic.AdvAudio"));
 	QIcon advIcon;
 	advIcon.addFile(QString::fromUtf8(":/settings/images/settings/advanced.svg"), QSize(16, 16),
 			QIcon::Mode::Normal, QIcon::State::Off);
@@ -155,7 +155,7 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 
 	layoutButton = new QAction(this);
 	layoutButton->setText("");
-	layoutButton->setToolTip("");
+	layoutButton->setToolTip(QTStr("Basic.AudioMixer.Layout.Vertical"));
 	QIcon layoutIcon;
 	layoutIcon.addFile(QString::fromUtf8(":/res/images/layout-vertical.svg"), QSize(16, 16), QIcon::Mode::Normal,
 			   QIcon::State::Off);
@@ -745,6 +745,7 @@ void AudioMixer::setMixerLayoutVertical(bool vertical)
 		layoutIcon.addFile(QString::fromUtf8(":/res/images/layout-horizontal.svg"), QSize(16, 16),
 				   QIcon::Mode::Normal, QIcon::State::Off);
 		layoutButton->setIcon(layoutIcon);
+		layoutButton->setToolTip(QTStr("Basic.AudioMixer.Layout.Horizontal"));
 	} else {
 		stackedMixerArea->setMinimumSize(220, 0);
 		stackedMixerArea->setCurrentIndex(0);
@@ -753,6 +754,7 @@ void AudioMixer::setMixerLayoutVertical(bool vertical)
 		layoutIcon.addFile(QString::fromUtf8(":/res/images/layout-vertical.svg"), QSize(16, 16),
 				   QIcon::Mode::Normal, QIcon::State::Off);
 		layoutButton->setIcon(layoutIcon);
+		layoutButton->setToolTip(QTStr("Basic.AudioMixer.Layout.Vertical"));
 	}
 
 	QWidget *buttonWidget = mixerToolbar->widgetForAction(layoutButton);


### PR DESCRIPTION
### Description
Fixes an incorrect string key for the Advanced Audio Properties button, and adds missing strings for the Vertical/Horizontal toggle button.

### Motivation and Context
Tooltips good.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
