### PR TITLE
plugins: Fix build issues in XCode 26.4 with macOS plugins

### DIFF
--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -438,16 +438,7 @@ static OSStatus input_callback(void *data, AudioUnitRenderActionFlags *action_fl
 									     : ca->buf_list->mNumberBuffers;
 	audio.format = ca->format;
 	audio.samples_per_sec = ca->sample_rate;
-	static double factor = 0.;
-	static mach_timebase_info_data_t info = {0, 0};
-	if (info.numer == 0 && info.denom == 0) {
-		mach_timebase_info(&info);
-		factor = ((double)info.numer) / info.denom;
-	}
-	if (info.numer != info.denom)
-		audio.timestamp = (uint64_t)(factor * ts_data->mHostTime);
-	else
-		audio.timestamp = ts_data->mHostTime;
+	audio.timestamp = AudioConvertHostTimeToNanos(ts_data->mHostTime);
 
 	obs_source_output_audio(ca->source, &audio);
 

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -444,10 +444,7 @@ static OSStatus input_callback(void *data, AudioUnitRenderActionFlags *action_fl
 		mach_timebase_info(&info);
 		factor = ((double)info.numer) / info.denom;
 	}
-	if (info.numer != info.denom)
-		audio.timestamp = (uint64_t)(factor * (double)ts_data->mHostTime);
-	else
-		audio.timestamp = ts_data->mHostTime;
+	audio.timestamp = AudioConvertHostTimeToNanos(ts_data->mHostTime);
 
 	obs_source_output_audio(ca->source, &audio);
 

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -445,7 +445,7 @@ static OSStatus input_callback(void *data, AudioUnitRenderActionFlags *action_fl
 		factor = ((double)info.numer) / info.denom;
 	}
 	if (info.numer != info.denom)
-		audio.timestamp = (uint64_t)(factor * ts_data->mHostTime);
+		audio.timestamp = (uint64_t)(factor * (double)ts_data->mHostTime);
 	else
 		audio.timestamp = ts_data->mHostTime;
 

--- a/plugins/mac-capture/mac-audio.c
+++ b/plugins/mac-capture/mac-audio.c
@@ -438,12 +438,6 @@ static OSStatus input_callback(void *data, AudioUnitRenderActionFlags *action_fl
 									     : ca->buf_list->mNumberBuffers;
 	audio.format = ca->format;
 	audio.samples_per_sec = ca->sample_rate;
-	static double factor = 0.;
-	static mach_timebase_info_data_t info = {0, 0};
-	if (info.numer == 0 && info.denom == 0) {
-		mach_timebase_info(&info);
-		factor = ((double)info.numer) / info.denom;
-	}
 	audio.timestamp = AudioConvertHostTimeToNanos(ts_data->mHostTime);
 
 	obs_source_output_audio(ca->source, &audio);

--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -278,9 +278,9 @@ API_AVAILABLE(macos(12.5)) void screen_stream_video_update(struct screen_capture
                 size_t width = CVPixelBufferGetWidth(image_buffer);
                 size_t height = CVPixelBufferGetHeight(image_buffer);
 
-                if ((sc->frame.size.width != width) || (sc->frame.size.height != height)) {
-                    sc->frame.size.width = width;
-                    sc->frame.size.height = height;
+                if (((size_t)sc->frame.size.width != width) || ((size_t)sc->frame.size.height != height)) {
+                    sc->frame.size.width = (CGFloat)width;
+                    sc->frame.size.height = (CGFloat)height;
                     needs_to_update_properties = true;
                 }
             }

--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -275,12 +275,15 @@ API_AVAILABLE(macos(12.5)) void screen_stream_video_update(struct screen_capture
                     needs_to_update_properties = true;
                 }
             } else {
-                size_t width = CVPixelBufferGetWidth(image_buffer);
-                size_t height = CVPixelBufferGetHeight(image_buffer);
+                int width = CVPixelBufferGetWidth(image_buffer);
+                int height = CVPixelBufferGetHeight(image_buffer);
 
-                if (((size_t)sc->frame.size.width != width) || ((size_t)sc->frame.size.height != height)) {
-                    sc->frame.size.width = (CGFloat)width;
-                    sc->frame.size.height = (CGFloat)height;
+                int frameWidth = (int) sc->frame.size.width;
+                int frameHeight = (int) sc->frame.size.height;
+
+                if ((frameWidth != width) || (frameHeight != height)) {
+                    sc->frame.size.width = width;
+                    sc->frame.size.height = height;
                     needs_to_update_properties = true;
                 }
             }

--- a/plugins/mac-capture/mac-sck-common.m
+++ b/plugins/mac-capture/mac-sck-common.m
@@ -275,10 +275,13 @@ API_AVAILABLE(macos(12.5)) void screen_stream_video_update(struct screen_capture
                     needs_to_update_properties = true;
                 }
             } else {
-                size_t width = CVPixelBufferGetWidth(image_buffer);
-                size_t height = CVPixelBufferGetHeight(image_buffer);
+                int width = CVPixelBufferGetWidth(image_buffer);
+                int height = CVPixelBufferGetHeight(image_buffer);
 
-                if ((sc->frame.size.width != width) || (sc->frame.size.height != height)) {
+                int frameWidth = (int) sc->frame.size.width;
+                int frameHeight = (int) sc->frame.size.height;
+
+                if ((frameWidth != width) || (frameHeight != height)) {
                     sc->frame.size.width = width;
                     sc->frame.size.height = height;
                     needs_to_update_properties = true;

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -630,10 +630,13 @@ static void syphon_video_tick(void *data, float seconds)
     if (s->crop)
         crop = &s->crop_rect;
 
+    float origin_x = (float) crop->origin.x;
+    float origin_y = (float) (s->height - crop->origin.y);
+    float end_x = (float) (s->width - crop->size.width);
+    float end_y = (float) crop->size.height;
+
     obs_enter_graphics();
-    build_sprite_rect(gs_vertexbuffer_get_data(s->vertbuffer), (float) crop->origin.x,
-                      (float) s->height - (float) crop->origin.y, (float) s->width - (float) crop->size.width,
-                      (float) crop->size.height);
+    build_sprite_rect(gs_vertexbuffer_get_data(s->vertbuffer), origin_x, origin_y, end_x, end_y);
     obs_leave_graphics();
 }
 

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -632,7 +632,7 @@ static void syphon_video_tick(void *data, float seconds)
 
     obs_enter_graphics();
     build_sprite_rect(gs_vertexbuffer_get_data(s->vertbuffer), (float) crop->origin.x,
-                      s->height - (float) crop->origin.y, s->width - (float) crop->size.width,
+                      (float) s->height - (float) crop->origin.y, (float) s->width - (float) crop->size.width,
                       (float) crop->size.height);
     obs_leave_graphics();
 }

--- a/plugins/mac-syphon/syphon.m
+++ b/plugins/mac-syphon/syphon.m
@@ -630,10 +630,13 @@ static void syphon_video_tick(void *data, float seconds)
     if (s->crop)
         crop = &s->crop_rect;
 
+    float origin_x = (float) crop->origin.x;
+    float origin_y = (float) (s->height - crop->origin.y);
+    float end_x = (float) (s->width - crop->size.width);
+    float end_y = (float) crop->size.height;
+
     obs_enter_graphics();
-    build_sprite_rect(gs_vertexbuffer_get_data(s->vertbuffer), (float) crop->origin.x,
-                      s->height - (float) crop->origin.y, s->width - (float) crop->size.width,
-                      (float) crop->size.height);
+    build_sprite_rect(gs_vertexbuffer_get_data(s->vertbuffer), origin_x, origin_y, end_x, end_y);
     obs_leave_graphics();
 }
 

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -539,8 +539,8 @@ static OSStatus create_encoder(struct vt_encoder *enc)
 					     kVTCompressionPropertyKey_AllowFrameReordering,
 					     kVTCompressionPropertyKey_ProfileLevel};
 
-		SInt32 key_frame_interval = (SInt32)(enc->keyint * ((float)enc->fps_num / enc->fps_den));
-		float expected_framerate = (float)enc->fps_num / enc->fps_den;
+		SInt32 key_frame_interval = (SInt32)((float)enc->keyint * ((float)enc->fps_num / (float)enc->fps_den));
+		float expected_framerate = (float)enc->fps_num / (float)enc->fps_den;
 		CFNumberRef MaxKeyFrameInterval =
 			CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &key_frame_interval);
 		CFNumberRef ExpectedFrameRate =

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -539,12 +539,13 @@ static OSStatus create_encoder(struct vt_encoder *enc)
 					     kVTCompressionPropertyKey_AllowFrameReordering,
 					     kVTCompressionPropertyKey_ProfileLevel};
 
