### PR TITLE
frontend: Update menu text when switching layouts

### DIFF
--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -757,6 +757,10 @@ void AudioMixer::setMixerLayoutVertical(bool vertical)
 		layoutButton->setToolTip(QTStr("Basic.AudioMixer.Layout.Vertical"));
 	}
 
+	// Qt caches the size of QWidgetActions so this is the simplest way to update the text
+	// of the checkboxes in the menu and make sure the menu size is recalculated.
+	createMixerContextMenu();
+
 	QWidget *buttonWidget = mixerToolbar->widgetForAction(layoutButton);
 	if (buttonWidget) {
 		idian::Utils::toggleClass(buttonWidget, "icon-layout-horizontal", vertical);
@@ -776,7 +780,7 @@ void AudioMixer::createMixerContextMenu()
 	QAction *unhideAllAction = new QAction(QTStr("UnhideAll"), mixerMenu);
 
 	showHiddenCheckBox = new MenuCheckBox(QTStr("Basic.AudioMixer.ShowHidden"), mixerMenu);
-	showHiddenAction = new QWidgetAction(mixerMenu);
+	QWidgetAction *showHiddenAction = new QWidgetAction(mixerMenu);
 	showHiddenCheckBox->setAction(showHiddenAction);
 	showHiddenCheckBox->setChecked(showHidden);
 	showHiddenAction->setDefaultWidget(showHiddenCheckBox);
@@ -788,17 +792,17 @@ void AudioMixer::createMixerContextMenu()
 	showInactiveAction->setDefaultWidget(showInactiveCheckBox);
 
 	QWidgetAction *hiddenLastAction = new QWidgetAction(mixerMenu);
-	const char *hiddenShifted = mixerVertical ? "Basic.AudioMixer.KeepHiddenRight"
-						  : "Basic.AudioMixer.KeepHiddenBottom";
-	MenuCheckBox *hiddenLastCheckBox = new MenuCheckBox(QTStr(hiddenShifted), mixerMenu);
+	const char *hiddenLastString = mixerVertical ? "Basic.AudioMixer.KeepHiddenRight"
+						     : "Basic.AudioMixer.KeepHiddenBottom";
+	MenuCheckBox *hiddenLastCheckBox = new MenuCheckBox(QTStr(hiddenLastString), mixerMenu);
 	hiddenLastCheckBox->setAction(hiddenLastAction);
 	hiddenLastCheckBox->setChecked(keepHiddenLast);
 	hiddenLastAction->setDefaultWidget(hiddenLastCheckBox);
 
 	QWidgetAction *inactiveLastAction = new QWidgetAction(mixerMenu);
-	const char *inactiveShifted = mixerVertical ? "Basic.AudioMixer.KeepInactiveRight"
-						    : "Basic.AudioMixer.KeepInactiveBottom";
-	MenuCheckBox *inactiveLastCheckBox = new MenuCheckBox(QTStr(inactiveShifted), mixerMenu);
+	const char *inactiveLastString = mixerVertical ? "Basic.AudioMixer.KeepInactiveRight"
+						       : "Basic.AudioMixer.KeepInactiveBottom";
+	MenuCheckBox *inactiveLastCheckBox = new MenuCheckBox(QTStr(inactiveLastString), mixerMenu);
 	inactiveLastCheckBox->setAction(inactiveLastAction);
 	inactiveLastCheckBox->setChecked(keepInactiveLast);
 	inactiveLastAction->setDefaultWidget(inactiveLastCheckBox);

--- a/frontend/widgets/AudioMixer.hpp
+++ b/frontend/widgets/AudioMixer.hpp
@@ -89,7 +89,6 @@ private:
 
 	QPointer<QMenu> mixerMenu;
 	QPointer<MenuCheckBox> showHiddenCheckBox;
-	QPointer<QWidgetAction> showHiddenAction;
 
 	QScrollArea *hMixerScrollArea{nullptr};
 	QWidget *hVolumeWidgets{nullptr};


### PR DESCRIPTION
### Description
Recreate the audio mixer menu when the layout changes so that the text for 'Keep sources at the right/bottom' is updated.

### Motivation and Context
The menu is already recreated whenever right-clicking but not when opening the menu from the toolbar button. This ensures the text is correct after swapping layouts and opening the menu from the toolbar.

Updating the text of the checkboxes is not enough here. Qt caches the size of actions so the only way to make it update is to remove/re-add the actions to the menu.

### How Has This Been Tested?
Swapped mixer layouts and checked the menu

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
