### PR TITLE
frontend: Handle add/removed sources in source dialog

### DIFF
--- a/frontend/components/SourceSelectButton.hpp
+++ b/frontend/components/SourceSelectButton.hpp
@@ -33,10 +33,10 @@ class SourceSelectButton : public QFrame {
 	Q_OBJECT
 
 public:
-	SourceSelectButton(obs_source_t *source, QWidget *parent = nullptr);
+	SourceSelectButton(OBSWeakSource source, QWidget *parent = nullptr);
 	~SourceSelectButton();
 
-	QPointer<QPushButton> getButton();
+	QPushButton *button();
 	QString text();
 
 	void setRectVisible(bool visible);
@@ -53,8 +53,10 @@ private:
 	std::shared_ptr<Thumbnail> thumbnail;
 	QPointer<QLabel> image;
 
-	QPushButton *button = nullptr;
-	QVBoxLayout *layout = nullptr;
+	std::vector<OBSSignal> signalHandlers;
+	static void obsSourceRemoved(void *param, calldata_t *calldata);
+
+	QPointer<QPushButton> button_ = nullptr;
 	QLabel *label = nullptr;
 	bool preload = true;
 	bool rectVisible = false;
@@ -64,5 +66,9 @@ private:
 	QPoint dragStartPosition;
 
 private slots:
-	void thumbnailUpdated(QPixmap pixmap);
+	void updatePixmap(QPixmap pixmap);
+	void handleSourceRemoved();
+
+signals:
+	void sourceRemoved();
 };

--- a/frontend/dialogs/OBSBasicSourceSelect.hpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.hpp
@@ -42,8 +42,11 @@ private:
 
 	QPointer<QButtonGroup> sourceButtons;
 
-	std::vector<obs_source_t *> sources;
-	std::vector<obs_source_t *> groups;
+	std::vector<OBSSignal> signalHandlers;
+	static void obsSourceCreated(void *param, calldata_t *calldata);
+	static void obsSourceRemoved(void *param, calldata_t *calldata);
+
+	std::vector<obs_weak_source_t *> weakSources;
 
 	QPointer<FlowLayout> existingFlowLayout = nullptr;
 
@@ -51,16 +54,12 @@ private:
 	void updateExistingSources(int limit = 0);
 
 	static bool enumSourcesCallback(void *data, obs_source_t *source);
-	static bool enumGroupsCallback(void *data, obs_source_t *source);
-
-	static void OBSSourceRemoved(void *data, calldata_t *calldata);
-	static void OBSSourceAdded(void *data, calldata_t *calldata);
 
 	void getSourceTypes();
 	void setSelectedSourceType(QListWidgetItem *item);
 
 	int lastSelectedIndex = -1;
-	std::vector<SourceSelectButton *> selectedItems;
+	std::vector<QPointer<SourceSelectButton>> selectedItems;
 	void setSelectedSource(SourceSelectButton *button);
 	void addSelectedItem(SourceSelectButton *button);
 	void removeSelectedItem(SourceSelectButton *button);
@@ -78,6 +77,9 @@ signals:
 public slots:
 	void on_createNewSource_clicked(bool checked);
 	void addSelectedSources();
+
+	void handleSourceCreated(QString uuid);
+	void handleSourceRemoved(QString uuid);
 
 	void sourceTypeSelected(QListWidgetItem *current, QListWidgetItem *previous);
 


### PR DESCRIPTION
### Description
Updates the add source dialog to handle adding and removal of sources while it's open.

Fixes a crash when a selected source is deleted.

### Motivation and Context
Crashes are bad. UI responding to changes is also good.

### How Has This Been Tested?
Added and removed sources multiple times both with/without them selected and with multiple selections.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
