### PR TITLE
frontend: Update interaction dialog to use weak source

### DIFF
--- a/frontend/dialogs/OBSBasicInteraction.cpp
+++ b/frontend/dialogs/OBSBasicInteraction.cpp
@@ -37,11 +37,11 @@
 
 using namespace std;
 
-OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
+OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source)
 	: QDialog(parent),
 	  main(qobject_cast<OBSBasic *>(parent)),
 	  ui(new Ui::OBSBasicInteraction),
-	  source(source_),
+	  weakSource(OBSGetWeakRef(source)),
 	  removedSignal(obs_source_get_signal_handler(source), "remove", OBSBasicInteraction::SourceRemoved, this),
 	  renamedSignal(obs_source_get_signal_handler(source), "rename", OBSBasicInteraction::SourceRenamed, this),
 	  eventFilter(BuildEventFilter())
@@ -122,12 +122,13 @@ void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
 void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 {
 	OBSBasicInteraction *window = static_cast<OBSBasicInteraction *>(data);
+	OBSSource source = window->getSource();
 
-	if (!window->source)
+	if (!source)
 		return;
 
-	uint32_t sourceCX = max(obs_source_get_width(window->source), 1u);
-	uint32_t sourceCY = max(obs_source_get_height(window->source), 1u);
+	uint32_t sourceCX = max(obs_source_get_width(source), 1u);
+	uint32_t sourceCY = max(obs_source_get_height(source), 1u);
 
 	int x, y;
 	int newCX, newCY;
@@ -144,7 +145,7 @@ void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 
 	gs_ortho(0.0f, float(sourceCX), 0.0f, float(sourceCY), -100.0f, 100.0f);
 	gs_set_viewport(x, y, newCX, newCY);
-	obs_source_video_render(window->source);
+	obs_source_video_render(source);
 
 	gs_set_linear_srgb(previous);
 	gs_projection_pop();
@@ -229,6 +230,11 @@ static int TranslateQtMouseEventModifiers(QMouseEvent *event)
 
 bool OBSBasicInteraction::GetSourceRelativeXY(int mouseX, int mouseY, int &relX, int &relY)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return false;
+
 	float pixelRatio = devicePixelRatioF();
 	int mouseXscaled = (int)roundf(mouseX * pixelRatio);
 	int mouseYscaled = (int)roundf(mouseY * pixelRatio);
@@ -262,6 +268,11 @@ bool OBSBasicInteraction::GetSourceRelativeXY(int mouseX, int mouseY, int &relX,
 
 bool OBSBasicInteraction::HandleMouseClickEvent(QMouseEvent *event)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return true;
+
 	bool mouseUp = event->type() == QEvent::MouseButtonRelease;
 	int clickCount = 1;
 	if (event->type() == QEvent::MouseButtonDblClick)
@@ -303,6 +314,11 @@ bool OBSBasicInteraction::HandleMouseClickEvent(QMouseEvent *event)
 
 bool OBSBasicInteraction::HandleMouseMoveEvent(QMouseEvent *event)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return true;
+
 	struct obs_mouse_event mouseEvent = {};
 
 	bool mouseLeave = event->type() == QEvent::Leave;
@@ -320,6 +336,11 @@ bool OBSBasicInteraction::HandleMouseMoveEvent(QMouseEvent *event)
 
 bool OBSBasicInteraction::HandleMouseWheelEvent(QWheelEvent *event)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return true;
+
 	struct obs_mouse_event mouseEvent = {};
 
 	mouseEvent.modifiers = TranslateQtKeyboardEventModifiers(event, true);
@@ -353,6 +374,11 @@ bool OBSBasicInteraction::HandleMouseWheelEvent(QWheelEvent *event)
 
 bool OBSBasicInteraction::HandleFocusEvent(QFocusEvent *event)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return true;
+
 	bool focus = event->type() == QEvent::FocusIn;
 
 	obs_source_send_focus(source, focus);
@@ -362,6 +388,11 @@ bool OBSBasicInteraction::HandleFocusEvent(QFocusEvent *event)
 
 bool OBSBasicInteraction::HandleKeyEvent(QKeyEvent *event)
 {
+	OBSSource source = getSource();
+
+	if (!source)
+		return true;
+
 	struct obs_key_event keyEvent;
 
 	QByteArray text = event->text().toUtf8();

--- a/frontend/dialogs/OBSBasicInteraction.hpp
+++ b/frontend/dialogs/OBSBasicInteraction.hpp
@@ -33,7 +33,7 @@ private:
 	OBSBasic *main;
 
 	std::unique_ptr<Ui::OBSBasicInteraction> ui;
-	OBSSource source;
+	OBSWeakSourceAutoRelease weakSource;
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	std::unique_ptr<OBSEventFilter> eventFilter;
@@ -53,10 +53,12 @@ private:
 	OBSEventFilter *BuildEventFilter();
 
 public:
-	OBSBasicInteraction(QWidget *parent, OBSSource source_);
+	OBSBasicInteraction(QWidget *parent, OBSSource source);
 	~OBSBasicInteraction();
 
 	void Init();
+
+	inline OBSSource getSource() { return OBSGetStrongRef(weakSource); }
 
 protected:
 	virtual void closeEvent(QCloseEvent *event) override;


### PR DESCRIPTION
### Description
UI elements shouldn't have strong references to sources, since they are the ones that don't own them.

### Motivation and Context
Split from https://github.com/obsproject/obs-studio/pull/6139

### How Has This Been Tested?
Interacted with browser source

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
