### PR TITLE
frontend: Use disabled meter colors when output muted

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -691,7 +691,6 @@ void VolumeControl::updateMixerState()
 	bool isActive = obs_source_active(source) && obs_source_audio_active(source);
 
 	mixerStatus().set(VolumeControl::MixerStatus::Active, isActive);
-	setUseDisabledColors(!isActive);
 	mixerStatus().set(VolumeControl::MixerStatus::Unassigned, unassigned);
 
 	QSignalBlocker blockMute(muteButton);
@@ -702,6 +701,7 @@ void VolumeControl::updateMixerState()
 	bool showAsUnassigned = !muted && unassigned;
 
 	volumeMeter->setMuted((showAsMuted || showAsUnassigned) && !showAsMonitored);
+	setUseDisabledColors(showAsMuted);
 
 	// Qt doesn't support overriding the QPushButton icon using pseudo state selectors like :checked
 	// in QSS so we set a checked class selector on the button to be used instead.

--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -438,6 +438,9 @@ void VolumeMeter::setUseDisabledColors(bool enable)
 	}
 
 	useDisabledColors = enable;
+
+	bool forceUpdate = true;
+	updateBackgroundCache(forceUpdate);
 }
 
 void VolumeMeter::setMuted(bool mute)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Adjusts the VolumeMeter widget to use the muted/disabled colors when the output is muted instead of when it's not outputting audio.

### Motivation and Context
The new volume mixer only truly mutes sources if they are also not set to monitor. This makes the Mute button a "Mute Output button rather than a toggle for actual source `mute` state.

This PR makes the mixer use the disabled greyscale colors when "muted" so that the color is a visual representation of output state, rather than literal audio state.

**Before**
<img width="120" height="285" alt="image" src="https://github.com/user-attachments/assets/e826ef78-37ce-40c0-9b96-2601a5c4a44d" />


**After**
<img width="118" height="298" alt="image" src="https://github.com/user-attachments/assets/327d4f91-ff03-4023-8398-7c3b4cd23c5b" />


### How Has This Been Tested?
👁

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
