### PR TITLE
obs-outputs: Fix path normalization logic

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -582,10 +582,10 @@ static void generate_filename(struct ffmpeg_muxer *stream, struct dstr *dst, boo
 	char *filename = os_generate_formatted_filename(ext, space, fmt);
 
 	dstr_copy(dst, dir);
-	dstr_replace(dst, "\\", "/");
-	if (dstr_end(dst) != '/')
+	if (dstr_end(dst) != '/' && dstr_end(dst) != '\\')
 		dstr_cat_ch(dst, '/');
 	dstr_cat(dst, filename);
+	dstr_replace(dst, "\\", "/");
 
 	char *slash = strrchr(dst->array, '/');
 	if (slash) {

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -582,10 +582,17 @@ static void generate_filename(struct ffmpeg_muxer *stream, struct dstr *dst, boo
 	char *filename = os_generate_formatted_filename(ext, space, fmt);
 
 	dstr_copy(dst, dir);
+#ifdef _WIN32
 	if (dstr_end(dst) != '/' && dstr_end(dst) != '\\')
 		dstr_cat_ch(dst, '/');
 	dstr_cat(dst, filename);
 	dstr_replace(dst, "\\", "/");
+#else
+	dstr_replace(dst, "\\", "/");
+	if (dstr_end(dst) != '/')
+		dstr_cat_ch(dst, '/');
+	dstr_cat(dst, filename);
+#endif
 
 	char *slash = strrchr(dst->array, '/');
 	if (slash) {

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -392,10 +392,10 @@ static void generate_filename(struct mp4_output *out, struct dstr *dst, bool ove
 	char *filename = os_generate_formatted_filename(ext, space, fmt);
 
 	dstr_copy(dst, dir);
-	dstr_replace(dst, "\\", "/");
-	if (dstr_end(dst) != '/')
+	if (dstr_end(dst) != '/' && dstr_end(dst) != '\\')
 		dstr_cat_ch(dst, '/');
 	dstr_cat(dst, filename);
+	dstr_replace(dst, "\\", "/");
 
 	char *slash = strrchr(dst->array, '/');
 	if (slash) {

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -392,10 +392,17 @@ static void generate_filename(struct mp4_output *out, struct dstr *dst, bool ove
 	char *filename = os_generate_formatted_filename(ext, space, fmt);
 
 	dstr_copy(dst, dir);
+#ifdef _WIN32
 	if (dstr_end(dst) != '/' && dstr_end(dst) != '\\')
 		dstr_cat_ch(dst, '/');
 	dstr_cat(dst, filename);
 	dstr_replace(dst, "\\", "/");
+#else
+	dstr_replace(dst, "\\", "/");
+	if (dstr_end(dst) != '/')
+		dstr_cat_ch(dst, '/');
+	dstr_cat(dst, filename);
+#endif
 
 	char *slash = strrchr(dst->array, '/');
 	if (slash) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
Changed order of operations in generate_filename() in both mp4-output.c and obs-ffmpeg-mux.c so that the full file path gets normalized to use forward slashes, instead of just the directory.
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the event that the user provides a formatting string with windows-style directories (%MM\\%DD\\%hh-%mm-%ss), encoding would either fail to open a new file or crash entirely if the file would be split after the date changes, due to the logic for making a new directory during file splitting only looking for the last forward slash.
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
To test, I set automatic file splitting to 1 minute, and made the formatting string "%ss\\%mm" so every split was guaranteed to make a new directory. Running a recording for one minute in each format no longer resulted in a crash or failure at the split, and a new directory being created was successfully observed in each test.
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
Testing environment:
Windows 11 Home 10.0.26200
AMD Ryzen 9 7900x Processor
Nvidia RTX 5070 Gpu
32GB GDDR5 Memory
<!--- and the tests you ran, including how it may affect other areas of code. -->
Testing was done manually, and I do not expect these changes to affect any other areas.


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
