### PR TITLE
libobs: Properly handle NULL data in json

### DIFF
--- a/libobs/obs-data.c
+++ b/libobs/obs-data.c
@@ -483,6 +483,11 @@ static void obs_data_add_json_array(obs_data_t *data, const char *key, json_t *j
 	obs_data_array_release(array);
 }
 
+static inline void obs_data_add_json_null(obs_data_t *data, const char *key)
+{
+	obs_data_set_obj(data, key, NULL);
+}
+
 static void obs_data_add_json_item(obs_data_t *data, const char *key, json_t *json)
 {
 	if (json_is_object(json))
@@ -499,6 +504,8 @@ static void obs_data_add_json_item(obs_data_t *data, const char *key, json_t *js
 		obs_data_set_bool(data, key, true);
 	else if (json_is_false(json))
 		obs_data_set_bool(data, key, false);
+	else if (json_is_null(json))
+		obs_data_add_json_null(data, key);
 }
 
 /* ------------------------------------------------------------------------- */
@@ -556,6 +563,9 @@ static inline void set_json_array(json_t *json, const char *name, obs_data_item_
 
 static json_t *obs_data_to_json(obs_data_t *data, bool with_defaults)
 {
+	if (!data)
+		return json_null();
+
 	json_t *json = json_object();
 
 	obs_data_item_t *item = NULL;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This allows proper conversion of `NULL` between obs_data_t and its json representation.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`obs_data_t` is allowed to have a value of `NULL`, but this isn't currently properly handled, causing a crash in `obs_data_to_json` if it is given such an object (backtrace attached below).
Though rare (if not abnormal) in usual operations of obs, this should not cause a crash.

[gdb_json.txt](https://github.com/user-attachments/files/25060175/gdb_json.txt)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ubuntu 24.04, ran a script to force a source's data's value to `NULL` verified correct saving and loading of the scene collection.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
