### PR TITLE
libobs: Add canvas audio mixes

### DIFF
--- a/docs/sphinx/reference-canvases.rst
+++ b/docs/sphinx/reference-canvases.rst
@@ -48,6 +48,11 @@ The following signals are defined for canvases:
    Called when the canvas's video mix has been reset after a call to
    :c:func:`obs_reset_video()` or :c:func:`obs_canvas_reset_video()`.
 
+**audio_reset** (ptr canvas)
+
+   Called when the canvas's audio mix has been reset after a call to
+   :c:func:`obs_reset_audio()`, :c:func:`obs_reset_audio2()` or :c:func:`obs_canvas_reset_video()`.
+
 **source_add** (ptr canvas, ptr source)
 
    Called when a source has been added to the canvas.
@@ -103,12 +108,37 @@ General Canvas Functions
 
 ---------------------
 
+.. function:: obs_canvas_t *obs_canvas_create2(const char *name, struct obs_video_info *ovi, struct obs_audio_info2 *oai, uint32_t flags)
+
+   Creates a new canvas.
+
+   :param name: Name, will be deduplicated if necessary
+   :param ovi: Video configuration to use for this canvas's video output
+   :param oai: Audio configuration to use for this canvas's audio output
+   :param flags: Canvas flags
+   :return: Canvas object
+
+
+---------------------
+
 .. function:: obs_canvas_t *obs_canvas_create_private(const char *name, struct obs_video_info *ovi, uint32_t flags)
 
    Creates a new private canvas.
 
    :param name: Name, will **not** be deduplicated
    :param ovi: Video configuration to use for this canvas's video output
+   :param flags: Canvas flags
+   :return: Canvas object
+
+---------------------
+
+.. function:: obs_canvas_t *obs_canvas_create_private2(const char *name, struct obs_video_info *ovi, struct obs_audio_info2, uint32_t flags)
+
+   Creates a new private canvas.
+
+   :param name: Name, will **not** be deduplicated
+   :param ovi: Video configuration to use for this canvas's video output
+   :param oai: Audio configuration to use for this canvas's audio output
    :param flags: Canvas flags
    :return: Canvas object
 
@@ -298,5 +328,32 @@ Canvas Video Functions
 .. function:: void obs_canvas_render(obs_canvas_t *canvas)
 
    Render the canvas's view. Must be called on the graphics thread.
+
+---------------------
+
+Canvas Audio Functions
+----------------------
+
+.. function:: bool obs_canvas_reset_audio(obs_canvas_t *canvas, struct obs_audio_info2 *oai)
+
+   Reset a canvas's audio configuration.
+
+---------------------
+
+.. function:: bool obs_canvas_has_audio(obs_canvas_t *canvas)
+
+   Returns true if the canvas audio is configured.
+
+---------------------
+
+.. function:: audio_t *obs_canvas_get_audio(const obs_canvas_t *canvas)
+
+   Get canvas audio output
+
+---------------------
+
+.. function:: bool obs_canvas_get_audio_info(const obs_canvas_t *canvas, struct obs_audio_info2 *oai)
+
+   Get canvas audio info (if any)
 
 ---------------------

--- a/docs/sphinx/reference-core.rst
+++ b/docs/sphinx/reference-core.rst
@@ -212,6 +212,20 @@ Initialization, Shutdown, and Information
 
 ---------------------
 
