### PR TITLE
shared/media-playback: Fix corrupt MaxCLL when reading HDR metadata

### DIFF
--- a/shared/media-playback/media-playback/decode.c
+++ b/shared/media-playback/media-playback/decode.c
@@ -119,7 +119,7 @@ static uint16_t get_max_luminance(const AVStream *stream)
 			break;
 		}
 		case AV_PKT_DATA_CONTENT_LIGHT_LEVEL: {
-			const AVContentLightMetadata *const md = (AVContentLightMetadata *)&sd->data;
+			const AVContentLightMetadata *const md = (AVContentLightMetadata *)sd->data;
 			max_luminance = md->MaxCLL;
 			break;
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The content light level metadata was being read incorrectly by taking the address of the data pointer instead of casting the pointer itself. This resulted in interpreting the pointer address as the MaxCLL value, leading to extremely large values.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fixes #12902
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Verified that the function now reads the correct MaxCLL value
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
