### PR TITLE
frontend: Ensure pending profile changes are saved

### DIFF
--- a/frontend/widgets/OBSBasic_Profiles.cpp
+++ b/frontend/widgets/OBSBasic_Profiles.cpp
@@ -704,6 +704,9 @@ void OBSBasic::ActivateProfile(const OBSProfile &profile, bool reset)
 		ResetProfileData();
 	}
 
+	// Ensure defaults and updates are saved to disk
+	activeConfiguration.SaveSafe("tmp");
+
 	RefreshProfiles();
 
 	UpdateTitleBar();


### PR DESCRIPTION
### Description
Saves the current active profile config data to disk when:
- Activating a profile

### Motivation and Context
#11465 fixed an issue where profiles were loaded before all modules were ready, which would cause settings to 'reset' due to the encoders being missing.

However this seems to have caused the side effect noted in #12458 where renaming/duplicating a fresh profile would crash upon opening settings. This is due to null values for `AdvOut` -> `AudioEncoder` / `RecAudioEncoder`.

The defaults for those values come from `InitBasicConfigDefaults2` and never get persisted to disk prior to the Rename/Duplicate. The Rename/Duplicate functions create a new profile file and then copy the current profile over it. This means any unsaved profile data which is not saved to disk yet (In the example scenario, pretty much all of them) is lost. We re-initialize defaults in `ActivateProfile` which means most of those values are transparently set up again but we do not call `InitBasicConfigDefaults2`. Thus anything set up there is not initialized in the copied profile.

The fix in this PR addresses the problem above and also solves a theoretical scenario where unsaved profile data is currently lost when doing Rename/Duplicate. I'm not actually sure if there's anywhere we are guilty of this, but it is solved all the same.

### How Has This Been Tested?
Launched OBS in Portable mode. With the freshly created Untitled profile, I can open Settings. If I Rename or Duplicate the profile and then open Settings, OBS will crash. With this fix it no longer crashes.

This crash can also be triggered by creating a brand new profile and then Renaming or Duplicating that new profile.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
