### PR TITLE
shared/bpm: Replace `sprintf` usage

### DIFF
--- a/shared/bpm/bpm.c
+++ b/shared/bpm/bpm.c
@@ -8,8 +8,11 @@ static void render_metrics_time(struct metrics_time *m_time)
 	 *   "2024-05-31T12:26:03.591Z"
 	 */
 	memset(&m_time->rfc3339_str, 0, sizeof(m_time->rfc3339_str));
-	strftime(m_time->rfc3339_str, sizeof(m_time->rfc3339_str), "%Y-%m-%dT%T", gmtime(&m_time->tspec.tv_sec));
-	sprintf(m_time->rfc3339_str + strlen(m_time->rfc3339_str), ".%03ldZ", m_time->tspec.tv_nsec / 1000000);
+	size_t current_length = strftime(m_time->rfc3339_str, sizeof(m_time->rfc3339_str), "%Y-%m-%dT%T",
+					 gmtime(&m_time->tspec.tv_sec));
+	size_t remaining_buffer_size = sizeof(m_time->rfc3339_str) - current_length;
+	snprintf(m_time->rfc3339_str + current_length, remaining_buffer_size, ".%03ldZ",
+		 m_time->tspec.tv_nsec / 1000000);
 	m_time->valid = true;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Replace `sprintf` use in `bpm` with safer `snprintf`, providing the length of the remaining buffer space in the string as the size parameter to `snprintf`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`sprintf` use can fire `-Wdeprecated` in AppleClang, causing build failures under typical `-Werror` OBS compilation settings.

For some reason, locally, this use of `sprintf` only seems to fire `-Wdeprecated` when the address sanitizer is on, even though it seems like we ought to be hitting it in all circumstances. Regardless, we want to be able to compile with ASAN, and `sprintf` use is typically unsafe, so replace with a safer alternative.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Enabled BPM, made sure it is still writing correct timestamps.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
