### PR TITLE
frontend: Use auto release weak source for media controls

### DIFF
--- a/frontend/components/MediaControls.hpp
+++ b/frontend/components/MediaControls.hpp
@@ -12,7 +12,7 @@ class MediaControls : public QWidget {
 
 private:
 	std::vector<OBSSignal> sigs;
-	OBSWeakSource weakSource = nullptr;
+	OBSWeakSourceAutoRelease weakSource;
 	QTimer mediaTimer;
 	QTimer seekTimer;
 	int seek;


### PR DESCRIPTION
### Description
The media controls were made before auto releasing objects were implemented.

### Motivation and Context
Code consistency

### How Has This Been Tested?
Used media controls

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
