### PR TITLE
linux-pipewire: Defer screencast portal init until source is shown

### DIFF
--- a/plugins/linux-pipewire/screencast-portal.c
+++ b/plugins/linux-pipewire/screencast-portal.c
@@ -519,8 +519,6 @@ static void *screencast_portal_desktop_capture_create(obs_data_t *settings, obs_
 	capture->restore_token = bstrdup(obs_data_get_string(settings, "RestoreToken"));
 	capture->source = source;
 
-	init_screencast_capture(capture);
-
 	return capture;
 }
 static void *screencast_portal_window_capture_create(obs_data_t *settings, obs_source_t *source)
@@ -532,8 +530,6 @@ static void *screencast_portal_window_capture_create(obs_data_t *settings, obs_s
 	capture->cursor_visible = obs_data_get_bool(settings, "ShowCursor");
 	capture->restore_token = bstrdup(obs_data_get_string(settings, "RestoreToken"));
 	capture->source = source;
-
-	init_screencast_capture(capture);
 
 	return capture;
 }
@@ -547,8 +543,6 @@ static void *screencast_portal_capture_create(obs_data_t *settings, obs_source_t
 	capture->cursor_visible = obs_data_get_bool(settings, "ShowCursor");
 	capture->restore_token = bstrdup(obs_data_get_string(settings, "RestoreToken"));
 	capture->source = source;
-
-	init_screencast_capture(capture);
 
 	return capture;
 }
@@ -630,6 +624,9 @@ static void screencast_portal_capture_update(void *data, obs_data_t *settings)
 static void screencast_portal_capture_show(void *data)
 {
 	struct screencast_portal_capture *capture = data;
+
+	if (!capture->obs_pw_stream && !capture->session_handle && !capture->cancellable)
+		init_screencast_capture(capture);
 
 	if (capture->obs_pw_stream)
 		obs_pipewire_stream_show(capture->obs_pw_stream);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
The previous behaviour would attempt screencast portal initialization even when the source is not shown, which can cause a flood of pop-ups, each indistinguishable from each other, on startup.

This commit defers portal init until the first time the source is shown, so the user isn't flooded with pop-ups when starting OBS.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
This change addresses the ideas.obsproject.com post found here: https://ideas.obsproject.com/posts/2318/do-not-open-screen-sharing-portals-on-startup

On KDE Wayland, all screencast portal requests open as a separate window, with no further information on which source the request belongs to. In setups with many capture sources across multiple scenes, this can easily result in 10-20+ picker windows all opening at startup, with no way to differentiate them.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
I built the OBS Flatpak with my code changes and tested it.
The screencast portal opens correctly when sources are shown, and the source shows correctly once a window is confirmed via the portal.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [X] My code is not on the master branch.
- [X] The code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
