### PR TITLE
frontend: Demangle ScreenshotObj and OBSBasic

### DIFF
--- a/frontend/utility/ScreenshotObj.cpp
+++ b/frontend/utility/ScreenshotObj.cpp
@@ -353,11 +353,7 @@ void ScreenshotObj::onFinished()
 
 	if (outputWidth > 0 && outputHeight > 0) {
 		if (outputToFile) {
-			OBSBasic *main = OBSBasic::Get();
-			main->ShowStatusBarMessage(
-				QTStr("Basic.StatusBar.ScreenshotSavedTo").arg(QT_UTF8(path.c_str())));
-			main->lastScreenshot = path;
-			main->OnEvent(OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);
+			emit imageSaved(path);
 		}
 
 		emit imageReady(image.copy());

--- a/frontend/utility/ScreenshotObj.cpp
+++ b/frontend/utility/ScreenshotObj.cpp
@@ -32,24 +32,14 @@
 
 #include "moc_ScreenshotObj.cpp"
 
-namespace {
-void renderTick(void *param, float)
-{
-	ScreenshotObj *self = static_cast<ScreenshotObj *>(param);
-	if (self->stage() == ScreenshotObj::Stage::Finished) {
-		return;
-	}
-
-	obs_enter_graphics();
-	self->processStage();
-	obs_leave_graphics();
-}
-} // namespace
-
-ScreenshotObj::ScreenshotObj(obs_source_t *source) : weakSource(OBSGetWeakRef(source))
+ScreenshotObj::ScreenshotObj(obs_source_t *source, const Options &options)
+	: weakSource(OBSGetWeakRef(source)),
+	  options(options)
 {
 	obs_add_tick_callback(renderTick, this);
 }
+
+ScreenshotObj::ScreenshotObj(obs_source_t *source) : ScreenshotObj(source, {}) {}
 
 ScreenshotObj::~ScreenshotObj()
 {
@@ -59,6 +49,18 @@ ScreenshotObj::~ScreenshotObj()
 	obs_leave_graphics();
 
 	obs_remove_tick_callback(renderTick, this);
+}
+
+void ScreenshotObj::renderTick(void *param, float)
+{
+	ScreenshotObj *self = static_cast<ScreenshotObj *>(param);
+	if (self->stage() == ScreenshotObj::Stage::Finished) {
+		return;
+	}
+
+	obs_enter_graphics();
+	self->processStage();
+	obs_leave_graphics();
 }
 
 void ScreenshotObj::renderScreenshot()
@@ -94,8 +96,8 @@ void ScreenshotObj::renderScreenshot()
 #endif
 	const enum gs_color_format format = gs_get_format_from_space(space);
 
-	outputWidth = customSize.isValid() ? customSize.width() : sourceWidth;
-	outputHeight = customSize.isValid() ? customSize.height() : sourceHeight;
+	outputWidth = options.size.isValid() ? options.size.width() : sourceWidth;
+	outputHeight = options.size.isValid() ? options.size.height() : sourceHeight;
 
 	texrender = gs_texrender_create(format, GS_ZS_NONE);
 	stagesurf = gs_stagesurface_create(outputWidth, outputHeight, format);
@@ -198,7 +200,7 @@ void ScreenshotObj::copyData()
 
 void ScreenshotObj::saveToFile()
 {
-	if (!outputToFile) {
+	if (!options.outputToFile) {
 		QMetaObject::invokeMethod(this, &ScreenshotObj::onFinished, Qt::QueuedConnection);
 		return;
 	}
@@ -352,7 +354,7 @@ void ScreenshotObj::onFinished()
 	}
 
 	if (outputWidth > 0 && outputHeight > 0) {
-		if (outputToFile) {
+		if (options.outputToFile) {
 			emit imageSaved(path);
 		}
 
@@ -360,21 +362,6 @@ void ScreenshotObj::onFinished()
 	}
 
 	this->deleteLater();
-}
-
-void ScreenshotObj::setSize(QSize size)
-{
-	customSize = size;
-}
-
-void ScreenshotObj::setSize(int width, int height)
-{
-	setSize(QSize(width, height));
-}
-
-void ScreenshotObj::setSaveToFile(bool save)
-{
-	outputToFile = save;
 }
 
 void ScreenshotObj::handleSave()

--- a/frontend/utility/ScreenshotObj.hpp
+++ b/frontend/utility/ScreenshotObj.hpp
@@ -34,14 +34,6 @@ public:
 
 	enum class Stage { Render, Download, Output, Finished };
 
-	void processStage();
-	void renderScreenshot();
-	void downloadData();
-	void copyData();
-	void saveToFile();
-	void muxFile();
-	void onFinished();
-
 	Stage stage() { return stage_; }
 	void setStage(Stage stage) { stage_ = stage; }
 
@@ -49,7 +41,16 @@ public:
 	void setSize(int width, int height);
 	void setSaveToFile(bool save);
 
+	void processStage();
+
 private:
+	void renderScreenshot();
+	void downloadData();
+	void copyData();
+	void saveToFile();
+	void muxFile();
+	void onFinished();
+
 	Stage stage_ = Stage::Render;
 
 	gs_texrender_t *texrender = nullptr;
@@ -69,6 +70,7 @@ private:
 	bool outputToFile = true;
 
 signals:
+	void imageSaved(std::string path);
 	void imageReady(QImage image);
 
 private slots:

--- a/frontend/utility/ScreenshotObj.hpp
+++ b/frontend/utility/ScreenshotObj.hpp
@@ -34,7 +34,15 @@ public:
 
 	enum class Stage { Render, Download, Output, Finished };
 
+	Stage stage() { return stage_; }
+
+	void setSize(QSize size);
+	void setSize(int width, int height);
+	void setSaveToFile(bool save);
+
 	void processStage();
+
+private:
 	void renderScreenshot();
 	void downloadData();
 	void copyData();
@@ -42,14 +50,6 @@ public:
 	void muxFile();
 	void onFinished();
 
-	Stage stage() { return stage_; }
-	void setStage(Stage stage) { stage_ = stage; }
-
-	void setSize(QSize size);
-	void setSize(int width, int height);
-	void setSaveToFile(bool save);
-
-private:
 	Stage stage_ = Stage::Render;
 
 	gs_texrender_t *texrender = nullptr;
@@ -69,6 +69,7 @@ private:
 	bool outputToFile = true;
 
 signals:
+	void imageSaved(std::string path);
 	void imageReady(QImage image);
 
 private slots:

--- a/frontend/utility/ScreenshotObj.hpp
+++ b/frontend/utility/ScreenshotObj.hpp
@@ -29,6 +29,12 @@ class ScreenshotObj : public QObject {
 	Q_OBJECT
 
 public:
+	struct Options {
+		QSize size{};
+		bool outputToFile{true};
+	};
+
+	ScreenshotObj(obs_source_t *source, const Options &options);
 	ScreenshotObj(obs_source_t *source);
 	~ScreenshotObj() override;
 
@@ -36,13 +42,10 @@ public:
 
 	Stage stage() { return stage_; }
 
-	void setSize(QSize size);
-	void setSize(int width, int height);
-	void setSaveToFile(bool save);
-
+private:
+	static void renderTick(void *param, float seconds);
 	void processStage();
 
-private:
 	void renderScreenshot();
 	void downloadData();
 	void copyData();
@@ -50,23 +53,24 @@ private:
 	void muxFile();
 	void onFinished();
 
+	OBSWeakSource weakSource;
+
 	Stage stage_ = Stage::Render;
+	Options options;
 
 	gs_texrender_t *texrender = nullptr;
 	gs_stagesurf_t *stagesurf = nullptr;
-	OBSWeakSource weakSource;
+
 	std::string path;
 	QImage image;
 	std::vector<uint8_t> half_bytes;
-	QSize customSize;
+
 	uint32_t sourceWidth = 0;
 	uint32_t sourceHeight = 0;
 	uint32_t outputWidth = 0;
 	uint32_t outputHeight = 0;
 
 	std::thread thread;
-	std::shared_ptr<QImage> imagePtr;
-	bool outputToFile = true;
 
 signals:
 	void imageSaved(std::string path);

--- a/frontend/utility/ThumbnailItem.cpp
+++ b/frontend/utility/ThumbnailItem.cpp
@@ -185,9 +185,11 @@ bool ThumbnailItem::update()
 			return false;
 		}
 
-		auto *obj = new ScreenshotObj(source);
-		obj->setSaveToFile(false);
-		obj->setSize(kDefaultWidth, kDefaultHeight);
+		ScreenshotObj::Options options;
+		options.outputToFile = false;
+		options.size = {kDefaultWidth, kDefaultHeight};
+
+		auto *obj = new ScreenshotObj(source, options);
 
 		connect(obj, &ScreenshotObj::imageReady, this, &ThumbnailItem::updatePixmapFromImage);
 	}

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -41,6 +41,7 @@
 #include <settings/OBSBasicSettings.hpp>
 #include <utility/QuickTransition.hpp>
 #include <utility/SceneRenameDelegate.hpp>
+#include <utility/ScreenshotObj.hpp>
 #if defined(_WIN32) || defined(WHATSNEW_ENABLED)
 #include <utility/WhatsNewInfoThread.hpp>
 #endif

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -41,6 +41,7 @@
 
 #include <QAccessible>
 #include <QSystemTrayIcon>
+#include <QPointer>
 
 #include <deque>
 
@@ -57,6 +58,7 @@ class OBSBasicTransform;
 class OBSLogViewer;
 class OBSMissingFiles;
 class OBSProjector;
+class ScreenshotObj;
 class VolumeControl;
 #ifdef YOUTUBE_ENABLED
 class YouTubeAppDock;
@@ -212,7 +214,6 @@ class OBSBasic : public OBSMainWindow {
 	friend class OBSYoutubeActions;
 	friend struct BasicOutputHandler;
 	friend struct OBSStudioAPI;
-	friend class ScreenshotObj;
 
 	enum class MoveDir { Up, Down, Left, Right };
 
@@ -1323,7 +1324,7 @@ public:
 	 * -------------------------------------
 	 */
 private:
-	QPointer<QObject> screenshotData;
+	QPointer<ScreenshotObj> screenshotData;
 	std::string lastScreenshot;
 
 private slots:

--- a/frontend/widgets/OBSBasic_Screenshots.cpp
+++ b/frontend/widgets/OBSBasic_Screenshots.cpp
@@ -30,6 +30,13 @@ void OBSBasic::Screenshot(OBSSource source)
 	}
 
 	screenshotData = new ScreenshotObj(source);
+
+	connect(screenshotData, &ScreenshotObj::imageSaved, this, [this](std::string path) {
+		ShowStatusBarMessage(QTStr("Basic.StatusBar.ScreenshotSavedTo").arg(QT_UTF8(path.c_str())));
+		lastScreenshot = path;
+
+		OnEvent(OBS_FRONTEND_EVENT_SCREENSHOT_TAKEN);
+	});
 }
 
 void OBSBasic::ScreenshotSelectedSource()


### PR DESCRIPTION
### Description
This adds a signal to ScreenshotObj so it doesn't have to directly call OBSBasic. Updated after the changes due to the Add Source dialog.

Revised version that supersedes #12186

### Motivation and Context
Less friends for OBSBasic and better code.

### How Has This Been Tested?
Took screenshots to make sure they still worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