-		SInt32 key_frame_interval = (SInt32)(enc->keyint * ((float)enc->fps_num / enc->fps_den));
-		float expected_framerate = (float)enc->fps_num / enc->fps_den;
+		int actual_frame_rate = enc->fps_num / enc->fps_den;
+		int key_frame_interval = enc->keyint * actual_frame_rate;
+
 		CFNumberRef MaxKeyFrameInterval =
-			CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &key_frame_interval);
+			CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &key_frame_interval);
 		CFNumberRef ExpectedFrameRate =
-			CFNumberCreate(kCFAllocatorDefault, kCFNumberFloat32Type, &expected_framerate);
+			CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &actual_frame_rate);
 		CFTypeRef AllowFrameReordering = enc->bframes ? kCFBooleanTrue : kCFBooleanFalse;
 
 		video_t *video = obs_encoder_video(enc->encoder);

--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -539,12 +539,13 @@ static OSStatus create_encoder(struct vt_encoder *enc)
 					     kVTCompressionPropertyKey_AllowFrameReordering,
 					     kVTCompressionPropertyKey_ProfileLevel};
 
-		SInt32 key_frame_interval = (SInt32)((float)enc->keyint * ((float)enc->fps_num / (float)enc->fps_den));
-		float expected_framerate = (float)enc->fps_num / (float)enc->fps_den;
+		int actual_frame_rate = enc->fps_num / enc->fps_den;
+		int key_frame_interval = enc->keyint * actual_frame_rate;
+
 		CFNumberRef MaxKeyFrameInterval =
