### PR TITLE
docs: Fix typo in obs_enum_canvases description

### DIFF
--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -332,7 +332,7 @@ Libobs Objects
    enumeration.
 
    Use :c:func:`obs_canvas_get_ref()` or
-   :c:func:`obs_canvas_get_weak_encoder()` if you want to retain a
+   :c:func:`obs_canvas_get_weak_canvas()` if you want to retain a
    reference after obs_enum_canvases finishes.
 
 ---------------------


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes documentation of `obs_enum_canvases` where in description instead of `obs_canvas_get_weak_canvas` to retain a weak reference it says `obs_canvas_get_weak_encoder`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
[https://docs.obsproject.com/reference-core#c.obs_enum_canvases](https://docs.obsproject.com/reference-core#c.obs_enum_canvases)

<img width="725" height="179" alt="image" src="https://github.com/user-attachments/assets/3b8ed518-9ee5-4629-937d-e98b7a27b052" />

### How Has This Been Tested?
checked the rendered output.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
