### PR TITLE
frontend: Move source selection handling to parent

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -563,13 +563,9 @@ void SourceTreeItem::ExpandClicked(bool checked)
 void SourceTreeItem::Select()
 {
 	tree->SelectItem(sceneitem, true);
-	OBSBasic::Get()->UpdateContextBarDeferred();
-	OBSBasic::Get()->UpdateEditMenu();
 }
 
 void SourceTreeItem::Deselect()
 {
 	tree->SelectItem(sceneitem, false);
-	OBSBasic::Get()->UpdateContextBarDeferred();
-	OBSBasic::Get()->UpdateEditMenu();
 }


### PR DESCRIPTION
### Description
Moves the calls to update various UI elements in OBSBasic from the SourceTreeItems up to SourceTree itself.

Fixes #13026

### Motivation and Context
Currently certain parts of the UI are updated whenever an individual SourceTreeItem is selected or deselected. This leads to the bug in #13026 as the item gets removed from the source list before it can call `Deselect`.

This PR moves the UI update calls to the event in the SourceTree itself instead. This also has the side effect of removing some redundant calls to `UpdateContextBarDeferred` and `UpdateEditMenu`, though the former is deferred anyway.


The fact that SourceTreeItems even hold a reference and make direct calls to the SourceTree is bad. The entire event hierarchy here is inverted with a lot of redundancy and arcane managing of `libobs`. It should be cleaned up in the future.


### How Has This Been Tested?
Selected multiple items, deselected multiple items, both in and outside of groups, including mixed selections.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
