### PR TITLE
frontend: Fix audio mixer dialog buttons on classic theme

### DIFF
--- a/frontend/data/themes/Yami_Classic.ovt
+++ b/frontend/data/themes/Yami_Classic.ovt
@@ -209,7 +209,7 @@ OBSBasicSettings QListWidget::item {
 }
 
 QPushButton:checked {
-  border-color: var(--primary);
+    border-color: var(--primary);
 }
 
 QToolButton,
@@ -220,22 +220,6 @@ QPushButton[toolButton="true"] {
 
 #stackedMixerArea QScrollArea {
   background: var(--bg_base);
-}
-
-#stackedMixerArea QPushButton {
-    min-width: var(--icon_base);
-    padding: var(--padding_large) var(--padding_large);
-    icon-size: var(--icon_base);
-}
-
-#stackedMixerArea QPushButton:!hover {
-    background-color: var(--bg_base);
-    border: none;
-}
-
-#stackedMixerArea QPushButton:hover {
-    background-color: var(--bg_base);
-    border: none;
 }
 
 #hMixerScrollArea VolControl {
@@ -286,13 +270,6 @@ QPushButton[toolButton="true"] {
 
 #contextContainer {
   background-color: var(--bg_window);
-}
-
-#stackedMixerArea QPushButton,
-#stackedMixerArea QPushButton:!hover {
-    width: var(--icon_base_mixer);
-    height: var(--icon_base_mixer);
-    padding: var(--spacing_base);
 }
 
 VolumeMeter {


### PR DESCRIPTION
### Description
Dialogs are considered children of the widget that spawned them if parented as such (Which is correct), which can lead to weird trickling down of styling rules.

This removes the rules from Classic theme that target `#stackedMixerArea QPushButton` as they inadvertently affect the rename dialog and also are no longer needed anyway.


### Motivation and Context
**Before**
<img width="557" height="147" alt="image" src="https://github.com/user-attachments/assets/611abed6-d901-46e6-84a0-f0fe562d9487" />

**After**
<img width="557" height="153" alt="image" src="https://github.com/user-attachments/assets/001a9249-5f2f-4175-aebd-eb3128d317ae" />

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x ] I have included updates to all appropriate documentation.
