### PR TITLE
frontend: Force update volume meter backgrounds

### DIFF
--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -275,7 +275,8 @@ void VolumeMeter::setPeakMeterType(enum obs_peak_meter_type peakMeterType)
 		break;
 	}
 
-	updateBackgroundCache();
+	bool forceUpdate = true;
+	updateBackgroundCache(forceUpdate);
 }
 
 VolumeMeter::VolumeMeter(QWidget *parent, obs_source_t *source)
@@ -455,7 +456,8 @@ void VolumeMeter::refreshColors()
 	setForegroundWarningColor(getForegroundWarningColor());
 	setForegroundErrorColor(getForegroundErrorColor());
 
-	updateBackgroundCache();
+	bool forceUpdate = true;
+	updateBackgroundCache(forceUpdate);
 }
 
 QRect VolumeMeter::getBarRect() const
@@ -648,17 +650,17 @@ void VolumeMeter::paintVTicks(QPainter &painter, int x, int y, int height)
 	}
 }
 
-void VolumeMeter::updateBackgroundCache()
+void VolumeMeter::updateBackgroundCache(bool force)
 {
-	if (!size().isValid()) {
+	if (!force && !size().isValid()) {
 		return;
 	}
 
-	if (backgroundCache.size() == size() && !backgroundCache.isNull()) {
+	if (!force && backgroundCache.size() == size() && !backgroundCache.isNull()) {
 		return;
 	}
 
-	if (displayNrAudioChannels <= 0) {
+	if (!force && displayNrAudioChannels <= 0) {
 		return;
 	}
 

--- a/frontend/components/VolumeMeter.hpp
+++ b/frontend/components/VolumeMeter.hpp
@@ -83,7 +83,7 @@ private:
 	uint64_t displayInputPeakHoldLastUpdateTime[MAX_AUDIO_CHANNELS];
 
 	QPixmap backgroundCache;
-	void updateBackgroundCache();
+	void updateBackgroundCache(bool force = false);
 
 	QFont tickFont;
 	QRect tickTextTokenRect;


### PR DESCRIPTION
### Description
Forces the VolumeMeter backgroundCache to be updated whenever colors are changed in accessibility settings, or when the peak meter type is changed.

Fixes #13057

### Motivation and Context
Currently `updateBackgroundCache()` skips updating if the background size and widget size match, to avoid unnecessary updates. However, these two situations require a background update despite the widget not changing dimensions.

### How Has This Been Tested?
Updated peak meter type and meter colors in accessibility. Verified meter background updates properly.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
