### PR TITLE
AI is bad

### DIFF
--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -1980,6 +1980,13 @@ uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder)
 	return encoder ? encoder->pause.ts_offset : 0;
 }
 
+void obs_encoder_request_keyframe(obs_encoder_t *encoder)
+{
+	if (!encoder || !encoder->info.request_keyframe)
+		return;
+	encoder->info.request_keyframe(encoder->context.data);
+}
+
 bool obs_encoder_has_roi(const obs_encoder_t *encoder)
 {
 	return encoder->roi.num > 0;

--- a/libobs/obs-encoder.h
+++ b/libobs/obs-encoder.h
@@ -347,6 +347,14 @@ struct obs_encoder_info {
 
 	/** Audio encoder only: Returns padding, in samples, that must be skipped at the start of the stream. */
 	uint32_t (*get_priming_samples)(void *data);
+
+	/**
+	 * Requests that the encoder produce a keyframe as soon as possible.
+	 * Used for WebRTC PLI (Picture Loss Indication) handling.
+	 *
+	 * @param  data  Data associated with this encoder context
+	 */
+	void (*request_keyframe)(void *data);
 };
 
 EXPORT void obs_register_encoder_s(const struct obs_encoder_info *info, size_t size);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2461,6 +2461,15 @@ EXPORT void obs_encoder_set_last_error(obs_encoder_t *encoder, const char *messa
 EXPORT uint64_t obs_encoder_get_pause_offset(const obs_encoder_t *encoder);
 
 /**
+ * Requests the encoder to produce a keyframe on the next frame.
+ * Used by outputs that receive keyframe requests from remote endpoints,
+ * such as WebRTC PLI (Picture Loss Indication) packets.
+ *
+ * @param encoder The encoder to request a keyframe from
+ */
+EXPORT void obs_encoder_request_keyframe(obs_encoder_t *encoder);
+
+/**
  * Creates an "encoder group", allowing synchronized startup of encoders within
  * the group. Encoder groups are single owner, and hold strong references to
  * encoders within the group. Calling destroy on an active group will not actually

--- a/plugins/obs-nvenc/nvenc-internal.h
+++ b/plugins/obs-nvenc/nvenc-internal.h
@@ -76,6 +76,7 @@ struct nvenc_data {
 	bool first_packet;
 	bool can_change_bitrate;
 	bool non_texture;
+	volatile bool force_keyframe;
 
 	DARRAY(struct handle_tex) input_textures;
 	DARRAY(struct nv_bitstream) bitstreams;
@@ -162,6 +163,7 @@ struct nv_texture {
 
 bool nvenc_encode_base(struct nvenc_data *enc, struct nv_bitstream *bs, void *pic, int64_t pts,
 		       struct encoder_packet *packet, bool *received_packet);
+void nvenc_request_keyframe(struct nvenc_data *enc);
 
 /* ------------------------------------------------------------------------- */
 /* Backend-specific functions                                                */

--- a/plugins/obs-webrtc/whip-output.h
+++ b/plugins/obs-webrtc/whip-output.h
@@ -47,6 +47,7 @@ private:
 	void ParseLinkHeader(std::string linkHeader, std::vector<rtc::IceServer> &iceServers);
 	void Send(void *data, uintptr_t size, uint64_t duration, std::shared_ptr<rtc::Track> track,
 		  std::shared_ptr<rtc::RtcpSrReporter> rtcp_sr_reporter);
+	void OnRtcpMessage(rtc::message_variant message);
 
 	obs_output_t *output;
 


### PR DESCRIPTION
## Summary
When a WHIP server sends a PLI (Picture Loss Indication) RTCP packet requesting a keyframe, OBS now responds by requesting the encoder produce a keyframe on the next frame.

This enables faster video start for new viewers joining a WebRTC stream, as the server can request an immediate keyframe rather than waiting for the next scheduled keyframe interval (often 2-4 seconds).

## Changes
- Add `obs_encoder_request_keyframe()` public API to libobs
- Add `request_keyframe` callback to `obs_encoder_info` struct
- Implement keyframe request for all NVENC encoder variants (H.264, HEVC, AV1 in both texture and non-texture modes)
- Handle PLI packets in WHIP output's RTCP message handler

## Technical notes
- PLI is defined in RFC 4585 as RTCP Payload-Specific Feedback (pt=206) with fmt=1
- The boolean flag approach naturally deduplicates rapid PLI bursts that some servers send for UDP reliability
- Other encoders (x264, QSV, etc.) can add support by implementing the `request_keyframe` callback

## Test plan
- [x] Build OBS with NVENC encoder
- [x] Stream via WHIP to a server that sends PLI requests (tested with SRS)
- [x] Verify keyframes are produced immediately when viewers connect
- [x] Verify multiple rapid PLIs result in single keyframe (deduplication works)

🤖 Generated with [Claude Code](https://claude.ai/code)