### PR TITLE
libobs, docs: Document intended use of obs_module_unload

### DIFF
--- a/docs/sphinx/reference-modules.rst
+++ b/docs/sphinx/reference-modules.rst
@@ -55,7 +55,19 @@ to communicate with libobs and front-ends.
 
 .. function:: void obs_module_unload(void)
 
-   Optional: Called when the module is unloaded.
+   Optional: Called when libobs is shutting down and the module is about
+   to be unloaded. All libobs objects are still active and valid at this
+   point. Use this function to save user settings and release any strong
+   references that the module itself is holding to libobs objects (sources,
+   canvases, outputs, encoders, and services).
+
+   Do not attempt to release or destroy any still-active objects provided
+   by the module - ensure that they can continue functioning even after
+   returning from this function, as libobs may still need to call into the
+   module's callbacks (e.g. destroy) to clean up any remaining instances.
+
+   After this function returns, do not make any further libobs API calls
+   outside of libobs callbacks.
 
 ---------------------
 

--- a/docs/sphinx/reference-modules.rst
+++ b/docs/sphinx/reference-modules.rst
@@ -55,7 +55,19 @@ to communicate with libobs and front-ends.
 
 .. function:: void obs_module_unload(void)
 
-   Optional: Called when the module is unloaded.
+   Optional: Called when libobs is shutting down and the module is about
+   to be unloaded. All libobs objects are still active and valid at this
+   point. Use this function to save user settings and release any strong
+   references that the module itself is holding to libobs objects (sources,
+   canvases, outputs, encoders, and services).
+
+   Do not attempt to release or destroy any still-active objects provided
+   by the module - ensure that they can continue functioning even after
+   returning from this function, as libobs may still need to call into the
+   module's callbacks (e.g., destroy) to clean up any remaining instances.
+
+   After this function returns, do not make any further libobs API calls
+   outside of libobs callbacks.
 
 ---------------------
 

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -100,7 +100,21 @@ bool obs_module_load(void)
  */
 MODULE_EXPORT bool obs_module_load(void);
 
-/** Optional: Called when the module is unloaded.  */
+/**
+ * Optional: Called when libobs is shutting down and the module is about
+ * to be unloaded. All libobs objects are still active and valid at this
+ * point. Use this function to save user settings and release any strong
+ * references that the module itself is holding to libobs objects (sources,
+ * canvases, outputs, encoders, and services).
+ *
+ * Do not attempt to release or destroy any still-active objects provided
+ * by the module - ensure that they can continue functioning even after
+ * returning from this function, as libobs may still need to call into the
+ * module's callbacks (e.g. destroy) to clean up any remaining instances.
+ *
+ * After this function returns, do not make any further libobs API calls
+ * outside of libobs callbacks.
+ */
 MODULE_EXPORT void obs_module_unload(void);
 
 /** Optional: Called when all modules have finished loading */

--- a/libobs/obs-module.h
+++ b/libobs/obs-module.h
@@ -100,7 +100,21 @@ bool obs_module_load(void)
  */
 MODULE_EXPORT bool obs_module_load(void);
 
-/** Optional: Called when the module is unloaded.  */
+/**
+ * Optional: Called when libobs is shutting down and the module is about
+ * to be unloaded. All libobs objects are still active and valid at this
+ * point. Use this function to save user settings and release any strong
+ * references that the module itself is holding to libobs objects (sources,
+ * canvases, outputs, encoders, and services).
+ *
+ * Do not attempt to release or destroy any still-active objects provided
+ * by the module - ensure that they can continue functioning even after
+ * returning from this function, as libobs may still need to call into the
+ * module's callbacks (e.g., destroy) to clean up any remaining instances.
+ *
+ * After this function returns, do not make any further libobs API calls
+ * outside of libobs callbacks.
+ */
 MODULE_EXPORT void obs_module_unload(void);
 
 /** Optional: Called when all modules have finished loading */


### PR DESCRIPTION
### Description
`obs_module_unload` was never properly documented, so some plugins use it to free resources, some use it to save data, etc. While libobs tries to ensure all objects are shut down and destroyed before calling unload, if another plugin is holding a strong reference, or if a reference leak has occurred, libobs may need to call back into a plugin-provided object's destroy function even after `obs_module_unload` has returned. If the plugin has freed memory or other resources needed for the callback then this likely results in a crash.

Going forward, we should document that `obs_module_unload` is now intended only for saving data and releasing references, and that calling libobs after it returns is not allowed. For cases where resource cleanup is actually needed (for example, an external out of process helper needs to be shut down or a release call to a hardware driver), a new `obs_module_destroy` callback is intended to be added in a future version.

### Motivation and Context
The shutdown process currently causes a lot of crashes due to different plugins making different assumptions. Several 1st-party plugins also violate this and will need fixing.

### How Has This Been Tested?
N/A

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
