### PR TITLE
obs-nvenc: Add 8bpc GBR support

### DIFF
--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -108,6 +108,8 @@ static inline DXGI_FORMAT ConvertGSTextureFormatResource(gs_color_format format)
 		return DXGI_FORMAT_B8G8R8A8_UNORM;
 	case GS_RG16:
 		return DXGI_FORMAT_R16G16_UNORM;
+	case GS_AYUV:
+		return DXGI_FORMAT_AYUV;
 	}
 
 	return DXGI_FORMAT_UNKNOWN;
@@ -116,6 +118,8 @@ static inline DXGI_FORMAT ConvertGSTextureFormatResource(gs_color_format format)
 static inline DXGI_FORMAT ConvertGSTextureFormatView(gs_color_format format)
 {
 	switch (format) {
+	case GS_AYUV:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
 	case GS_RGBA:
 		return DXGI_FORMAT_R8G8B8A8_UNORM;
 	case GS_BGRX:
@@ -130,6 +134,8 @@ static inline DXGI_FORMAT ConvertGSTextureFormatView(gs_color_format format)
 static inline DXGI_FORMAT ConvertGSTextureFormatViewLinear(gs_color_format format)
 {
 	switch (format) {
+	case GS_AYUV:
+		return DXGI_FORMAT_R8G8B8A8_UNORM;
 	case GS_RGBA:
 		return DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
 	case GS_BGRX:

--- a/libobs/data/format_conversion.effect
+++ b/libobs/data/format_conversion.effect
@@ -1120,6 +1120,21 @@ float4 PSR10L_HLG_2020_709_Limited_Reverse(FragPos frag_in) : TARGET
 	return float4(rgb, 1.);
 }
 
+float4 PSFake_AYUV(FragPos frag_in) : TARGET
+{
+	float4 rgba = image.Load(int3(frag_in.pos.xy, 0));
+	return float4(rgba.r, rgba.b, rgba.g, rgba.a);
+}
+
+technique Fake_AYUV
+{
+	pass
+	{
+		vertex_shader = VSPos(id);
+		pixel_shader  = PSFake_AYUV(frag_in);
+	}
+}
+
 technique Planar_Y
 {
 	pass

--- a/libobs/graphics/graphics.h
+++ b/libobs/graphics/graphics.h
@@ -77,6 +77,7 @@ enum gs_color_format {
 	GS_BGRX_UNORM,
 	GS_BGRA_UNORM,
 	GS_RG16,
+	GS_AYUV,
 };
 
 enum gs_color_space {

--- a/libobs/obs-encoder.c
+++ b/libobs/obs-encoder.c
@@ -222,7 +222,7 @@ static inline bool gpu_encode_available(const struct obs_encoder *encoder)
 	if (!video)
 		return false;
 	return (encoder->info.caps & OBS_ENCODER_CAP_PASS_TEXTURE) != 0 &&
-	       (video->using_p010_tex || video->using_nv12_tex);
+	       (video->using_p010_tex || video->using_nv12_tex || video->using_ayuv_tex);
 }
 
 /**
@@ -2158,6 +2158,8 @@ bool obs_encoder_video_tex_active(const obs_encoder_t *encoder, enum video_forma
 		return mix->using_nv12_tex;
 	if (format == VIDEO_FORMAT_P010)
 		return mix->using_p010_tex;
+	if (format == VIDEO_FORMAT_BGRA)
+		return mix->using_ayuv_tex;
 
 	return false;
 }

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -347,6 +347,7 @@ struct obs_core_video_mix {
 	bool texture_converted;
 	bool using_nv12_tex;
 	bool using_p010_tex;
+	bool using_ayuv_tex;
 	struct deque vframe_info_buffer;
 	struct deque vframe_info_buffer_gpu;
 	gs_stagesurf_t *mapped_surfaces[NUM_CHANNELS];

--- a/libobs/obs-video-gpu-encode.c
+++ b/libobs/obs-video-gpu-encode.c
@@ -232,15 +232,18 @@ bool init_gpu_encoding(struct obs_core_video_mix *video)
 
 	deque_reserve(&video->gpu_encoder_avail_queue, NUM_ENCODE_TEXTURES);
 	for (size_t i = 0; i < NUM_ENCODE_TEXTURES; i++) {
-		gs_texture_t *tex;
+		gs_texture_t *tex = NULL;
 		gs_texture_t *tex_uv;
 
 		if (info->format == VIDEO_FORMAT_P010) {
 			gs_texture_create_p010(&tex, &tex_uv, info->width, info->height,
 					       GS_RENDER_TARGET | GS_SHARED_KM_TEX);
-		} else {
+		} else if (info->format == VIDEO_FORMAT_NV12) {
 			gs_texture_create_nv12(&tex, &tex_uv, info->width, info->height,
 					       GS_RENDER_TARGET | GS_SHARED_KM_TEX);
+		} else if (info->format == VIDEO_FORMAT_BGRA) {
+			tex = gs_texture_create(info->width, info->height, GS_AYUV, 1, NULL, GS_RENDER_TARGET | GS_SHARED_KM_TEX);
+			tex_uv = NULL;
 		}
 		if (!tex) {
 			return false;

--- a/plugins/obs-nvenc/nvenc-d3d11.c
+++ b/plugins/obs-nvenc/nvenc-d3d11.c
@@ -94,13 +94,14 @@ void d3d11_free(struct nvenc_data *enc)
 static bool d3d11_texture_init(struct nvenc_data *enc, struct nv_texture *nvtex)
 {
 	const bool p010 = obs_encoder_video_tex_active(enc->encoder, VIDEO_FORMAT_P010);
+	const bool fake_ayuv = obs_encoder_video_tex_active(enc->encoder, VIDEO_FORMAT_BGRA);
 
 	D3D11_TEXTURE2D_DESC desc = {0};
 	desc.Width = enc->cx;
 	desc.Height = enc->cy;
 	desc.MipLevels = 1;
 	desc.ArraySize = 1;
-	desc.Format = p010 ? DXGI_FORMAT_P010 : DXGI_FORMAT_NV12;
+	desc.Format = fake_ayuv ? DXGI_FORMAT_AYUV : (p010 ? DXGI_FORMAT_P010 : DXGI_FORMAT_NV12); // FIXME: ugly
 	desc.SampleDesc.Count = 1;
 	desc.BindFlags = D3D11_BIND_RENDER_TARGET;
 
@@ -119,7 +120,7 @@ static bool d3d11_texture_init(struct nvenc_data *enc, struct nv_texture *nvtex)
 	res.resourceToRegister = tex;
 	res.width = enc->cx;
 	res.height = enc->cy;
-	res.bufferFormat = p010 ? NV_ENC_BUFFER_FORMAT_YUV420_10BIT : NV_ENC_BUFFER_FORMAT_NV12;
+	res.bufferFormat = fake_ayuv ? NV_ENC_BUFFER_FORMAT_AYUV : (p010 ? NV_ENC_BUFFER_FORMAT_YUV420_10BIT : NV_ENC_BUFFER_FORMAT_NV12); // FIXME: ugly
 
 	if (NV_FAILED(nv.nvEncRegisterResource(enc->session, &res))) {
 		tex->lpVtbl->Release(tex);

--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -466,7 +466,7 @@ static bool init_encoder_h264(struct nvenc_data *enc, obs_data_t *settings)
 	case VIDEO_CS_SRGB:
 		vui_params->colourPrimaries = 1;
 		vui_params->transferCharacteristics = 13;
-		vui_params->colourMatrix = 1;
+		vui_params->colourMatrix = 0;
 		break;
 	default:
 		break;
@@ -570,7 +570,7 @@ static bool init_encoder_hevc(struct nvenc_data *enc, obs_data_t *settings)
 	case VIDEO_CS_SRGB:
 		vui_params->colourPrimaries = 1;
 		vui_params->transferCharacteristics = 13;
-		vui_params->colourMatrix = 1;
+		vui_params->colourMatrix = 0;
 		break;
 	case VIDEO_CS_2100_PQ:
 		vui_params->colourPrimaries = 9;
@@ -949,8 +949,9 @@ static void *nvenc_create_base(enum codec_type codec, obs_data_t *settings, obs_
 	}
 
 	if (texture && !obs_encoder_video_tex_active(encoder, VIDEO_FORMAT_NV12) &&
-	    !obs_encoder_video_tex_active(encoder, VIDEO_FORMAT_P010)) {
-		blog(LOG_INFO, "[obs-nvenc] nv12/p010 not active, falling back to "
+	    !obs_encoder_video_tex_active(encoder, VIDEO_FORMAT_P010) &&
+	    !obs_encoder_video_tex_active(encoder, VIDEO_FORMAT_BGRA)) {
+		blog(LOG_INFO, "[obs-nvenc] nv12/p010/ayuv not active, falling back to "
 			       "non-texture encoder");
 		goto reroute;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
**This is a preliminary patch and should not be merged for now, comments are welcome. If this feature is appropriate, I can continue to improve my patch. If not, I can abandon it at early stage.**

This patch adds RGB (more specifically GBR, according to Table E.5 of ITU-T H.265) support for obs-nvenc. This is implemented by passing textures on gpu directly (no data copy between cpu and gpu), so this patch enables very fast raw RGB gpu-encoding using NVENC H264 or NVENC HEVC encoder.

Implementation details: a GS_AYUV texture is created on GPU, `Fake_AYUV` pixel shader converts rendered RGB image to packed GBR and these GBR values are stored directly into that GS_AYUV texture, no color space conversion is occurred, then this texture is passed (copied) to NVENC for encoding.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
This patch can help users who want to do pixel-perfect lossless recording (especially for 4K resolution). Currently only YUV4:2:0 (i.e. NV12/P010) is supported by texture-mode gpu-encoding, and chroma subsampling is unavoidable in this case.

Although using ffmpeg custom output with `hevc_nvenc` encoder and `preset=lossless pixel_format=gbrp` encoding setting can achive same output, it is very slow even on modern CPUs because data is copied between cpu and gpu back and forth, and most importantly, pixel formats are converted by `sws_scale` which is single threaded (may be I can fix this later).

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Because this patch is a preliminary version, please use Windows (no other os support for now). To test, you need to set "Output" settings like this:
<img width="1476" height="1142" alt="1" src="https://github.com/user-attachments/assets/0c7f9992-24e1-4654-9739-d7cf0e131d7b" />
Set "Video" settings like this:
<img width="1476" height="1142" alt="2" src="https://github.com/user-attachments/assets/4779ebaf-c4d6-40a6-86b3-2cb4a7ed1407" />
Then you can start recording. To play the recorded video, please use a media player with `gbrp` support, e.g. [mpv](https://mpv.io/))
<img width="1091" height="865" alt="3" src="https://github.com/user-attachments/assets/1184ee86-f2ef-4f21-8abb-9eefda279d79" />
You can also verify the recorded video is pixel perfect, like this: (1) start recording, (2) take a screenshot of output, (3) stop recording, (4) use ffmpeg to hash frames
```
./ffmpeg.exe -i "2026-02-12 20-48-31.mkv" -pix_fmt rgb24 -an -f framehash video_hash.txt
./ffmpeg.exe -i "Screenshot 2026-02-12 20-48-34.png" -pix_fmt rgb24 -an -f framehash screenshot_hash.txt
```
(5) search the hash of screenshot in video frame hashes. If hash is matched, the capture is (likely) pixel perfect.
<img width="1419" height="659" alt="4" src="https://github.com/user-attachments/assets/a9a3b37d-e9ca-4b1f-8204-5677fc0a54c7" />

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