+.. function:: bool obs_video_active(void)
+
+   Determines if video is active.
+
+   :return: *true* if active or *false* if not active
+
+---------------------
+
+.. function:: bool obs_audio_active(void)
+
+   Determines if audio is active.
+
+   :return: *true* if active or *false* if not active
+
 
 Libobs Objects
 --------------

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -147,7 +147,7 @@ extern bool devices_match(const char *id1, const char *id2);
 
 static bool audio_monitor_init(struct audio_monitor *monitor, obs_source_t *source)
 {
-	const struct audio_output_info *info = audio_output_get_info(obs->audio.audio);
+	const struct audio_output_info *info = audio_output_get_info(obs_get_audio());
 	uint32_t channels = get_audio_channels(info->speakers);
 	OSStatus stat;
 

--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -405,7 +405,7 @@ static bool audio_monitor_init(struct audio_monitor *monitor, obs_source_t *sour
 		return false;
 	}
 
-	const struct audio_output_info *info = audio_output_get_info(obs->audio.audio);
+	const struct audio_output_info *info = audio_output_get_info(obs_get_audio());
 
 	struct resample_info from = {.samples_per_sec = info->samples_per_sec,
 				     .speakers = info->speakers,

--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -203,7 +203,7 @@ static bool audio_monitor_init_wasapi(struct audio_monitor *monitor)
 	/* ------------------------------------------ *
 	 * Init resampler                             */
 
-	const struct audio_output_info *info = audio_output_get_info(obs->audio.audio);
+	const struct audio_output_info *info = audio_output_get_info(obs_get_audio());
 	WAVEFORMATEXTENSIBLE *ext = (WAVEFORMATEXTENSIBLE *)wfex;
 	struct resample_info from;
 	struct resample_info to;

--- a/libobs/media-io/audio-io.c
+++ b/libobs/media-io/audio-io.c
@@ -69,7 +69,8 @@ struct audio_output {
 	size_t planes;
 
 	pthread_t thread;
-	os_event_t *stop_event;
+	os_sem_t *update_semaphore;
+	bool stop;
 
 	bool initialized;
 
@@ -77,7 +78,13 @@ struct audio_output {
 	void *input_param;
 	pthread_mutex_t input_mutex;
 	struct audio_mix mixes[MAX_AUDIO_MIXES];
+
+	struct audio_output *next;
+	struct audio_output *previous;
 };
+
+static struct audio_output *first;
+static pthread_mutex_t audio_mutex;
 
 /* ------------------------------------------------------------------------- */
 
@@ -220,7 +227,10 @@ static void *audio_thread(void *param)
 	const char *audio_thread_name =
 		profile_store_name(obs_get_profiler_name_store(), "audio_thread(%s)", audio->info.name);
 
-	while (os_event_try(audio->stop_event) == EAGAIN) {
+	while (os_sem_wait(audio->update_semaphore) == 0) {
+		if (audio->stop)
+			break;
+
 		samples += AUDIO_OUTPUT_FRAMES;
 		uint64_t audio_time = start_time + audio_frames_to_ns(rate, samples);
 
@@ -234,6 +244,8 @@ static void *audio_thread(void *param)
 		profile_end(audio_thread_name);
 
 		profile_reenable_thread();
+
+		os_sem_post(audio->next->update_semaphore);
 	}
 
 #ifdef _WIN32
@@ -369,21 +381,43 @@ int audio_output_open(audio_t **audio, struct audio_output_info *info)
 	out->input_param = info->input_param;
 	out->block_size = (planar ? 1 : out->channels) * get_audio_bytes_per_channel(info->format);
 
-	if (pthread_mutex_init_recursive(&out->input_mutex) != 0)
+	if (pthread_mutex_init_recursive(&audio_mutex) != 0)
 		goto fail0;
-	if (os_event_init(&out->stop_event, OS_EVENT_TYPE_MANUAL) != 0)
+	if (pthread_mutex_init_recursive(&out->input_mutex) != 0)
 		goto fail1;
-	if (pthread_create(&out->thread, NULL, audio_thread, out) != 0)
+	if (os_sem_init(&out->update_semaphore, 0) != 0)
 		goto fail2;
+	if (pthread_create(&out->thread, NULL, audio_thread, out) != 0)
+		goto fail3;
 
 	out->initialized = true;
+
+	pthread_mutex_lock(&audio_mutex);
+	if (!first) {
+		out->next = out;
+		out->previous = out;
+		first = out;
+		os_sem_post(first->update_semaphore);
+	} else {
+		out->next = first;
+		out->previous = first->previous;
+
+		first->previous->next = out;
+		first->previous = out;
+
+		first = out;
+	}
+	pthread_mutex_unlock(&audio_mutex);
+
 	*audio = out;
 	return AUDIO_OUTPUT_SUCCESS;
 
+fail3:
+	os_sem_destroy(out->update_semaphore);
 fail2:
-	os_event_destroy(out->stop_event);
-fail1:
 	pthread_mutex_destroy(&out->input_mutex);
+fail1:
+	pthread_mutex_destroy(&audio_mutex);
 fail0:
 	audio_output_close(out);
 	return AUDIO_OUTPUT_FAIL;
@@ -396,11 +430,27 @@ void audio_output_close(audio_t *audio)
 	if (!audio)
 		return;
 
-	if (audio->initialized) {
-		os_event_signal(audio->stop_event);
+	if (audio->initialized && !audio->stop) {
+		audio->stop = true;
+		os_sem_post(audio->update_semaphore);
 		pthread_join(audio->thread, &thread_ret);
-		os_event_destroy(audio->stop_event);
+		os_sem_destroy(audio->update_semaphore);
 		pthread_mutex_destroy(&audio->input_mutex);
+
+		pthread_mutex_lock(&audio_mutex);
+		if (audio->next == audio) {
+			first = NULL;
+		} else {
+			audio->previous->next = audio->next;
+			audio->next->previous = audio->previous;
+
+			if (first == audio)
+				first = audio->next;
+		}
+		pthread_mutex_unlock(&audio_mutex);
+
+		if (!first)
+			pthread_mutex_destroy(&audio_mutex);
 	}
 
 	for (size_t mix_idx = 0; mix_idx < MAX_AUDIO_MIXES; mix_idx++) {
@@ -452,4 +502,30 @@ size_t audio_output_get_channels(const audio_t *audio)
 uint32_t audio_output_get_sample_rate(const audio_t *audio)
 {
 	return audio->info.samples_per_sec;
+}
+
+bool audio_output_is_first(const audio_t *audio)
+{
+	bool is_first = false;
+
+	pthread_mutex_lock(&audio_mutex);
+	if (audio->next == first) {
+		is_first = true;
+	}
+	pthread_mutex_unlock(&audio_mutex);
+
+	return is_first;
+}
+
+bool audio_output_is_last(const audio_t *audio)
+{
+	bool is_last = false;
+
+	pthread_mutex_lock(&audio_mutex);
+	if (audio == first) {
+		is_last = true;
+	}
+	pthread_mutex_unlock(&audio_mutex);
+
+	return is_last;
 }

--- a/libobs/media-io/audio-io.h
+++ b/libobs/media-io/audio-io.h
@@ -222,6 +222,8 @@ EXPORT size_t audio_output_get_planes(const audio_t *audio);
 EXPORT size_t audio_output_get_channels(const audio_t *audio);
 EXPORT uint32_t audio_output_get_sample_rate(const audio_t *audio);
 EXPORT const struct audio_output_info *audio_output_get_info(const audio_t *audio);
+EXPORT bool audio_output_is_first(const audio_t *audio);
+EXPORT bool audio_output_is_last(const audio_t *audio);
 
 #ifdef __cplusplus
 }

--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -27,9 +27,24 @@ struct ts_info {
 #define DEBUG_AUDIO 0
 #define DEBUG_LAGGED_AUDIO 0
 
+static inline bool is_audio_source(const struct obs_source *source)
+{
+	return source->info.output_flags & OBS_SOURCE_AUDIO;
+}
+
+static inline bool is_composite_source(const struct obs_source *source)
+{
+	return source->info.output_flags & OBS_SOURCE_COMPOSITE;
+}
+
+static inline bool is_individual_audio_source(obs_source_t *source)
+{
+	return source->info.type == OBS_SOURCE_TYPE_INPUT && is_audio_source(source) && !is_composite_source(source);
+}
+
 static void push_audio_tree(obs_source_t *parent, obs_source_t *source, void *p)
 {
-	struct obs_core_audio *audio = p;
+	struct obs_core_audio_mix *audio = p;
 
 	if (da_find(audio->render_order, &source, 0) == DARRAY_INVALID) {
 		obs_source_t *s = obs_source_get_ref(source);
@@ -40,12 +55,6 @@ static void push_audio_tree(obs_source_t *parent, obs_source_t *source, void *p)
 	}
 
 	UNUSED_PARAMETER(parent);
-}
-
-static inline bool is_individual_audio_source(obs_source_t *source)
-{
-	return source->info.type == OBS_SOURCE_TYPE_INPUT && (source->info.output_flags & OBS_SOURCE_AUDIO) &&
-	       !(source->info.output_flags & OBS_SOURCE_COMPOSITE);
 }
 
 /*
@@ -61,7 +70,7 @@ static void push_audio_tree2(obs_source_t *parent, obs_source_t *source, void *p
 	if (obs_source_removed(source))
 		return;
 
-	struct obs_core_audio *audio = p;
+	struct obs_core_audio_mix *audio = p;
 	size_t idx = da_find(audio->render_order, &source, 0);
 
 	if (idx == DARRAY_INVALID) {
@@ -220,7 +229,7 @@ static bool discard_if_stopped(obs_source_t *source, size_t channels)
 
 #define MAX_AUDIO_SIZE (AUDIO_OUTPUT_FRAMES * sizeof(float))
 
-static inline void discard_audio(struct obs_core_audio *audio, obs_source_t *source, size_t channels,
+static inline void discard_audio(struct obs_core_audio_mix *audio, obs_source_t *source, size_t channels,
 				 size_t sample_rate, struct ts_info *ts)
 {
 	size_t total_floats = AUDIO_OUTPUT_FRAMES;
@@ -312,12 +321,12 @@ static inline void discard_audio(struct obs_core_audio *audio, obs_source_t *sou
 	source->audio_ts = ts->end;
 }
 
-static inline bool audio_buffering_maxed(struct obs_core_audio *audio)
+static inline bool audio_buffering_maxed(struct obs_core_audio_mix *audio)
 {
 	return audio->total_buffering_ticks == audio->max_buffering_ticks;
 }
 
-static void set_fixed_audio_buffering(struct obs_core_audio *audio, size_t sample_rate, struct ts_info *ts)
+static void set_fixed_audio_buffering(struct obs_core_audio_mix *audio, size_t sample_rate, struct ts_info *ts)
 {
 	struct ts_info new_ts;
 	size_t total_ms;
@@ -358,8 +367,8 @@ static void set_fixed_audio_buffering(struct obs_core_audio *audio, size_t sampl
 	*ts = new_ts;
 }
 
-static void add_audio_buffering(struct obs_core_audio *audio, size_t sample_rate, struct ts_info *ts, uint64_t min_ts,
-				const char *buffering_name)
+static void add_audio_buffering(struct obs_core_audio_mix *audio, size_t sample_rate, struct ts_info *ts,
+				uint64_t min_ts, const char *buffering_name)
 {
 	struct ts_info new_ts;
 	uint64_t offset;
@@ -448,43 +457,46 @@ static bool audio_buffer_insufficient(struct obs_source *source, size_t sample_r
 	return false;
 }
 
-static inline const char *find_min_ts(struct obs_core_data *data, uint64_t *min_ts)
+static inline const char *find_min_ts(struct obs_core_audio_mix *audio, uint64_t *min_ts)
 {
 	obs_source_t *buffering_source = NULL;
-	struct obs_source *source = data->first_audio_source;
-	while (source) {
+
+	for (size_t i = 0; i < audio->render_order.num; i++) {
+		obs_source_t *source = audio->render_order.array[i];
+
+		if (!is_audio_source(source))
+			continue;
+
 		if (!source->audio_pending && source->audio_ts && source->audio_ts < *min_ts) {
 			*min_ts = source->audio_ts;
 			buffering_source = source;
 		}
-
-		source = (struct obs_source *)source->next_audio_source;
 	}
+
 	return buffering_source ? obs_source_get_name(buffering_source) : NULL;
 }
 
-static inline bool mark_invalid_sources(struct obs_core_data *data, size_t sample_rate, uint64_t min_ts)
+static inline bool mark_invalid_sources(struct obs_core_audio_mix *audio, size_t sample_rate, uint64_t min_ts)
 {
 	bool recalculate = false;
 
-	struct obs_source *source = data->first_audio_source;
-	while (source) {
-		recalculate |= audio_buffer_insufficient(source, sample_rate, min_ts);
-		source = (struct obs_source *)source->next_audio_source;
+	for (size_t i = 0; i < audio->render_order.num; i++) {
+		obs_source_t *source = audio->render_order.array[i];
+		recalculate |= is_audio_source(source) && audio_buffer_insufficient(source, sample_rate, min_ts);
 	}
 
 	return recalculate;
 }
 
-static inline const char *calc_min_ts(struct obs_core_data *data, size_t sample_rate, uint64_t *min_ts)
+static inline const char *calc_min_ts(struct obs_core_audio_mix *audio, size_t sample_rate, uint64_t *min_ts)
 {
-	const char *buffering_name = find_min_ts(data, min_ts);
-	if (mark_invalid_sources(data, sample_rate, *min_ts))
-		buffering_name = find_min_ts(data, min_ts);
+	const char *buffering_name = find_min_ts(audio, min_ts);
+	if (mark_invalid_sources(audio, sample_rate, *min_ts))
+		buffering_name = find_min_ts(audio, min_ts);
 	return buffering_name;
 }
 
-static inline void release_audio_sources(struct obs_core_audio *audio)
+static inline void release_audio_sources(struct obs_core_audio_mix *audio)
 {
 	for (size_t i = 0; i < audio->render_order.num; i++)
 		obs_source_release(audio->render_order.array[i]);
@@ -552,15 +564,22 @@ static inline void clear_audio_output_buf(obs_source_t *source, struct obs_core_
 	}
 }
 
+static uint64_t start_ts;
+
 bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint64_t *out_ts, uint32_t mixers,
 		    struct audio_output_data *mixes)
 {
+	struct obs_canvas *canvas = (struct obs_canvas *)param;
+	struct obs_core_audio_mix *audio = canvas->audio_mix;
 	struct obs_core_data *data = &obs->data;
-	struct obs_core_audio *audio = &obs->audio;
 	struct obs_source *source;
 	size_t sample_rate = audio_output_get_sample_rate(audio->audio);
 	size_t channels = audio_output_get_channels(audio->audio);
-	struct ts_info ts = {start_ts_in, end_ts_in};
+
+	if (audio_output_is_first(audio->audio))
+		start_ts = start_ts_in;
+
+	struct ts_info ts = {start_ts, end_ts_in};
 	size_t audio_size;
 	uint64_t min_ts;
 
@@ -579,27 +598,22 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* build audio render order */
-
-	pthread_mutex_lock(&obs->video.mixes_mutex);
-	for (size_t j = 0; j < obs->video.mixes.num; j++) {
-		struct obs_view *view = obs->video.mixes.array[j]->view;
-		if (!view)
-			continue;
+	if (canvas->video_mix) {
+		struct obs_view *view = canvas->video_mix->view;
 
 		pthread_mutex_lock(&view->channels_mutex);
-
 		/* NOTE: these are source channels, not audio channels */
 		for (uint32_t i = 0; i < MAX_CHANNELS; i++) {
 			obs_source_t *source = view->channels[i];
 			if (!source)
 				continue;
-			if (!obs_source_active(source))
+			if ((canvas->flags & ACTIVATE) && !obs_source_active(source))
 				continue;
 			if (obs_source_removed(source))
 				continue;
 
 			/* first, add top - level sources as root_nodes */
-			if (obs->video.mixes.array[j]->mix_audio)
+			if (canvas->video_mix->mix_audio)
 				da_push_back(audio->root_nodes, &source);
 
 			/* Build audio tree, tag duplicate individual sources */
@@ -610,27 +624,28 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 		}
 		pthread_mutex_unlock(&view->channels_mutex);
 	}
-	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	pthread_mutex_lock(&data->audio_sources_mutex);
-
-	source = data->first_audio_source;
+	pthread_mutex_lock(&canvas->sources_mutex);
+	source = canvas->sources;
 	while (source) {
 		if (!obs_source_removed(source)) {
+			obs_source_enum_full_tree(source, push_audio_tree, audio);
 			push_audio_tree(NULL, source, audio);
 		}
-		source = (struct obs_source *)source->next_audio_source;
-	}
 
-	pthread_mutex_unlock(&data->audio_sources_mutex);
+		source = (obs_source_t *)source->context.hh.next;
+	}
+	pthread_mutex_unlock(&canvas->sources_mutex);
 
 	/* ------------------------------------------------ */
 	/* render audio data */
 	for (size_t i = 0; i < audio->render_order.num; i++) {
 		obs_source_t *source = audio->render_order.array[i];
+
 		obs_source_audio_render(source, mixers, channels, sample_rate, audio_size);
-		if (should_silence_monitored_source(source, audio))
-			clear_audio_output_buf(source, audio);
+
+		if (should_silence_monitored_source(source, &obs->audio))
+			clear_audio_output_buf(source, &obs->audio);
 
 		/* if a source has gone backward in time and we can no
 		 * longer buffer, drop some or all of its audio */
@@ -661,9 +676,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* get minimum audio timestamp */
-	pthread_mutex_lock(&data->audio_sources_mutex);
-	const char *buffering_name = calc_min_ts(data, sample_rate, &min_ts);
-	pthread_mutex_unlock(&data->audio_sources_mutex);
+	const char *buffering_name = calc_min_ts(audio, sample_rate, &min_ts);
 
 	/* ------------------------------------------------ */
 	/* if a source has gone backward in time, buffer    */
@@ -686,8 +699,10 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 			pthread_mutex_lock(&source->audio_buf_mutex);
 
-			if (source->audio_output_buf[0][0] && source->audio_ts)
-				mix_audio(mixes, source, channels, sample_rate, &ts);
+			if (source->audio_output_buf[0][0] && source->audio_ts) {
+				struct ts_info source_ts = {source->audio_ts, ts.end};
+				mix_audio(mixes, source, channels, sample_rate, &source_ts);
+			}
 
 			pthread_mutex_unlock(&source->audio_buf_mutex);
 		}
@@ -695,18 +710,21 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	/* ------------------------------------------------ */
 	/* discard audio */
-	pthread_mutex_lock(&data->audio_sources_mutex);
+	if (audio_output_is_last(audio->audio)) {
+		pthread_mutex_lock(&data->audio_sources_mutex);
 
-	source = data->first_audio_source;
-	while (source) {
-		pthread_mutex_lock(&source->audio_buf_mutex);
-		discard_audio(audio, source, channels, sample_rate, &ts);
-		pthread_mutex_unlock(&source->audio_buf_mutex);
+		source = data->first_audio_source;
+		while (source) {
+			pthread_mutex_lock(&source->audio_buf_mutex);
+			struct ts_info source_ts = {source->audio_ts, ts.end};
+			discard_audio(audio, source, channels, sample_rate, &source_ts);
+			pthread_mutex_unlock(&source->audio_buf_mutex);
 
-		source = (struct obs_source *)source->next_audio_source;
+			source = (struct obs_source *)source->next_audio_source;
+		}
+
+		pthread_mutex_unlock(&data->audio_sources_mutex);
 	}
-
-	pthread_mutex_unlock(&data->audio_sources_mutex);
 
 	/* ------------------------------------------------ */
 	/* release audio sources */
@@ -723,6 +741,5 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	execute_audio_tasks();
 
-	UNUSED_PARAMETER(param);
 	return true;
 }

--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -31,6 +31,7 @@ static const char *canvas_signals[] = {
 	"void destroy(ptr canvas)",
 	"void remove(ptr canvas)",
 	"void video_reset(ptr canvas)",
+	"void audio_reset(ptr canvas)",
 
 	"void source_add(ptr canvas, ptr source)",
 	"void source_remove(ptr canvas, ptr source)",
@@ -136,7 +137,7 @@ obs_canvas_t *obs_weak_canvas_get_canvas(obs_weak_canvas_t *weak)
 /*** Creation / Destruction ***/
 
 static obs_canvas_t *obs_canvas_create_internal(const char *name, const char *uuid, struct obs_video_info *ovi,
-						uint32_t flags, bool private)
+						struct obs_audio_info2 *oai, uint32_t flags, bool private)
 {
 	struct obs_canvas *canvas = bzalloc(sizeof(struct obs_canvas));
 	canvas->flags = flags;
@@ -162,14 +163,24 @@ static obs_canvas_t *obs_canvas_create_internal(const char *name, const char *uu
 	/* A canvas can be created without a mix. */
 	if (ovi) {
 		canvas->ovi = *ovi;
-		canvas->mix = obs_create_video_mix(ovi);
-		if (canvas->mix) {
-			canvas->mix->view = &canvas->view;
-			canvas->mix->mix_audio = (flags & MIX_AUDIO) != 0;
+		canvas->video_mix = obs_create_video_mix(ovi);
+		if (canvas->video_mix) {
+			canvas->video_mix->view = &canvas->view;
+			canvas->video_mix->mix_audio = (flags & MIX_AUDIO) != 0;
 
 			pthread_mutex_lock(&obs->video.mixes_mutex);
-			da_push_back(obs->video.mixes, &canvas->mix);
+			da_push_back(obs->video.mixes, &canvas->video_mix);
 			pthread_mutex_unlock(&obs->video.mixes_mutex);
+		}
+	}
+
+	if (oai) {
+		canvas->oai = *oai;
+		canvas->audio_mix = obs_create_audio_mix(canvas, oai);
+		if (canvas->audio_mix) {
+			pthread_mutex_lock(&obs->audio.mixes_mutex);
+			da_push_back(obs->audio.mixes, &canvas->audio_mix);
+			pthread_mutex_unlock(&obs->audio.mixes_mutex);
 		}
 	}
 
@@ -188,26 +199,41 @@ static obs_canvas_t *obs_canvas_create_internal(const char *name, const char *uu
 obs_canvas_t *obs_create_main_canvas(void)
 {
 	const uint32_t main_flags = MAIN | PROGRAM;
-	return obs_canvas_create_internal(MAIN_CANVAS_NAME, MAIN_CANVAS_UUID, NULL, main_flags, false);
+	return obs_canvas_create_internal(MAIN_CANVAS_NAME, MAIN_CANVAS_UUID, NULL, NULL, main_flags, false);
 }
 
 obs_canvas_t *obs_canvas_create(const char *name, struct obs_video_info *ovi, uint32_t flags)
 {
 	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
-	return obs_canvas_create_internal(name, NULL, ovi, flags, false);
+	return obs_canvas_create_internal(name, NULL, ovi, NULL, flags, false);
 }
 
 obs_canvas_t *obs_canvas_create_private(const char *name, struct obs_video_info *ovi, uint32_t flags)
 {
 	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
-	return obs_canvas_create_internal(name, NULL, ovi, flags, true);
+	return obs_canvas_create_internal(name, NULL, ovi, NULL, flags, true);
+}
+
+obs_canvas_t *obs_canvas_create2(const char *name, struct obs_video_info *ovi, struct obs_audio_info2 *oai,
+				 uint32_t flags)
+{
+	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
+	return obs_canvas_create_internal(name, NULL, ovi, oai, flags, false);
+}
+
+obs_canvas_t *obs_canvas_create_private2(const char *name, struct obs_video_info *ovi, struct obs_audio_info2 *oai,
+					 uint32_t flags)
+{
+	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
+	return obs_canvas_create_internal(name, NULL, ovi, oai, flags, true);
 }
 
 void obs_canvas_destroy(obs_canvas_t *canvas)
 {
 	canvas_dosignal(canvas, "canvas_destroy", "destroy");
 
-	obs_canvas_clear_mix(canvas);
+	obs_canvas_clear_video_mix(canvas);
+	obs_canvas_clear_audio_mix(canvas);
 
 	obs_source_t *source = canvas->sources;
 	while (source) {
@@ -257,21 +283,21 @@ obs_canvas_t *obs_load_canvas(obs_data_t *data)
 	uint32_t flags = (uint32_t)obs_data_get_int(data, "flags");
 
 	flags &= ~MAIN; /* Prevent user from creating a MAIN canvas. */
-	return obs_canvas_create_internal(name, uuid, NULL, flags, private);
+	return obs_canvas_create_internal(name, uuid, NULL, NULL, flags, private);
 }
 
 /*** Internal API ***/
 
 /* Free canvas mix (if any) */
-void obs_canvas_clear_mix(obs_canvas_t *canvas)
+void obs_canvas_clear_video_mix(obs_canvas_t *canvas)
 {
-	if (!canvas->mix)
+	if (!canvas->video_mix)
 		return;
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t i = 0; i < obs->video.mixes.num; i++) {
 		struct obs_core_video_mix *mix = obs->video.mixes.array[i];
-		if (mix == canvas->mix) {
+		if (mix == canvas->video_mix) {
 			da_erase(obs->video.mixes, i);
 			obs_free_video_mix(mix);
 			break;
@@ -279,17 +305,47 @@ void obs_canvas_clear_mix(obs_canvas_t *canvas)
 	}
 	pthread_mutex_unlock(&obs->video.mixes_mutex);
 
-	canvas->mix = NULL;
+	canvas->video_mix = NULL;
+}
+
+void obs_canvas_clear_audio_mix(obs_canvas_t *canvas)
+{
+	if (!canvas->audio_mix)
+		return;
+
+	pthread_mutex_lock(&obs->audio.mixes_mutex);
+	for (size_t i = 0; i < obs->audio.mixes.num; i++) {
+		struct obs_core_audio_mix *mix = obs->audio.mixes.array[i];
+		if (mix == canvas->audio_mix) {
+			da_erase(obs->audio.mixes, i);
+			obs_free_audio_mix(mix);
+			break;
+		}
+	}
+	pthread_mutex_unlock(&obs->audio.mixes_mutex);
+
+	canvas->audio_mix = NULL;
 }
 
 /* Clear mixes attached to canvases */
-void obs_free_canvas_mixes(void)
+void obs_free_canvas_video_mixes(void)
 {
 	pthread_mutex_lock(&obs->data.canvases_mutex);
 	struct obs_context_data *ctx, *tmp;
 	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
 		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
-		obs_canvas_clear_mix(canvas);
+		obs_canvas_clear_video_mix(canvas);
+	}
+	pthread_mutex_unlock(&obs->data.canvases_mutex);
+}
+
+void obs_free_canvas_audio_mixes(void)
+{
+	pthread_mutex_lock(&obs->data.canvases_mutex);
+	struct obs_context_data *ctx, *tmp;
+	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
+		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
+		obs_canvas_clear_audio_mix(canvas);
 	}
 	pthread_mutex_unlock(&obs->data.canvases_mutex);
 }
@@ -303,22 +359,44 @@ bool obs_canvas_has_valid_video_info(obs_canvas_t *canvas)
 
 bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
-	obs_canvas_clear_mix(canvas);
+	obs_canvas_clear_video_mix(canvas);
 
 	canvas->ovi = *ovi;
-	canvas->mix = obs_create_video_mix(&canvas->ovi);
-	if (canvas->mix) {
-		canvas->mix->view = &canvas->view;
-		canvas->mix->mix_audio = (canvas->flags & MIX_AUDIO) != 0;
+	canvas->video_mix = obs_create_video_mix(&canvas->ovi);
+	if (canvas->video_mix) {
+		canvas->video_mix->view = &canvas->view;
+		canvas->video_mix->mix_audio = (canvas->flags & MIX_AUDIO) != 0;
 
 		pthread_mutex_lock(&obs->video.mixes_mutex);
-		da_push_back(obs->video.mixes, &canvas->mix);
+		da_push_back(obs->video.mixes, &canvas->video_mix);
 		pthread_mutex_unlock(&obs->video.mixes_mutex);
 	}
 
 	canvas_dosignal(canvas, "canvas_video_reset", "video_reset");
 
-	return !!canvas->mix;
+	return !!canvas->video_mix;
+}
+
+bool obs_canvas_reset_audio_internal(obs_canvas_t *canvas, struct obs_audio_info2 *oai)
+{
+	if (!oai && !canvas->audio_mix)
+		return true;
+
+	obs_canvas_clear_audio_mix(canvas);
+
+	if (oai)
+		canvas->oai = *oai;
+
+	canvas->audio_mix = obs_create_audio_mix(canvas, &canvas->oai);
+	if (canvas->audio_mix) {
+		pthread_mutex_lock(&obs->audio.mixes_mutex);
+		da_push_back(obs->audio.mixes, &canvas->audio_mix);
+		pthread_mutex_unlock(&obs->audio.mixes_mutex);
+	}
+
+	canvas_dosignal(canvas, "canvas_audio_reset", "audio_reset");
+
+	return !!canvas->audio_mix;
 }
 
 void obs_canvas_insert_source(obs_canvas_t *canvas, obs_source_t *source)
@@ -409,17 +487,39 @@ bool obs_canvas_reset_video(obs_canvas_t *canvas, struct obs_video_info *ovi)
 	return obs_canvas_reset_video_internal(canvas, ovi);
 }
 
+bool obs_canvas_reset_audio(obs_canvas_t *canvas, struct obs_audio_info2 *oai)
+{
+	if (canvas->flags & MAIN || obs_audio_active())
+		return false;
+
+	return obs_canvas_reset_audio_internal(canvas, oai);
+}
+
 video_t *obs_canvas_get_video(const obs_canvas_t *canvas)
 {
-	return canvas->mix ? canvas->mix->video : NULL;
+	return canvas->video_mix ? canvas->video_mix->video : NULL;
+}
+
+audio_t *obs_canvas_get_audio(const obs_canvas_t *canvas)
+{
+	return canvas->audio_mix ? canvas->audio_mix->audio : NULL;
 }
 
 bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info *ovi)
 {
-	if (!obs->video.graphics || !canvas->mix)
+	if (!obs->video.graphics || !canvas->video_mix)
 		return false;
 
-	*ovi = canvas->mix->ovi;
+	*ovi = canvas->video_mix->ovi;
+	return true;
+}
+
+bool obs_canvas_get_audio_info(const obs_canvas_t *canvas, struct obs_audio_info2 *oai)
+{
+	if (!canvas->audio_mix)
+		return false;
+
+	*oai = canvas->oai;
 	return true;
 }
 
@@ -583,7 +683,12 @@ bool obs_canvas_removed(obs_canvas_t *canvas)
 
 bool obs_canvas_has_video(obs_canvas_t *canvas)
 {
-	return canvas->mix != NULL;
+	return canvas->video_mix != NULL;
+}
+
+bool obs_canvas_has_audio(obs_canvas_t *canvas)
+{
+	return canvas->audio_mix != NULL;
 }
 
 void obs_canvas_render(obs_canvas_t *canvas)

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -437,10 +437,14 @@ struct obs_core_video {
 
 extern void add_ready_encoder_group(obs_encoder_t *encoder);
 
+extern struct obs_core_audio_mix *obs_create_audio_mix(struct obs_canvas *canvas, struct obs_audio_info2 *oai);
+extern void obs_free_audio_mix(struct obs_core_audio_mix *audio);
+
 struct audio_monitor;
 
-struct obs_core_audio {
+struct obs_core_audio_mix {
 	audio_t *audio;
+	struct obs_audio_info2 oai;
 
 	DARRAY(struct obs_source *) render_order;
 	DARRAY(struct obs_source *) root_nodes;
@@ -451,7 +455,9 @@ struct obs_core_audio {
 	int total_buffering_ticks;
 	int max_buffering_ticks;
 	bool fixed_buffer;
+};
 
+struct obs_core_audio {
 	pthread_mutex_t monitoring_mutex;
 	DARRAY(struct audio_monitor *) monitors;
 	char *monitoring_device_name;
@@ -461,6 +467,9 @@ struct obs_core_audio {
 	struct deque tasks;
 
 	struct obs_source *monitoring_duplicating_source;
+
+	pthread_mutex_t mixes_mutex;
+	DARRAY(struct obs_core_audio_mix *) mixes;
 };
 
 /* user sources, output channels, and displays */
@@ -733,18 +742,27 @@ struct obs_canvas {
 	/* For now, canvas objects mainly act as a proxy for the existing view and video mix objects,
 	 * though this may change in the future. */
 	struct obs_view view;
-	struct obs_core_video_mix *mix;
+	struct obs_core_video_mix *video_mix;
+	struct obs_core_audio_mix *audio_mix;
+
+	struct obs_audio_info2 oai;
 };
 
 extern obs_canvas_t *obs_create_main_canvas(void);
 extern void obs_canvas_destroy(obs_canvas_t *canvas);
 extern void obs_canvas_clear_mix(obs_canvas_t *canvas);
 extern void obs_free_canvas_mixes(void);
+extern void obs_canvas_clear_video_mix(obs_canvas_t *canvas);
+extern void obs_canvas_clear_audio_mix(obs_canvas_t *canvas);
+extern void obs_free_canvas_video_mixes(void);
+extern void obs_free_canvas_audio_mixes(void);
 extern bool obs_canvas_has_valid_video_info(obs_canvas_t *canvas);
 extern bool obs_canvas_reset_video_internal(obs_canvas_t *canvas, struct obs_video_info *ovi);
+extern bool obs_canvas_reset_audio_internal(obs_canvas_t *canvas, struct obs_audio_info2 *oai);
 extern void obs_canvas_insert_source(obs_canvas_t *canvas, obs_source_t *source);
 extern void obs_canvas_remove_source(obs_source_t *source);
 extern void obs_canvas_rename_source(obs_source_t *source, const char *name);
+extern bool obs_canvas_has_valid_video_info(obs_canvas_t *canvas);
 
 /* ------------------------------------------------------------------------- */
 /* sources  */

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -344,8 +344,8 @@ static inline void get_scene_dimensions(const obs_sceneitem_t *item, float *x, f
 {
 	obs_scene_t *parent = item->parent;
 	if (!parent || (parent->is_group && !parent->source->canvas)) {
-		*x = (float)obs->data.main_canvas->mix->ovi.base_width;
-		*y = (float)obs->data.main_canvas->mix->ovi.base_height;
+		*x = (float)obs->data.main_canvas->video_mix->ovi.base_width;
+		*y = (float)obs->data.main_canvas->video_mix->ovi.base_height;
 	} else if (parent->is_group) {
 		*x = (float)canvas_getwidth(parent->source->canvas);
 		*y = (float)canvas_getheight(parent->source->canvas);
@@ -1492,8 +1492,8 @@ static uint32_t scene_getwidth(void *data)
 		return scene->cx;
 	if (scene->source->canvas)
 		return canvas_getwidth(scene->source->canvas);
-	if (obs->data.main_canvas->mix)
-		return obs->data.main_canvas->mix->ovi.base_width;
+	if (obs->data.main_canvas->video_mix)
+		return obs->data.main_canvas->video_mix->ovi.base_width;
 	return 0;
 }
 
@@ -1504,8 +1504,8 @@ static uint32_t scene_getheight(void *data)
 		return scene->cy;
 	if (scene->source->canvas)
 		return canvas_getheight(scene->source->canvas);
-	if (obs->data.main_canvas->mix)
-		return obs->data.main_canvas->mix->ovi.base_height;
+	if (obs->data.main_canvas->video_mix)
+		return obs->data.main_canvas->video_mix->ovi.base_height;
 	return 0;
 }
 

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1507,7 +1507,7 @@ static inline size_t get_buf_placement(audio_t *audio, uint64_t offset)
 
 static void source_output_audio_place(obs_source_t *source, const struct audio_data *in)
 {
-	audio_t *audio = obs->audio.audio;
+	audio_t *audio = obs_get_audio();
 	size_t buf_placement;
 	size_t channels = audio_output_get_channels(audio);
 	size_t size = in->frames * sizeof(float);
@@ -1538,7 +1538,7 @@ static void source_output_audio_place(obs_source_t *source, const struct audio_d
 
 static inline void source_output_audio_push_back(obs_source_t *source, const struct audio_data *in)
 {
-	audio_t *audio = obs->audio.audio;
+	audio_t *audio = obs_get_audio();
 	size_t channels = audio_output_get_channels(audio);
 	size_t size = in->frames * sizeof(float);
 
@@ -1571,7 +1571,7 @@ static inline bool source_muted(obs_source_t *source, uint64_t os_time)
 
 static void source_output_audio_data(obs_source_t *source, const struct audio_data *data)
 {
-	size_t sample_rate = audio_output_get_sample_rate(obs->audio.audio);
+	size_t sample_rate = audio_output_get_sample_rate(obs_get_audio());
 	struct audio_data in = *data;
 	uint64_t diff;
 	uint64_t os_time = os_gettime_ns();
@@ -3888,7 +3888,7 @@ static inline void reset_resampler(obs_source_t *source, const struct obs_source
 	const struct audio_output_info *obs_info;
 	struct resample_info output_info;
 
-	obs_info = audio_output_get_info(obs->audio.audio);
+	obs_info = audio_output_get_info(obs_get_audio());
 
 	output_info.format = obs_info->format;
 	output_info.samples_per_sec = obs_info->samples_per_sec;
@@ -3917,8 +3917,9 @@ static inline void reset_resampler(obs_source_t *source, const struct obs_source
 
 static void copy_audio_data(obs_source_t *source, const uint8_t *const data[], uint32_t frames, uint64_t ts)
 {
-	size_t planes = audio_output_get_planes(obs->audio.audio);
-	size_t blocksize = audio_output_get_block_size(obs->audio.audio);
+	audio_t *audio = obs_get_audio();
+	size_t planes = audio_output_get_planes(audio);
+	size_t blocksize = audio_output_get_block_size(audio);
 	size_t size = (size_t)frames * blocksize;
 	bool resize = source->audio_storage_size < size;
 
@@ -3942,7 +3943,7 @@ static void copy_audio_data(obs_source_t *source, const uint8_t *const data[], u
 /* TODO: SSE optimization */
 static void downmix_to_mono_planar(struct obs_source *source, uint32_t frames)
 {
-	size_t channels = audio_output_get_channels(obs->audio.audio);
+	size_t channels = audio_output_get_channels(obs_get_audio());
 	const float channels_i = 1.0f / (float)channels;
 	float **data = (float **)source->audio_data.data;
 
@@ -4015,7 +4016,7 @@ static void process_audio(obs_source_t *source, const struct obs_source_audio *a
 		copy_audio_data(source, audio->data, audio->frames, audio->timestamp);
 	}
 
-	mono_output = audio_output_get_channels(obs->audio.audio) == 1;
+	mono_output = audio_output_get_channels(obs_get_audio()) == 1;
 
 	if (!mono_output && source->sample_info.speakers == SPEAKERS_STEREO &&
 	    (source->balance > 0.51f || source->balance < 0.49f)) {

--- a/libobs/obs-view.c
+++ b/libobs/obs-view.c
@@ -142,9 +142,9 @@ void obs_view_render(obs_view_t *view)
 
 video_t *obs_view_add(obs_view_t *view)
 {
-	if (!obs->data.main_canvas->mix)
+	if (!obs->data.main_canvas->video_mix)
 		return NULL;
-	return obs_view_add2(view, &obs->data.main_canvas->mix->ovi);
+	return obs_view_add2(view, &obs->data.main_canvas->video_mix->ovi);
 }
 
 video_t *obs_view_add2(obs_view_t *view, struct obs_video_info *ovi)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -615,8 +615,8 @@ static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_
 	 * so share FPS settings for aux views */
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	size_t num = obs->video.mixes.num;
-	if (num && obs->data.main_canvas->mix) {
-		struct obs_video_info main_ovi = obs->data.main_canvas->mix->ovi;
+	if (num && obs->data.main_canvas->video_mix) {
+		struct obs_video_info main_ovi = obs->data.main_canvas->video_mix->ovi;
 		video->ovi.fps_num = main_ovi.fps_num;
 		video->ovi.fps_den = main_ovi.fps_den;
 	}
@@ -655,6 +655,32 @@ static int obs_init_video_mix(struct obs_video_info *ovi, struct obs_core_video_
 	return OBS_VIDEO_SUCCESS;
 }
 
+static bool obs_init_audio_mix(struct obs_canvas *canvas, struct obs_audio_info2 *oai, struct obs_core_audio_mix *audio)
+{
+	audio->oai = *oai;
+
+	struct audio_output_info ai;
+	ai.name = "Audio";
+	ai.samples_per_sec = oai->samples_per_sec;
+	ai.format = AUDIO_FORMAT_FLOAT_PLANAR;
+	ai.speakers = oai->speakers;
+	ai.input_callback = audio_callback;
+	ai.input_param = canvas;
+
+	int errorcode = audio_output_open(&audio->audio, &ai);
+	if (errorcode != AUDIO_OUTPUT_SUCCESS) {
+		if (errorcode == AUDIO_OUTPUT_INVALIDPARAM) {
+			blog(LOG_ERROR, "Invalid audio parameters specified");
+			return AUDIO_OUTPUT_INVALIDPARAM;
+		} else {
+			blog(LOG_ERROR, "Could not open audio output");
+		}
+		return AUDIO_OUTPUT_FAIL;
+	}
+
+	return AUDIO_OUTPUT_SUCCESS;
+}
+
 struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
 {
 	struct obs_core_video_mix *video = bzalloc(sizeof(struct obs_core_video_mix));
@@ -665,7 +691,17 @@ struct obs_core_video_mix *obs_create_video_mix(struct obs_video_info *ovi)
 	return video;
 }
 
-static bool restore_canvases(void)
+struct obs_core_audio_mix *obs_create_audio_mix(struct obs_canvas *canvas, struct obs_audio_info2 *oai)
+{
+	struct obs_core_audio_mix *audio = bzalloc(sizeof(struct obs_core_audio_mix));
+	if (obs_init_audio_mix(canvas, oai, audio) != AUDIO_OUTPUT_SUCCESS) {
+		bfree(audio);
+		audio = NULL;
+	}
+	return audio;
+}
+
+static bool restore_canvas_video(void)
 {
 	bool success = true;
 
@@ -680,6 +716,27 @@ static bool restore_canvases(void)
 
 		if (!obs_canvas_reset_video_internal(canvas, &canvas->ovi)) {
 			blog(LOG_ERROR, "Failed restoring video mix for canvas '%s'", canvas->context.name);
+			success = false;
+		}
+	}
+	pthread_mutex_unlock(&obs->data.canvases_mutex);
+
+	return success;
+}
+
+static bool restore_canvas_audio(void)
+{
+	bool success = true;
+
+	pthread_mutex_lock(&obs->data.canvases_mutex);
+	struct obs_context_data *ctx, *tmp;
+	HASH_ITER (hh, (struct obs_context_data *)obs->data.canvases, ctx, tmp) {
+		obs_canvas_t *canvas = (obs_canvas_t *)ctx;
+		if (canvas->flags & MAIN)
+			continue;
+
+		if (!obs_canvas_reset_audio_internal(canvas, NULL)) {
+			blog(LOG_ERROR, "Failed restoring audio mix for canvas '%s'", canvas->context.name);
 			success = false;
 		}
 	}
@@ -705,7 +762,7 @@ static int obs_init_video(struct obs_video_info *ovi)
 	if (!obs_canvas_reset_video_internal(obs->data.main_canvas, ovi))
 		return OBS_VIDEO_FAIL;
 	/* Reset mixes for remaining canvases using their existing video info. */
-	if (!restore_canvases())
+	if (!restore_canvas_video())
 		return OBS_VIDEO_FAIL;
 
 	int errorcode;
@@ -820,6 +877,19 @@ void obs_free_video_mix(struct obs_core_video_mix *video)
 	bfree(video);
 }
 
+void obs_free_audio_mix(struct obs_core_audio_mix *audio)
+{
+	if (audio->audio) {
+		audio_output_close(audio->audio);
+		audio->audio = NULL;
+
+		deque_free(&audio->buffered_timestamps);
+		da_free(audio->render_order);
+		da_free(audio->root_nodes);
+	}
+	bfree(audio);
+}
+
 static void obs_free_video(void)
 {
 	pthread_mutex_lock(&obs->video.mixes_mutex);
@@ -900,10 +970,13 @@ static void apply_monitoring_deduplication(void *ignored, calldata_t *cd)
 
 static void set_audio_thread(void *unused);
 
-static bool obs_init_audio(struct audio_output_info *ai)
+#ifndef SEC_TO_MSEC
+#define SEC_TO_MSEC 1000
+#endif
+
+static bool obs_init_audio(struct obs_audio_info2 *oai)
 {
 	struct obs_core_audio *audio = &obs->audio;
-	int errorcode;
 
 	pthread_mutex_init_value(&audio->monitoring_mutex);
 
@@ -911,6 +984,39 @@ static bool obs_init_audio(struct audio_output_info *ai)
 		return false;
 	if (pthread_mutex_init(&audio->task_mutex, NULL) != 0)
 		return false;
+	if (pthread_mutex_init(&audio->mixes_mutex, NULL) != 0)
+		return false;
+
+	/* Reset main canvas mix first so it remains first in the rendering order. */
+	if (!obs_canvas_reset_audio_internal(obs->data.main_canvas, oai))
+		return false;
+	/* Reset mixes for remaining canvases using their existing audio info. */
+	if (!restore_canvas_audio())
+		return false;
+
+	struct obs_core_audio_mix *audio_mix = obs->data.main_canvas->audio_mix;
+
+	if (oai->max_buffering_ms) {
+		uint32_t max_frames = oai->max_buffering_ms * oai->samples_per_sec / SEC_TO_MSEC;
+		max_frames += (AUDIO_OUTPUT_FRAMES - 1);
+		audio_mix->max_buffering_ticks = max_frames / AUDIO_OUTPUT_FRAMES;
+	} else {
+		audio_mix->max_buffering_ticks = 45;
+	}
+	audio_mix->fixed_buffer = oai->fixed_buffering;
+
+	int max_buffering_ms =
+		audio_mix->max_buffering_ticks * AUDIO_OUTPUT_FRAMES * SEC_TO_MSEC / (int)oai->samples_per_sec;
+
+	blog(LOG_INFO, "---------------------------------");
+	blog(LOG_INFO,
+	     "audio settings reset:\n"
+	     "\tsamples per sec: %d\n"
+	     "\tspeakers:        %d\n"
+	     "\tmax buffering:   %d milliseconds\n"
+	     "\tbuffering type:  %s",
+	     (int)oai->samples_per_sec, (int)oai->speakers, max_buffering_ms,
+	     oai->fixed_buffering ? "fixed" : "dynamically increasing");
 
 	struct obs_task_info audio_init = {.task = set_audio_thread};
 	deque_push_back(&audio->tasks, &audio_init, sizeof(audio_init));
@@ -922,36 +1028,23 @@ static bool obs_init_audio(struct audio_output_info *ai)
 	signal_handler_add(obs->signals, "void deduplication_changed(ptr source)");
 	signal_handler_connect(obs->signals, "deduplication_changed", apply_monitoring_deduplication, NULL);
 
-	errorcode = audio_output_open(&audio->audio, ai);
-	if (errorcode == AUDIO_OUTPUT_SUCCESS)
-		return true;
-	else if (errorcode == AUDIO_OUTPUT_INVALIDPARAM)
-		blog(LOG_ERROR, "Invalid audio parameters specified");
-	else
-		blog(LOG_ERROR, "Could not open audio output");
-
-	return false;
-}
-
-static void stop_audio(void)
-{
-	struct obs_core_audio *audio = &obs->audio;
-
-	if (audio->audio) {
-		audio_output_close(audio->audio);
-		audio->audio = NULL;
-	}
+	return true;
 }
 
 static void obs_free_audio(void)
 {
 	struct obs_core_audio *audio = &obs->audio;
-	if (audio->audio)
-		audio_output_close(audio->audio);
 
-	deque_free(&audio->buffered_timestamps);
-	da_free(audio->render_order);
-	da_free(audio->root_nodes);
+	pthread_mutex_lock(&obs->audio.mixes_mutex);
+	for (size_t i = 0; i < obs->audio.mixes.num; i++) {
+		obs_free_audio_mix(audio->mixes.array[i]);
+		audio->mixes.array[i] = NULL;
+	}
+	da_free(obs->audio.mixes);
+	pthread_mutex_unlock(&obs->audio.mixes_mutex);
+
+	pthread_mutex_destroy(&obs->audio.mixes_mutex);
+	pthread_mutex_init_value(&obs->audio.mixes_mutex);
 
 	da_free(audio->monitors);
 	bfree(audio->monitoring_device_name);
@@ -1111,6 +1204,7 @@ static const char *obs_signals[] = {
 	"void canvas_remove(ptr canvas)",
 	"void canvas_destroy(ptr canvas)",
 	"void canvas_video_reset(ptr canvas)",
+	"void canvas_audio_reset(ptr canvas)",
 	"void canvas_rename(ptr canvas, string new_name, string prev_name)",
 
 	"void video_reset()",
@@ -1226,6 +1320,7 @@ static bool obs_init(const char *locale, const char *module_config_path, profile
 
 	pthread_mutex_init_value(&obs->audio.monitoring_mutex);
 	pthread_mutex_init_value(&obs->audio.task_mutex);
+	pthread_mutex_init_value(&obs->audio.mixes_mutex);
 	pthread_mutex_init_value(&obs->video.task_mutex);
 	pthread_mutex_init_value(&obs->video.encoder_group_mutex);
 	pthread_mutex_init_value(&obs->video.mixes_mutex);
@@ -1412,7 +1507,6 @@ void obs_shutdown(void)
 	da_free(obs->transition_types);
 
 	stop_video();
-	stop_audio();
 	stop_hotkeys();
 
 	module = obs->first_module;
@@ -1535,7 +1629,7 @@ int obs_reset_video(struct obs_video_info *ovi)
 		return OBS_VIDEO_INVALID_PARAM;
 
 	stop_video();
-	obs_free_canvas_mixes();
+	obs_free_canvas_video_mixes();
 	obs_free_video();
 
 	/* align to multiple-of-two and SSE alignment sizes */
@@ -1594,52 +1688,17 @@ int obs_reset_video(struct obs_video_info *ovi)
 	return obs_init_video(ovi);
 }
 
-#ifndef SEC_TO_MSEC
-#define SEC_TO_MSEC 1000
-#endif
-
 bool obs_reset_audio2(const struct obs_audio_info2 *oai)
 {
-	struct obs_core_audio *audio = &obs->audio;
-	struct audio_output_info ai;
-
-	/* don't allow changing of audio settings if active. */
-	if (!obs || (audio->audio && audio_output_active(audio->audio)))
+	if (obs_audio_active())
 		return false;
 
+	obs_free_canvas_audio_mixes();
 	obs_free_audio();
 	if (!oai)
 		return true;
 
-	if (oai->max_buffering_ms) {
-		uint32_t max_frames = oai->max_buffering_ms * oai->samples_per_sec / SEC_TO_MSEC;
-		max_frames += (AUDIO_OUTPUT_FRAMES - 1);
-		audio->max_buffering_ticks = max_frames / AUDIO_OUTPUT_FRAMES;
-	} else {
-		audio->max_buffering_ticks = 45;
-	}
-	audio->fixed_buffer = oai->fixed_buffering;
-
-	int max_buffering_ms =
-		audio->max_buffering_ticks * AUDIO_OUTPUT_FRAMES * SEC_TO_MSEC / (int)oai->samples_per_sec;
-
-	ai.name = "Audio";
-	ai.samples_per_sec = oai->samples_per_sec;
-	ai.format = AUDIO_FORMAT_FLOAT_PLANAR;
-	ai.speakers = oai->speakers;
-	ai.input_callback = audio_callback;
-
-	blog(LOG_INFO, "---------------------------------");
-	blog(LOG_INFO,
-	     "audio settings reset:\n"
-	     "\tsamples per sec: %d\n"
-	     "\tspeakers:        %d\n"
-	     "\tmax buffering:   %d milliseconds\n"
-	     "\tbuffering type:  %s",
-	     (int)ai.samples_per_sec, (int)ai.speakers, max_buffering_ms,
-	     oai->fixed_buffering ? "fixed" : "dynamically increasing");
-
-	return obs_init_audio(&ai);
+	return obs_init_audio((struct obs_audio_info2 *)oai);
 }
 
 bool obs_reset_audio(const struct obs_audio_info *oai)
@@ -1654,10 +1713,10 @@ bool obs_reset_audio(const struct obs_audio_info *oai)
 
 bool obs_get_video_info(struct obs_video_info *ovi)
 {
-	if (!obs->video.graphics || !obs->data.main_canvas->mix)
+	if (!obs->video.graphics || !obs->data.main_canvas->video_mix)
 		return false;
 
-	*ovi = obs->data.main_canvas->mix->ovi;
+	*ovi = obs->data.main_canvas->video_mix->ovi;
 	return true;
 }
 
@@ -1684,7 +1743,7 @@ void obs_set_video_levels(float sdr_white_level, float hdr_nominal_peak_level)
 
 bool obs_get_audio_info(struct obs_audio_info *oai)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_core_audio_mix *audio = obs->data.main_canvas->audio_mix;
 	const struct audio_output_info *info;
 
 	if (!oai || !audio->audio)
@@ -1699,10 +1758,10 @@ bool obs_get_audio_info(struct obs_audio_info *oai)
 
 bool obs_get_audio_info2(struct obs_audio_info2 *oai2)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_core_audio_mix *audio = obs->data.main_canvas->audio_mix;
 	struct obs_audio_info oai;
 
-	if (!obs_get_audio_info(&oai) || !oai2 || !audio->audio) {
+	if (!obs_get_audio_info(&oai) || !oai2 || !audio) {
 		return false;
 	} else {
 		oai2->samples_per_sec = oai.samples_per_sec;
@@ -1818,12 +1877,12 @@ void obs_leave_graphics(void)
 
 audio_t *obs_get_audio(void)
 {
-	return obs->audio.audio;
+	return obs->data.main_canvas->audio_mix->audio;
 }
 
 video_t *obs_get_video(void)
 {
-	return obs->data.main_canvas->mix->video;
+	return obs->data.main_canvas->video_mix->video;
 }
 
 obs_source_t *obs_get_output_source(uint32_t channel)
@@ -2176,7 +2235,7 @@ static void obs_render_canvas_texture_internal(obs_canvas_t *canvas, enum gs_ble
 	gs_effect_t *effect;
 	gs_eparam_t *param;
 
-	video = canvas->mix;
+	video = canvas->video_mix;
 	if (!video || !video->texture_rendered)
 		return;
 
@@ -2246,7 +2305,7 @@ gs_texture_t *obs_get_main_texture(void)
 {
 	struct obs_core_video_mix *video;
 
-	video = obs->data.main_canvas->mix;
+	video = obs->data.main_canvas->video_mix;
 	if (!video->texture_rendered)
 		return NULL;
 
@@ -3132,26 +3191,26 @@ void obs_add_raw_video_callback(const struct video_scale_info *conversion,
 void obs_add_raw_video_callback2(const struct video_scale_info *conversion, uint32_t frame_rate_divisor,
 				 void (*callback)(void *param, struct video_data *frame), void *param)
 {
-	struct obs_core_video_mix *video = obs->data.main_canvas->mix;
+	struct obs_core_video_mix *video = obs->data.main_canvas->video_mix;
 	start_raw_video(video->video, conversion, frame_rate_divisor, callback, param);
 }
 
 void obs_remove_raw_video_callback(void (*callback)(void *param, struct video_data *frame), void *param)
 {
-	struct obs_core_video_mix *video = obs->data.main_canvas->mix;
+	struct obs_core_video_mix *video = obs->data.main_canvas->video_mix;
 	stop_raw_video(video->video, callback, param);
 }
 
 void obs_add_raw_audio_callback(size_t mix_idx, const struct audio_convert_info *conversion,
 				audio_output_callback_t callback, void *param)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_core_audio_mix *audio = obs->data.main_canvas->audio_mix;
 	audio_output_connect(audio->audio, mix_idx, conversion, callback, param);
 }
 
 void obs_remove_raw_audio_callback(size_t mix_idx, audio_output_callback_t callback, void *param)
 {
-	struct obs_core_audio *audio = &obs->audio;
+	struct obs_core_audio_mix *audio = obs->data.main_canvas->audio_mix;
 	audio_output_disconnect(audio->audio, mix_idx, callback, param);
 }
 
@@ -3255,13 +3314,13 @@ bool obs_video_active(void)
 
 bool obs_nv12_tex_active(void)
 {
-	struct obs_core_video_mix *video = obs->data.main_canvas->mix;
+	struct obs_core_video_mix *video = obs->data.main_canvas->video_mix;
 	return video->using_nv12_tex;
 }
 
 bool obs_p010_tex_active(void)
 {
-	struct obs_core_video_mix *video = obs->data.main_canvas->mix;
+	struct obs_core_video_mix *video = obs->data.main_canvas->video_mix;
 	return video->using_p010_tex;
 }
 
@@ -3357,7 +3416,7 @@ bool obs_wait_for_destroy_queue(void)
 {
 	struct task_wait_info info = {0};
 
-	if (!obs->video.thread_initialized || !obs->audio.audio)
+	if (!obs->video.thread_initialized || !obs_get_audio())
 		return false;
 
 	/* allow video and audio threads time to release objects */
@@ -3480,4 +3539,22 @@ bool obs_enum_output_protocols(size_t idx, char **protocol)
 obs_canvas_t *obs_get_main_canvas(void)
 {
 	return obs_canvas_get_ref(obs->data.main_canvas);
+}
+
+bool obs_audio_active(void)
+{
+	bool result = false;
+
+	pthread_mutex_lock(&obs->audio.mixes_mutex);
+	for (size_t i = 0, num = obs->audio.mixes.num; i < num; i++) {
+		struct obs_core_audio_mix *audio = obs->audio.mixes.array[i];
+
+		if (audio_output_active(audio->audio)) {
+			result = true;
+			break;
+		}
+	}
+	pthread_mutex_unlock(&obs->audio.mixes_mutex);
+
+	return result;
 }

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -714,6 +714,9 @@ EXPORT video_t *obs_get_video(void);
 /** Returns true if video is active, false otherwise */
 EXPORT bool obs_video_active(void);
 
+/** Returns true if audio is active, false otherwise */
+EXPORT bool obs_audio_active(void);
+
 /** Sets the primary output source for a channel. */
 EXPORT void obs_set_output_source(uint32_t channel, obs_source_t *source);
 
@@ -2619,8 +2622,12 @@ EXPORT obs_canvas_t *obs_get_main_canvas(void);
 
 /** Creates a new canvas */
 EXPORT obs_canvas_t *obs_canvas_create(const char *name, struct obs_video_info *ovi, uint32_t flags);
+EXPORT obs_canvas_t *obs_canvas_create2(const char *name, struct obs_video_info *ovi, struct obs_audio_info2 *oai,
+					uint32_t flags);
 /** Creates a new private canvas */
 EXPORT obs_canvas_t *obs_canvas_create_private(const char *name, struct obs_video_info *ovi, uint32_t flags);
+EXPORT obs_canvas_t *obs_canvas_create_private2(const char *name, struct obs_video_info *ovi,
+						struct obs_audio_info2 *oai, uint32_t flags);
 
 /** Signal that references to canvas should be released and mark the canvas as removed. */
 EXPORT void obs_canvas_remove(obs_canvas_t *canvas);
@@ -2692,6 +2699,16 @@ EXPORT video_t *obs_canvas_get_video(const obs_canvas_t *canvas);
 EXPORT bool obs_canvas_get_video_info(const obs_canvas_t *canvas, struct obs_video_info *ovi);
 /** Renders the sources of this canvas's view context */
 EXPORT void obs_canvas_render(obs_canvas_t *canvas);
+
+/* Canvas audio */
+/** Reset a canvas's audio mix */
+EXPORT bool obs_canvas_reset_audio(obs_canvas_t *canvas, struct obs_audio_info2 *oai);
+/** Returns true if the canvas audio is configured */
+EXPORT bool obs_canvas_has_audio(obs_canvas_t *canvas);
+/** Get canvas audio output */
+EXPORT audio_t *obs_canvas_get_audio(const obs_canvas_t *canvas);
+/** Get canvas audio info (if it exists) */
+EXPORT bool obs_canvas_get_audio_info(const obs_canvas_t *canvas, struct obs_audio_info2 *oai);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description
This adds an audio mix to each canvas, similar to how video mixes work.

### Motivation and Context
This allows each canvas to have its own audio sources. In the future, it will make it possible to add audio monitoring busses and move audio monitoring out of libobs, in to its own plugin.

### How Has This Been Tested?
Tested by using the main canvas. Will still need to test with multiple canvasses.

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
