### PR TITLE
libobs: Add module version number to Windows crash handler

### DIFF
--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -221,14 +221,24 @@ static BOOL CALLBACK enum_all_modules(PCTSTR module_name, DWORD64 module_base, U
 		dstr_copy(&data->module_name, name_utf8);
 		strlwr(data->module_name.array);
 	}
-
+	struct win_version_info ver = {0};
+	if (get_dll_ver(module_name, &ver)) {
 #ifdef _WIN64
-	dstr_catf(&data->module_list, "%016" PRIX64 "-%016" PRIX64 " %s\r\n", module_base, module_base + module_size,
-		  name_utf8);
+		dstr_catf(&data->module_list, "%016" PRIX64 "-%016" PRIX64 " %s (%d.%d.%d.%d)\r\n", module_base,
+			  module_base + module_size, name_utf8, ver.major, ver.minor, ver.build, ver.revis);
 #else
-	dstr_catf(&data->module_list, "%08" PRIX64 "-%08" PRIX64 " %s\r\n", module_base, module_base + module_size,
-		  name_utf8);
+		dstr_catf(&data->module_list, "%08" PRIX64 "-%08" PRIX64 " %s (%d.%d.%d.%d)\r\n", module_base,
+			  module_base + module_size, name_utf8, ver.major, ver.minor, ver.build, ver.revis);
 #endif
+	} else {
+#ifdef _WIN64
+		dstr_catf(&data->module_list, "%016" PRIX64 "-%016" PRIX64 " %s\r\n", module_base,
+			  module_base + module_size, name_utf8);
+#else
+		dstr_catf(&data->module_list, "%08" PRIX64 "-%08" PRIX64 " %s\r\n", module_base,
+			  module_base + module_size, name_utf8);
+#endif
+	}
 	return true;
 }
 


### PR DESCRIPTION
### Description
Add module version number to Windows crash handler

### Motivation and Context
Want to know if the users used the latest version to get the crash
example:
`00007FFFB8D30000-00007FFFB8D42000 C:\git\obs-studio\build_x64\rundir\RelWithDebInfo\obs-plugins\64bit\3d-effect.dll (0.1.4.0)`


### How Has This Been Tested?
On Windows 11 by crash

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
