### PR TITLE
Add groupconnect sockopt to SRT connection

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -81,7 +81,7 @@ typedef struct SRTContext {
 	char *localport;
 	int linger;
 	int tsbpd;
-#ifdef SRT_ENABLE_BONDING
+#if SRT_VERSION_VALUE >= 0x010500
 	int groupconnect;
 #endif
 	double time; // time in s in order to post logs at definite intervals
@@ -417,7 +417,7 @@ static int libsrt_set_options_pre(URLContext *h, SRTSOCKET fd)
 	     libsrt_setsockopt(h, fd, SRTO_MESSAGEAPI, "SRTO_MESSAGEAPI", &s->messageapi, sizeof(s->messageapi)) < 0) ||
 	    (s->payload_size >= 0 && libsrt_setsockopt(h, fd, SRTO_PAYLOADSIZE, "SRTO_PAYLOADSIZE", &s->payload_size,
 						       sizeof(s->payload_size)) < 0) ||
-#ifdef SRT_ENABLE_BONDING
+#if SRT_VERSION_VALUE >= 0x010500
 	    (s->groupconnect >= 0 && libsrt_setsockopt(h, fd, SRTO_GROUPCONNECT, "SRTO_GROUPCONNECT", &s->groupconnect,
 						       sizeof(s->groupconnect)) < 0) ||
 #endif
@@ -658,7 +658,7 @@ static void libsrt_set_defaults(SRTContext *s)
 	s->transtype = SRTT_LIVE;
 	s->linger = -1;
 	s->tsbpd = -1;
-#ifdef SRT_ENABLE_BONDING
+#if SRT_VERSION_VALUE >= 0x010500
 	s->groupconnect = -1;
 #endif
 }
@@ -814,7 +814,7 @@ static int libsrt_open(URLContext *h, const char *uri)
 		if (av_find_info_tag(buf, sizeof(buf), "localport", p)) {
 			s->localport = av_strndup(buf, strlen(buf));
 		}
-#ifdef SRT_ENABLE_BONDING
+#if SRT_VERSION_VALUE >= 0x010500
 		if (av_find_info_tag(buf, sizeof(buf), "groupconnect", p)) {
 			s->groupconnect = strtol(buf, NULL, 10);
 		}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description

Adds a parameter to set `SRTO_GROUPCONNECT` on the SRT socket.

### Motivation and Context

This enables connection bonding on an SRT listener socket. https://github.com/Haivision/srt/blob/master/docs/features/socket-groups.md

### How Has This Been Tested?

Tested manually with an OBS build.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
