### PR TITLE
frontend: Fix user config subfolder creation

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -591,13 +591,38 @@ bool OBSApp::InitGlobalConfig()
 							    : std::move(defaultPluginManagerLocation);
 	}
 
-	bool userConfigResult = InitUserConfig(userConfigLocation, lastVersion);
-
-	return userConfigResult;
+	return true;
 }
 
-bool OBSApp::InitUserConfig(std::filesystem::path &userConfigLocation, uint32_t lastVersion)
+constexpr std::string_view OBSUserConfigSubDirectory = "obs-studio";
+
+static bool MakeUserConfigDir()
 {
+	const std::filesystem::path userConfigPath =
+		App()->userConfigLocation / std::filesystem::u8path(OBSUserConfigSubDirectory);
+
+	try {
+		if (!std::filesystem::exists(userConfigPath)) {
+			std::filesystem::create_directories(userConfigPath);
+		}
+
+	} catch (const std::filesystem::filesystem_error &error) {
+		blog(LOG_ERROR, "Failed to create user config directory '%s'\n%s", userConfigPath.u8string().c_str(),
+		     error.what());
+		return false;
+	}
+
+	return true;
+}
+
+bool OBSApp::InitUserConfig()
+{
+	if (!MakeUserConfigDir()) {
+		return false;
+	}
+
+	uint32_t lastVersion = config_get_int(appConfig, "General", "LastVersion");
+
 	const std::string userConfigFile = userConfigLocation.u8string() + "/obs-studio/user.ini";
 
 	int errorCode = userConfig.Open(userConfigFile.c_str(), CONFIG_OPEN_ALWAYS);
@@ -1055,6 +1080,8 @@ void OBSApp::AppInit()
 		throw "Failed to create required user directories";
 	if (!InitGlobalConfig())
 		throw "Failed to initialize global config";
+	if (!InitUserConfig())
+		throw "Failed to initialize user config";
 	if (!InitLocale())
 		throw "Failed to load locale";
 	if (!InitTheme())

--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -101,7 +101,7 @@ private:
 	bool MigrateGlobalSettings();
 	void MigrateLegacySettings(uint32_t lastVersion);
 
-	bool InitUserConfig(std::filesystem::path &userConfigLocation, uint32_t lastVersion);
+	bool InitUserConfig();
 	void InitUserConfigDefaults();
 
 	bool InitLocale();


### PR DESCRIPTION
### Description
Fixes OBS failing to launch when `Configuration` in global.ini is set to a folder that exists but does not have an obs-studio subfolder inside it.

### Motivation and Context
global.ini allows the configuration of four different paths:
```ini
[Locations]
Configuration=
SceneCollections=
Profiles=
PluginManagerSettings=
```

All of these locations are used as a base path and anything using them places files into `<base>/obs-studio/`

`SceneCollections`, `Profiles`, and `PluginManagerSettings` all ensure that the `obs-studio` subfolder exists.
`Configuration` does not.

As a result OBS will fail to create it's `user.ini` file during startup and immediately close.

### How Has This Been Tested?
- Set paths of all Locations to a folder that **does not** exist
  - OBS falls back to the default locations and launches with my normal settings, stored in appdata
  
- Set paths of all Locations to a folder that **does** exist but with no obs-studio subfolder
  - OBS cannot create user.ini and fails during startup
  
- Created obs-studio folder manually in the specified location
  - OBS launches successfully and creates all data in the specified location 
  
- Set `Configuration` to it's default AppData location but changed the others to a custom folder
  - OBS launches using normal user.ini, all other locations correctly set up obs-studio subfolders

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
