### PR TITLE
linux-pipewire: Fix uninitialized camera resolution access

### DIFF
--- a/plugins/linux-pipewire/camera-portal.c
+++ b/plugins/linux-pipewire/camera-portal.c
@@ -366,7 +366,7 @@ static void camera_format_list(struct camera_device *dev, obs_property_t *prop)
 		}
 
 		if (spa_pod_parse_object(p->param, SPA_TYPE_OBJECT_Format, format ? &format : NULL,
-					 SPA_FORMAT_VIDEO_size, SPA_POD_OPT_Rectangle(&resolution)) < 0)
+					 SPA_FORMAT_VIDEO_size, SPA_POD_Rectangle(&resolution)) < 0)
 			continue;
 
 		obs_data_set_int(data, "width", resolution.width);
@@ -677,7 +677,7 @@ static bool framerate_list(struct camera_device *dev, uint32_t pixelformat, cons
 			continue;
 
 		if (spa_pod_parse_object(p->param, SPA_TYPE_OBJECT_Format, NULL, SPA_FORMAT_VIDEO_size,
-					 SPA_POD_OPT_Rectangle(&this_resolution)) < 0)
+					 SPA_POD_Rectangle(&this_resolution)) < 0)
 			continue;
 
 		if (this_resolution.width != resolution->width || this_resolution.height != resolution->height)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description + Motvation and Context
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The use of `SPA_POD_OPT_Rectangle()` means that if the rectangle cannot be parsed, then no error will be returned. In that case uninitialized variables will be used. This can happen if the pod object contains e.g. a list of resolutions (`SPA_CHOICE_Enum`).

Fix that by using `SPA_POD_Rectangle()`, which enforces successful parsing.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

With the current pipewire master branch, with a video node that uses enumerated choice for size, as well as nodes that don't use enumerated choices.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
