### PR TITLE
frontend: Abort if obs-transitions failed to load

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1488,8 +1488,8 @@ private:
 	std::unordered_map<std::string, std::string> transitionNameToUuids;
 	int transitionDuration;
 	std::string currentTransitionUuid;
-	obs_source_t *fadeTransition;
-	obs_source_t *cutTransition;
+	obs_source_t *fadeTransition = nullptr;
+	obs_source_t *cutTransition = nullptr;
 	std::vector<QuickTransition> quickTransitions;
 	bool swapScenesMode = true;
 

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -70,6 +70,13 @@ void OBSBasic::InitDefaultTransitions()
 		}
 	}
 
+	// We require transitions in order to function, so exit with an error if
+	// obs-transitions failed to load for whatever reason.
+	if (!fadeTransition || !cutTransition) {
+		throw "InitDefaultTransitions: Could not load default transitions. Try re-installing OBS Studio from "
+		      "<a href=\"https://obsproject.com/\">obsproject.com</a>.";
+	}
+
 	for (OBSSource &tr : defaultTransitions) {
 		std::string uuid = obs_source_get_uuid(tr);
 

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -70,6 +70,14 @@ void OBSBasic::InitDefaultTransitions()
 		}
 	}
 
+	// We require transitions in order to function, so exit with an error if
+	// obs-transitions failed to load for whatever reason.
+	if (!fadeTransition || !cutTransition) {
+		// FIXME: https://github.com/obsproject/obs-studio/issues/13394
+		throw "InitDefaultTransitions: Could not load default transitions. Try re-installing OBS Studio from "
+		      "<a href=\"https://obsproject.com/\">obsproject.com</a>.";
+	}
+
 	for (OBSSource &tr : defaultTransitions) {
 		std::string uuid = obs_source_get_uuid(tr);
 


### PR DESCRIPTION
### Description
The frontend UI assumes transitions are always available and crashes if none are present. Resolving the crashes resulted in a completely broken UI, so it's safe to assume that transitions are a core requirement for a working OBS.

Crash reports indicate that obs-transitions is failing to load for some users, so we should handle the case where no transitions load and abort with an error instead of crashing.

### Motivation and Context
https://obsproject.com/logs/crashes/09jMYJwaWSRscFNd

### How Has This Been Tested?
Deleted `obs-transitions.dll`, ran OBS.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
