### PR TITLE
frontend: Fix warning for themeWatcher

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -962,7 +962,6 @@ bool OBSApp::SetTheme(const QString &name)
 
 void OBSApp::themeFileChanged(const QString &path)
 {
-	themeWatcher->blockSignals(true);
 	blog(LOG_INFO, "Theme file \"%s\" changed, reloading...", QT_TO_UTF8(path));
 	SetTheme(currentTheme->id);
 }
@@ -1002,12 +1001,6 @@ bool OBSApp::InitTheme()
 	/* Load list of themes and read their metadata */
 	FindThemes();
 
-	if (config_get_bool(userConfig, "Appearance", "AutoReload")) {
-		/* Set up Qt file watcher to automatically reload themes */
-		themeWatcher = new QFileSystemWatcher(this);
-		connect(themeWatcher.get(), &QFileSystemWatcher::fileChanged, this, &OBSApp::themeFileChanged);
-	}
-
 	/* Migrate old theme config key */
 	if (config_has_user_value(userConfig, "General", "CurrentTheme3") &&
 	    !config_has_user_value(userConfig, "Appearance", "Theme")) {
@@ -1040,6 +1033,12 @@ bool OBSApp::InitTheme()
 		     "system theme as last resort.",
 		     QT_TO_UTF8(themeName));
 		return SetTheme("com.obsproject.System");
+	}
+
+	if (config_get_bool(userConfig, "Appearance", "AutoReload")) {
+		/* Set up Qt file watcher to automatically reload themes */
+		themeWatcher = new QFileSystemWatcher(this);
+		connect(themeWatcher.get(), &QFileSystemWatcher::fileChanged, this, &OBSApp::themeFileChanged);
 	}
 
 	return true;


### PR DESCRIPTION
### Description
Fixes a Qt warning during startup when the AutoReload setting for themes is enabled.

setTheme calls `themeWatcher->removePaths` and when the theme is first set up `themeWatcher->files()` is empty.

Any other time except when the theme is first being set up this call will be fine, so the setup of themeWatcher is moved after the first setTheme call.

### Motivation and Context
Warnings are bad. Found using QT_FATAL_WARNINGS

### How Has This Been Tested?
Built and launched OBS, no more warning.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
