### PR TITLE
rtmp-services: Update SOOP ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 285,
+    "version": 286,
     "files": [
         {
             "name": "services.json",
-            "version": 285
+            "version": 286
         }
     ]
 }

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 286,
+    "version": 287,
     "files": [
         {
             "name": "services.json",
-            "version": 286
+            "version": 287
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -855,36 +855,18 @@
             ]
         },
         {
-            "name": "SOOP Korea",
+            "name": "SOOP",
             "alt_names": [
                 "AfreecaTV",
                 "아프리카TV",
-                "Afreeca.TV"
+                "Afreeca.TV",
+                "SOOP Korea",
+                "SOOP Global"
             ],
             "servers": [
                 {
-                    "name": "Asia : Korea",
-                    "url": "rtmp://stream.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "North America : US East",
-                    "url": "rtmp://rtmp-esu.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "North America : US West",
-                    "url": "rtmp://rtmp-wsu.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "South America : Brazil",
-                    "url": "rtmp://rtmp-brz.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "Europe : UK",
-                    "url": "rtmp://rtmp-uk.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "Asia : Singapore",
-                    "url": "rtmp://rtmp-sgp.sooplive.co.kr/app/"
+                    "name": "Default",
+                    "url": "rtmp://stream.soop.live/app/"
                 }
             ],
             "recommended": {
@@ -3487,81 +3469,6 @@
             "recommended": {
                 "keyint": 1,
                 "max video bitrate": 6000
-            }
-        },
-        {
-            "name": "SOOP Global",
-            "common": false,
-            "more_info_link": "https://sooplive.helpshift.com/hc/en/3-soop/faq/20",
-            "stream_key_link": "https://www.sooplive.com/dashboard",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://global-stream.sooplive.com/app"
-                }
-            ],
-            "protocol": "RTMP",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
-            "recommended": {
-                "keyint": 1,
-                "profile": "main",
-                "bframes": 0,
-                "supported resolutions": [
-                    "1920x1080",
-                    "1280x720",
-                    "960x540",
-                    "640x360"
-                ],
-                "bitrate matrix": [
-                    {
-                        "res": "640x360",
-                        "fps": 30,
-                        "max bitrate": 500
-                    },
-                    {
-                        "res": "640x360",
-                        "fps": 60,
-                        "max bitrate": 1000
-                    },
-                    {
-                        "res": "960x540",
-                        "fps": 30,
-                        "max bitrate": 2000
-                    },
-                    {
-                        "res": "960x540",
-                        "fps": 60,
-                        "max bitrate": 2000
-                    },
-                    {
-                        "res": "1280x720",
-                        "fps": 30,
-                        "max bitrate": 4000
-                    },
-                    {
-                        "res": "1280x720",
-                        "fps": 60,
-                        "max bitrate": 4000
-                    },
-                    {
-                        "res": "1920x1080",
-                        "fps": 30,
-                        "max bitrate": 8000
-                    },
-                    {
-                        "res": "1920x1080",
-                        "fps": 60,
-                        "max bitrate": 8000
-                    }
-                ],
-                "max fps": 60,
-                "max video bitrate": 8000,
-                "max audio bitrate": 192
             }
         },
         {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -855,36 +855,18 @@
             ]
         },
         {
-            "name": "SOOP Korea",
+            "name": "SOOP",
             "alt_names": [
                 "AfreecaTV",
                 "아프리카TV",
-                "Afreeca.TV"
+                "Afreeca.TV",
+                "SOOP Korea",
+                "SOOP Global"
             ],
             "servers": [
                 {
-                    "name": "Asia : Korea",
-                    "url": "rtmp://stream.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "North America : US East",
-                    "url": "rtmp://rtmp-esu.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "North America : US West",
-                    "url": "rtmp://rtmp-wsu.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "South America : Brazil",
-                    "url": "rtmp://rtmp-brz.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "Europe : UK",
-                    "url": "rtmp://rtmp-uk.sooplive.co.kr/app/"
-                },
-                {
-                    "name": "Asia : Singapore",
-                    "url": "rtmp://rtmp-sgp.sooplive.co.kr/app/"
+                    "name": "Default",
+                    "url": "rtmp://stream.soop.live/app/"
                 }
             ],
             "recommended": {
@@ -3499,81 +3481,6 @@
             "recommended": {
                 "keyint": 1,
                 "max video bitrate": 6000
-            }
-        },
-        {
-            "name": "SOOP Global",
-            "common": false,
-            "more_info_link": "https://sooplive.helpshift.com/hc/en/3-soop/faq/20",
-            "stream_key_link": "https://www.sooplive.com/dashboard",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://global-stream.sooplive.com/app"
-                }
-            ],
-            "protocol": "RTMP",
-            "supported video codecs": [
-                "h264"
-            ],
-            "supported audio codecs": [
-                "aac"
-            ],
-            "recommended": {
-                "keyint": 1,
-                "profile": "main",
-                "bframes": 0,
-                "supported resolutions": [
-                    "1920x1080",
-                    "1280x720",
-                    "960x540",
-                    "640x360"
-                ],
-                "bitrate matrix": [
-                    {
-                        "res": "640x360",
-                        "fps": 30,
-                        "max bitrate": 500
-                    },
-                    {
-                        "res": "640x360",
-                        "fps": 60,
-                        "max bitrate": 1000
-                    },
-                    {
-                        "res": "960x540",
-                        "fps": 30,
-                        "max bitrate": 2000
-                    },
-                    {
-                        "res": "960x540",
-                        "fps": 60,
-                        "max bitrate": 2000
-                    },
-                    {
-                        "res": "1280x720",
-                        "fps": 30,
-                        "max bitrate": 4000
-                    },
-                    {
-                        "res": "1280x720",
-                        "fps": 60,
-                        "max bitrate": 4000
-                    },
-                    {
-                        "res": "1920x1080",
-                        "fps": 30,
-                        "max bitrate": 8000
-                    },
-                    {
-                        "res": "1920x1080",
-                        "fps": 60,
-                        "max bitrate": 8000
-                    }
-                ],
-                "max fps": 60,
-                "max video bitrate": 8000,
-                "max audio bitrate": 192
             }
         },
         {


### PR DESCRIPTION
### Description
This change unifies the OBS RTMP service entries 'SOOP Global' and 'SOOP Korea'.
The SOOP Global entry is removed, and the existing SOOP Korea entry is renamed to 'SOOP'.
Legacy names ('SOOP Korea' and 'SOOP Global') are kept in 'alt_names' for compatibility.

### Motivation and Context
SOOP has unified into a single platform, so separate 'Global' and 'Korea' OBS entries are no longer needed.
This consolidates them into one 'SOOP' entry to reduce confusion.

SOOP officially announced this migration/unification in the following Help Center article:
(https://sooplive.helpshift.com/hc/en/3-soop/faq/112-how-to-migrate-to-brand-new-soop/)

### How Has This Been Tested?
Tested streaming in OBS after overwriting `services.json` at the following path with the updated file.
Path: `%APPDATA%\obs-studio\plugin_config\rtmp-services`

1. With the original `services.json`, select 'SOOP Korea' or SOOP Global' in OBS 
2. Replace with the updated `services.json` 
3. Confirm streaming works correctly via SOOP.

### Types of changes
Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
