### PR TITLE
frontend: Skip background paint for invalid sizes

### DIFF
--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -657,7 +657,7 @@ void VolumeMeter::paintVTicks(QPainter &painter, int x, int y, int height)
 
 void VolumeMeter::updateBackgroundCache(bool force)
 {
-	if (!force && !size().isValid()) {
+	if (!force && size().isEmpty()) {
 		return;
 	}
 


### PR DESCRIPTION
### Description
Skip updating the background cache when width or height are 0. This was intended before but the wrong check was used.

Fixes issue reported on Discord that would cause Qt to report these warnings when swapping mixer layout:

```
QPainter::begin: Paint device returned engine == 0, type: 2
QPainter::setFont: Painter not active
QPainter::setPen: Painter not active
QPainter::fillRect: Painter not active
QPainter::fillRect: Painter not active
QPainter::fillRect: Painter not active
QPainter::fillRect: Painter not active
QPainter::fillRect: Painter not active
QPainter::fillRect: Painter not active
```

### Motivation and Context
QSize `isValid` returns true when width and height are **>=** 0. `isEmpty` returns true when width or height are **<=** 0.

### How Has This Been Tested?
Toggled mixer layout, saw background cache update is skipped and observed log warnings are gone.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
