### PR TITLE
mac-capture: Don't capture cursor for macOS Audio Capture sources

### DIFF
--- a/plugins/mac-capture/mac-sck-audio-capture.m
+++ b/plugins/mac-capture/mac-sck-audio-capture.m
@@ -106,6 +106,7 @@ API_AVAILABLE(macos(13.0)) static bool init_audio_screen_stream(struct screen_ca
 
     [sc->stream_properties setCapturesAudio:TRUE];
     [sc->stream_properties setExcludesCurrentProcessAudio:TRUE];
+    [sc->stream_properties setShowsCursor:FALSE];
 
     struct obs_audio_info audio_info;
     BOOL did_get_audio_info = obs_get_audio_info(&audio_info);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Sets the stream object on a ScreenCaptureKit stream for macOS Audio Capture sources to not include the mouse cursor in the stream (conferring a performance benefit).

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
macOS Audio Capture is implemented as a ScreenCaptureKit stream that ignores video stream frames and only handles audio delivered by the SCK system. Despite the fact that OBS ignores video frames delivered to these sources, there is still performance overhead associated with the SCK system needing to deliver video frames on time to the application. Performance issues have manifested recently, particularly under the Metal graphics backend, with symptoms including the cursor framerate across the entire operating system dropping severely. The reasons for these performance issues in Metal (which manifest less so under OpenGL) are still being investigated. 

Removing the mouse cursor from the stream lessens the overhead associated with these sources and mitigates the performance issue.

> [!NOTE]
> While diagnosing the nature of this performance issue in Metal remains important, as it could indicate further underlying issues, this change is appropriate regardless, as audio capture sources simply have no reason to care about mouse update events.

### On macOS Audio Capture

Just some further notes about macOS Audio Capture for further context;

Looking to the future, it would be better to re-implement macOS Audio Capture as a [CATap](https://developer.apple.com/documentation/coreaudio/catapdescription?language=objc) to obviate the need to go through the ScreenCaptureKit API in any way. The source was only originally implemented as a ScreenCaptureKit source because, at the time of implementation, CATap was not exposed by Apple. A clean implementation of macOS Audio Capture would most likely perform better, while also avoiding the awkwardness of needing to subscribe to video events in order to receive audio.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Locally tested on Apple Silicon, macOS 15.7.4 to verify performance benefit; audio source still functions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
