### PR TITLE
frontend: Scale simple output recording audio bitrate by channel count

### DIFF
--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -375,13 +375,26 @@ void SimpleOutput::Update()
 void SimpleOutput::UpdateRecordingAudioSettings()
 {
 	OBSDataAutoRelease settings = obs_data_create();
-	obs_data_set_int(settings, "bitrate", 192);
 	obs_data_set_string(settings, "rate_control", "CBR");
 
+	const char *audioEncoder = config_get_string(main->Config(), "SimpleOutput", "RecAudioEncoder");
 	int tracks = config_get_int(main->Config(), "SimpleOutput", "RecTracks");
 	const char *recFormat = config_get_string(main->Config(), "SimpleOutput", "RecFormat2");
 	const char *quality = config_get_string(main->Config(), "SimpleOutput", "RecQuality");
 	bool flv = strcmp(recFormat, "flv") == 0;
+
+	// Scale the stereo reference bitrate (192 kbps) by the active channel
+	// count so that multi-channel layouts such as 5.1 are not starved of
+	// bandwidth relative to a stereo mix.
+	int channels = (int)audio_output_get_channels(obs_get_audio());
+	int bitrate = 192 * channels / 2;
+	if (strcmp(audioEncoder, "opus") == 0) {
+		bitrate = FindClosestAvailableSimpleOpusBitrate(bitrate);
+	} else {
+		bitrate = FindClosestAvailableSimpleAACBitrate(bitrate);
+	}
+
+	obs_data_set_int(settings, "bitrate", bitrate);
 
 	if (flv || strcmp(quality, "Stream") == 0) {
 		obs_encoder_update(audioRecording, settings);

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -392,13 +392,24 @@ void SimpleOutput::Update()
 void SimpleOutput::UpdateRecordingAudioSettings()
 {
 	OBSDataAutoRelease settings = obs_data_create();
-	obs_data_set_int(settings, "bitrate", 192);
 	obs_data_set_string(settings, "rate_control", "CBR");
 
+	const char *audioEncoder = config_get_string(main->Config(), "SimpleOutput", "RecAudioEncoder");
 	int tracks = config_get_int(main->Config(), "SimpleOutput", "RecTracks");
 	const char *recFormat = config_get_string(main->Config(), "SimpleOutput", "RecFormat2");
 	const char *quality = config_get_string(main->Config(), "SimpleOutput", "RecQuality");
 	bool flv = strcmp(recFormat, "flv") == 0;
+
+	constexpr int kDefaultStereoBitrateKbps{192};
+	constexpr int kStereoChannelCount{2};
+
+	int channels = (int)audio_output_get_channels(obs_get_audio());
+	int channelScaledBitrate{kDefaultStereoBitrateKbps * channels / kStereoChannelCount};
+
+	int bitrate = strcmp(audioEncoder, "opus") == 0 ? FindClosestAvailableSimpleOpusBitrate(channelScaledBitrate)
+							: FindClosestAvailableSimpleAACBitrate(channelScaledBitrate);
+
+	obs_data_set_int(settings, "bitrate", bitrate);
 
 	if (flv || strcmp(quality, "Stream") == 0) {
 		obs_encoder_update(audioRecording, settings);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
In Simple output mode, the recording audio bitrate was hardcoded to 192 kbps regardless of channel layout. The intention of this based on the git log was to ensure a high enough quality for recording regardless of the streaming setting. It didn't account for recordings with more than 2 channels where 192 kbps will not suffice.

This change replaces the hardcoded 192 value with a value calculated by scaling proportionally from the stereo reference (192 kbps) using the active channel count, snapping to the closest bitrate supported by the selected encoder (AAC or Opus).

Stereo recordings are unchanged (192 * 2 / 2 = 192 kbps).
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Currently, users recording in 5.1 or 7.1 formats will have degraded audio encoding (~32 kbps per channel) unless they switch to advanced mode. This does not seem like ideal behavior, especially since it's not clear this is happening based on the UI. By scaling the encoding quality depending on the channel count, we can ensure a quality experience.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Built on Windows 11 and tested by recording a capture with 6 channels in simple mode, confirming that the bitrate was increased as expected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
