### PR TITLE
frontend: Fix crash on startup when using tbar apis in non-studio-mode

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -115,7 +115,7 @@ void OBSStudioAPI::obs_frontend_set_tbar_position(int position)
 
 int OBSStudioAPI::obs_frontend_get_tbar_position()
 {
-	return main->tBar->value();
+	return main->GetTbarPosition();
 }
 
 void OBSStudioAPI::obs_frontend_get_scene_collections(std::vector<std::string> &strings)

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -710,6 +710,9 @@ void OBSBasic::TransitionClicked()
 
 void OBSBasic::TBarReleased()
 {
+	if (!tBar || !previewProgramMode)
+		return;
+
 	int val = tBar->value();
 
 	OBSSourceAutoRelease transition = obs_get_output_source(0);
@@ -755,6 +758,9 @@ static bool ValidTBarTransition(OBSSource transition)
 
 void OBSBasic::TBarChanged(int value)
 {
+	if (!tBar || !previewProgramMode)
+		return;
+
 	OBSSourceAutoRelease transition = obs_get_output_source(0);
 
 	if (!tBarActive) {
@@ -786,6 +792,9 @@ void OBSBasic::TBarChanged(int value)
 
 int OBSBasic::GetTbarPosition()
 {
+	if (!tBar || !previewProgramMode)
+		return 0;
+
 	return tBar->value();
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes crash on accessing tbar apis such as `obs_frontend_get_tbar_position`, `obs_frontend_set_tbar_position` and `obs_frontend_release_tbar` when not in studio-mode on obs startup.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
TBar apis should be a noop if studio-mode is active.
Instead it crashes obs if accessed in non-studio mode.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built OBS with this pr and accessed the tbar apis in non-studio mode from a plugin.
Everything working fine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
