### PR TITLE
frontend: Cleanup some theme variable handling

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -524,8 +524,8 @@ static bool ResolveVariable(const QHash<QString, OBSThemeVariable> &vars, OBSThe
 	}
 }
 
-static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBSThemeVariable &var,
-			const OBSThemeVariable::VariableType type, const int recursion = 0);
+static std::optional<QString> EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBSThemeVariable &var,
+				       const OBSThemeVariable::VariableType type, const int recursion = 0);
 
 static OBSThemeVariable ParseMathVariable(const QHash<QString, OBSThemeVariable> &vars, const QString &value,
 					  const int recursion = 0)
@@ -558,7 +558,8 @@ static OBSThemeVariable ParseMathVariable(const QHash<QString, OBSThemeVariable>
 		/* Handle nested math calculations */
 		if (var.type == OBSThemeVariable::Calc || var.type == OBSThemeVariable::Max ||
 		    var.type == OBSThemeVariable::Min) {
-			QString val = EvalMath(vars, var, var.type, recursion + 1);
+			auto result = EvalMath(vars, var, var.type, recursion + 1);
+			QString val = result.has_value() ? result.value() : QString();
 			var = ParseMathVariable(vars, val, recursion + 1);
 		}
 
@@ -573,18 +574,18 @@ static OBSThemeVariable ParseMathVariable(const QHash<QString, OBSThemeVariable>
 	return var;
 }
 
-static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBSThemeVariable &var,
-			const OBSThemeVariable::VariableType type, const int recursion)
+static std::optional<QString> EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBSThemeVariable &var,
+				       const OBSThemeVariable::VariableType type, const int recursion)
 {
 	if (recursion >= 30) {
 		/* Abort after 30 levels of recursion */
 		blog(LOG_ERROR, "Maximum recursion levels hit!");
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	if (type != OBSThemeVariable::Calc && type != OBSThemeVariable::Max && type != OBSThemeVariable::Min) {
 		blog(LOG_ERROR, "Invalid type for math operation!");
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	QStringList args = var.value.toStringList();
@@ -592,18 +593,18 @@ static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBST
 	if (args.length() != 3) {
 		blog(LOG_ERROR, "Math parse had invalid number of arguments: %lld (%s)", args.length(),
 		     QT_TO_UTF8(args.join(", ")));
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	QString &opt = args[1];
 	if (type == OBSThemeVariable::Calc && (opt != '*' && opt != '+' && opt != '-' && opt != '/')) {
 		blog(LOG_ERROR, "Unknown/invalid calc() operator: %s", QT_TO_UTF8(opt));
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	if ((type == OBSThemeVariable::Max || type == OBSThemeVariable::Min) && opt != ',') {
 		blog(LOG_ERROR, "Invalid math separator: %s", QT_TO_UTF8(opt));
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	OBSThemeVariable val1, val2;
@@ -611,14 +612,15 @@ static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBST
 		val1 = ParseMathVariable(vars, args[0], recursion + 1);
 		val2 = ParseMathVariable(vars, args[2], recursion + 1);
 	} catch (...) {
-		return "'Invalid expression'";
+		blog(LOG_ERROR, "EvalMath exception");
+		return std::nullopt;
 	}
 
 	/* Ensure that suffixes match (if any) */
 	if (!val1.suffix.isEmpty() && !val2.suffix.isEmpty() && val1.suffix != val2.suffix) {
 		blog(LOG_ERROR, "Math operation requires suffixes to match or only one to be present! %s != %s",
 		     QT_TO_UTF8(val1.suffix), QT_TO_UTF8(val2.suffix));
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	double d1 = val1.userValue.isValid() ? val1.userValue.toDouble() : val1.value.toDouble();
@@ -629,7 +631,7 @@ static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBST
 		     "At least one invalid math value:"
 		     " op1: %f, op2: %f",
 		     d1, d2);
-		return "'Invalid expression'";
+		return std::nullopt;
 	}
 
 	double val = numeric_limits<double>::quiet_NaN();
@@ -647,7 +649,7 @@ static QString EvalMath(const QHash<QString, OBSThemeVariable> &vars, const OBST
 		if (!isnormal(val)) {
 			blog(LOG_ERROR, "Invalid calc() resulted in non-normal number: %f %s %f = %f", d1,
 			     QT_TO_UTF8(opt), d2, val);
-			return "'Invalid expression'";
+			return std::nullopt;
 		}
 	} else if (type == OBSThemeVariable::Max) {
 		val = d1 > d2 ? d1 : d2;
@@ -710,7 +712,8 @@ static QString PrepareQSS(const QHash<QString, OBSThemeVariable> &vars, const QS
 			replace = value.value<QColor>().name(QColor::HexRgb);
 		} else if (var.type == OBSThemeVariable::Calc || var.type == OBSThemeVariable::Max ||
 			   var.type == OBSThemeVariable::Min) {
-			replace = EvalMath(vars, var, var.type);
+			auto result = EvalMath(vars, var, var.type);
+			replace = result.has_value() ? result.value() : replace;
 		} else if (var.type == OBSThemeVariable::Size || var.type == OBSThemeVariable::Number) {
 			double val = value.toDouble();
 


### PR DESCRIPTION
### Description
Some adjustments to how theme variables are handled to try and solve a weird crash on startup reported on Discord.

### Motivation and Context
A user on Discord reported an issue with 32.0.4 where trying to open OBS simply did nothing. The process would start and then exit before any window was shown.

The various data directories for OBS were being created, but no log file was generated. This suggested the failure was somewhere inside OBSApp::AppInit(). After guiding them through the steps to generate a DMP file using ProcDump, the WinDbg analysis revealed a stack overflow inside `OBSApp_Themes.cpp` due to recursive alternating calls between `EvalMath` and `ParseMathVariable`.

Looking at the stack frames showed the following
```
0:000> dx -r1 *(OBSThemeVariable*)0x26594b75820
*(OBSThemeVariable*)0x26594b75820                 [Type: OBSThemeVariable]
    [+0x000] editable         : true [Type: bool]
    [+0x008] suffix           [Type: QString]
    [+0x020] type             : Color (0) [Type: OBSThemeVariable::VariableType]
    [+0x028] name             [Type: QString]
    [+0x040] value            [Type: QVariant]
    [+0x060] userValue        [Type: QVariant]
0:000> dx -r1 *(OBSThemeVariable*)0x26594b75700
*(OBSThemeVariable*)0x26594b75700                 [Type: OBSThemeVariable]
    [+0x000] editable         : true [Type: bool]
    [+0x008] suffix           [Type: QString]
    [+0x020] type             : -**1414812757** [Type: OBSThemeVariable::VariableType]    <----------
    [+0x028] name             [Type: QString]
    [+0x040] value            [Type: QVariant]
    [+0x060] userValue        [Type: QVariant]
0:000> dx -r1 *(OBSThemeVariable*)0x26594b755e0
*(OBSThemeVariable*)0x26594b755e0                 [Type: OBSThemeVariable]
    [+0x000] editable         : true [Type: bool]
    [+0x008] suffix           [Type: QString]
    [+0x020] type             : -**1802246144** [Type: OBSThemeVariable::VariableType]    <----------
    [+0x028] name             [Type: QString]
    [+0x040] value            [Type: QVariant]
    [+0x060] userValue        [Type: QVariant]
```
_AI Disclosure: An LLM was used to assist with analyzing the DMP file using WinDbg_

The invalid `type` values here led to me looking for ways OBSThemeVariable could be uninitialized or partially initialized.

I also cleaned up some other potential pitfalls in the code here, including our recursion guard that was not working correctly in this instance.

### How Has This Been Tested?
The same user has tested this build and was able to launch OBS thanks to the fixed recursion check.

I am not sure that whatever bug is causing this issue in the first place has been resolved.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
