### PR TITLE
libobs: Add BLERP, an optimized bicubic scaler

### DIFF
--- a/libobs/data/bicubic_scale.effect
+++ b/libobs/data/bicubic_scale.effect
@@ -12,6 +12,7 @@ uniform float2 base_dimension;
 uniform float2 base_dimension_i;
 uniform float undistort_factor = 1.0;
 uniform float multiplier;
+uniform bool use_blerp = false;
 
 sampler_state textureSampler {
 	Filter    = Linear;
@@ -113,6 +114,27 @@ float4 DrawBicubic(FragData f_in, bool undistort)
 
 	int2 coord_top_left = int2(max(uv0 * base_dimension, 0.5));
 	int2 coord_bottom_right = int2(min(uv3 * base_dimension, base_dimension - 0.5));
+
+	if (use_blerp) {
+		float4 top_left = image.Load(int3(coord_top_left, 0));
+		float4 top_right = image.Load(int3(coord_bottom_right.x, coord_top_left.y, 0));
+		float4 mid_middle = image.Sample(textureSampler, float2(u_middle, v_middle));
+		float4 bot_left = image.Load(int3(coord_top_left.x, coord_bottom_right.y, 0));
+		float4 bot_right = image.Load(int3(coord_bottom_right, 0));
+
+		// I am replacing all the mid points with lerps from corner to corner to avoid
+		// the extra texture reads.
+		// Interestingly lerp seems to be a bit more expensive than just doing this math
+		float4 mid_left = (top_left + bot_left) * 0.5;
+		float4 mid_right = (top_right + bot_right) * 0.5;
+		float4 top_middle = (top_left + top_right) * 0.5;
+		float4 bot_middle = (bot_left + bot_right) * 0.5;
+
+		float4 top = (top_left * rowtaps.x) + (top_middle * u_weight_sum) + (top_right * rowtaps.w);
+		float4 middle = (mid_left * rowtaps.x) + (mid_middle * u_weight_sum) + (mid_right * rowtaps.w);
+		float4 bottom = (bot_left * rowtaps.x) + (bot_middle * u_weight_sum) + (bot_right * rowtaps.w);
+		return (top * coltaps.x) + (middle * v_weight_sum) + (bottom * coltaps.w);
+	}
 
 	float4 top = image.Load(int3(coord_top_left, 0)) * rowtaps.x;
 	top += image.Sample(textureSampler, float2(u_middle, uv0.y)) * u_weight_sum;

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -765,7 +765,7 @@ static void render_item_texture(struct obs_scene_item *item, enum gs_color_space
 			   !close_float(item->output_scale.y, 1.0f, EPSILON)) {
 			if (item->output_scale.x < 0.5f || item->output_scale.y < 0.5f) {
 				effect = obs->video.bilinear_lowres_effect;
-			} else if (type == OBS_SCALE_BICUBIC) {
+			} else if (type == OBS_SCALE_BICUBIC || type == OBS_SCALE_BLERP) {
 				effect = obs->video.bicubic_effect;
 			} else if (type == OBS_SCALE_LANCZOS) {
 				effect = obs->video.lanczos_effect;
@@ -787,6 +787,10 @@ static void render_item_texture(struct obs_scene_item *item, enum gs_color_space
 
 				gs_effect_set_vec2(scale_i_param, &base_res_i);
 			}
+
+			gs_eparam_t *const blerp_param = gs_effect_get_param_by_name(effect, "use_blerp");
+			if (blerp_param)
+				gs_effect_set_bool(blerp_param, type == OBS_SCALE_BLERP);
 		}
 	}
 
@@ -1225,6 +1229,8 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 			item->scale_filter = OBS_SCALE_LANCZOS;
 		else if (astrcmpi(scale_filter_str, "area") == 0)
 			item->scale_filter = OBS_SCALE_AREA;
+		else if (astrcmpi(scale_filter_str, "blerp") == 0)
+			item->scale_filter = OBS_SCALE_BLERP;
 	}
 
 	blend_method_str = obs_data_get_string(item_data, "blend_method");
