### PR TITLE
rtmp-services: Add LiveJasmin service plugin

### DIFF
--- a/frontend/settings/OBSBasicSettings.hpp
+++ b/frontend/settings/OBSBasicSettings.hpp
@@ -205,6 +205,7 @@ private:
 	void InitStreamPage();
 	bool IsCustomService() const;
 	inline bool IsWHIP() const;
+	inline bool IsLiveJasmin() const;
 	void LoadServices(bool showAll);
 	void OnOAuthStreamKeyConnected();
 	void OnAuthConnected();

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -30,6 +30,7 @@ enum class ListOpt : int {
 	ShowAll = 1,
 	Custom,
 	WHIP,
+	LiveJasmin,
 };
 
 enum class Section : int {
@@ -45,6 +46,11 @@ bool OBSBasicSettings::IsCustomService() const
 inline bool OBSBasicSettings::IsWHIP() const
 {
 	return ui->service->currentData().toInt() == (int)ListOpt::WHIP;
+}
+
+inline bool OBSBasicSettings::IsLiveJasmin() const
+{
+	return ui->service->currentData().toInt() == (int)ListOpt::LiveJasmin;
 }
 
 void OBSBasicSettings::InitStreamPage()
@@ -102,6 +108,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	bool is_rtmp_custom = (strcmp(type, "rtmp_custom") == 0);
 	bool is_rtmp_common = (strcmp(type, "rtmp_common") == 0);
 	bool is_whip = (strcmp(type, "whip_custom") == 0);
+	bool is_livejasmin = (strcmp(type, "livejasmin") == 0);
 
 	loading = true;
 
@@ -114,7 +121,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	protocol = QT_UTF8(obs_service_get_protocol(service_obj));
 	const char *bearer_token = obs_data_get_string(settings, "bearer_token");
 
-	if (is_rtmp_custom || is_whip)
+	if (is_rtmp_custom || is_whip || is_livejasmin)
 		ui->customServer->setText(server);
 
 	if (is_rtmp_custom) {
@@ -128,6 +135,12 @@ void OBSBasicSettings::LoadStream1Settings()
 		ui->authUsername->setText(QT_UTF8(username));
 		ui->authPw->setText(QT_UTF8(password));
 		ui->useAuth->setChecked(use_auth);
+	} else if (is_livejasmin) {
+		int idx = ui->service->findData(QVariant((int)ListOpt::LiveJasmin));
+		if (idx != -1) {
+			ui->service->setCurrentIndex(idx);
+			lastServiceIdx = idx;
+		}
 	} else {
 		int idx = ui->service->findText(service);
 		if (idx == -1) {
@@ -261,12 +274,15 @@ void OBSBasicSettings::SaveStream1Settings()
 {
 	bool customServer = IsCustomService();
 	bool whip = IsWHIP();
+	bool livejasmin = IsLiveJasmin();
 	const char *service_id = "rtmp_common";
 
 	if (customServer) {
 		service_id = "rtmp_custom";
 	} else if (whip) {
 		service_id = "whip_custom";
+	} else if (livejasmin) {
+		service_id = "livejasmin";
 	}
 
 	obs_service_t *oldService = main->GetService();
@@ -274,7 +290,7 @@ void OBSBasicSettings::SaveStream1Settings()
 
 	OBSDataAutoRelease settings = obs_data_create();
 
-	if (!customServer && !whip) {
+	if (!customServer && !whip && !livejasmin) {
 		obs_data_set_string(settings, "service", QT_TO_UTF8(ui->service->currentText()));
 		obs_data_set_string(settings, "protocol", QT_TO_UTF8(protocol));
 		if (ui->server->currentData() == CustomServerUUID()) {
@@ -313,6 +329,10 @@ void OBSBasicSettings::SaveStream1Settings()
 		obs_data_set_string(settings, "bearer_token", QT_TO_UTF8(ui->key->text()));
 	} else {
 		obs_data_set_string(settings, "key", QT_TO_UTF8(ui->key->text()));
+	}
+
+	if (livejasmin) {
+		obs_data_set_string(settings, "service", "LiveJasmin");
 	}
 
 	OBSServiceAutoRelease newService = obs_service_create(service_id, "default_service", settings, hotkeyData);
@@ -372,7 +392,7 @@ void OBSBasicSettings::SaveStream1Settings()
 
 void OBSBasicSettings::UpdateMoreInfoLink()
 {
-	if (IsCustomService() || IsWHIP()) {
+	if (IsCustomService() || IsWHIP() || IsLiveJasmin()) {
 		ui->moreInfoButton->hide();
 		return;
 	}
@@ -415,6 +435,10 @@ void OBSBasicSettings::UpdateKeyLink()
 
 	if (customServer.contains("fbcdn.net") && IsCustomService()) {
 		streamKeyLink = "https://www.facebook.com/live/producer?ref=OBS";
+	}
+
+	if (IsLiveJasmin()) {
+		streamKeyLink = "https://cam.jasmin.com/#OBS";
 	}
 
 	if (serviceName == "Dacast") {
@@ -484,6 +508,8 @@ void OBSBasicSettings::LoadServices(bool showAll)
 	if (obs_is_output_protocol_registered("WHIP")) {
 		ui->service->addItem(QTStr("WHIP"), QVariant((int)ListOpt::WHIP));
 	}
+
+	ui->service->addItem("LiveJasmin", QVariant((int)ListOpt::LiveJasmin));
 
 	if (!showAll) {
 		ui->service->addItem(QTStr("Basic.AutoConfig.StreamPage.Service.ShowAll"),
@@ -624,6 +650,7 @@ void OBSBasicSettings::ServiceChanged(bool resetFields)
 	std::string service = QT_TO_UTF8(ui->service->currentText());
 	bool custom = IsCustomService();
 	bool whip = IsWHIP();
+	bool livejasmin = IsLiveJasmin();
 
 	ui->disconnectAccount->setVisible(false);
 	ui->bandwidthTestEnable->setVisible(false);
@@ -644,7 +671,7 @@ void OBSBasicSettings::ServiceChanged(bool resetFields)
 	ui->authPwLabel->setVisible(custom);
 	ui->authPwWidget->setVisible(custom);
 
-	if (custom || whip) {
+	if (custom || whip || livejasmin) {
 		ui->destinationLayout->insertRow(1, ui->serverLabel, ui->serverStackedWidget);
 
 		ui->serverStackedWidget->setCurrentIndex(1);
@@ -767,17 +794,20 @@ OBSService OBSBasicSettings::SpawnTempService()
 {
 	bool custom = IsCustomService();
 	bool whip = IsWHIP();
+	bool livejasmin = IsLiveJasmin();
 	const char *service_id = "rtmp_common";
 
 	if (custom) {
 		service_id = "rtmp_custom";
 	} else if (whip) {
 		service_id = "whip_custom";
+	} else if (livejasmin) {
+		service_id = "livejasmin";
 	}
 
 	OBSDataAutoRelease settings = obs_data_create();
 
-	if (!custom && !whip) {
+	if (!custom && !whip && !livejasmin) {
 		obs_data_set_string(settings, "service", QT_TO_UTF8(ui->service->currentText()));
 		obs_data_set_string(settings, "server", QT_TO_UTF8(ui->server->currentData().toString()));
 	} else {

--- a/plugins/rtmp-services/CMakeLists.txt
+++ b/plugins/rtmp-services/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(
     service-specific/amazon-ivs.h
     service-specific/dacast.c
     service-specific/dacast.h
+    service-specific/livejasmin.c
+    service-specific/livejasmin.h
     service-specific/nimotv.c
     service-specific/nimotv.h
     service-specific/service-ingest.c

--- a/plugins/rtmp-services/rtmp-services-main.c
+++ b/plugins/rtmp-services/rtmp-services-main.c
@@ -9,6 +9,7 @@
 
 #include "service-specific/showroom.h"
 #include "service-specific/dacast.h"
+#include "service-specific/livejasmin.h"
 
 OBS_DECLARE_MODULE()
 OBS_MODULE_USE_DEFAULT_LOCALE("rtmp-services", "en-US")
@@ -24,6 +25,7 @@ static const char *RTMP_SERVICES_URL = (const char *)SERVICES_URL;
 
 extern struct obs_service_info rtmp_common_service;
 extern struct obs_service_info rtmp_custom_service;
+extern struct obs_service_info livejasmin_service;
 
 static update_info_t *update_info = NULL;
 static struct dstr module_name = {0};
@@ -95,6 +97,7 @@ bool obs_module_load(void)
 	init_twitch_data();
 	init_dacast_data();
 	init_amazon_ivs_data();
+	init_livejasmin_data();
 
 	dstr_copy(&module_name, "rtmp-services plugin (libobs ");
 	dstr_cat(&module_name, obs_get_version_string());
@@ -124,6 +127,7 @@ bool obs_module_load(void)
 
 	obs_register_service(&rtmp_common_service);
 	obs_register_service(&rtmp_custom_service);
+	obs_register_service(&livejasmin_service);
 	return true;
 }
 
@@ -134,5 +138,6 @@ void obs_module_unload(void)
 	free_showroom_data();
 	unload_dacast_data();
 	unload_amazon_ivs_data();
+	unload_livejasmin_data();
 	dstr_free(&module_name);
 }

--- a/plugins/rtmp-services/service-specific/livejasmin.c
+++ b/plugins/rtmp-services/service-specific/livejasmin.c
@@ -1,0 +1,240 @@
+#include <obs-module.h>
+#include <util/dstr.h>
+
+#include "livejasmin.h"
+
+struct livejasmin_service {
+	char *server;
+	char *key;
+};
+
+static const char *livejasmin_name(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+	return "LiveJasmin";
+}
+
+static void livejasmin_update(void *data, obs_data_t *settings)
+{
+	struct livejasmin_service *service = data;
+
+	bfree(service->server);
+	bfree(service->key);
+
+	service->server = bstrdup(obs_data_get_string(settings, "server"));
+	service->key = bstrdup(obs_data_get_string(settings, "key"));
+}
+
+static void livejasmin_destroy(void *data)
+{
+	struct livejasmin_service *service = data;
+
+	bfree(service->server);
+	bfree(service->key);
+	bfree(service);
+}
+
+static void *livejasmin_create(obs_data_t *settings, obs_service_t *service)
+{
+	struct livejasmin_service *data = bzalloc(sizeof(struct livejasmin_service));
+	livejasmin_update(data, settings);
+
+	UNUSED_PARAMETER(service);
+	return data;
+}
+
+static obs_properties_t *livejasmin_properties(void *unused)
+{
+	UNUSED_PARAMETER(unused);
+
+	obs_properties_t *ppts = obs_properties_create();
+
+	obs_properties_add_text(ppts, "server", obs_module_text("Server"), OBS_TEXT_DEFAULT);
+	obs_properties_add_text(ppts, "key", obs_module_text("StreamKey"), OBS_TEXT_PASSWORD);
+
+	return ppts;
+}
+
+static void livejasmin_defaults(obs_data_t *settings)
+{
+	obs_data_set_default_string(settings, "server", "");
+}
+
+static const char *livejasmin_url(void *data)
+{
+	struct livejasmin_service *service = data;
+	return service->server;
+}
+
+static const char *livejasmin_key(void *data)
+{
+	struct livejasmin_service *service = data;
+	return service->key;
+}
+
+static const char *livejasmin_get_protocol(void *data)
+{
+	struct livejasmin_service *service = data;
+
+	if (service->server && strncmp(service->server, "rtmps://", 8) == 0)
+		return "RTMPS";
+
+	return "RTMP";
+}
+
+struct livejasmin_bitrate_entry {
+	int cx, cy, fps, max_bitrate;
+};
+
+static const struct livejasmin_bitrate_entry bitrate_matrix[] = {
+	{1920, 1080, 30, 7500},
+	{1280, 720, 30, 3000},
+};
+
+static int livejasmin_get_bitrate_matrix_max(void)
+{
+	struct obs_video_info ovi;
+	if (!obs_get_video_info(&ovi))
+		return 0;
+
+	double cur_fps = (double)ovi.fps_num / (double)ovi.fps_den;
+
+	for (size_t i = 0; i < sizeof(bitrate_matrix) / sizeof(bitrate_matrix[0]); i++) {
+		const struct livejasmin_bitrate_entry *e = &bitrate_matrix[i];
+		if ((int)ovi.output_width == e->cx && (int)ovi.output_height == e->cy &&
+		    cur_fps <= (double)e->fps + 0.0000001)
+			return e->max_bitrate;
+	}
+
+	return 0;
+}
+
+static void livejasmin_apply_settings(void *data, obs_data_t *video_settings, obs_data_t *audio_settings)
+{
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(audio_settings);
+
+	if (!video_settings)
+		return;
+
+	/* LiveJasmin recommended settings: low latency */
+	obs_data_set_int(video_settings, "bf", 0);
+	obs_data_set_int(video_settings, "keyint_sec", 1);
+
+	/* Set encoder profile */
+	obs_data_item_t *item = obs_data_item_byname(video_settings, "profile");
+	if (obs_data_item_gettype(item) == OBS_DATA_STRING)
+		obs_data_set_string(video_settings, "profile", "high");
+	obs_data_item_release(&item);
+
+	/* Cap bitrate to matrix max */
+	int max_bitrate = livejasmin_get_bitrate_matrix_max();
+	if (!max_bitrate)
+		max_bitrate = 7500;
+
+	if (obs_data_get_int(video_settings, "bitrate") > max_bitrate) {
+		obs_data_set_int(video_settings, "bitrate", max_bitrate);
+		obs_data_set_int(video_settings, "buffer_size", max_bitrate);
+	}
+}
+
+static const char *livejasmin_get_connect_info(void *data, uint32_t type)
+{
+	switch ((enum obs_service_connect_info)type) {
+	case OBS_SERVICE_CONNECT_INFO_SERVER_URL:
+		return livejasmin_url(data);
+	case OBS_SERVICE_CONNECT_INFO_STREAM_ID:
+		return livejasmin_key(data);
+	default:
+		return NULL;
+	}
+}
+
+static bool livejasmin_can_try_to_connect(void *data)
+{
+	struct livejasmin_service *service = data;
+	return (service->server != NULL && service->server[0] != '\0');
+}
+
+static const char *livejasmin_get_output_type(void *data)
+{
+	UNUSED_PARAMETER(data);
+	return "rtmp_output";
+}
+
+static const char **livejasmin_get_supported_video_codecs(void *data)
+{
+	static const char *codecs[] = {"h264", NULL};
+	UNUSED_PARAMETER(data);
+	return codecs;
+}
+
+static const char **livejasmin_get_supported_audio_codecs(void *data)
+{
+	static const char *codecs[] = {"aac", NULL};
+	UNUSED_PARAMETER(data);
+	return codecs;
+}
+
+static void livejasmin_get_max_fps(void *data, int *fps)
+{
+	UNUSED_PARAMETER(data);
+	if (fps)
+		*fps = 30;
+}
+
+static void livejasmin_get_max_bitrate(void *data, int *video_bitrate, int *audio_bitrate)
+{
+	UNUSED_PARAMETER(data);
+	if (video_bitrate) {
+		int max = livejasmin_get_bitrate_matrix_max();
+		*video_bitrate = max ? max : 7500;
+	}
+	if (audio_bitrate)
+		*audio_bitrate = 160;
+}
+
+static void livejasmin_get_supported_resolutions(void *data, struct obs_service_resolution **resolutions, size_t *count)
+{
+	UNUSED_PARAMETER(data);
+
+	static const struct obs_service_resolution res[] = {
+		{1920, 1080},
+		{1280, 720},
+	};
+
+	*count = sizeof(res) / sizeof(res[0]);
+	*resolutions = bmemdup(res, sizeof(res));
+}
+
+struct obs_service_info livejasmin_service = {
+	.id = "livejasmin",
+	.get_name = livejasmin_name,
+	.create = livejasmin_create,
+	.destroy = livejasmin_destroy,
+	.update = livejasmin_update,
+	.get_defaults = livejasmin_defaults,
+	.get_properties = livejasmin_properties,
+	.get_protocol = livejasmin_get_protocol,
+	.get_url = livejasmin_url,
+	.get_key = livejasmin_key,
+	.get_connect_info = livejasmin_get_connect_info,
+	.apply_encoder_settings = livejasmin_apply_settings,
+	.get_supported_resolutions = livejasmin_get_supported_resolutions,
+	.get_max_fps = livejasmin_get_max_fps,
+	.get_max_bitrate = livejasmin_get_max_bitrate,
+	.get_supported_video_codecs = livejasmin_get_supported_video_codecs,
+	.get_supported_audio_codecs = livejasmin_get_supported_audio_codecs,
+	.can_try_to_connect = livejasmin_can_try_to_connect,
+	.get_output_type = livejasmin_get_output_type,
+};
+
+void init_livejasmin_data(void)
+{
+	/* Nothing to initialize */
+}
+
+void unload_livejasmin_data(void)
+{
+	/* Nothing to cleanup */
+}

--- a/plugins/rtmp-services/service-specific/livejasmin.h
+++ b/plugins/rtmp-services/service-specific/livejasmin.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void init_livejasmin_data(void);
+void unload_livejasmin_data(void);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Add native LiveJasmin streaming service support to OBS Studio.
This implements a service-specific plugin providing:
- Automatic encoder configuration (0 B-frames, 1s keyframe, high profile).
- Resolution-aware bitrate capping (1080p30: 7500 kbps, 720p30: 3000 kbps).
- Codec constraints (H.264 video, AAC audio at 160 kbps max).
- 30 FPS maximum enforcement.
<img width="1093" height="874" alt="OBSStudio-RTMP-Service-LiveJasmin" src="https://github.com/user-attachments/assets/c9431fa0-31fc-4e1a-bda4-e5b7e9823f74" />

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
LiveJasmin is a major live streaming platform that requires specific encoder settings for optimal stream quality and compatibility. This PR adds first-class support, allowing users to select LiveJasmin directly from the service dropdown rather than using "Custom RTMP Server".

The service-specific plugin approach (vs. services.json entry) enables:
- Automatic encoder configuration per LiveJasmin's requirements
- Resolution/bitrate validation before streaming

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Built on MacOS Tahoe with Xcode and Windows 11.
- Verified service appears in Settings > Stream > Service dropdown.
- Confirmed server URL and stream key fields display correctly.
- Verified encoder settings are applied (B-frames=0, keyint=1s, profile=high).
- Confirmed bitrate capping at 1080p30 and 720p30.
- Tested streaming to LiveJasmin ingest server.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomm
ent all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x]  My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
