### PR TITLE
libobs: Correct FPS in obs_canvas_get_video_info to match main canvas

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -417,7 +417,7 @@ bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info
 	if (!obs->video.graphics || !canvas->mix)
 		return false;
 
-	*ovi = canvas->ovi;
+	*ovi = canvas->mix->ovi;
 	return true;
 }
 


### PR DESCRIPTION
### Description

Sets the FPS value for canvases so it always matches the main canvas, regardless of what was set.

### Motivation and Context

Noticed that the FPS sent via the multitrack API is sometimes wrong when the OBS FPS is changed without restarting. This caused some issues.

### How Has This Been Tested?

Tested multitrack API requests.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
