### PR TITLE
frontend: Avoid hiding floating docks when the OBS app is not active on macOS

### DIFF
--- a/frontend/docks/OBSDock.cpp
+++ b/frontend/docks/OBSDock.cpp
@@ -7,6 +7,16 @@
 
 #include "moc_OBSDock.cpp"
 
+OBSDock::OBSDock(QWidget *parent) : QDockWidget(parent)
+{
+	this->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+}
+
+OBSDock::OBSDock(const QString &title, QWidget *parent) : QDockWidget(title, parent)
+{
+	this->setAttribute(Qt::WA_MacAlwaysShowToolWindow, true);
+}
+
 void OBSDock::closeEvent(QCloseEvent *event)
 {
 	auto msgBox = []() {

--- a/frontend/docks/OBSDock.hpp
+++ b/frontend/docks/OBSDock.hpp
@@ -10,8 +10,8 @@ class OBSDock : public QDockWidget {
 	Q_OBJECT
 
 public:
-	inline OBSDock(QWidget *parent = nullptr) : QDockWidget(parent) {}
-	inline OBSDock(const QString &title, QWidget *parent = nullptr) : QDockWidget(title, parent) {}
+	OBSDock(QWidget *parent = nullptr);
+	OBSDock(const QString &title, QWidget *parent = nullptr);
 
 	virtual void closeEvent(QCloseEvent *event);
 	virtual void showEvent(QShowEvent *event);


### PR DESCRIPTION
### Description
This PR changes the behavior of floating docks on macOS to have them stay visible while the OBS app is not active.

The main change is to set [Qt::WA_MacAlwaysShowToolWindow](https://doc.qt.io/qt-6/qt.html#WidgetAttribute-enum) which sets the macOS' `NSWindow.hidesOnDeactivate` setting to false. This is enough to keep the docks visible.

### Motivation and Context

In macOS, only one app can be "active" (aka "focused") at the time, and "floating panels" (OBS' docks in this case) disappear by default when their parent app is not active. 

The issue is that disappearing floating panels defy many of the use cases that OBS is great for. For example: 
- I'm doing game streaming on Twitch. I want to keep track of my chat.
- I have a floating panel displaying the "Twitch chat" dock on a side monitor.
- I click on my game, which becomes the active app. OBS is not the active app anymore, therefore the chat dock panel disappears.

This is a common issue between macOS users:
- https://obsproject.com/forum/threads/popped-out-docks-disappear-when-obs-is-not-in-focus.165011/
- https://obsproject.com/forum/threads/keep-dock-windows-visible-even-when-obs-is-not-in-focus.167324/

### How Has This Been Tested?

I tested this change on my MacBook Pro M4 Pro, running macOS Tahoe 26.4.1.
Test by:
- open obs, float a dock.
- click on a different app to make it active.
- the floating dock should still be visible.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [ ] My code is not on the master branch.
       I'm not sure what I'm supposed to do here. My PR targets the master branch, but I found no other indications of what to target otherwise.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
