### PR TITLE
frontend: Ignore sources with disabled audio in mixer

### DIFF
--- a/frontend/widgets/AudioMixer.hpp
+++ b/frontend/widgets/AudioMixer.hpp
@@ -129,8 +129,8 @@ private:
 	static void obsSceneItemVisibleChange(void *data, calldata_t *params);
 
 private slots:
-	void sourceCreated(QString uuid);
-	void sourceRemoved(QString uuid);
+	void addSource(QString uuid);
+	void removeSource(QString uuid);
 	void updatePreviewSources();
 	void updateGlobalSources();
 	void unhideAllAudioControls();


### PR DESCRIPTION
### Description
Updates the mixer to not display sources that support audio but do not have it active. This fixes a few source types from appearing in the mixer when they are not actually configured to have audio. Namely the Browser source, Game Capture and Window Capture.

### Motivation and Context
As the new mixer supports the ability to see inactive sources, it was showing sources that _could_ have audio, but currently do not. This is different from sources that have audio, but are not active and thus not outputting it.

### How Has This Been Tested?
Added a Browser Source and Game Capture with mixer set to show inactive sources. Tested enabling 'Control audio via OBS' for the browser source and 'Capture Audio' for Game Capture.

Observed that the sources properly appeared/disappeared from the mixer.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
