### PR TITLE
libobs: Fix transition start during active transition

### DIFF
--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -347,16 +347,24 @@ bool obs_transition_start(obs_source_t *transition, enum obs_transition_mode mod
 	if (active && mode == OBS_TRANSITION_MODE_MANUAL && same_mode && same_as_dest)
 		return true;
 
+	if (active && !same_as_dest) {
+
+		obs_transition_set(transition, transition->transition_sources[1]);
+
+		// Re-initialize after change
+		lock_transition(transition);
+		same_as_source = dest == transition->transition_sources[0];
+		same_as_dest = dest == transition->transition_sources[1];
+		same_mode = mode == transition->transition_mode;
+		active = transition_active(transition);
+		unlock_transition(transition);
+	}
+
 	lock_transition(transition);
 	transition->transition_mode = mode;
 	transition->transition_manual_val = 0.0f;
 	transition->transition_manual_target = 0.0f;
 	unlock_transition(transition);
-
-	if (active) {
-		obs_transition_set(transition, transition->transition_sources[1]);
-		active = false;
-	}
 
 	if (transition->info.transition_start)
 		transition->info.transition_start(transition->context.data);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes `obs_transition_start()` using outdated info to configure new transition if transition was already active.

Here's a snippet from _obs-source-transition.c_ of what needs re-initializing / checking after `obs_transition_start()` calls `obs_transition_set()`

```
lock_transition(transition);
same_as_source = dest == transition->transition_sources[0];
same_as_dest = dest == transition->transition_sources[1];
same_mode = mode == transition->transition_mode;
active = transition_active(transition);
unlock_transition(transition);

if (same_as_source && !active)
	return false;
if (active && mode == OBS_TRANSITION_MODE_MANUAL && same_mode && same_as_dest)
	return true;
```

Knowing `obs_transition_set()` will set the dest as source, we should also check for `same_as_dest` before interrupting current transition since if it is same, it would appear as the transition just turned into a cut. (transition cancel + then having same source and dest).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
After pr #12622 slideshow fails to fade black/transparent with Stop if used during active transition of slides and instead the last image is shown. This works in 32.0.4.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Used slideshow to check transitions work again. 

Needs testing with the general transition controls.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
