### PR TITLE
frontend: Defer mixer rename dialog

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -474,53 +474,68 @@ void VolumeControl::showVolumeControlMenu(QPoint pos)
 void VolumeControl::renameSource()
 {
 	QAction *action = reinterpret_cast<QAction *>(sender());
-	obs_source_t *source = action->property("source").value<OBSSource>();
+	OBSSource source = action->property("source").value<OBSSource>();
 
-	const char *prevName = obs_source_get_name(source);
+	std::string uuid = obs_source_get_uuid(source);
 
-	for (;;) {
-		std::string name;
-		bool accepted = NameDialog::AskForName(this, QTStr("Basic.Main.MixerRename.Title"),
-						       QTStr("Basic.Main.MixerRename.Text"), name, QT_UTF8(prevName));
-		if (!accepted) {
+	OBSBasic *main = OBSBasic::Get();
+
+	// Defer the rename dialog to avoid blocking the UI thread while the context menu is closing, which can cause issues on some platforms
+	QTimer::singleShot(0, main, [main, uuid]() {
+		if (!main) {
 			return;
 		}
 
-		if (name.empty()) {
-			OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
-			continue;
-		}
-
-		if (name == prevName) {
+		OBSSourceAutoRelease source = obs_get_source_by_uuid(uuid.c_str());
+		if (!source) {
 			return;
 		}
 
-		OBSSourceAutoRelease sourceTest = obs_get_source_by_name(name.c_str());
+		const char *prevName = obs_source_get_name(source);
 
-		if (sourceTest) {
-			OBSMessageBox::warning(this, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
-			continue;
+		for (;;) {
+			std::string name;
+			bool accepted = NameDialog::AskForName(main, QTStr("Basic.Main.MixerRename.Title"),
+							       QTStr("Basic.Main.MixerRename.Text"), name,
+							       QT_UTF8(prevName));
+			if (!accepted) {
+				return;
+			}
+
+			if (name.empty()) {
+				OBSMessageBox::warning(main, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
+				continue;
+			}
+
+			if (name == prevName) {
+				return;
+			}
+
+			OBSSourceAutoRelease sourceTest = obs_get_source_by_name(name.c_str());
+
+			if (sourceTest) {
+				OBSMessageBox::warning(main, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
+				continue;
+			}
+
+			std::string prevName(obs_source_get_name(source));
+			auto undo = [prevName](const std::string &data) {
+				OBSSourceAutoRelease source = obs_get_source_by_uuid(data.c_str());
+				obs_source_set_name(source, prevName.c_str());
+			};
+
+			std::string editedName = name;
+			auto redo = [editedName](const std::string &data) {
+				OBSSourceAutoRelease source = obs_get_source_by_uuid(data.c_str());
+				obs_source_set_name(source, editedName.c_str());
+			};
+
+			main->undo_s.add_action(QTStr("Undo.Rename").arg(name.c_str()), undo, redo, uuid, uuid);
+
+			obs_source_set_name(source, name.c_str());
+			break;
 		}
-
-		std::string prevName(obs_source_get_name(source));
-		auto undo = [prevName](const std::string &data) {
-			OBSSourceAutoRelease source = obs_get_source_by_uuid(data.c_str());
-			obs_source_set_name(source, prevName.c_str());
-		};
-
-		std::string editedName = name;
-		auto redo = [editedName](const std::string &data) {
-			OBSSourceAutoRelease source = obs_get_source_by_uuid(data.c_str());
-			obs_source_set_name(source, editedName.c_str());
-		};
-
-		OBSBasic *main = OBSBasic::Get();
-		const char *uuid = obs_source_get_uuid(source);
-		main->undo_s.add_action(QTStr("Undo.Rename").arg(name.c_str()), undo, redo, uuid, uuid);
-
-		obs_source_set_name(source, name.c_str());
-		break;
-	}
+	});
 }
 
 void VolumeControl::changeVolume()


### PR DESCRIPTION
### Description
Defers opening the rename dialog in the audio mixer.

### Motivation and Context
On Ubuntu the opening of this dialog leads to a bizarre memory allocation issue with malloc which causes a crash. This seems to only affect the older version of Qt used for Ubuntu and stack trace hinted it had something to do with the QMenu.

I suspected this has something to do with `NameDialog::AskForName` calling exec which blocks the event loop while the menu is being closed. While we should generally remove all our usages of `exec`, this is a smaller fix for this particular crash.

### How Has This Been Tested?
@Penwy on Discord was able to reproduce the crash quite reliably (>90%) simply by opening the mixer rename dialog and closing it. With the change in this PR, they were no longer able to repro.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
