### PR TITLE
frontend, libobs: Base work for localization and utf-8

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -285,7 +285,7 @@ string CurrentDateTimeString()
 	struct tm tstruct;
 	char buf[80];
 	tstruct = *localtime(&now);
-	strftime(buf, sizeof(buf), "%Y-%m-%d, %X", &tstruct);
+	strftime(buf, sizeof(buf), "%Y-%m-%d, %H:%M:%S", &tstruct);
 	return buf;
 }
 

--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -339,7 +339,7 @@ static vector<OBSThemeVariable> ParseThemeVariables(const char *themeData)
 
 			/* Look for a suffix and mark variable as size if it exists */
 			while (ch < end) {
-				if (!isdigit(*ch) && !isspace(*ch) && *ch != '.') {
+				if (!isdigit((unsigned char)*ch) && !isspace((unsigned char)*ch) && *ch != '.') {
 					var.suffix = QString::fromUtf8(ch, end - ch);
 					var.type = OBSThemeVariable::Size;
 					break;
@@ -526,14 +526,14 @@ static OBSThemeVariable ParseMathVariable(const QHash<QString, OBSThemeVariable>
 	const QByteArray utf8 = value.toUtf8();
 	const char *data = utf8.constData();
 
-	if (isdigit(*data)) {
+	if (isdigit((unsigned char)*data)) {
 		double f = os_strtod(data);
 		var.type = OBSThemeVariable::Number;
 		var.value = f;
 
 		const char *dataEnd = data + utf8.size();
 		while (data < dataEnd) {
-			if (*data && !isdigit(*data) && *data != '.') {
+			if (*data && !isdigit((unsigned char)*data) && *data != '.') {
 				var.suffix = QString::fromUtf8(data, dataEnd - data);
 				var.type = OBSThemeVariable::Size;
 				break;

--- a/frontend/cmake/windows/obs.manifest
+++ b/frontend/cmake/windows/obs.manifest
@@ -11,6 +11,11 @@
             </requestedPrivileges>
         </security>
     </trustInfo>
+    <application>
+	<windowsSettings>
+	    <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+        </windowsSettings>
+    </application>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>
             <!-- Windows 10 and Windows 11 -->

--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -245,7 +245,7 @@ static inline void write_header(struct exception_handler_data *data)
 	time_t now = time(0);
 	struct tm ts;
 	ts = *localtime(&now);
-	strftime(date_time, sizeof(date_time), "%Y-%m-%d, %X", &ts);
+	strftime(date_time, sizeof(date_time), "%Y-%m-%d, %H:%M:%S", &ts);
 
 	const char *obs_bitness;
 	if (sizeof(void *) == 8)

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -382,8 +382,11 @@ EXPORT const char *obs_get_version_string(void);
  * and safely copies argv/argc from main(). Subsequent calls do nothing.
  *
  * @param  argc  The count of command line arguments, from main()
- * @param  argv  An array of command line arguments, copied from main() and ends
+ * @param  argv  An array of command line arguments in UTF-8, copied from main() and ends
  *               with NULL.
+ * 
+ *		 On Windows this requires that active code page is UTF-8.
+ *		 For example as a declaration in obs.manifest.
  */
 EXPORT void obs_set_cmdline_args(int argc, const char *const *argv);
 

--- a/libobs/util/cf-lexer.c
+++ b/libobs/util/cf-lexer.c
@@ -71,7 +71,7 @@ static inline void cf_convert_from_escape_literal(char **p_dst, const char **p_s
 
 	/* oct */
 	default:
-		if (isdigit(*src)) {
+		if (isdigit((unsigned char)*src)) {
 			*(dst++) = (char)strtoul(src, NULL, 8);
 			src += 3;
 		}

--- a/libobs/util/dstr.c
+++ b/libobs/util/dstr.c
@@ -43,8 +43,8 @@ int astrcmpi(const char *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1 = (char)toupper(*str1);
-		char ch2 = (char)toupper(*str2);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*str1);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;
@@ -85,8 +85,8 @@ int astrcmp_n(const char *str1, const char *str2, size_t n)
 		str2 = astrblank;
 
 	do {
-		char ch1 = *str1;
-		char ch2 = *str2;
+		unsigned char ch1 = (unsigned char)*str1;
+		unsigned char ch2 = (unsigned char)*str2;
 
 		if (ch1 < ch2)
 			return -1;
@@ -129,8 +129,8 @@ int astrcmpi_n(const char *str1, const char *str2, size_t n)
 		str2 = astrblank;
 
 	do {
-		char ch1 = (char)toupper(*str1);
-		char ch2 = (char)toupper(*str2);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*str1);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;

--- a/libobs/util/lexer.c
+++ b/libobs/util/lexer.c
@@ -29,7 +29,8 @@ int strref_cmp(const struct strref *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
 		ch1 = (i < str1->len) ? str1->array[i] : 0;
 		ch2 = *str2;
@@ -53,10 +54,11 @@ int strref_cmpi(const struct strref *str1, const char *str2)
 		str2 = astrblank;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
-		ch1 = (i < str1->len) ? (char)toupper(str1->array[i]) : 0;
-		ch2 = (char)toupper(*str2);
+		ch1 = (i < str1->len) ? (unsigned char)toupper((unsigned char)str1->array[i]) : 0;
+		ch2 = (unsigned char)toupper((unsigned char)*str2);
 
 		if (ch1 < ch2)
 			return -1;
@@ -77,7 +79,8 @@ int strref_cmp_strref(const struct strref *str1, const struct strref *str2)
 		return -1;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
 		ch1 = (i < str1->len) ? str1->array[i] : 0;
 		ch2 = (i < str2->len) ? str2->array[i] : 0;
@@ -103,10 +106,11 @@ int strref_cmpi_strref(const struct strref *str1, const struct strref *str2)
 		return -1;
 
 	do {
-		char ch1, ch2;
+		unsigned char ch1;
+		unsigned char ch2;
 
-		ch1 = (i < str1->len) ? (char)toupper(str1->array[i]) : 0;
-		ch2 = (i < str2->len) ? (char)toupper(str2->array[i]) : 0;
+		ch1 = (i < str1->len) ? (unsigned char)toupper((unsigned char)str1->array[i]) : 0;
+		ch2 = (i < str2->len) ? (unsigned char)toupper((unsigned char)str2->array[i]) : 0;
 
 		if (ch1 < ch2)
 			return -1;

--- a/plugins/text-freetype2/find-font.c
+++ b/plugins/text-freetype2/find-font.c
@@ -333,8 +333,8 @@ static inline size_t get_rating(struct font_path_info *info, struct dstr *cmp)
 	size_t num = 0;
 
 	do {
-		char ch1 = (char)toupper(*src);
-		char ch2 = (char)toupper(*dst);
+		unsigned char ch1 = (unsigned char)toupper((unsigned char)*src);
+		unsigned char ch2 = (unsigned char)toupper((unsigned char)*dst);
 
 		if (ch1 != ch2)
 			break;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

- Sets UTF-8 as [active codepage for Windows](https://learn.microsoft.com/en-us/windows/apps/design/globalizing/use-utf8-code-page) in obs.manifest file. 
  - This changes Windows APIs to use utf-8 for the A(nsi) functions instead of the language dependent ANSI codepage. The W(ide) functions are untouched and are still used by default since we use the UNICODE build flag. This also helps directing less encoding-aware 3rd party plugins and libraries towards a supported encoding.

  - Active codepage also encodes commandline arguments on Windows as utf-8, which allows for example `./obs64.exe --profile <name>` to load profiles with special characters correctly.

- Change time formatting for logging to use ISO standard without localization to preserve logging format in different locales.

- Casts ctype function parameters from `char` to `unsigned char` to prevent non-ascii input from crashing them. Functions expect parameters to be in 0-255 range, which char using utf-8 casted to int might not be (signed char range is -128 to 127)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

This is based on discussion PR #12624 and split from the main issue there.
This serves as ground work for enabling localization and handling utf-8 data with C APIs

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested active code page effect by naming a scene with some Japanese characters, selecting another scene so it's not opened by default on restart and then restarting the app with command line

`./obs64.exe --scene <japanese characters> `

This wasn't working in current version on Windows.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
  - 3rd party plugins etc, that have been using -A versions of Windows API have to expect them to give out/take in strings encoded in utf-8 instead of default ANSI code page. 
    - It's still not broken if: 
      - It's in ASCII range 
      - If they needed wchar of it they used  `MultiByteToWideChar()` with `CP_ACP` flag (using other flag may have been broken, but if it was CP_UTF8 it is now fixed)
      - Otherwise if the text was used as input to an obs api directly, it's now coincidentally in correct encoding.
    - It is breaking if:
      - Their source file is in their default ansi non-utf8 encoding, their build options reflected that, they have non-ascii hardcoded strings there and they used them for a Windows -A api, but not for an obs api
      - They saved the string, it was non-ascii, and they try to use it now for Windows A function again.
    - Otherwise it was probably already broken
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
