### PR TITLE
Fix formatting for OBS Studio link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-OBS Studio <https://obsproject.com>
+`OBS Studio <https://obsproject.com>`_
 ===================================
 
 .. image:: https://github.com/obsproject/obs-studio/actions/workflows/push.yaml/badge.svg?branch=master


### PR DESCRIPTION
### Description
Fixed the RST hyperlink syntax in the title of `README.rst`.
The title was missing the trailing underscore (`_`) required for a valid RST external hyperlink, and the underline length was also corrected to match the title length.

### Motivation and Context
The original title `OBS Studio <https://obsproject.com>` was not a valid RST hyperlink — it was missing the closing underscore (`_`). This caused the title to not render as a clickable link in RST viewers and on PyPI/GitHub documentation renderers.

### How Has This Been Tested?
Verified the RST syntax locally by rendering the `README.rst` file using a RST previewer. The title now correctly renders as a clickable hyperlink.

### Types of changes
<!--- Uncomment the one that applies -->
- Documentation (a change to documentation pages)

### Checklist:
- [ ] My code has been run through clang-format.
- [x] I have read the **contributing** document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
