### PR TITLE
frontend: Ensure meter background refresh on style change

### DIFF
--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -347,6 +347,8 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_source_t *source)
 		}
 		repaint();
 	});
+
+	connect(App(), &OBSApp::StyleChanged, this, &VolumeMeter::updateBackgroundCache);
 }
 
 VolumeMeter::~VolumeMeter()


### PR DESCRIPTION
### Description
Swapping styles _usually_ causes the widgets to resize, which indirectly triggers the meter background cache to get updated. This is unreliable however and in some cases, it does not fire in time, or inconsistently.

<img width="544" height="375" alt="image" src="https://github.com/user-attachments/assets/158b3dce-a0ed-4b8a-b632-ad459fb98939" />

[](url)

<img width="228" height="232" alt="image" src="https://github.com/user-attachments/assets/7f35e1ad-0aca-4f77-a75f-2b24b86154f7" />

 This PR hooks up directly to the StyleChanged event.

### Motivation and Context

Want things to look correct.

### How Has This Been Tested?
👁 and swapped themes/appearance settings a bunch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
