### PR TITLE
rtmp-services: Add Twitcast (ツイキャス)

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 285,
+    "version": 286,
     "files": [
         {
             "name": "services.json",
-            "version": 285
+            "version": 286
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3586,6 +3586,29 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Twitcast (ツイキャス)",
+            "more_info_link": "https://twitcasting.tv/helpcenter.php?pid=HELP_OBS_INDEX",
+            "stream_key_link": "https://twitcasting.tv/rtmpstreamkey.php",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://rtmp401.twitcasting.tv/live"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "main",
+                "max fps": 60,
+                "max video bitrate": 5700,
+                "max audio bitrate": 256,
+                "bframes": 0
+            },
+            "supported video codecs": [
+                "h264",
+                "hevc"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Add Twitcast to the streaming services list.

### Motivation and Context
Twitcast users currently need to manually enter the RTMP URL as a custom server.
Adding it as a built-in service simplifies setup and allows centralized URL management.

### How Has This Been Tested?
- Replaced services.json locally and confirmed the service appears in the service dropdown
- Verified streaming to the ingest endpoint

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
