### PR TITLE
frontend: Round all output theme values

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -705,12 +705,6 @@ static QString PrepareQSS(const QHash<QString, OBSThemeVariable> &vars, const QS
 		} else if (var.type == OBSThemeVariable::Size || var.type == OBSThemeVariable::Number) {
 			double val = value.toDouble();
 
-			// Round any values with a px suffix. Qt does this anyway for some properties,
-			// but then will flat out break with decimals for others.
-			if (var.suffix == "px") {
-				val = std::roundf(val);
-			}
-
 			bool isInteger = ceill(val) == val;
 			replace = QString::number(val, 'f', isInteger ? 0 : -1);
 
@@ -718,6 +712,15 @@ static QString PrepareQSS(const QHash<QString, OBSThemeVariable> &vars, const QS
 				replace += var.suffix;
 		} else {
 			replace = value.toString();
+		}
+
+		// Round any values with a px suffix. Qt does this anyway for some properties,
+		// but then will flat out break with decimals for others.
+		if (replace.right(2) == "px") {
+			QString replaceValue = replace.sliced(0, replace.length() - 2);
+			int val = (int)std::roundf(replaceValue.toDouble());
+
+			replace = QString::number(val) + "px";
 		}
 
 		stylesheet = stylesheet.replace(needle, replace);


### PR DESCRIPTION
### Description
Round 3 follow up to #13029 and #13022. Rounds the value in the final result output string in theme files if they are a `px` value

#13022 was rounding ALL math calculations.
#13029 was only rounding size literals. Calculated results or aliased values were skipped.

### Motivation and Context
Fix #13071 for real I swear.

### How Has This Been Tested?
Modified `os_mac_font_base_value` to `os_win_font_base_value` for testing on Windows and ensured the resulting value for `icon_small` got rounded.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
