### PR TITLE
Deprecate hiding

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -976,6 +976,8 @@ General Source Functions
    Gets/sets the hidden property that determines whether it should be hidden from the user.
    Used when the source is still alive but should not be referenced.
 
+   .. deprecated:: 33.0
+
 ---------------------
 
 .. function:: uint32_t obs_source_get_output_flags(const obs_source_t *source)

--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -482,10 +482,6 @@ void OBSBasicSourceSelect::updateExistingSources(int limit)
 
 bool OBSBasicSourceSelect::enumSourcesCallback(void *data, obs_source_t *source)
 {
-	if (obs_source_is_hidden(source)) {
-		return true;
-	}
-
 	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
 
 	OBSWeakSourceAutoRelease weakSource = obs_source_get_weak_source(source);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1074,11 +1074,13 @@ EXPORT bool obs_source_removed(const obs_source_t *source);
 
 /** The 'hidden' flag is not the same as a sceneitem's visibility. It is a
   * property the determines if it can be found through searches. **/
+/** TODO: Remove both functions and temp_removed in 34.0 (https://github.com/obsproject/obs-studio/issues/13768) */
+
 /** Simply sets a 'hidden' flag when the source is still alive but shouldn't be found */
-EXPORT void obs_source_set_hidden(obs_source_t *source, bool hidden);
+OBS_DEPRECATED EXPORT void obs_source_set_hidden(obs_source_t *source, bool hidden);
 
 /** Returns the current 'hidden' state on the source */
-EXPORT bool obs_source_is_hidden(obs_source_t *source);
+OBS_DEPRECATED EXPORT bool obs_source_is_hidden(obs_source_t *source);
 
 /** Returns capability flags of a source */
 EXPORT uint32_t obs_source_get_output_flags(const obs_source_t *source);


### PR DESCRIPTION
### Description

The hiding feature was added in #3426 for undo/redo, but has since been superseeded with just saving/loading sources.

### Motivation and Context

This doesn't seem to be used anyhwere, whether OBS itself or plugins, so it should be safe to deprecate and remove soon.

### How Has This Been Tested?

OBS still builds and works.

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
