### PR TITLE
frontend: Fix audio mixer monitoring state

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -698,7 +698,7 @@ void VolumeControl::updateMixerState()
 	QSignalBlocker blockMonitor(monitorButton);
 
 	bool showAsMuted = muted || monitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY;
-	bool showAsMonitored = monitoringType != OBS_MONITORING_TYPE_NONE;
+	bool showAsMonitored = !muted && monitoringType != OBS_MONITORING_TYPE_NONE;
 	bool showAsUnassigned = !muted && unassigned;
 
 	volumeMeter->setMuted((showAsMuted || showAsUnassigned) && !showAsMonitored);


### PR DESCRIPTION
### Description
This fixes a bug where sources that are internally muted but set to monitor would show incorrectly as being monitored in the audio mixer. This is the case for any sources that both were muted and set to monitor prior to the new mixer.

This PR fixes the button in the audio mixer being incorrect. The new audio mixer cannot put sources into this state.
This PR does **not** fix the Advanced Audio Properties window still being able to put sources into this state, but the mixer button will appear correct.

### Motivation and Context
The new audio mixer cannot put sources into this state as it now unmutes a source that is set to be monitored. However any existing sources set to monitor only can be, as before the only way to toggle them was the mute button.

### How Has This Been Tested?
Tested with a scene collection provided on Discord.

This can also be tested by setting up a scene collection in OBS prior to this fix with a source set to monitor only and muted.
It can also be tested by muting a source that is set to Monitor Off, and then changing it's monitoring type to Monitor Only via the Advanced Audio Properties window.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
