### PR TITLE
libobs-d3d11: Guard CreateTexture2D against SEH faults

### DIFF
--- a/libobs-d3d11/d3d11-texture2d.cpp
+++ b/libobs-d3d11/d3d11-texture2d.cpp
@@ -94,6 +94,18 @@ void gs_texture_2d::GetSharedHandle(IDXGIResource *dxgi_res)
 	}
 }
 
+static HRESULT create_texture2d_seh_guarded(ID3D11Device *device, const D3D11_TEXTURE2D_DESC *desc,
+					    const D3D11_SUBRESOURCE_DATA *init_data, ID3D11Texture2D **texture)
+{
+	__try {
+		return device->CreateTexture2D(desc, init_data, texture);
+	} __except (EXCEPTION_EXECUTE_HANDLER) {
+		blog(LOG_ERROR, "CreateTexture2D raised structured exception 0x%08lX (width=%u height=%u format=%u)",
+		     (unsigned long)GetExceptionCode(), desc->Width, desc->Height, (unsigned int)desc->Format);
+		return E_FAIL;
+	}
+}
+
 void gs_texture_2d::InitTexture(const uint8_t *const *data)
 {
 	HRESULT hr;
@@ -128,7 +140,8 @@ void gs_texture_2d::InitTexture(const uint8_t *const *data)
 		InitSRD(srd);
 	}
 
-	hr = device->device->CreateTexture2D(&td, data ? srd.data() : NULL, texture.Assign());
+	hr = create_texture2d_seh_guarded(device->device, &td, data ? srd.data() : NULL, texture.Assign());
+
 	if (FAILED(hr))
 		throw HRError("Failed to create 2D texture", hr);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Catch structured exceptions around CreateTexture2D, return E_FAIL so this is handled gracefully instead of crashing OBS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I saw reports of a crash when adding an image using an image source that is 16000x9000px. Although the Microsoft documentation states that the D3D size limit per side is 16384 for a 2D texture, large images like the one attached below cause an exception to be thrown in the driver call path for both AMD and NVIDIA drivers when testing. 

<img width="16000" height="9000" alt="TestImage" src="https://github.com/user-attachments/assets/8045f09d-723f-45c4-9539-6a7a09e9fcc9" />

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Fixes the crash with the above image and logs the error as expected

`19:10:35.641: CreateTexture2D raised structured exception 0xC0000005 (width=16000 height=9000 format=27)
19:10:35.642: device_texture_create (D3D11): Failed to create 2D texture (80004005)`

This is an area of OBS I am not very familiar with but wanted to PR since I took the time to research and work on a fix, open to feedback of whether or not this approach is the correct way to fix this or if there are further implications to this change that I do not understand.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
