### PR TITLE
linux-pulseaudio: Fix bad channels message format

### DIFF
--- a/plugins/linux-pulseaudio/pulse-input.c
+++ b/plugins/linux-pulseaudio/pulse-input.c
@@ -292,9 +292,7 @@ static void pulse_source_info(pa_context *c, const pa_source_info *i, int eol, v
 	if (pulse_channels_to_obs_speakers(channels) == SPEAKERS_UNKNOWN) {
 		channels = 2;
 
-		blog(LOG_INFO,
-		     "%c channels not supported by OBS,"
-		     "using %c instead for recording",
+		blog(LOG_INFO, "%" PRIu8 " channels not supported by OBS, using %" PRIu8 " instead for recording",
 		     i->sample_spec.channels, channels);
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fix the format specifiers in the message string for unsupported audio channels in the linux-pulseaudio plugin.

### Motivation and Context
I was debugging an issue and the message in the log was not helpful.

### How Has This Been Tested?
Add a PulseAudio output capture and target a sink with unsupported channels.
Before:
```
info: pulse-input: 	 channels not supported by OBS,using  instead for recording
```
After:
```
info: pulse-input: 9 channels not supported by OBS, using 2 instead for recording
```

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
