### PR TITLE
frontend: Show seek controls for media sources with seekable enabled

### DIFF
--- a/frontend/widgets/OBSBasic_ContextToolbar.cpp
+++ b/frontend/widgets/OBSBasic_ContextToolbar.cpp
@@ -88,15 +88,16 @@ void OBSBasic::UpdateContextBarVisibility()
 	UpdateContextBarDeferred();
 }
 
-static bool is_network_media_source(obs_source_t *source, const char *id)
+static bool is_source_seekable(obs_source_t *source, const char *id)
 {
 	if (strcmp(id, "ffmpeg_source") != 0)
-		return false;
+		return true;
 
 	OBSDataAutoRelease s = obs_source_get_settings(source);
 	bool is_local_file = obs_data_get_bool(s, "is_local_file");
+	bool seekable = obs_data_get_bool(s, "seekable");
 
-	return !is_local_file;
+	return is_local_file || seekable;
 }
 
 void OBSBasic::UpdateContextBarDeferred(bool force)
@@ -162,7 +163,7 @@ void OBSBasic::UpdateContextBar(bool force)
 		if (contextBarSize >= ContextBarSize_Reduced && (updateNeeded || force)) {
 			ClearContextBar();
 			if (flags & OBS_SOURCE_CONTROLLABLE_MEDIA) {
-				if (!is_network_media_source(source, id)) {
+				if (is_source_seekable(source, id)) {
 					MediaControls *mediaControls = new MediaControls(ui->emptySpace);
 					mediaControls->SetSource(source);
 


### PR DESCRIPTION
### Description
This shows the media seek controls if `seekable` is enabled in the media source.  An example of a seekable network resource is an mp4 file hosted on a web server.

### Motivation and Context
Commit c9182a987885da948941d486117aa4afefeceee2 added the `seekable` parameter when "Local File" is unchecked in the settings, allowing the user to specify that even though the resource is network-based, it still supports being seeked.

### How Has This Been Tested?
This has not been tested. It's a simple enough change and I currently don't have the time to test.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [ ] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