@@ -1387,6 +1393,8 @@ static void scene_save_item(obs_data_array_t *array, struct obs_scene_item *item
 		scale_filter = "lanczos";
 	else if (item->scale_filter == OBS_SCALE_AREA)
 		scale_filter = "area";
+	else if (item->scale_filter == OBS_SCALE_BLERP)
+		scale_filter = "blerp";
 	else
 		scale_filter = "disable";
 

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -236,6 +236,7 @@ static inline gs_effect_t *get_scale_effect_internal(struct obs_core_video_mix *
 	case OBS_SCALE_AREA:
 		return video->area_effect;
 	case OBS_SCALE_BICUBIC:
+	case OBS_SCALE_BLERP:
 	default:;
 	}
 
@@ -303,6 +304,10 @@ static inline gs_texture_t *render_output_texture(struct obs_core_video_mix *mix
 	}
 
 	gs_effect_set_texture_srgb(image, texture);
+
+	gs_eparam_t *use_blerp = gs_effect_get_param_by_name(effect, "use_blerp");
+	if (use_blerp)
+		gs_effect_set_bool(use_blerp, mix->ovi.scale_type == OBS_SCALE_BLERP);
 
 	gs_enable_framebuffer_srgb(true);
 	gs_enable_blending(false);

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1568,6 +1568,9 @@ int obs_reset_video(struct obs_video_info *ovi)
 	case OBS_SCALE_AREA:
 		scale_type_name = "Area";
 		break;
+	case OBS_SCALE_BLERP:
+		scale_type_name = "Blerp";
+		break;
 	}
 
 	bool yuv = format_is_yuv(ovi->output_format);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -128,6 +128,7 @@ enum obs_scale_type {
 	OBS_SCALE_BILINEAR,
 	OBS_SCALE_LANCZOS,
 	OBS_SCALE_AREA,
+	OBS_SCALE_BLERP,
 };
 
 enum obs_blending_method {


### PR DESCRIPTION
### Description
Add OBS_SCALE_BLERP, a bicubic scaling variant that reduces
texture reads from 9 to 5 per output pixel. It loads only the
4 corner texels and 1 center sample, then computes edge
midpoints via linear interpolation instead of additional
texture fetches.  No aspects of the bicubic algorithm were
changed.  The same kernel is used and all math operations
are the same.

BLERP is integrated as a parameterized path in the existing
bicubic_scale.effect via a uniform bool use_blerp toggle
rather than a separate effect file. 

This commit wires BLERP through the core pipeline, scene
item serialization, and multitrack video config only. UI
integration was not done, as the primary motivation is
improving multi-track scaling performance.

### Motivation and Context
This is scaler  is particularly useful for multi-track video encoding
where multiple renditions must be scaled simultaneously. Each
rendition competes for the same GPU scaling resources, so
reducing per-pixel texture read cost has a multiplied effect
across the full set of encoder outputs.  Testing showed a 30-45%
improvement in performance which is in line with expectations from
a reduction from 9 to 5 texture reads.

The original motivation for this change was to find an optimization
that would provide better quality than bilinear but could potentially
be a bit worse than the existing bicubic.  A middle ground to use 
for some lower end GPUs to unlock better quality for multi-track 
scenarios.  VMAF generally prefers this over the original bicubic 
implementation though (a pleasant surprise).  While PSNR scores 
absolutely did fall in between bilinear and bicubic.

### How Has This Been Tested?
I have done VMAF comparisons and PSNR comparisons which for 
almost all clips are comparable to bicubic with VMAF usually being
slightly higher and PSNR being very slightly lower.  

We have had this the Twitch Portable Build for a few weeks now.  Our
client configuration endpoint prefers it over bicubic, so all TEB users
of this build have been getting BLERP.  Additionally it was exposed in
the UI in this build to allow other to inspect the results more easily.  
There have been0 complaints, and in fact a few comments suggesting 
that the output of BLERP was preferred over bicubic which suggest the 
quality bar has been maintained well enough while at the same time 
improving performance.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
