### PR TITLE
frontend: Fix the UI color for estimated memory values

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -41,6 +41,8 @@
 #include <properties-view.hpp>
 #include <qt-wrappers.hpp>
 
+#include <Idian/Utils.hpp>
+
 #include <QCompleter>
 #include <QStandardItemModel>
 
@@ -4984,18 +4986,18 @@ void OBSBasicSettings::SimpleReplayBufferChanged()
 	if (streamQuality) {
 		if (memMB <= memMaxMB) {
 			ui->simpleRBEstimate->setText(QTStr(ESTIMATE_STR).arg(QString::number(int(memMB))));
+			idian::Utils::removeClass(ui->advRBEstimate, "text-warning");
 		} else {
 			ui->simpleRBEstimate->setText(
 				QTStr(ESTIMATE_TOO_LARGE_STR)
 					.arg(QString::number(int(memMB)), QString::number(int(memMaxMB))));
-			ui->simpleRBEstimate->setProperty("class", "text-warning");
+			idian::Utils::addClass(ui->advRBEstimate, "text-warning");
 		}
 	} else {
 		ui->simpleRBEstimate->setText(QTStr(ESTIMATE_UNKNOWN_STR));
 		ui->simpleRBMegsMax->setMaximum(memMaxMB);
+		ui->simpleRBEstimate->style()->polish(ui->simpleRBEstimate);
 	}
-
-	ui->simpleRBEstimate->style()->polish(ui->simpleRBEstimate);
 
 	UpdateAutomaticReplayBufferCheckboxes();
 }
@@ -5077,21 +5079,22 @@ void OBSBasicSettings::AdvReplayBufferChanged()
 
 		if (memMB <= memMaxMB) {
 			ui->advRBEstimate->setText(QTStr(ESTIMATE_STR).arg(QString::number(int(memMB))));
+			idian::Utils::removeClass(ui->advRBEstimate, "text-warning");
 		} else {
 			ui->advRBEstimate->setText(
 				QTStr(ESTIMATE_TOO_LARGE_STR)
 					.arg(QString::number(int(memMB)), QString::number(int(memMaxMB))));
-			ui->advRBEstimate->setProperty("class", "text-warning");
+			idian::Utils::addClass(ui->advRBEstimate, "text-warning");
 		}
 	} else {
 		ui->advRBMegsMax->setVisible(true);
 		ui->advRBMegsMaxLabel->setVisible(true);
 		ui->advRBMegsMax->setMaximum(memMaxMB);
 		ui->advRBEstimate->setText(QTStr(ESTIMATE_UNKNOWN_STR));
+		ui->advRBEstimate->style()->polish(ui->advRBEstimate);
 	}
 
 	ui->advReplayBufferFrame->setEnabled(!lossless && replayBufferEnabled);
-	ui->advRBEstimate->style()->polish(ui->advRBEstimate);
 	ui->advReplayBuf->setEnabled(!lossless);
 
 	UpdateAutomaticReplayBufferCheckboxes();


### PR DESCRIPTION
# Description
Added styling change to show white coloring for values under `memMaxMB` for the slots `AdvReplayBufferChanged()` and `SimpleReplayBufferChanged()` in `OBSBasicSettings.cpp`.

After:

<img width="785" height="94" alt="correct" src="https://github.com/user-attachments/assets/4033c5aa-e759-4ec7-afc8-00cc3aa5601e" />

<img width="784" height="97" alt="incorrect" src="https://github.com/user-attachments/assets/d9eb683e-bad3-452a-91fe-bd3535320184" />

Before:

<img width="781" height="91" alt="image" src="https://github.com/user-attachments/assets/d4832860-4beb-46f4-b9ad-250a1c80c7a5" />
 

# Motivation and Context

This fixes the coloring of the text, which retains the previous coloring from an estimated memory value that exceeds the recommended maximum for replay time of the replay buffer (`memMB <= memMaxMB.`).

Although the text displays a warning message when the estimation exceeds the max, returning the text coloring to white for estimations under the max will eliminate possible confusion, with incorrect coloring being associated with acceptable estimations. 



Resolves [issue #13171](https://github.com/obsproject/obs-studio/issues/13171)
# How Has This Been Tested?
Testing the changes locally on Windows 11. 

# Types of changes
- Tweak (non-breaking change to improve existing functionality).
# Checklist:
- [x] My code has been run through clang-format.
- [x] I have read the contributing document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.