### PR TITLE
text-freetype2: Track text length explicitly to permit embedded null bytes

### DIFF
--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -270,7 +270,7 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 
 	if (srcdata->tex == NULL || srcdata->vbuf == NULL)
 		return;
-	if (srcdata->text == NULL || *srcdata->text == 0)
+	if (srcdata->text == NULL || srcdata->text_len == 0)
 		return;
 
 	gs_reset_blend_state();
@@ -279,7 +279,7 @@ static void ft2_source_render(void *data, gs_effect_t *effect)
 	if (srcdata->drop_shadow)
 		draw_drop_shadow(srcdata);
 
-	draw_uv_vbuffer(srcdata->vbuf, srcdata->tex, srcdata->draw_effect, (uint32_t)wcslen(srcdata->text) * 6, true);
+	draw_uv_vbuffer(srcdata->vbuf, srcdata->tex, srcdata->draw_effect, (uint32_t)srcdata->text_len * 6, true);
 
 	UNUSED_PARAMETER(effect);
 }
@@ -301,7 +301,7 @@ static void ft2_video_tick(void *data, float seconds)
 				read_from_end(srcdata, srcdata->text_file);
 			else
 				load_text_from_file(srcdata, srcdata->text_file);
-			cache_glyphs(srcdata, srcdata->text);
+			cache_glyphs(srcdata, srcdata->text, srcdata->text_len);
 			set_up_vertex_buffer(srcdata);
 			srcdata->update_file = false;
 		}
@@ -481,8 +481,9 @@ skip_font_load:
 
 			bfree(srcdata->text);
 			srcdata->text = NULL;
+			srcdata->text_len = 0;
 
-			os_utf8_to_wcs_ptr(emptystr, strlen(emptystr), &srcdata->text);
+			srcdata->text_len = os_utf8_to_wcs_ptr(emptystr, strlen(emptystr), &srcdata->text);
 			blog(LOG_WARNING,
 			     "FT2-text: Failed to open %s for "
 			     "reading",
@@ -508,13 +509,14 @@ skip_font_load:
 		if (srcdata->text != NULL) {
 			bfree(srcdata->text);
 			srcdata->text = NULL;
+			srcdata->text_len = 0;
 		}
 
-		os_utf8_to_wcs_ptr(tmp, strlen(tmp), &srcdata->text);
+		srcdata->text_len = os_utf8_to_wcs_ptr(tmp, strlen(tmp), &srcdata->text);
 	}
 
 	if (srcdata->font_face) {
-		cache_glyphs(srcdata, srcdata->text);
+		cache_glyphs(srcdata, srcdata->text, srcdata->text_len);
 		set_up_vertex_buffer(srcdata);
 	}
 

--- a/plugins/text-freetype2/text-freetype2.h
+++ b/plugins/text-freetype2/text-freetype2.h
@@ -40,6 +40,7 @@ struct ft2_source {
 	bool antialiasing;
 	char *text_file;
 	wchar_t *text;
+	size_t text_len;
 	time_t m_timestamp;
 	bool update_file;
 	uint64_t last_checked;
@@ -73,14 +74,14 @@ extern FT_Library ft2_lib;
 void draw_outlines(struct ft2_source *srcdata);
 void draw_drop_shadow(struct ft2_source *srcdata);
 
-uint32_t get_ft2_text_width(wchar_t *text, struct ft2_source *srcdata);
+uint32_t get_ft2_text_width(wchar_t *text, size_t text_len, struct ft2_source *srcdata);
 
 time_t get_modified_timestamp(char *filename);
 void load_text_from_file(struct ft2_source *srcdata, const char *filename);
 void read_from_end(struct ft2_source *srcdata, const char *filename);
 
 void cache_standard_glyphs(struct ft2_source *srcdata);
-void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs);
+void cache_glyphs(struct ft2_source *srcdata, wchar_t *cache_glyphs, size_t len);
 
 void set_up_vertex_buffer(struct ft2_source *srcdata);
 void fill_vertex_buffer(struct ft2_source *srcdata);


### PR DESCRIPTION
## Description

When 'Read from file' is enabled, files containing embedded null bytes are truncated at the first null because `strlen()` treats it as end-of-string. This causes only partial file content to display.

## Approach

Instead of stripping null bytes (as in the initial version of this PR), this now follows the explicit length-tracking approach discussed in #11045:

- Added `text_len` field to `ft2_source` struct to track wide string length explicitly
- Pass the known buffer size (`filesize`) to `os_utf8_to_wcs_ptr` instead of `strlen()`, allowing embedded null bytes to be converted as regular characters
- Replace all `wcslen(srcdata->text)` calls with `srcdata->text_len` throughout the plugin
- Updated `remove_cr()`, `cache_glyphs()`, and `get_ft2_text_width()` to work with explicit lengths
- No changes needed to `libobs/util/utf8.c` — the existing `utf8_to_wchar` already handles embedded nulls correctly when `insize` is provided

This is safe because null bytes never appear as continuation bytes in valid UTF-8 sequences, and `utf8_to_wchar` documents that "If UTF-8 string contains zero symbols, they will be translated as regular symbols" when explicit size is given.

## Testing

- Files with embedded null bytes between lines display completely
- Standard multi-line UTF-8 files show no regression
- Chat log mode (`read_from_end` path) tested with both null-byte and clean files
- Empty files handled without crashes

Resolves #7595

## Checklist

- [x] I have updated the code with `clang-format`
- [x] I have reviewed the [contributing guidelines](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst)
- [x] I have tested the code
- [x] All commit messages are properly formatted and commits are squashed where appropriate