### PR TITLE
Fix compilation with VLC 4.0

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.c
+++ b/plugins/vlc-video/vlc-video-plugin.c
@@ -38,7 +38,7 @@ LIBVLC_VIDEO_SET_FORMAT_CALLBACKS libvlc_video_set_format_callbacks_;
 LIBVLC_AUDIO_SET_CALLBACKS libvlc_audio_set_callbacks_;
 LIBVLC_AUDIO_SET_FORMAT_CALLBACKS libvlc_audio_set_format_callbacks_;
 LIBVLC_MEDIA_PLAYER_PLAY libvlc_media_player_play_;
-LIBVLC_MEDIA_PLAYER_STOP libvlc_media_player_stop_;
+LIBVLC_MEDIA_PLAYER_STOP_ASYNC libvlc_media_player_stop_async_;
 LIBVLC_MEDIA_PLAYER_GET_TIME libvlc_media_player_get_time_;
 LIBVLC_MEDIA_PLAYER_SET_TIME libvlc_media_player_set_time_;
 LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
@@ -60,7 +60,7 @@ LIBVLC_MEDIA_LIST_PLAYER_NEW libvlc_media_list_player_new_;
 LIBVLC_MEDIA_LIST_PLAYER_RELEASE libvlc_media_list_player_release_;
 LIBVLC_MEDIA_LIST_PLAYER_PLAY libvlc_media_list_player_play_;
 LIBVLC_MEDIA_LIST_PLAYER_PAUSE libvlc_media_list_player_pause_;
-LIBVLC_MEDIA_LIST_PLAYER_STOP libvlc_media_list_player_stop_;
+LIBVLC_MEDIA_LIST_PLAYER_STOP_ASYNC libvlc_media_list_player_stop_async_;
 LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_PLAYER
 libvlc_media_list_player_set_media_player_;
 LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_LIST libvlc_media_list_player_set_media_list_;
@@ -71,6 +71,7 @@ LIBVLC_MEDIA_LIST_PLAYER_NEXT libvlc_media_list_player_next_;
 LIBVLC_MEDIA_LIST_PLAYER_PREVIOUS libvlc_media_list_player_previous_;
 
 void *libvlc_module = NULL;
+bool is_v4 = false;
 #ifdef __APPLE__
 void *libvlc_core_module = NULL;
 #endif
@@ -118,7 +119,7 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_audio_set_callbacks);
 	LOAD_VLC_FUNC(libvlc_audio_set_format_callbacks);
 	LOAD_VLC_FUNC(libvlc_media_player_play);
-	LOAD_VLC_FUNC(libvlc_media_player_stop);
+	LOAD_VLC_FUNC(libvlc_media_player_stop_async);
 	LOAD_VLC_FUNC(libvlc_media_player_get_time);
 	LOAD_VLC_FUNC(libvlc_media_player_set_time);
 	LOAD_VLC_FUNC(libvlc_video_get_size);
@@ -140,7 +141,7 @@ static bool load_vlc_funcs(void)
 	LOAD_VLC_FUNC(libvlc_media_list_player_release);
 	LOAD_VLC_FUNC(libvlc_media_list_player_play);
 	LOAD_VLC_FUNC(libvlc_media_list_player_pause);
-	LOAD_VLC_FUNC(libvlc_media_list_player_stop);
+	LOAD_VLC_FUNC(libvlc_media_list_player_stop_async);
 	LOAD_VLC_FUNC(libvlc_media_list_player_set_media_player);
 	LOAD_VLC_FUNC(libvlc_media_list_player_set_media_list);
 	LOAD_VLC_FUNC(libvlc_media_list_player_event_manager);
@@ -173,7 +174,16 @@ static bool load_libvlc_module(void)
 		libvlc_module = os_dlopen(path_utf8);
 		bfree(path_utf8);
 	}
-
+	status = RegQueryValueExW(key, L"Version", NULL, NULL, (LPBYTE)path,
+				  &size);
+	if (status == ERROR_SUCCESS) {
+		os_wcs_to_utf8_ptr(path, 0, &path_utf8);
+		if (strncmp(path_utf8, "4", 1) == 0)
+			is_v4 = true;
+		bfree(path_utf8);
+		if (!is_v4)
+			return false;
+	}
 	RegCloseKey(key);
 #else
 
@@ -181,14 +191,15 @@ static bool load_libvlc_module(void)
 #ifdef __APPLE__
 #define LIBVLC_DIR "/Applications/VLC.app/Contents/MacOS/"
 #define LIBVLC_CORE_FILE LIBVLC_DIR "lib/libvlccore.dylib"
-#define LIBVLC_FILE LIBVLC_DIR "lib/libvlc.5.dylib"
+/* Load first vlc 3 */
+#define LIBVLC_FILE LIBVLC_DIR "lib/libvlc.12.dylib"
 	setenv("VLC_PLUGIN_PATH", LIBVLC_DIR "plugins", false);
 	libvlc_core_module = os_dlopen(LIBVLC_CORE_FILE);
 
 	if (!libvlc_core_module)
 		return false;
 #else
