### PR TITLE
frontend: Restrict audio meter update region

### DIFF
--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -344,8 +344,10 @@ VolumeMeter::VolumeMeter(QWidget *parent, obs_source_t *source)
 	connect(updateTimer, &QTimer::timeout, this, [this]() {
 		if (needLayoutChange()) {
 			doLayout();
+			update();
+		} else {
+			update(getBarRect());
 		}
-		repaint();
 	});
 
 	connect(App(), &OBSApp::StyleChanged, this, &VolumeMeter::updateBackgroundCache);


### PR DESCRIPTION
### Description
Re-adds a paint optimization from the old mixer that was erroneously removed and uses `update()` instead of `repaint()`

### Motivation and Context
`update()` is the preferred method to call when forcing a paint update rather than `repaint()` and on macOS this appears to have a significant performance impact.

### How Has This Been Tested?
Compiled and tested on Windows. Confirmed with @PatTheMav off thread this improved call time.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