-			CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &key_frame_interval);
+			CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &key_frame_interval);
 		CFNumberRef ExpectedFrameRate =
-			CFNumberCreate(kCFAllocatorDefault, kCFNumberFloat32Type, &expected_framerate);
+			CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &actual_frame_rate);
 		CFTypeRef AllowFrameReordering = enc->bframes ? kCFBooleanTrue : kCFBooleanFalse;
 
 		video_t *video = obs_encoder_video(enc->encoder);

--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -19,7 +19,8 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, uint3
     CMTimeScale scale = 600;
     CMSampleTimingInfo timing;
     timing.duration = CMTimeMake(fpsDenominator * scale, fpsNumerator * scale);
-    timing.presentationTimeStamp = CMTimeMakeWithSeconds(timestampNanos / (double) NSEC_PER_SEC, scale);
+    CMTime timestamp = CMTimeMake(timestampNanos, NSEC_PER_SEC);
+    timing.presentationTimeStamp = CMTimeConvertScale(timestamp, scale, kCMTimeRoundingMethod_QuickTime);
     timing.decodeTimeStamp = kCMTimeInvalid;
     return timing;
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -19,7 +19,8 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, uint3
     CMTimeScale scale = 600;
     CMSampleTimingInfo timing;
     timing.duration = CMTimeMake(fpsDenominator * scale, fpsNumerator * scale);
