### PR TITLE
frontend: Enforce minimum size for mixer toolbar

### DIFF
--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -139,6 +139,7 @@ AudioMixer::AudioMixer(QWidget *parent) : QFrame(parent)
 	stackedMixerArea->addWidget(vMixerScrollArea);
 
 	mixerToolbar = new QToolBar(this);
+	mixerToolbar->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Preferred);
 	mixerToolbar->setIconSize(QSize(16, 16));
 	mixerToolbar->setFloatable(false);
 


### PR DESCRIPTION
### Description
Adds a sizePolicy to the audio mixer toolbar.

### Motivation and Context
Prevents resizing the mixer too small for the buttons.

### How Has This Been Tested?
Resized the audio mixer.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
