### PR TITLE
Fixes #13040, fixes spelling

### DIFF
--- a/plugins/win-dshow/win-dshow-encoder.cpp
+++ b/plugins/win-dshow/win-dshow-encoder.cpp
@@ -303,7 +303,7 @@ static void GetDShowVideoInfo(void *data, struct video_scale_info *info)
 	}
 }
 
-static void GetDShowEncoderDefauts(obs_data_t *settings)
+static void GetDShowEncoderDefaults(obs_data_t *settings)
 {
 	obs_data_set_default_int(settings, "bitrate", 1000);
 }


### PR DESCRIPTION
Description
static void GetDShowEncoderDefauts(obs_data_t *settings) should be static void GetDShowEncoderDefaults(obs_data_t *settings) (one "l" in "Defaults" more)

Motivation and Context

I've found this and thought that this should be fixed because I like OBS and use it myself and want to help the project

How Has This Been Tested?
It doesn't change anything inside the logic -> it should be working.

Types of changes
Bug fix (non-breaking change which fixes an issue)

Checklist:
 x My code is not on the master branch. (I guess this refers to the master branche of my own clone, so thats true that it isn't there.)
 x The code has been tested. (It doesn't change anything inside the logic -> it should be working.)
 x All commit messages are properly formatted and commits squashed where appropriate.
 x I have included updates to all appropriate documentation. (I guess that a bug fix that small doesn't need documentation.)
