### PR TITLE
libobs: Fix obs_canvas_reset_video when other canvas is active

### DIFF
--- a/docs/sphinx/reference-canvases.rst
+++ b/docs/sphinx/reference-canvases.rst
@@ -300,3 +300,9 @@ Canvas Video Functions
    Render the canvas's view. Must be called on the graphics thread.
 
 ---------------------
+
+.. function:: bool obs_canvas_video_active(obs_canvas_t *canvas)
+
+   Returns true if video of the canvas is active, false otherwise.
+
+---------------------

--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -403,7 +403,7 @@ void obs_canvas_rename_source(obs_source_t *source, const char *name)
 
 bool obs_canvas_reset_video(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
-	if (!ovi || canvas->flags & MAIN || obs_video_active())
+	if (canvas->flags & MAIN || obs_canvas_video_active(canvas))
 		return false;
 
 	return obs_canvas_reset_video_internal(canvas, ovi);
@@ -589,4 +589,28 @@ bool obs_canvas_has_video(obs_canvas_t *canvas)
 void obs_canvas_render(obs_canvas_t *canvas)
 {
 	obs_view_render(&canvas->view);
+}
+
+bool obs_canvas_video_active(obs_canvas_t *canvas)
+{
+	bool result = false;
+
+	if (!canvas || !canvas->mix)
+		return result;
+
+	pthread_mutex_lock(&obs->video.mixes_mutex);
+	for (size_t i = 0, num = obs->video.mixes.num; i < num; i++) {
+		struct obs_core_video_mix *video = obs->video.mixes.array[i];
+		if (video != canvas->mix)
+			continue;
+
+		if (os_atomic_load_long(&video->raw_active) > 0 ||
+		    os_atomic_load_long(&video->gpu_encoder_active) > 0) {
+			result = true;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&obs->video.mixes_mutex);
+
+	return result;
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2688,6 +2688,8 @@ EXPORT video_t *obs_canvas_get_video(const obs_canvas_t *canvas);
 EXPORT bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info *ovi);
 /** Renders the sources of this canvas's view context */
 EXPORT void obs_canvas_render(obs_canvas_t *canvas);
+/** Returns true if video of the canvas is active, false otherwise */
+EXPORT bool obs_canvas_video_active(obs_canvas_t *canvas);
 
 #ifdef __cplusplus
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -2692,6 +2692,8 @@ EXPORT video_t *obs_canvas_get_video(const obs_canvas_t *canvas);
 EXPORT bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info *ovi);
 /** Renders the sources of this canvas's view context */
 EXPORT void obs_canvas_render(obs_canvas_t *canvas);
+/** Returns true if video of the canvas is active, false otherwise */
+EXPORT bool obs_canvas_video_active(obs_canvas_t *canvas);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
Fix obs_canvas_reset_video when other canvas is active
`obs_video_active` call is replaced by the new `obs_canvas_video_active`

### Motivation and Context
Want to initialize extra canvas while the main canvas is active.

### How Has This Been Tested?
On windows 11 by starting output of main canvas before calling `obs_canvas_reset_video` on an extra canvas

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.