### PR TITLE
libobs: Save and restore resolution of canvases

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -245,6 +245,10 @@ obs_data_t *obs_save_canvas(obs_canvas_t *canvas)
 	obs_data_set_string(canvas_data, "uuid", canvas->context.uuid);
 	obs_data_set_bool(canvas_data, "private", canvas->context.private);
 	obs_data_set_int(canvas_data, "flags", canvas->flags);
+	obs_data_set_int(canvas_data, "base_width", canvas->ovi.base_width);
+	obs_data_set_int(canvas_data, "base_height", canvas->ovi.base_height);
+	obs_data_set_int(canvas_data, "output_width", canvas->ovi.output_width);
+	obs_data_set_int(canvas_data, "output_height", canvas->ovi.output_height);
 
 	return canvas_data;
 }
@@ -255,9 +259,15 @@ obs_canvas_t *obs_load_canvas(obs_data_t *data)
 	const char *uuid = obs_data_get_string(data, "uuid");
 	const bool private = obs_data_get_bool(data, "private");
 	uint32_t flags = (uint32_t)obs_data_get_int(data, "flags");
+	struct obs_video_info ovi;
+	obs_get_video_info(&ovi);
+	ovi.base_width = (uint32_t)obs_data_get_int(data, "base_width");
+	ovi.base_height = (uint32_t)obs_data_get_int(data, "base_height");
+	ovi.output_width = (uint32_t)obs_data_get_int(data, "output_width");
+	ovi.output_height = (uint32_t)obs_data_get_int(data, "output_height");
 
 	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
-	return obs_canvas_create_internal(name, uuid, NULL, flags, private);
+	return obs_canvas_create_internal(name, uuid, &ovi, flags, private);
 }
 
 /*** Internal API ***/


### PR DESCRIPTION
### Description
Save and restore resolution of canvases

### Motivation and Context
When a canvas is loaded it needs a resolution otherwise all scenes on the canvas will have divide by 0 issues on the scene items. 

### How Has This Been Tested?
On windows 11 by having a scene collection with an extra canvas, but the plugin controlling that canvas disabled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
