### PR TITLE
frontend: Update previewed sources in mixer by visibility

### DIFF
--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -260,6 +260,7 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 
 	updateShowToolbar();
 	updatePreviewSources();
+	updatePreviewHandlers();
 	updateGlobalSources();
 
 	reloadVolumeControls();
@@ -413,6 +414,10 @@ void AudioMixer::updatePreviewSources()
 		}
 
 		auto getPreviewSources = [this](obs_scene_t *, obs_sceneitem_t *item) {
+			if (!obs_sceneitem_visible(item)) {
+				return true;
+			}
+
 			obs_source_t *source = obs_sceneitem_get_source(item);
 			if (!source) {
 				return true;
@@ -882,6 +887,7 @@ void AudioMixer::handleFrontendEvent(obs_frontend_event event)
 	case OBS_FRONTEND_EVENT_STUDIO_MODE_ENABLED:
 	case OBS_FRONTEND_EVENT_STUDIO_MODE_DISABLED:
 		updatePreviewSources();
+		updatePreviewHandlers();
 		queueLayoutUpdate();
 		break;
 	case OBS_FRONTEND_EVENT_EXIT:
@@ -889,6 +895,24 @@ void AudioMixer::handleFrontendEvent(obs_frontend_event event)
 		break;
 	default:
 		break;
+	}
+}
+
+void AudioMixer::updatePreviewHandlers()
+{
+	previewSignals.clear();
+
+	bool isStudioMode = obs_frontend_preview_program_mode_active();
+	if (isStudioMode) {
+		OBSSourceAutoRelease previewSource = obs_frontend_get_current_preview_scene();
+		if (!previewSource) {
+			return;
+		}
+
+		previewSignals.reserve(1);
+
+		previewSignals.emplace_back(obs_source_get_signal_handler(previewSource), "item_visible",
+					    AudioMixer::obsSceneItemVisibleChange, this);
 	}
 }
 
@@ -1028,4 +1052,28 @@ void AudioMixer::obsSourceRemove(void *data, calldata_t *params)
 void AudioMixer::obsSourceRename(void *data, calldata_t *)
 {
 	QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "queueLayoutUpdate", Qt::QueuedConnection);
+}
+
+void AudioMixer::obsSceneItemVisibleChange(void *data, calldata_t *params)
+{
+	obs_sceneitem_t *sceneItem = static_cast<obs_sceneitem_t *>(calldata_ptr(params, "item"));
+	if (!sceneItem) {
+		return;
+	}
+
+	obs_source_t *source = obs_sceneitem_get_source(sceneItem);
+	if (!source) {
+		return;
+	}
+
+	uint32_t flags = obs_source_get_output_flags(source);
+
+	if (flags & OBS_SOURCE_AUDIO) {
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updatePreviewSources",
+					  Qt::QueuedConnection);
+
+		auto uuidPointer = obs_source_get_uuid(source);
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updateControlVisibility",
+					  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+	}
 }

--- a/frontend/widgets/AudioMixer.hpp
+++ b/frontend/widgets/AudioMixer.hpp
@@ -56,8 +56,10 @@ public:
 
 private:
 	std::vector<OBSSignal> signalHandlers;
+	std::vector<OBSSignal> previewSignals;
 	static void onFrontendEvent(enum obs_frontend_event event, void *data);
 	void handleFrontendEvent(enum obs_frontend_event event);
+	void updatePreviewHandlers();
 
 	std::unordered_map<QString, QPointer<VolumeControl>> volumeList;
 	void addControlForUuid(QString uuid);
@@ -124,6 +126,7 @@ private:
 	static void obsSourceCreate(void *data, calldata_t *params);
 	static void obsSourceRemove(void *data, calldata_t *params);
 	static void obsSourceRename(void *data, calldata_t *params);
+	static void obsSceneItemVisibleChange(void *data, calldata_t *params);
 
 private slots:
 	void sourceCreated(QString uuid);


### PR DESCRIPTION
### Description
Improves the status of previewed sources in the mixer to be based on and update by scene item visibility.

### Motivation and Context
Currently any source in the previewed scene gets flagged as Preview even if it's hidden and wouldn't be audible after transition. This change takes scene item visibility into account, and also updates when visibility is changed.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
