### PR TITLE
mac-capture: Use RGBA64Half pixel format for screen capture

### DIFF
--- a/libobs-opengl/gl-cocoa.m
+++ b/libobs-opengl/gl-cocoa.m
@@ -495,6 +495,12 @@ gs_texture_t *device_texture_create_from_iosurface(gs_device_t *device, void *io
             texture_type = GL_UNSIGNED_INT_8_8_8_8_REV;
             break;
         }
+        case kCVPixelFormatType_64RGBAHalf: {
+            color_format = GL_RGBA;
+            internal_format = GL_RGBA_FLOAT16_APPLE;
+            texture_type = GL_HALF_APPLE;
+            break;
+        }
         default:
             blog(LOG_ERROR, "Unexpected pixel format: %d (%c%c%c%c)", pixelFormat, pixelFormat >> 24, pixelFormat >> 16,
                  pixelFormat >> 8, pixelFormat);
@@ -579,6 +585,7 @@ bool gs_texture_rebind_iosurface(gs_texture_t *texture, void *iosurf)
     switch (pixelFormat) {
         case kCVPixelFormatType_ARGB2101010LEPacked:
         case kCVPixelFormatType_32BGRA:
+        case kCVPixelFormatType_64RGBAHalf:
             break;
         case 0:
             blog(LOG_ERROR, "Invalid IOSurface Buffer");

--- a/plugins/mac-capture/mac-sck-video-capture.m
+++ b/plugins/mac-capture/mac-sck-video-capture.m
@@ -209,9 +209,13 @@ API_AVAILABLE(macos(12.5)) static bool init_screen_stream(struct screen_capture 
     } else {
         blog(LOG_WARNING, "Unable to retrieve OBS output FPS when initializing macOS Screen Capture");
     }
-    FourCharCode l10r_type = 0;
-    l10r_type = ('l' << 24) | ('1' << 16) | ('0' << 8) | 'r';
-    [sc->stream_properties setPixelFormat:l10r_type];
+    // Use 64RGBAHalf where available, for superior 16-bit float color and alpha depth. On prior macOS versions where
+    // 64RGBAHalf is unavailable, fall back to 32BGRA (8-bit UInt color and alpha).
+    if (@available(macOS 15.0, *)) {
+        [sc->stream_properties setPixelFormat:kCVPixelFormatType_64RGBAHalf];
+    } else {
+        [sc->stream_properties setPixelFormat:kCVPixelFormatType_32BGRA];
+    }
 
     if (@available(macOS 13.0, *)) {
         [sc->stream_properties setCapturesAudio:YES];


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Changes ScreenCaptureKit content to use the RGBA64Half pixel format, improving both color and transparency fidelity for macOS Screen Capture.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Existing macOS Screen Captures have poor transparency fidelity because of the `l10r` pixel format, which uses only two bits of alpha, but which features high fidelity 10-bit color for representing content in the Display P3 color space.

Using RGBA64 enables us to both improve color fidelity with 16 bit floats per channel of color while granting the same fidelity to the alpha channel.

Higher fidelity transparency allows users to composite macOS Screen Capture window and application captures in front of arbitrary content in OBS with accurate transparency, enabling various creative usecases.

`l10r` (before) / `RGhA` (after):
<img width="300" alt="Screenshot 2026-01-15 at 12 30 49 PM" src="https://github.com/user-attachments/assets/c8cc37f3-c71f-4e0f-b2c9-08d58938e9e8" /><img width="300" alt="Screenshot 2026-01-15 at 12 28 45 PM" src="https://github.com/user-attachments/assets/d4aa67ae-1bd9-4354-a49c-0c852843d409" />

Supersedes #12945.

> [!NOTE]
> Support for this format inside ScreenCaptureKit is technically not documented. It is, however, used internally by macOS, and we have received guidance indicating that it should be acceptable to use for our purposes.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on Apple Silicon, macOS 15.7.1.

This change should be further verified to work on earlier macOS deployment targets, particularly macOS 13, before merging.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