-    timing.presentationTimeStamp = CMTimeMakeWithSeconds((double)timestampNanos / (double) NSEC_PER_SEC, scale);
+    CMTime timestamp = CMTimeMake(timestampNanos, NSEC_PER_SEC);
+    timing.presentationTimeStamp = CMTimeConvertScale(timestamp, scale, kCMTimeRoundingMethod_QuickTime);
     timing.decodeTimeStamp = kCMTimeInvalid;
     return timing;
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/CMSampleBufferUtils.mm
@@ -19,7 +19,7 @@ CMSampleTimingInfo CMSampleTimingInfoForTimestamp(uint64_t timestampNanos, uint3
     CMTimeScale scale = 600;
     CMSampleTimingInfo timing;
     timing.duration = CMTimeMake(fpsDenominator * scale, fpsNumerator * scale);
-    timing.presentationTimeStamp = CMTimeMakeWithSeconds(timestampNanos / (double) NSEC_PER_SEC, scale);
+    timing.presentationTimeStamp = CMTimeMakeWithSeconds((double)timestampNanos / (double) NSEC_PER_SEC, scale);
     timing.decodeTimeStamp = kCMTimeInvalid;
     return timing;
 }

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -123,8 +123,8 @@
 {
     if (NSEqualSizes(_testCardSize, NSZeroSize)) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSInteger width = [[defaults objectForKey:kTestCardWidthKey] integerValue];
-        NSInteger height = [[defaults objectForKey:kTestCardHeightKey] integerValue];
+        double width = [[defaults objectForKey:kTestCardWidthKey] doubleValue];
+        double height = [[defaults objectForKey:kTestCardHeightKey] doubleValue];
         if (width == 0 || height == 0) {
             _testCardSize = NSMakeSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         } else {
@@ -238,9 +238,9 @@
     NSParameterAssert(pxdata != NULL);
 
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(pxdata, width, height, 8,
-                                                 CVPixelBufferGetBytesPerRowOfPlane(pxbuffer, 0), rgbColorSpace,
-                                                 kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Big);
+    CGContextRef context =
+        CGBitmapContextCreate(pxdata, width, height, 8, CVPixelBufferGetBytesPerRowOfPlane(pxbuffer, 0), rgbColorSpace,
+                              (CGBitmapInfo) kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Big);
     CFRelease(rgbColorSpace);
     NSParameterAssert(context);
 
@@ -249,7 +249,8 @@
 
     NSRect rect = NSMakeRect(0, 0, self.testCardImage.size.width, self.testCardImage.size.height);
     CGImageRef image = [self.testCardImage CGImageForProposedRect:&rect context:nsContext hints:nil];
-    CGContextDrawImage(context, CGRectMake(0, 0, CGImageGetWidth(image), CGImageGetHeight(image)), image);
+    CGContextDrawImage(context, CGRectMake(0, 0, (double) CGImageGetWidth(image), (double) CGImageGetHeight(image)),
+                       image);
 
     //	DrawDialWithFrame(
     //		NSMakeRect(0, 0, width, height),

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -123,12 +123,12 @@
 {
     if (NSEqualSizes(_testCardSize, NSZeroSize)) {
         NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSInteger width = [[defaults objectForKey:kTestCardWidthKey] integerValue];
-        NSInteger height = [[defaults objectForKey:kTestCardHeightKey] integerValue];
+        double width = [[defaults objectForKey:kTestCardWidthKey] doubleValue];
+        double height = [[defaults objectForKey:kTestCardHeightKey] doubleValue];
         if (width == 0 || height == 0) {
             _testCardSize = NSMakeSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         } else {
-            _testCardSize = NSMakeSize((double)width, (double)height);
+            _testCardSize = NSMakeSize(width, height);
         }
     }
     return _testCardSize;
@@ -238,9 +238,9 @@
     NSParameterAssert(pxdata != NULL);
 
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef context = CGBitmapContextCreate(pxdata, width, height, 8,
-                                                 CVPixelBufferGetBytesPerRowOfPlane(pxbuffer, 0), rgbColorSpace,
-                                                 ((int)kCGImageAlphaPremultipliedFirst) | ((int)kCGImageByteOrder32Big));
+    CGContextRef context =
+        CGBitmapContextCreate(pxdata, width, height, 8, CVPixelBufferGetBytesPerRowOfPlane(pxbuffer, 0), rgbColorSpace,
+                              (CGBitmapInfo) kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Big);
     CFRelease(rgbColorSpace);
     NSParameterAssert(context);
 
@@ -249,7 +249,8 @@
 
     NSRect rect = NSMakeRect(0, 0, self.testCardImage.size.width, self.testCardImage.size.height);
     CGImageRef image = [self.testCardImage CGImageForProposedRect:&rect context:nsContext hints:nil];
-    CGContextDrawImage(context, CGRectMake(0, 0, (double)CGImageGetWidth(image), (double)CGImageGetHeight(image)), image);
+    CGContextDrawImage(context, CGRectMake(0, 0, (double) CGImageGetWidth(image), (double) CGImageGetHeight(image)),
+                       image);
 
     //	DrawDialWithFrame(
     //		NSMakeRect(0, 0, width, height),

--- a/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
+++ b/plugins/mac-virtualcam/src/dal-plugin/OBSDALStream.mm
@@ -128,7 +128,7 @@
         if (width == 0 || height == 0) {
             _testCardSize = NSMakeSize(DEFAULT_WIDTH, DEFAULT_HEIGHT);
         } else {
-            _testCardSize = NSMakeSize(width, height);
+            _testCardSize = NSMakeSize((double)width, (double)height);
         }
     }
     return _testCardSize;
@@ -240,7 +240,7 @@
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
     CGContextRef context = CGBitmapContextCreate(pxdata, width, height, 8,
                                                  CVPixelBufferGetBytesPerRowOfPlane(pxbuffer, 0), rgbColorSpace,
-                                                 kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Big);
+                                                 ((int)kCGImageAlphaPremultipliedFirst) | ((int)kCGImageByteOrder32Big));
     CFRelease(rgbColorSpace);
     NSParameterAssert(context);
 
@@ -249,7 +249,7 @@
 
     NSRect rect = NSMakeRect(0, 0, self.testCardImage.size.width, self.testCardImage.size.height);
     CGImageRef image = [self.testCardImage CGImageForProposedRect:&rect context:nsContext hints:nil];
-    CGContextDrawImage(context, CGRectMake(0, 0, CGImageGetWidth(image), CGImageGetHeight(image)), image);
+    CGContextDrawImage(context, CGRectMake(0, 0, (double)CGImageGetWidth(image), (double)CGImageGetHeight(image)), image);
 
     //	DrawDialWithFrame(
     //		NSMakeRect(0, 0, width, height),


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Adds explicit type conversion within mac plugins:
- mac-capture
- mac-syphon
- mac-videotoolbox
- mac-virtualcam
With the newest XCode 26.4 version, the compiler raises an error when there is an implicit type conversion between types with different sizes. Because of this, the code for the above plugins raise a compile error when compiled using the latest Apple Clang 21.0 and XCode 26.4.
While there are many reasons for why doing type conversion between types with different sizes may be bad, the cases where they are used within the above plugins are well within range of the smaller type or are simple enum values.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
The current obs-studio master branch [fails](https://github.com/obsproject/obs-studio/issues/13267) to build with Apple Clang 21.0 and XCode 26.4 due to compile errors. The error has been reproduced by another member of the community (@WizardCM) The compile errors all come from implicit conversion of types within the source code of the the above mentioned plugins.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Used Cmake to build the macos preset and used Xcode to compile. More specifically, followed the instructions [here](https://github.com/obsproject/obs-studio/wiki/Build-Instructions-For-Mac).
Used 
```bash
cmake --preset macos
```
to generate a xcode project and used
```bash
xcodebuild -configuration Debug -scheme obs-studio -parallelizeTargets -destination "generic/platform=macOS,name=Any Mac"
```
to build the XCode Project and confirmed that there were no compile errors with the OBS source code.

While after applying the changes there are no more compile/build errors within the OBS source code, there is now a build error with the included qt library file, more specifically the obs-studio/.deps/obs-deps-qt6-2025-08-23-universal/lib/QtCore.framework/Headers/qyieldcpu.h file.
The error message is as follows:
<img width="2842" height="344" alt="image" src="https://github.com/user-attachments/assets/02ec521a-f55e-4597-8f7c-90fc9bb8ad18" />

While I was able to find [this](https://forum.qt.io/topic/164491/qmake-nmake-fails-on-macosx26.4-with-qt-6.11-with-error-implicitly-declaring-library-function-__yield/3) forum thread and apply changes listed there to the qyieldcpu.h and have it finally build without error, I was not able to include the changes to the included qt library in the pull request. 


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
