### PR TITLE
Fix C++20 issues

### DIFF
--- a/frontend/dialogs/OBSUpdate.hpp
+++ b/frontend/dialogs/OBSUpdate.hpp
@@ -2,6 +2,10 @@
 
 #include <QDialog>
 
+#include "ui_OBSUpdate.h"
+
+#include <memory>
+
 class Ui_OBSUpdate;
 
 class OBSUpdate : public QDialog {

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -2405,9 +2405,9 @@ void OBSBasicSettings::LoadAudioSources()
 		label->setMinimumSize(QSize(170, 0));
 		label->setAlignment(Qt::AlignRight | Qt::AlignTrailing | Qt::AlignVCenter);
 		connect(label, &OBSSourceLabel::removed, this,
-			[=]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[this]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
 		connect(label, &OBSSourceLabel::destroyed, this,
-			[=]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[this]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
 
 		layout->addRow(label, form);
 		return true;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fix an include issue for C++20.

Change lambdas from implicitly capturing `this` to explicitly capturing `this` as needed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Want to keep OBS Studio ready for C++20 and eventually build with C++20.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested locally on Windows 11 with:
* https://github.com/obsproject/obs-browser/pull/518
* https://github.com/obsproject/obs-websocket/pull/1338

See test builds with the original messy branch:
* Building with C++20 (failed due to websocketpp): https://github.com/RytoEX/obs-studio/actions/runs/23929960754
* Building with C++17: https://github.com/RytoEX/obs-studio/actions/runs/23929940788

As written on the obs-websocket PR, we may have to globally switch obs-studio to C++20 while forcing obs-websocket to C++17 until we can resolve the websocketpp issue or replace it.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
