### PR TITLE
plugins, util: Prioritize stop events over processing

### DIFF
--- a/plugins/frontend-tools/captions-mssapi.cpp
+++ b/plugins/frontend-tools/captions-mssapi.cpp
@@ -126,13 +126,13 @@ try {
 		throw HRError("SetRecoState(SPRST_ACTIVE) failed", hr);
 	}
 
-	HANDLE events[] = {notify, stop};
+	HANDLE events[] = {stop, notify};
 
 	started = true;
 
 	for (;;) {
 		DWORD ret = WaitForMultipleObjects(2, events, false, INFINITE);
-		if (ret != WAIT_OBJECT_0) {
+		if (ret != WAIT_OBJECT_0 + 1) {
 			break;
 		}
 

--- a/plugins/obs-outputs/rtmp-windows.c
+++ b/plugins/obs-outputs/rtmp-windows.c
@@ -267,7 +267,7 @@ static inline void socket_thread_windows_internal(struct rtmp_stream *stream)
 		}
 
 		int status = WaitForMultipleObjects(3, objs, false, INFINITE);
-		if (status == WAIT_ABANDONED || status == WAIT_FAILED) {
+		if ((status >= WAIT_ABANDONED_0 && status < WAIT_ABANDONED_0 + 3) || status == WAIT_FAILED) {
 			blog(LOG_ERROR, "socket_thread_windows: Aborting due "
 					"to WaitForMultipleObjects failure");
 			fatal_sock_shutdown(stream);

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -579,13 +579,13 @@ static DWORD CALLBACK copy_thread(LPVOID unused)
 	HANDLE events[2] = {NULL, NULL};
 	int shmem_id = 0;
 
-	if (!duplicate_handle(&events[0], thread_data.copy_event)) {
-		hlog_hr("copy_thread: Failed to duplicate copy event: %d", GetLastError());
+	if (!duplicate_handle(&events[0], thread_data.stop_event)) {
+		hlog_hr("copy_thread: Failed to duplicate stop event: %d", GetLastError());
 		return 0;
 	}
 
-	if (!duplicate_handle(&events[1], thread_data.stop_event)) {
-		hlog_hr("copy_thread: Failed to duplicate stop event: %d", GetLastError());
+	if (!duplicate_handle(&events[1], thread_data.copy_event)) {
+		hlog_hr("copy_thread: Failed to duplicate copy event: %d", GetLastError());
 		goto finish;
 	}
 
@@ -594,7 +594,7 @@ static DWORD CALLBACK copy_thread(LPVOID unused)
 		void *cur_data;
 
 		DWORD ret = WaitForMultipleObjects(2, events, false, INFINITE);
-		if (ret != WAIT_OBJECT_0) {
+		if (ret != WAIT_OBJECT_0 + 1) {
 			break;
 		}
 

--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -160,9 +160,9 @@ inline uint64_t VCamFilter::GetTime()
 
 void VCamFilter::Thread()
 {
-	HANDLE h[2] = {thread_start, thread_stop};
+	HANDLE h[2] = {thread_stop, thread_start};
 	DWORD ret = WaitForMultipleObjects(2, h, false, INFINITE);
-	if (ret != WAIT_OBJECT_0) {
+	if (ret != WAIT_OBJECT_0 + 1) {
 		return;
 	}
 

--- a/shared/ipc-util/ipc-util/pipe-windows.h
+++ b/shared/ipc-util/ipc-util/pipe-windows.h
@@ -24,6 +24,7 @@ struct ipc_pipe_server {
 	HANDLE ready_event;
 	HANDLE stop_event;
 	HANDLE thread;
+	bool connected;
 
 	uint8_t *read_data;
 	size_t size;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

For `WaitForMultipleObjects()` the order of handles determines priority. This puts stop events as the first handle where appropriate to allow threads to exit when system is busy and multiple waited events are signaled at the same time.

A potential problem with the re-prioritizing is that it might leave queued data unprocessed, so I added some handling where it could matter, but ignored the parts where it shouldn't.

---

Some additional changes for Windows ipc pipe (game capture)
There is one actual bug fix, while the rest is supporting robustness / refactoring.

- Check for stop event at beginning of the server thread, in case the game capture never actually readies itself
- Change waited `ready_event` to be manual resetting as suggested for asynchronous [ConnectPipe](https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe) and [OVERLAPPED struct](https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped) in general
  - Manual seems correct, since `WaitFor*` is followed by `GetOverlappedResult` with wait `true`. (Earlier this worked with auto only because for stopping we also call `cancelIoEx` from outside the thread, which is not necessary anymore). The event is also reset by `ReadFile` and restarting pipe re-creates the events, which both support the manual resetting behavior.
- Move the mentioned `cancelIoEx` from `ipc_pipe_server_free` to thread and let `stop_event` handle stopping instead of racing the events for more deterministic path
- #### [The Bugfix] Instead of exiting right away when `stop_event` is signaled or `WaitForMultipleObjects` fails altogether, cancel current io and wait for completion in `GetOverlappedResults`, so we can avoid race conditions to `pipe->overlap` when pipe is restarted and asynchronous writes to to-be-freed `buf` once thread goes out of scope. 
  - This is also the reason why we can't just make `GetOverlappedResults` wait false after it has been waiting in `WaitForMultipleObjects`
- support client connections between pipe create and connect calls (not currently used though)

---

For _rtmp-windows.c_ I only added a robustness check for abandoned handles. It doesn't wait for its `stop_event` in `socket_thread_windows_internal()` at all, but it instead should work through `send_thread_signaled_exit` event regardless of `WaitForMultipleObjects()` handle order, so I left it as it was.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Noticed this being a potentially problematic pattern around the codebase when fixing a hang issue for captions. (#12729)

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested game capture (ipc pipe) that it works, closes itself and restarts properly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
