### PR TITLE
libobs: Add process uptime to Windows crash logs

### DIFF
--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -239,6 +239,32 @@ static inline void init_module_info(struct exception_handler_data *data)
 
 extern const char *get_win_release_id();
 
+static int get_process_uptime_seconds()
+{
+	FILETIME creation_time = {0};
+	FILETIME exit_time = {0};
+	FILETIME kernel_time = {0};
+	FILETIME user_time = {0};
+
+	if (!GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time, &kernel_time, &user_time))
+		return -1;
+
+	FILETIME current_time = {0};
+	GetSystemTimeAsFileTime(&current_time);
+
+	// Can't cast directly due to alignment requirements of ULARGE_INTEGER
+	ULARGE_INTEGER creation_time_ularge = {0};
+	ULARGE_INTEGER current_time_ularge = {0};
+
+	creation_time_ularge.LowPart = creation_time.dwLowDateTime;
+	creation_time_ularge.HighPart = creation_time.dwHighDateTime;
+
+	current_time_ularge.LowPart = current_time.dwLowDateTime;
+	current_time_ularge.HighPart = current_time.dwHighDateTime;
+
+	return (int)((current_time_ularge.QuadPart - creation_time_ularge.QuadPart) / 10000000);
+}
+
 static inline void write_header(struct exception_handler_data *data)
 {
 	char date_time[80];
@@ -255,6 +281,8 @@ static inline void write_header(struct exception_handler_data *data)
 
 	const char *release_id = get_win_release_id();
 
+	int process_uptime_seconds = get_process_uptime_seconds();
+
 	dstr_catf(&data->str,
 		  "Unhandled exception: %x\r\n"
 		  "Date/Time: %s\r\n"
@@ -262,11 +290,14 @@ static inline void write_header(struct exception_handler_data *data)
 		  "libobs version: " OBS_VERSION " (%s-bit)\r\n"
 		  "Windows version: %d.%d build %d (release: %s; revision: %d; "
 		  "%s-bit)\r\n"
-		  "CPU: %s\r\n\r\n",
+		  "CPU: %s\r\n"
+		  "Process Uptime: %dh %dm %ds\r\n"
+		  "\r\n",
 		  data->exception->ExceptionRecord->ExceptionCode, date_time, data->main_trace.instruction_ptr,
 		  data->module_name.array, obs_bitness, data->win_version.major, data->win_version.minor,
 		  data->win_version.build, release_id, data->win_version.revis, is_64_bit_windows() ? "64" : "32",
-		  data->cpu_info.array);
+		  data->cpu_info.array, process_uptime_seconds / 3600, (process_uptime_seconds % 3600) / 60,
+		  process_uptime_seconds % 60);
 }
 
 struct module_info {


### PR DESCRIPTION
### Description
Logs the process uptime during a crash.

### Motivation and Context
For some crashes it is useful to know if they happened immediately upon launch or during normal use of the application.

### How Has This Been Tested?
Crashed OBS, verified it showed up.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
