### PR TITLE
frontend: Clean up mixer hidden state

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -583,7 +583,9 @@ void VolumeControl::updateCategoryLabel()
 	categoryLabel->setText(labelText);
 
 	utils->polishChildren();
-	volumeMeter->updateBackgroundCache();
+
+	bool forceUpdate = true;
+	volumeMeter->updateBackgroundCache(forceUpdate);
 }
 
 void VolumeControl::updateDecayRate()

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -1879,15 +1879,6 @@ VolumeControl.volume-preview .mixer-category {
     background: var(--grey8);
 }
 
-VolumeControl.volume-hidden VolumeMeter {
-    qproperty-backgroundNominalColor: var(--grey5);
-    qproperty-backgroundWarningColor: var(--grey3);
-    qproperty-backgroundErrorColor: var(--grey5);
-    qproperty-foregroundNominalColor: var(--green4);
-    qproperty-foregroundWarningColor: var(--yellow4);
-    qproperty-foregroundErrorColor: var(--red4);
-}
-
 /* Status Bar */
 
 QStatusBar::item {

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -179,10 +179,6 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 	toggleHiddenButton->setChecked(showHidden);
 	toggleHiddenButton->setText(QTStr("Basic.AudioMixer.HiddenTotal").arg(0));
 	toggleHiddenButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
-	QIcon hiddenIcon;
-	hiddenIcon.addFile(QString::fromUtf8(":/res/images/hidden.svg"), QSize(16, 16), QIcon::Mode::Normal,
-			   QIcon::State::Off);
-	toggleHiddenButton->setIcon(hiddenIcon);
 	idian::Utils::addClass(toggleHiddenButton, "toolbar-button");
 	idian::Utils::addClass(toggleHiddenButton, "toggle-hidden");
 


### PR DESCRIPTION
### Description
Removes some unused/unfinished hidden state code in the audio mixer and ensures the meter background is updated.

### Motivation and Context
Visual fixes and removes missing icon warning.

### How Has This Been Tested?
Compiled and 👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
