### PR TITLE
updater: Check return values in ClearShaderCache

### DIFF
--- a/frontend/updater/updater.cpp
+++ b/frontend/updater/updater.cpp
@@ -1235,9 +1235,11 @@ static void UpdateRegistryVersion(const Manifest &manifest)
 static void ClearShaderCache()
 {
 	wchar_t shader_path[MAX_PATH];
-	SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, SHGFP_TYPE_CURRENT, shader_path);
-	StringCbCatW(shader_path, sizeof(shader_path), L"\\obs-studio\\shader-cache");
-	filesystem::remove_all(shader_path);
+	if (SHGetFolderPathW(NULL, CSIDL_COMMON_APPDATA, NULL, SHGFP_TYPE_CURRENT, shader_path) == S_OK) {
+		if (SUCCEEDED(StringCbCatW(shader_path, sizeof(shader_path), L"\\obs-studio\\shader-cache"))) {
+			filesystem::remove_all(shader_path);
+		}
+	}
 }
 
 extern "C" void UpdateHookFiles(void);


### PR DESCRIPTION
### Description
Invoking `filesystem::remove_all` on potentially truncated paths seems like a bad idea.

### Motivation and Context
Saw potentially dangerous code and wanted to fix it.

### How Has This Been Tested?
Compiled.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
