### PR TITLE
frontend: Fix VolumeControl rendering

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -52,8 +52,6 @@ VolumeControl::VolumeControl(obs_source_t *source, QWidget *parent, bool vertica
 	  contextMenu(nullptr),
 	  QFrame(parent)
 {
-	setAttribute(Qt::WA_OpaquePaintEvent, true);
-
 	utils = std::make_unique<idian::Utils>(this);
 
 	uuid = obs_source_get_uuid(source);


### PR DESCRIPTION
### Description
Removes `WA_OpaquePaintEvent` attribute from VolumeControl.

### Motivation and Context
This attribute is meant for widgets that have a custom paintEvent and will ensure that they paint the entirety of their background. VolumeControl does not have a paintEvent so this attribute does not make sense and causes rendering issues on some systems.

### How Has This Been Tested?
Swapped to System theme as it does not define a background color for VolumeControl and observed that the widget renders correctly. This was also tested by @mihawk90 on Discord who reported the issue originally on Linux.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
