### PR TITLE
linux-v4l2: Fix missing fd close

### DIFF
--- a/plugins/linux-v4l2/v4l2-input.c
+++ b/plugins/linux-v4l2/v4l2-input.c
@@ -670,8 +670,10 @@ static bool format_selected(obs_properties_t *props, obs_property_t *p, obs_data
 
 	int input = (int)obs_data_get_int(settings, "input");
 	uint32_t caps = 0;
-	if (v4l2_get_input_caps(dev, input, &caps) < 0)
+	if (v4l2_get_input_caps(dev, input, &caps) < 0) {
+		v4l2_close(dev);
 		return false;
+	}
 	caps &= V4L2_IN_CAP_STD | V4L2_IN_CAP_DV_TIMINGS;
 
 	obs_property_t *resolution = obs_properties_get(props, "resolution");


### PR DESCRIPTION
### Description

`close()` the V4L2 device when we fail to get input capabilities when the format is selected.


### Motivation and Context

I was looking for something that might explain https://github.com/obsproject/obs-studio/issues/12508 - but still no luck. But at least I found this.


### How Has This Been Tested?

Hasn't been tested - I would need a device that I can disable the input on: but it doesn't impact the case where the device can select input.


### Types of changes

-    Bug fix (non-breaking change which fixes an issue)


### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
