### PR TITLE
frontend: Implement sizeHint for VolumeMeter

### DIFF
--- a/frontend/components/VolumeMeter.hpp
+++ b/frontend/components/VolumeMeter.hpp
@@ -69,7 +69,6 @@ private:
 
 	QMutex dataMutex;
 
-	bool recalculateLayout{true};
 	uint64_t currentLastUpdateTime{0};
 	float currentMagnitude[MAX_AUDIO_CHANNELS];
 	float currentPeak[MAX_AUDIO_CHANNELS];
@@ -87,6 +86,8 @@ private:
 	void updateBackgroundCache();
 
 	QFont tickFont;
+	QRect tickTextTokenRect;
+
 	QColor backgroundNominalColor;
 	QColor backgroundWarningColor;
 	QColor backgroundErrorColor;
@@ -140,7 +141,6 @@ public:
 
 	void setLevels(const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],
 		       const float inputPeak[MAX_AUDIO_CHANNELS]);
-	QRect getBarRect() const;
 	bool needLayoutChange();
 
 	void setVertical(bool vertical = true);
@@ -148,6 +148,7 @@ public:
 	void setMuted(bool mute);
 
 	void refreshColors();
+	QRect getBarRect() const;
 
 	QColor getBackgroundNominalColor() const;
 	void setBackgroundNominalColor(QColor c);
@@ -190,12 +191,15 @@ public:
 	void setPeakDecayRate(qreal v);
 	void setPeakMeterType(enum obs_peak_meter_type peakMeterType);
 
+	virtual void resizeEvent(QResizeEvent *event) override;
 	virtual void mousePressEvent(QMouseEvent *event) override;
 	virtual void wheelEvent(QWheelEvent *event) override;
 
+	QSize minimumSizeHint() const override;
+	QSize sizeHint() const override;
+
 protected:
 	void paintEvent(QPaintEvent *event) override;
-	void changeEvent(QEvent *e) override;
 
 private slots:
 	void handleSourceDestroyed() { deleteLater(); }

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -110,6 +110,7 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 	hVolumeWidgets->setLayout(hVolumeControlLayout);
 	hVolumeControlLayout->setContentsMargins(0, 0, 0, 0);
 	hVolumeControlLayout->setSpacing(0);
+	hVolumeControlLayout->setAlignment(Qt::AlignTop);
 
 	hMixerScrollArea->setWidget(hVolumeWidgets);
 
@@ -683,8 +684,8 @@ void AudioMixer::updateVolumeLayouts()
 	vMixerScrollArea->setWidgetResizable(false);
 	hMixerScrollArea->setWidgetResizable(false);
 
+	QSize minimumSize{};
 	for (const auto &entry : rankedVolumes) {
-
 		VolumeControl *volControl = entry.control;
 		if (!volControl) {
 			continue;
@@ -712,6 +713,10 @@ void AudioMixer::updateVolumeLayouts()
 
 		prevControl = volControl;
 
+		if (!minimumSize.isValid()) {
+			minimumSize = volControl->minimumSizeHint();
+		}
+
 		++index;
 	}
 
@@ -727,6 +732,9 @@ void AudioMixer::updateVolumeLayouts()
 	vMixerScrollArea->setWidgetResizable(true);
 	hMixerScrollArea->setWidgetResizable(true);
 
+	int scrollBarSize = QApplication::style()->pixelMetric(QStyle::PM_ScrollBarExtent);
+	stackedMixerArea->setMinimumSize(minimumSize.width() + scrollBarSize, minimumSize.height() + scrollBarSize);
+
 	setUpdatesEnabled(true);
 }
 
@@ -740,7 +748,6 @@ void AudioMixer::setMixerLayoutVertical(bool vertical)
 	mixerVertical = vertical;
 
 	if (vertical) {
-		stackedMixerArea->setMinimumSize(180, 220);
 		stackedMixerArea->setCurrentIndex(1);
 
 		QIcon layoutIcon;
@@ -749,7 +756,6 @@ void AudioMixer::setMixerLayoutVertical(bool vertical)
 		layoutButton->setIcon(layoutIcon);
 		layoutButton->setToolTip(QTStr("Basic.AudioMixer.Layout.Horizontal"));
 	} else {
-		stackedMixerArea->setMinimumSize(220, 0);
 		stackedMixerArea->setCurrentIndex(0);
 
 		QIcon layoutIcon;


### PR DESCRIPTION
### Description
Implements sizeHint for VolumeMeter so that a minimum size for the Audio Mixer widget can be set.

### Motivation and Context
Want to be able to set minimumSize for the mixer widget using computed values rather than a hardcoded number.

This fixes a bug where the current hardcoded size is too small, causing widgets to be cut off at small sizes.

https://github.com/user-attachments/assets/3b0b5e0e-dbf4-4f47-a400-1c4a9456bffd

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
