### PR TITLE
obs-nvenc: Fix resource destruction order

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -1029,16 +1029,19 @@ static void nvenc_destroy(void *data)
 	for (size_t i = 0; i < enc->bitstreams.num; i++) {
 		nv_bitstream_free(enc, &enc->bitstreams.array[i]);
 	}
-	if (enc->session)
-		nv.nvEncDestroyEncoder(enc->session);
-
 #ifdef _WIN32
 	d3d11_free_textures(enc);
-	d3d11_free(enc);
 #else
 	cuda_opengl_free(enc);
 #endif
 	cuda_free_surfaces(enc);
+
+	if (enc->session)
+		nv.nvEncDestroyEncoder(enc->session);
+
+#ifdef _WIN32
+	d3d11_free(enc);
+#endif
 	cuda_ctx_free(enc);
 
 	bfree(enc->header);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
The NVENC session was destroyed before its child resources (textures, surfaces) were cleaned up, causing resource cleanup calls to operate on an invalid session handle.

Reorder destruction to free all registered resources before destroying the encoder session.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fix use-after-free during encoder shutdown.

Fixes #12146 
Fixes #13446

### How Has This Been Tested?
Tested on Windows with NVENC recording.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
