### PR TITLE
Fix D3D9 capture for D3DFMT_A2R10G10B10 (e.g. GTA: SA) and MSAA D3D9 memory capture

### DIFF
--- a/plugins/win-capture/data/compatibility.json
+++ b/plugins/win-capture/data/compatibility.json
@@ -213,20 +213,6 @@
             "url": "https://www.bungie.net/en/Help/Article/46101"
         },
         {
-            "name": "Grand Theft Auto: San Andreas",
-            "translation_key": "Compatibility.GameCapture.Blocked",
-            "severity": 2,
-            "executable": "gta-sa.exe",
-            "window_class": "",
-            "window_title": "",
-            "match_flags": 1,
-            "game_capture": true,
-            "window_capture": false,
-            "window_capture_wgc": false,
-            "message": "Grand Theft Auto: San Andreas cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
-            "url": ""
-        },
-        {
             "name": "League of Legends Launcher",
             "translation_key": "Compatibility.GameCapture.Blocked",
             "severity": 1,
@@ -238,20 +224,6 @@
             "window_capture": false,
             "window_capture_wgc": false,
             "message": "League of Legends Launcher cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
-            "url": ""
-        },
-        {
-            "name": "San Andreas Multiplayer",
-            "translation_key": "Compatibility.GameCapture.Blocked",
-            "severity": 2,
-            "executable": "samp.exe",
-            "window_class": "",
-            "window_title": "",
-            "match_flags": 1,
-            "game_capture": true,
-            "window_capture": false,
-            "window_capture_wgc": false,
-            "message": "San Andreas Multiplayer cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
             "url": ""
         },
         {

--- a/plugins/win-capture/graphics-hook/d3d10-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d10-capture.cpp
@@ -348,7 +348,7 @@ void d3d10_capture(void *swap_ptr, void *backbuffer_ptr)
 	if (capture_should_init()) {
 		d3d10_init(swap);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		ID3D10Resource *backbuffer;
 
 		hr = dxgi_backbuffer->QueryInterface(__uuidof(ID3D10Resource), (void **)&backbuffer);

--- a/plugins/win-capture/graphics-hook/d3d11-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d11-capture.cpp
@@ -306,7 +306,7 @@ void d3d11_capture(void *swap_ptr, void *backbuffer_ptr)
 	if (capture_should_init()) {
 		d3d11_init(swap);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		ID3D11Resource *backbuffer;
 
 		hr = dxgi_backbuffer->QueryInterface(__uuidof(ID3D11Resource), (void **)&backbuffer);

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -93,7 +93,7 @@ static void d3d9_free()
 static DXGI_FORMAT d3d9_to_dxgi_format(D3DFORMAT format)
 {
 	switch (format) {
-	case D3DFMT_A2B10G10R10:
+	case D3DFMT_A2R10G10B10:
 		return DXGI_FORMAT_R10G10B10A2_UNORM;
 	case D3DFMT_A8R8G8B8:
 		return DXGI_FORMAT_B8G8R8A8_UNORM;
@@ -211,6 +211,14 @@ static inline bool d3d9_shtex_init_shtex()
 	return true;
 }
 
+static inline D3DFORMAT get_dxgi_compatible_format(const D3DFORMAT format)
+{
+	if (format == D3DFMT_A2R10G10B10) {
+		return D3DFMT_A2B10G10R10;
+	}
+	return format;
+}
+
 static inline bool d3d9_shtex_init_copytex()
 {
 	struct d3d9_offsets offsets = global_hook_info->offsets.d3d9;
@@ -242,8 +250,9 @@ static inline bool d3d9_shtex_init_copytex()
 		memcpy(patch_addr, patch[data.patch].data, patch_size);
 	}
 
-	hr = data.device->CreateTexture(data.cx, data.cy, 1, D3DUSAGE_RENDERTARGET, data.d3d9_format, D3DPOOL_DEFAULT,
-					&tex, &data.handle);
+	hr = data.device->CreateTexture(data.cx, data.cy, 1, D3DUSAGE_RENDERTARGET,
+					get_dxgi_compatible_format(data.d3d9_format), D3DPOOL_DEFAULT, &tex,
+					&data.handle);
 
 	if (p_is_d3d9) {
 		*p_is_d3d9 = was_d3d9ex;

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -31,6 +31,7 @@ struct d3d9_data {
 	D3DFORMAT d3d9_format;
 	DXGI_FORMAT dxgi_format;
 	bool using_shtex;
+	bool d3d9_multisampled;
 
 	/* shared texture */
 	IDirect3DSurface9 *d3d9_copytex;
@@ -43,6 +44,7 @@ struct d3d9_data {
 
 	/* shared memory */
 	IDirect3DSurface9 *copy_surfaces[NUM_BUFFERS];
+	IDirect3DSurface9 *intermediate_surfaces[NUM_BUFFERS];
 	IDirect3DQuery9 *queries[NUM_BUFFERS];
 	struct shmem_data *shmem_info;
 	bool texture_mapped[NUM_BUFFERS];
@@ -78,6 +80,9 @@ static void d3d9_free()
 					data.copy_surfaces[i]->UnlockRect();
 				}
 				data.copy_surfaces[i]->Release();
+			}
+			if (data.intermediate_surfaces[i]) {
+				data.intermediate_surfaces[i]->Release();
 			}
 			if (data.queries[i]) {
 				data.queries[i]->Release();
@@ -219,6 +224,11 @@ static inline D3DFORMAT get_dxgi_compatible_format(const D3DFORMAT format)
 	return format;
 }
 
+static inline bool d3d9_shmem_needs_intermediate()
+{
+	return data.d3d9_multisampled || get_dxgi_compatible_format(data.d3d9_format) != data.d3d9_format;
+}
+
 static inline bool d3d9_shtex_init_copytex()
 {
 	struct d3d9_offsets offsets = global_hook_info->offsets.d3d9;
@@ -304,7 +314,18 @@ static bool d3d9_shmem_init_buffers(size_t buffer)
 {
 	HRESULT hr;
 
-	hr = data.device->CreateOffscreenPlainSurface(data.cx, data.cy, data.d3d9_format, D3DPOOL_SYSTEMMEM,
+	D3DFORMAT copy_format = data.d3d9_format;
+	if (d3d9_shmem_needs_intermediate()) {
+		copy_format = get_dxgi_compatible_format(copy_format);
+		hr = data.device->CreateRenderTarget(data.cx, data.cy, copy_format, D3DMULTISAMPLE_NONE, 0, FALSE,
+						     &data.intermediate_surfaces[buffer], nullptr);
+		if (FAILED(hr)) {
+			hlog_hr("d3d9_shmem_init_buffers: Failed to create intermediate render target", hr);
+			return false;
+		}
+	}
+
+	hr = data.device->CreateOffscreenPlainSurface(data.cx, data.cy, copy_format, D3DPOOL_SYSTEMMEM,
 						      &data.copy_surfaces[buffer], nullptr);
 	if (FAILED(hr)) {
 		hlog_hr("d3d9_shmem_init_buffers: Failed to create surface", hr);
@@ -403,6 +424,7 @@ static bool d3d9_init_format_backbuffer(HWND &window)
 
 	data.d3d9_format = desc.Format;
 	data.dxgi_format = d3d9_to_dxgi_format(desc.Format);
+	data.d3d9_multisampled = desc.MultiSampleType != D3DMULTISAMPLE_NONE;
 	window = pp.hDeviceWindow;
 
 	data.cx = desc.Width;
@@ -421,6 +443,7 @@ static bool d3d9_init_format_swapchain(HWND &window)
 
 	data.dxgi_format = d3d9_to_dxgi_format(pp.BackBufferFormat);
 	data.d3d9_format = pp.BackBufferFormat;
+	data.d3d9_multisampled = pp.MultiSampleType != D3DMULTISAMPLE_NONE;
 	window = pp.hDeviceWindow;
 
 	data.cx = pp.BackBufferWidth;
@@ -539,11 +562,24 @@ static inline void d3d9_shmem_capture(IDirect3DSurface9 *backbuffer)
 			shmem_texture_data_unlock(data.cur_tex);
 		}
 
-		hr = data.device->GetRenderTargetData(src, dst);
-		if (FAILED(hr)) {
-			hlog_hr("d3d9_shmem_capture: GetRenderTargetData "
-				"failed",
-				hr);
+		if (d3d9_shmem_needs_intermediate()) {
+			IDirect3DSurface9 *intermediate = data.intermediate_surfaces[data.cur_tex];
+			hr = data.device->StretchRect(src, nullptr, intermediate, nullptr, D3DTEXF_NONE);
+			if (FAILED(hr)) {
+				hlog_hr("d3d9_shmem_capture: StretchRect failed", hr);
+
+			} else {
+				hr = data.device->GetRenderTargetData(intermediate, dst);
+				if (FAILED(hr)) {
+					hlog_hr("d3d9_shmem_capture: GetRenderTargetData (intermediate) failed", hr);
+				}
+			}
+
+		} else {
+			hr = data.device->GetRenderTargetData(src, dst);
+			if (FAILED(hr)) {
+				hlog_hr("d3d9_shmem_capture: GetRenderTargetData failed", hr);
+			}
 		}
 
 		data.queries[data.cur_tex]->Issue(D3DISSUE_END);

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -552,7 +552,7 @@ static void d3d9_capture(IDirect3DDevice9 *device, IDirect3DSurface9 *backbuffer
 	if (capture_should_init()) {
 		d3d9_init(device);
 	}
-	if (data.handle != nullptr && capture_ready()) {
+	if ((data.using_shtex ? data.handle : data.shmem_info) != nullptr && capture_ready()) {
 		if (data.device != device) {
 			d3d9_free();
 			return;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
Fixes D3D9 capture with format `D3DFMT_A2R10G10B10` and MSAA memory capture.

Builds on #12794 for testing D3D9 memory capture.

Known titles that use `D3DFMT_A2R10G10B10` (that I’ve tested):

- Grand Theft Auto: San Andreas
- Death to Spies
- Death to Spies: Moment of Truth

There may be other titles using this format that are also affected.
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
Fixes capture of GTA: SA and other games using `D3DFMT_A2R10G10B10`. Also fixes memory capture with MSAA in D3D9 games.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
Tested on Windows 10.

Verified both shared texture and shared memory capture with:

- Grand Theft Auto: San Andreas
- Death to Spies
- Death to Spies: Moment of Truth

Verified shared memory capture with MSAA using Portal.

No regressions observed in D3D9 capture for other formats.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
