### PR TITLE
libobs: Fix canvas mixes not being restored after video reset

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -296,9 +296,6 @@ void obs_free_canvas_mixes(void)
 
 bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
-	if (!ovi && !canvas->mix)
-		return true;
-
 	obs_canvas_clear_mix(canvas);
 
 	if (ovi)

--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -294,13 +294,18 @@ void obs_free_canvas_mixes(void)
 	pthread_mutex_unlock(&obs->data.canvases_mutex);
 }
 
+bool obs_canvas_has_valid_video_info(obs_canvas_t *canvas)
+{
+	struct obs_video_info *ovi = &canvas->ovi;
+	return ovi->base_width && ovi->base_height && ovi->output_width && ovi->output_height &&
+	       ovi->output_format != VIDEO_FORMAT_NONE;
+}
+
 bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
 	obs_canvas_clear_mix(canvas);
 
-	if (ovi)
-		canvas->ovi = *ovi;
-
+	canvas->ovi = *ovi;
 	canvas->mix = obs_create_video_mix(&canvas->ovi);
 	if (canvas->mix) {
 		canvas->mix->view = &canvas->view;
@@ -398,7 +403,7 @@ void obs_canvas_rename_source(obs_source_t *source, const char *name)
 
 bool obs_canvas_reset_video(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
-	if (canvas->flags & MAIN || obs_video_active())
+	if (!ovi || canvas->flags & MAIN || obs_video_active())
 		return false;
 
 	return obs_canvas_reset_video_internal(canvas, ovi);

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -740,6 +740,7 @@ extern obs_canvas_t *obs_create_main_canvas(void);
 extern void obs_canvas_destroy(obs_canvas_t *canvas);
 extern void obs_canvas_clear_mix(obs_canvas_t *canvas);
 extern void obs_free_canvas_mixes(void);
+extern bool obs_canvas_has_valid_video_info(obs_canvas_t *canvas);
 extern bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi);
 extern void obs_canvas_insert_source(obs_canvas_t *canvas, obs_source_t *source);
 extern void obs_canvas_remove_source(obs_source_t *source);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -675,8 +675,10 @@ static bool restore_canvases(void)
 		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
 		if (canvas->flags & MAIN)
 			continue;
+		if (!obs_canvas_has_valid_video_info(canvas))
+			continue;
 
-		if (!obs_canvas_reset_video_internal(canvas, NULL)) {
+		if (!obs_canvas_reset_video_internal(canvas, &canvas->ovi)) {
 			blog(LOG_ERROR, "Failed restoring video mix for canvas '%s'", canvas->context.name);
 			success = false;
 		}


### PR DESCRIPTION
### Description

Fixes a regression introduced in #12960 that results in canvas mixes not being restored during a video reset because `ovi` and `canvas->mix` were `NULL` at that point by explicitly passing in the existing video configuration when resetting.

### Motivation and Context

Discovered while working on #13216

### How Has This Been Tested?

Locally.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
