### PR TITLE
frontend: call setDesktopFileName earlier

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -928,7 +928,6 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 	setWindowIcon(QIcon::fromTheme("obs", QIcon(":/res/images/obs.png")));
 #endif
 
-	setDesktopFileName("com.obsproject.Studio");
 	pluginManager_ = std::make_unique<OBS::PluginManager>();
 }
 

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -505,6 +505,7 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 #ifdef _WIN32
 	QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
+	QGuiApplication::setDesktopFileName("com.obsproject.Studio");
 
 	QCoreApplication::addLibraryPath(".");
 


### PR DESCRIPTION
### Description
Qt 6.10.1+ will register the dbus app ID when outside a sandbox, but that requires the desktop file name to be set earlier
   
### Motivation and Context
This fixes portal dialogs using Qt dbus having the wrong app name when launching OBS e.g via a terminal / not through the desktop file

see https://github.com/leia-uwu/obs-wayland-hotkeys/issues/5

### How Has This Been Tested?
I ran OBS with this patch and with my wayland hotkeys plugin from inside konsole and the portal dialog properly showed up as "OBS Studio" requesting the hotkeys instead of "Konsole"

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
