### PR TITLE
libobs: Fix interrupted transitions

### DIFF
--- a/libobs/obs-source-transition.c
+++ b/libobs/obs-source-transition.c
@@ -335,6 +335,10 @@ bool obs_transition_start(obs_source_t *transition, enum obs_transition_mode mod
 	if (!transition_valid(transition, "obs_transition_start"))
 		return false;
 
+	if (transition_active(transition)) {
+		obs_transition_set(transition, transition->transition_sources[1]);
+	}
+
 	lock_transition(transition);
 	same_as_source = dest == transition->transition_sources[0];
 	same_as_dest = dest == transition->transition_sources[1];
@@ -352,11 +356,6 @@ bool obs_transition_start(obs_source_t *transition, enum obs_transition_mode mod
 	transition->transition_manual_val = 0.0f;
 	transition->transition_manual_target = 0.0f;
 	unlock_transition(transition);
-
-	if (active) {
-		obs_transition_set(transition, transition->transition_sources[1]);
-		active = false;
-	}
 
 	if (transition->info.transition_start)
 		transition->info.transition_start(transition->context.data);


### PR DESCRIPTION
### Description
When the slideshow is stopped mid-transition, skip the rest of the transition before fading out.

### Motivation and Context
Alternative solution to #13074 and fixes the bug mentioned there. After the changes in #12622, stopping the slideshow mid-transition would freeze it on the next slide rather than hiding it.

### How Has This Been Tested?
Stopped a slideshow when it was paused on a slide and when it was mid transition. Checked that behaviour matched 32.0.4 before the change.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
