### PR TITLE
obs-transitions: Fix HDR for transitions other than Fade

### DIFF
--- a/plugins/obs-transitions/transition-cut.c
+++ b/plugins/obs-transitions/transition-cut.c
@@ -30,9 +30,14 @@ static void cut_destroy(void *data)
 
 static void cut_video_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
+	const bool previous = gs_set_linear_srgb(true);
+
 	struct cut_info *cut = data;
 	obs_transition_video_render(cut->source, NULL);
-	UNUSED_PARAMETER(effect);
+
+	gs_set_linear_srgb(previous);
 }
 
 static float mix_a(void *data, float t)

--- a/plugins/obs-transitions/transition-luma-wipe.c
+++ b/plugins/obs-transitions/transition-luma-wipe.c
@@ -181,9 +181,14 @@ static void luma_wipe_callback(void *data, gs_texture_t *a, gs_texture_t *b, flo
 
 void luma_wipe_video_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
+	const bool previous = gs_set_linear_srgb(true);
+
 	struct luma_wipe_info *lwipe = data;
 	obs_transition_video_render(lwipe->source, luma_wipe_callback);
-	UNUSED_PARAMETER(effect);
+
+	gs_set_linear_srgb(previous);
 }
 
 static float mix_a(void *data, float t)

--- a/plugins/obs-transitions/transition-slide.c
+++ b/plugins/obs-transitions/transition-slide.c
@@ -107,9 +107,14 @@ static void slide_callback(void *data, gs_texture_t *a, gs_texture_t *b, float t
 
 void slide_video_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
+	const bool previous = gs_set_linear_srgb(true);
+
 	struct slide_info *slide = data;
 	obs_transition_video_render(slide->source, slide_callback);
-	UNUSED_PARAMETER(effect);
+
+	gs_set_linear_srgb(previous);
 }
 
 static float mix_a(void *data, float t)

--- a/plugins/obs-transitions/transition-swipe.c
+++ b/plugins/obs-transitions/transition-swipe.c
@@ -101,9 +101,14 @@ static void swipe_callback(void *data, gs_texture_t *a, gs_texture_t *b, float t
 
 static void swipe_video_render(void *data, gs_effect_t *effect)
 {
+	UNUSED_PARAMETER(effect);
+
+	const bool previous = gs_set_linear_srgb(true);
+
 	struct swipe_info *swipe = data;
 	obs_transition_video_render(swipe->source, swipe_callback);
-	UNUSED_PARAMETER(effect);
+
+	gs_set_linear_srgb(previous);
 }
 
 static float mix_a(void *data, float t)


### PR DESCRIPTION
### Description
This resolves the issue where the HDR game capture layer on Linux ([obs-vkcapture](https://github.com/nowrep/obs-vkcapture)) shows shifted gamma due to a colorspace mismatch.

### Motivation and Context
The "Fade" transition effect correctly handles different kinds of colorspaces, but other transition plugins do not.

The original bug report for obs-vkcapture: https://github.com/nowrep/obs-vkcapture/issues/285

### How Has This Been Tested?
1. Install the game capture layer on a Linux distro
2. Run OBS
3. Add the "Game Capture" source

Then, either
1. Run a regular sRGB Vulkan app/game (set `OBS_VKCAPTURE=1`)
2. Wait for OBS to register the app
3. Make the source fullscreen
4. Crop the source even by a tiny amount

or
1. Set the colorspace in OBS to Rec.2100 (PQ/HLG)
2. Run an sRGB linear HDR Vulkan app/game, Quake II RTX is a good choice since it's gratis on Steam (also set `OBS_VKCAPTURE=1` in addition to `SDL_VIDEODRIVER=wayland` for Wayland HDR support)
3. Wait for OBS to register the app
4. Make the source fullscreen

A shift in gamma is present, as seen below:
<img width="1469" height="1103" alt="Screenshot_20260321_231518" src="https://github.com/user-attachments/assets/521313db-83f0-4c03-a699-cba37fd0ee6e" />

Meanwhile the "Fade" effect works just fine:
<img width="1469" height="1103" alt="Screenshot_20260321_231525" src="https://github.com/user-attachments/assets/17d7778e-a4c2-4e2b-8209-f2c73cc25373" />

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
