### PR TITLE
text-freetype2: Fix font index retrieval and increase texture buffer size; add support for Cyrillic characters in glyph caching

### DIFF
--- a/plugins/text-freetype2/find-font-unix.c
+++ b/plugins/text-freetype2/find-font-unix.c
@@ -59,7 +59,7 @@ const char *get_font_path(const char *family, uint16_t size, const char *style, 
 		FcStrFree(path);
 
 		int fc_index = 0;
-		FcPatternGetInteger(match, FC_INDEX, 1, &fc_index);
+		FcPatternGetInteger(match, FC_INDEX, 0, &fc_index);
 		*idx = (FT_Long)fc_index;
 
 		FcPatternDestroy(match);

--- a/plugins/text-freetype2/text-freetype2.c
+++ b/plugins/text-freetype2/text-freetype2.c
@@ -33,7 +33,7 @@ MODULE_EXPORT const char *obs_module_description(void)
 	return "FreeType2 text source";
 }
 
-uint32_t texbuf_w = 2048, texbuf_h = 2048;
+uint32_t texbuf_w = 4096, texbuf_h = 4096;
 
 static const char *ft2_source_get_name(void *unused);
 static void *ft2_source_create(obs_data_t *settings, obs_source_t *source);

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -205,7 +205,9 @@ void cache_standard_glyphs(struct ft2_source *srcdata)
 
 	cache_glyphs(srcdata, L"abcdefghijklmnopqrstuvwxyz"
 			      L"ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
-			      L"!@#$%^&*()-_=+,<.>/?\\|[]{}`~ \'\"\0");
+			      L"!@#$%^&*()-_=+,<.>/?\\|[]{}`~ \'\""
+			      L"абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+			      L"АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ\0");
 }
 
 FT_Render_Mode get_render_mode(struct ft2_source *srcdata)


### PR DESCRIPTION
### Description
Fix multiple issues in `text-freetype2` that cause glyphs to be silently dropped on Linux:
1. **Fix `FC_INDEX` retrieval in Fontconfig** (`find-font-unix.c`): `FcPatternGetInteger` was called with value index `1` instead of `0`, requesting a non-existent second value. For TTC/OTC font collections, this caused the wrong face (with incomplete glyph coverage) to be loaded.
2. **Increase glyph atlas from 2048×2048 to 4096×4096** (`text-freetype2.c`): At larger font sizes (e.g. v2 default 256px), the atlas overflows after caching Latin glyphs. `cache_glyphs` hits `break` on "Out of space", and `fill_vertex_buffer` skips uncached glyphs — producing missing characters.
3. **Pre-cache Cyrillic in `cache_standard_glyphs`** (`text-functionality.c`): Only ASCII was pre-cached. Cyrillic letters are now included alongside Latin.
### Motivation and Context
Fixes https://github.com/obsproject/obs-studio/issues/11819
On Linux, `text-freetype2` renders strings with missing characters — especially Cyrillic. Windows is unaffected because it uses `text-gdiplus`, which has no fixed-size atlas.
### How Has This Been Tested?
- Built patched `text-freetype2.so` on Arch Linux (GCC 15.2.1) against OBS 32.1.1 (Flatpak).
- Cyrillic text via OBS WebSocket (`SetInputSettings`) renders completely.
- No `"Out of space trying to render glyphs"` warnings at font sizes up to 256px with mixed Latin/Cyrillic.
- Latin text unaffected.
### Types of changes
- Bug fix (non-breaking change which fixes an issue)
### Checklist:
- [x] My code has been run through clang-format.
- [x] I have read the contributing document.
- [ ] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.