### PR TITLE
frontend: Update unassigned audio track warning text

### DIFF
--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -601,7 +601,7 @@ VolControl.SliderMuted="Volume slider for '%1': (currently muted)"
 VolControl.Mute="Mute '%1'"
 VolControl.Properties="Properties for '%1'"
 VolControl.UnassignedWarning.Title="Unassigned Audio Source"
-VolControl.UnassignedWarning.Text="\"%1\" is not assigned to any audio tracks and it will not be audible in streams or recordings.\n\nTo assign an audio source to a track, open the Advanced Audio Properties via the right-click menu or the cog button in the mixer dock toolbar."
+VolControl.UnassignedWarning.Text="\"%1\" is not assigned to any audio tracks and it will not be audible in streams or recordings.\n\nTo assign an audio source to a track, open the Advanced Audio Properties via the Edit menu on the menu bar, or the cog button in the mixer dock toolbar."
 
 # add scene dialog
 Basic.Main.AddSceneDlg.Title="Add Scene"


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Updates the warning text shown when an audio source is not assigned to any audio tracks.

The “Advanced Audio Properties” option is no longer available from the context (right-click) menu, so the text has been updated accordingly.
A menu bar option is now referenced instead of right-clicking.

Note: English is not my first language, so please feel free to update or rewrite the wording directly if needed.

**Before**

<img width="502" height="248" alt="before-unassigned-text" src="https://github.com/user-attachments/assets/5236d890-9dec-46a2-a092-6d299a0e675b" />

https://github.com/user-attachments/assets/cd04b4d1-a0a9-4bf4-8223-759e6de6c165

**After**

<img width="502" height="248" alt="after-unassigned-text" src="https://github.com/user-attachments/assets/f67e5992-7949-42ad-a1c6-6bbcf47fbfdf" />

https://github.com/user-attachments/assets/42c9055e-4170-451b-bb74-9ecd11f358c0

This is the best I could do with my current knowledge.
If you see a better approach, please feel free to update or close this PR.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The previous warning text instructed users to right-click to access Advanced Audio Properties, but this no longer works, which could be confusing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Modified `en-US.ini` and confirmed that the updated text is displayed correctly in the warning dialog.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
