### PR TITLE
obs-nvenc: Only update Target Quality in CQVBR mode

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -98,8 +98,17 @@ static bool nvenc_update(void *data, obs_data_t *settings)
 		enc->props.bitrate = obs_data_get_int(settings, "bitrate");
 		enc->props.max_bitrate = obs_data_get_int(settings, "max_bitrate");
 
+		bool cqvbr = astrcmpi(enc->props.rate_control, "CQVBR") == 0;
 		bool vbr = (enc->config.rcParams.rateControlMode == NV_ENC_PARAMS_RC_VBR);
-		enc->config.rcParams.averageBitRate = (uint32_t)enc->props.bitrate * 1000;
+
+		if (cqvbr) {
+			enc->config.rcParams.targetQuality = (uint8_t)obs_data_get_int(settings, "target_quality");
+			enc->config.rcParams.averageBitRate = 0;
+		} else {
+			enc->config.rcParams.targetQuality = 0;
+			enc->config.rcParams.averageBitRate = (uint32_t)enc->props.bitrate * 1000;
+		}
+
 		enc->config.rcParams.maxBitRate = vbr ? (uint32_t)enc->props.max_bitrate * 1000
 						      : (uint32_t)enc->props.bitrate * 1000;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Previously while CQVBR (Variable Bitrate with Target Quality) is enabled and the encoder is updated (e.g. changing target quality, b-frames, etc.) it was setting the `averageBitRate` value to what is being set in Variable Bitrate rate control mode.

However, CQVBR is initialized with a value of `0` and instead Target Quality is being used. This adds a check for the CQVBR mode and if it's updated in the Output settings will update the `targetQuality` value for the encoder, otherwise (if VBR is active) it will update `averageBitRate`.

(It was also updating it internally when the Replay Buffer was started while a recording was on-going (or the other way around) since OBS is calling the `UpdateRecordingSettings` method)

*Big thanks to Bleuzen on the OBS Discord for spotting where in the code the issue is occuring.*

### Motivation and Context
Fixing the newly (32.0) added CQVBR / Variable Bitrate with Target Quality mode when using both Replay Buffer and Recording.

### How Has This Been Tested?
Latest 32.1 portable instance - Setting the recording to CQVBR with a Target Quality of 20, then playing some high motion content and starting the recording, then observing the Stats window / dock. Afterwards either starting Replay Buffer or updating the Target Quality setting in the Output tab.
In the latest public build it will drop the bitrate massively (as in, to the average that is set in Variable Bitrate rate control mode).

Additionally the same in this build. However, updating the settings while this mode is active works properly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
