### PR TITLE
frontend: Fix setting the T-bar position through the API

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -110,7 +110,7 @@ void OBSStudioAPI::obs_frontend_release_tbar()
 
 void OBSStudioAPI::obs_frontend_set_tbar_position(int position)
 {
-	QMetaObject::invokeMethod(main, "TBarChanged", Q_ARG(int, position));
+	main->SetTbarPosition(position);
 }
 
 int OBSStudioAPI::obs_frontend_get_tbar_position()

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1589,6 +1589,7 @@ signals:
 public:
 	int GetTransitionDuration();
 	int GetTbarPosition();
+	void SetTbarPosition(int position);
 
 	/* -------------------------------------
 	 * MARK: - OBSBasic_Updater

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -789,6 +789,11 @@ int OBSBasic::GetTbarPosition()
 	return tBar->value();
 }
 
+void OBSBasic::SetTbarPosition(int position)
+{
+	tBar->setValue(position);
+}
+
 static inline void ResetQuickTransitionText(QuickTransition *qt)
 {
 	qt->button->setText(MakeQuickTransitionText(qt));


### PR DESCRIPTION
### Description
Fixes the ``obs_frontend_set_tbar_position`` function and makes it actually set the position (value) of the T-bar slider instead of invoking the ``TBarChanged`` method directly.

### Motivation and Context
This fix is required as, without it, it is impossible to perform T-bar transitions through the API.

This is because the ``TBarReleased`` method, which is responsible for finishing the transition from one scene to another, checks the T-bar position, which never gets set by this function.

Fixing this function would make it possible to implement support for physical T-bars on video switcher boards through plugins.

Resolves [issue 11372](https://github.com/obsproject/obs-studio/issues/11372).

### How Has This Been Tested?
I've tested this fix with a plugin that lets me control the T-bar position by moving a physical T-bar.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
