### PR TITLE
frontend: Only send event when scene list changed

### DIFF
--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -168,6 +168,7 @@ void OBSBasic::RemoveScene(OBSSource source)
 {
 	obs_scene_t *scene = obs_scene_from_source(source);
 
+	bool foundItem = false;
 	QListWidgetItem *sel = nullptr;
 	int count = ui->scenes->count();
 
@@ -177,6 +178,7 @@ void OBSBasic::RemoveScene(OBSSource source)
 		if (cur_scene != scene)
 			continue;
 
+		foundItem = true;
 		sel = item;
 		break;
 	}
@@ -195,7 +197,9 @@ void OBSBasic::RemoveScene(OBSSource source)
 		OBSProjector::UpdateMultiviewProjectors();
 	}
 
-	OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	if (foundItem) {
+		OnEvent(OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED);
+	}
 }
 
 static bool select_one(obs_scene_t * /* scene */, obs_sceneitem_t *item, void *param)


### PR DESCRIPTION
### Description
Only send `OBS_FRONTEND_EVENT_SCENE_LIST_CHANGED` when an item is actually removed from the frontend scene list.

### Motivation and Context
Simpler bandaid fix alternative to #13150. 

Fixing this properly means connecting the scenes dock to canvas signals which is a larger scope. Unfortunately the scenes QList widget itself is load bearing for a number of things it should not be.

### How Has This Been Tested?
Barely

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
