### PR TITLE
obs-ffmpeg: Fix build when ENABLE_HEVC=false

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-vaapi.c
@@ -1010,8 +1010,10 @@ static bool vaapi_device_codec_supported(const char *path, enum codec_type codec
 	switch (codec) {
 	case CODEC_H264:
 		return vaapi_device_h264_supported(path);
+#if ENABLE_HEVC
 	case CODEC_HEVC:
 		return vaapi_device_hevc_supported(path);
+#endif
 	case CODEC_AV1:
 		return vaapi_device_av1_supported(path);
 	default:


### PR DESCRIPTION
### Description

Simple fix for missing pre-processing condition around HEVC-specific code.


### Motivation and Context

Build with `ENABLE_HEVC: false` fails due to missing definition(s) + implicit declaration.


### How Has This Been Tested?

Make with `-DENABLE_HEVC=OFF` or use `CMakeUserPresets.json` to define custom build without HEVC.


### Types of changes

- Tweak (non-breaking change to improve existing functionality)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.