-#define LIBVLC_FILE "libvlc.so.5"
+#define LIBVLC_FILE "libvlc.so.12"
 #endif
 	libvlc_module = os_dlopen(LIBVLC_FILE);
 
@@ -217,7 +228,7 @@ bool load_libvlc(void)
 bool obs_module_load(void)
 {
 	if (!load_libvlc_module()) {
-		blog(LOG_INFO, "[vlc-video]: Couldn't find VLC installation, "
+		blog(LOG_INFO, "[vlc-video]: Couldn't find VLC 4 installation, "
 			       "VLC video source disabled");
 		return true;
 	}
@@ -225,7 +236,8 @@ bool obs_module_load(void)
 	if (!load_vlc_funcs())
 		return true;
 
-	blog(LOG_INFO, "[vlc-video]: VLC %s found, VLC video source enabled", libvlc_get_version_());
+	blog(LOG_INFO, "[vlc-video]: VLC 4 %s found, VLC video source enabled",
+	     libvlc_get_version_());
 
 	obs_register_source(&vlc_source_info);
 	return true;

--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -50,9 +50,9 @@ typedef void (*LIBVLC_AUDIO_SET_CALLBACKS)(libvlc_media_player_t *mp, libvlc_aud
 typedef void (*LIBVLC_AUDIO_SET_FORMAT_CALLBACKS)(libvlc_media_player_t *mp, libvlc_audio_setup_cb setup,
 						  libvlc_audio_cleanup_cb cleanup);
 typedef int (*LIBVLC_MEDIA_PLAYER_PLAY)(libvlc_media_player_t *p_mi);
-typedef void (*LIBVLC_MEDIA_PLAYER_STOP)(libvlc_media_player_t *p_mi);
+typedef void (*LIBVLC_MEDIA_PLAYER_STOP_ASYNC)(libvlc_media_player_t *p_mi);
 typedef libvlc_time_t (*LIBVLC_MEDIA_PLAYER_GET_TIME)(libvlc_media_player_t *p_mi);
-typedef void (*LIBVLC_MEDIA_PLAYER_SET_TIME)(libvlc_media_player_t *p_mi, libvlc_time_t i_time);
+typedef void (*LIBVLC_MEDIA_PLAYER_SET_TIME)(libvlc_media_player_t *p_mi, libvlc_time_t i_time, bool b_fast);
 typedef int (*LIBVLC_VIDEO_GET_SIZE)(libvlc_media_player_t *p_mi, unsigned num, unsigned *px, unsigned *py);
 typedef libvlc_event_manager_t *(*LIBVLC_MEDIA_PLAYER_EVENT_MANAGER)(libvlc_media_player_t *p_mp);
 typedef libvlc_state_t (*LIBVLC_MEDIA_PLAYER_GET_STATE)(libvlc_media_player_t *p_mi);
@@ -72,7 +72,7 @@ typedef libvlc_media_list_player_t *(*LIBVLC_MEDIA_LIST_PLAYER_NEW)(libvlc_insta
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_RELEASE)(libvlc_media_list_player_t *p_mlp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_PLAY)(libvlc_media_list_player_t *p_mlp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_PAUSE)(libvlc_media_list_player_t *p_mlp);
-typedef void (*LIBVLC_MEDIA_LIST_PLAYER_STOP)(libvlc_media_list_player_t *p_mlp);
+typedef void (*LIBVLC_MEDIA_LIST_PLAYER_STOP_ASYNC)(libvlc_media_list_player_t *p_mlp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_PLAYER)(libvlc_media_list_player_t *p_mlp,
 							  libvlc_media_player_t *p_mp);
 typedef void (*LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_LIST)(libvlc_media_list_player_t *p_mlp,
@@ -111,7 +111,7 @@ extern LIBVLC_VIDEO_SET_FORMAT_CALLBACKS libvlc_video_set_format_callbacks_;
 extern LIBVLC_AUDIO_SET_CALLBACKS libvlc_audio_set_callbacks_;
 extern LIBVLC_AUDIO_SET_FORMAT_CALLBACKS libvlc_audio_set_format_callbacks_;
 extern LIBVLC_MEDIA_PLAYER_PLAY libvlc_media_player_play_;
-extern LIBVLC_MEDIA_PLAYER_STOP libvlc_media_player_stop_;
+extern LIBVLC_MEDIA_PLAYER_STOP_ASYNC libvlc_media_player_stop_async_;
 extern LIBVLC_MEDIA_PLAYER_GET_TIME libvlc_media_player_get_time_;
 extern LIBVLC_MEDIA_PLAYER_SET_TIME libvlc_media_player_set_time_;
 extern LIBVLC_VIDEO_GET_SIZE libvlc_video_get_size_;
@@ -133,7 +133,7 @@ extern LIBVLC_MEDIA_LIST_PLAYER_NEW libvlc_media_list_player_new_;
 extern LIBVLC_MEDIA_LIST_PLAYER_RELEASE libvlc_media_list_player_release_;
 extern LIBVLC_MEDIA_LIST_PLAYER_PLAY libvlc_media_list_player_play_;
 extern LIBVLC_MEDIA_LIST_PLAYER_PAUSE libvlc_media_list_player_pause_;
-extern LIBVLC_MEDIA_LIST_PLAYER_STOP libvlc_media_list_player_stop_;
+extern LIBVLC_MEDIA_LIST_PLAYER_STOP_ASYNC libvlc_media_list_player_stop_async_;
 extern LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_PLAYER libvlc_media_list_player_set_media_player_;
 extern LIBVLC_MEDIA_LIST_PLAYER_SET_MEDIA_LIST libvlc_media_list_player_set_media_list_;
 extern LIBVLC_MEDIA_LIST_PLAYER_EVENT_MANAGER libvlc_media_list_player_event_manager_;

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -337,7 +337,7 @@ static void vlcs_destroy(void *data)
 	struct vlc_source *c = data;
 
 	if (c->media_list_player) {
-		libvlc_media_list_player_stop_(c->media_list_player);
+		libvlc_media_list_player_stop_async_(c->media_list_player);
 		libvlc_media_list_player_release_(c->media_list_player);
 	}
 	if (c->media_player) {
@@ -677,7 +677,7 @@ static void vlcs_update(void *data, obs_data_t *settings)
 	/* ------------------------------------- */
 	/* update settings data */
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 
 	pthread_mutex_lock(&c->mutex);
 	old_files = c->files;
@@ -778,7 +778,7 @@ static enum obs_media_state vlcs_get_state(void *data)
 		return OBS_MEDIA_STATE_PAUSED;
 	case libvlc_Stopped:
 		return OBS_MEDIA_STATE_STOPPED;
-	case libvlc_Ended:
+	case libvlc_Stopping:
 		return OBS_MEDIA_STATE_ENDED;
 	case libvlc_Error:
 		return OBS_MEDIA_STATE_ERROR;
@@ -803,7 +803,7 @@ static void vlcs_restart(void *data)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 	libvlc_media_list_player_play_(c->media_list_player);
 }
 
@@ -811,7 +811,7 @@ static void vlcs_stop(void *data)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_list_player_stop_(c->media_list_player);
+	libvlc_media_list_player_stop_async_(c->media_list_player);
 	obs_source_output_video(c->source, NULL);
 }
 
@@ -847,7 +847,8 @@ static void vlcs_set_time(void *data, int64_t ms)
 {
 	struct vlc_source *c = data;
 
-	libvlc_media_player_set_time_(c->media_player, (libvlc_time_t)ms);
+	libvlc_media_player_set_time_(c->media_player, (libvlc_time_t)ms,
+				      false);
 }
 
 static void vlcs_play_pause_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
@@ -956,7 +957,7 @@ static void *vlcs_create(obs_data_t *settings, obs_source_t *source)
 
 	libvlc_event_manager_t *event_manager;
 	event_manager = libvlc_media_player_event_manager_(c->media_player);
-	libvlc_event_attach_(event_manager, libvlc_MediaPlayerEndReached, vlcs_stopped, c);
+	libvlc_event_attach_(event_manager, libvlc_MediaPlayerStopping, vlcs_stopped, c);
 	libvlc_event_attach_(event_manager, libvlc_MediaPlayerOpening, vlcs_started, c);
 
 	proc_handler_t *ph = obs_source_get_proc_handler(source);
@@ -989,7 +990,7 @@ static void vlcs_deactivate(void *data)
 	struct vlc_source *c = data;
 
 	if (c->behavior == BEHAVIOR_STOP_RESTART) {
-		libvlc_media_list_player_stop_(c->media_list_player);
+		libvlc_media_list_player_stop_async_(c->media_list_player);
 		obs_source_output_video(c->source, NULL);
 
 	} else if (c->behavior == BEHAVIOR_PAUSE_UNPAUSE) {


### PR DESCRIPTION
This patch fixes compilation against VLC 4.0.

Closes #13319.

### Description
VLC 4.0 has some API changes. This PR intents to fix compilation against VLC 4.0 with the new API.

Unfortunately this patch is [not](https://paste.gentoo.zip/kwHEQOIs) backwards compatible with VLC 3.

### Motivation and Context
This solves a compilation failure against VLC 4.0 as described in #13319. Also [936240](https://bugs.gentoo.org/936240).

### How Has This Been Tested?
Ran the CI tests and compiled locally on Gentoo Linux version 23.
`wget -O /etc/portage/patches/media-video/obs-studio/vlc-4.patch https://bugs.gentoo.org/attachment.cgi?id=956045`
`emerge -q '>=media-video/vlc-4.0.0_pre20260320'`
`emerge -q obs-studio`

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
