### PR TITLE
frontend: Fix unclean shutdown on Windows

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1407,8 +1407,6 @@ void OBSBasic::applicationShutdown() noexcept
 		patronJsonThread->wait();
 
 	delete screenshotData;
-	delete previewProjector;
-	delete studioProgramProjector;
 	delete previewProjectorSource;
 	delete previewProjectorMain;
 	delete sourceProjector;

--- a/frontend/widgets/OBSBasic_SysTray.cpp
+++ b/frontend/widgets/OBSBasic_SysTray.cpp
@@ -47,8 +47,8 @@ void OBSBasic::SystemTrayInit()
 					trayMenu);
 	exit = new QAction(QTStr("Exit"), trayMenu);
 
-	previewProjector = new QMenu(QTStr("Projector.Open.Preview"));
-	studioProgramProjector = new QMenu(QTStr("Projector.Open.Program"));
+	previewProjector = new QMenu(QTStr("Projector.Open.Preview"), trayMenu);
+	studioProgramProjector = new QMenu(QTStr("Projector.Open.Program"), trayMenu);
 	OBSBasic::updateSysTrayProjectorMenu();
 
 	trayMenu->addAction(showHide);


### PR DESCRIPTION
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This issue was brought back by a somewhat recent change ( https://github.com/obsproject/obs-studio/pull/12951 ) to fix slow shutdown times on Linux.

To paraphrase @xtfo from the OBS Discord ([Message](https://discord.com/channels/348973006581923840/1461086655292112937/1473394279551602798)):
> I think the issue is that all the tray actions are parented to trayIcon, so when it's deleted, Qt auto deletes them as children, then `delete trayMenu;` on the next line accesses those dead actions.

We now create the tray menu first, then setting the parent of the actions (Show / Hide, Stop / Start Streaming, etc.) to the tray menu.

### Motivation and Context
Ever since 32.1 Beta 1 my OBS background instance that I use on my 2 PC setup (to send my microphone over to the 2nd PC) has been coming up with the unclean shutdown prompt on every single boot.

### How Has This Been Tested?
Several reboots and logging out and back in.

Also, in case anyone wants to try to reproduce it on a previous version:
- Enable the settings `System Tray -> Minimise to system tray when started` and `System Tray -> Always minimize to system tray instead of task bar`
- Have OBS autostart (either through the Task Scheduler, or a shortcut in `shell:startup`)
- Log out (or shut off your computer)
- Log in
- OBS should autostart but bring up the unclean shutdown / safe mode prompt

The optimal way I found to test it was to logout, login, OBS autostarts here, then log out *again*, and log in again.
On this 2nd autostart it should bring up the prompt.
(I've had this for the past few weeks on every single PC boot ever since 32.1 Beta 1)

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
