### PR TITLE
frontend: Add switch input methods for the browser and size follow window

### DIFF
--- a/frontend/dialogs/OBSBasicInteraction.cpp
+++ b/frontend/dialogs/OBSBasicInteraction.cpp
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "OBSBasicInteraction.hpp"
+#include "QInputMethodQueryEvent"
 
 #include <dialogs/OBSBasicProperties.hpp>
 #include <utility/OBSEventFilter.hpp>
@@ -46,21 +47,21 @@ OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 	  renamedSignal(obs_source_get_signal_handler(source), "rename", OBSBasicInteraction::SourceRenamed, this),
 	  eventFilter(BuildEventFilter())
 {
-	int cx = (int)config_get_int(App()->GetAppConfig(), "InteractionWindow", "cx");
-	int cy = (int)config_get_int(App()->GetAppConfig(), "InteractionWindow", "cy");
 
 	Qt::WindowFlags flags = windowFlags();
 	Qt::WindowFlags helpFlag = Qt::WindowContextHelpButtonHint;
 	setWindowFlags(flags & (~helpFlag));
 
 	ui->setupUi(this);
-
+	this->setAttribute(Qt::WA_DeleteOnClose);
 	ui->preview->setMouseTracking(true);
 	ui->preview->setFocusPolicy(Qt::StrongFocus);
 	ui->preview->installEventFilter(eventFilter.get());
+	ui->preview->setAttribute(Qt::WA_InputMethodEnabled, true);
 
-	if (cx > 400 && cy > 400)
-		resize(cx, cy);
+	auto handle = obs_source_get_signal_handler(source);
+	signal_handler_add(handle, "void composition_change(ptr source)");
+	signal_handler_connect(handle, "composition_change", composiytionChanged, this);
 
 	const char *name = obs_source_get_name(source);
 	setWindowTitle(QTStr("Basic.InteractionWindow").arg(QT_UTF8(name)));
@@ -70,10 +71,40 @@ OBSBasicInteraction::OBSBasicInteraction(QWidget *parent, OBSSource source_)
 	};
 
 	connect(ui->preview, &OBSQTDisplay::DisplayCreated, this, addDrawCallback);
+
+	auto s = obs_source_get_settings(source);
+	sizeFollowWindow = obs_data_get_bool(s, "size_follow_window");
+
+	if (sizeFollowWindow) {
+		int w, h;
+		w = obs_data_get_int(s, "width");
+		h = obs_data_get_int(s, "height");
+		int l, r, t, b;
+		ui->verticalLayout->getContentsMargins(&l, &t, &r, &b);
+		resize(w + l + r, h + t + b);
+		auto resizeCallback = [&]() {
+			QSize size = ui->preview->size();
+			auto s = obs_source_get_settings(source);
+			obs_data_set_int(s, "width", size.width());
+			obs_data_set_int(s, "height", size.height());
+			obs_source_update(source, s);
+			obs_data_release(s);
+		};
+		connect(ui->preview, &OBSQTDisplay::DisplayResized, this, resizeCallback);
+	}
+
+	obs_data_release(s);
+}
+
+QPoint OBSBasicInteraction::getDisplayPos()
+{
+	return ui->preview->pos();
 }
 
 OBSBasicInteraction::~OBSBasicInteraction()
 {
+	auto handle = obs_source_get_signal_handler(source);
+	signal_handler_disconnect(handle, "composition_change", composiytionChanged, this);
 	// since QT fakes a mouse movement while destructing a widget
 	// remove our event filter
 	ui->preview->removeEventFilter(eventFilter.get());
@@ -100,6 +131,10 @@ OBSEventFilter *OBSBasicInteraction::BuildEventFilter()
 		case QEvent::KeyPress:
 		case QEvent::KeyRelease:
 			return this->HandleKeyEvent(static_cast<QKeyEvent *>(event));
+		case QEvent::InputMethod:
+			return this->HandleInputMethodEvent(static_cast<QInputMethodEvent *>(event));
+		case QEvent::InputMethodQuery:
+			return this->HandleInputMethodQuery(static_cast<QInputMethodQueryEvent *>(event));
 		default:
 			return false;
 		}
@@ -149,6 +184,40 @@ void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)
 	gs_set_linear_srgb(previous);
 	gs_projection_pop();
 	gs_viewport_pop();
+}
+
+void OBSBasicInteraction::composiytionChanged(void *data, calldata_t *params)
+{
+	long long x_, y_, w_, h_;
+	calldata_get_int(params, "x", &x_);
+	calldata_get_int(params, "y", &y_);
+	calldata_get_int(params, "w", &w_);
+	calldata_get_int(params, "h", &h_);
+	OBSBasicInteraction *tmp = static_cast<OBSBasicInteraction *>(data);
+	QPoint pos = tmp->getDisplayPos();
+
+	if (!tmp->sizeFollowWindow) {
+		uint32_t sourceCX = max(obs_source_get_width(tmp->source), 1u);
+		uint32_t sourceCY = max(obs_source_get_height(tmp->source), 1u);
+		int x, y;
+		float scale;
+		QSize size = GetPixelSize(tmp);
+		int cx = size.width();
+		int cy = size.height();
+		qreal ratio = tmp->devicePixelRatioF();
+		GetScaleAndCenterPos(sourceCX, sourceCY, cx, cy, x, y, scale);
+
+		float srcX = float(x_) / ratio;
+		float srcY = float(y_) / ratio;
+		float srcW = float(w_) / ratio;
+		float srcH = float(h_) / ratio;
+
+		x_ = int(scale * srcX) + x;
+		y_ = int(scale * srcY) + y;
+		w_ = int(scale * srcW);
+		h_ = int(scale * srcH);
+	}
+	tmp->SetCompositionRect(QRect(x_ + pos.x(), y_ + pos.y(), w_, h_));
 }
 
 void OBSBasicInteraction::closeEvent(QCloseEvent *event)
@@ -376,6 +445,58 @@ bool OBSBasicInteraction::HandleKeyEvent(QKeyEvent *event)
 	obs_source_send_key_click(source, &keyEvent, keyUp);
 
 	return true;
+}
+
+bool OBSBasicInteraction::HandleInputMethodEvent(QInputMethodEvent *event)
+{
+	auto composingText = event->preeditString();
+	auto composedText = event->commitString();
+
+	if (!composedText.isEmpty()) {
+		obs_source_send_commit_text(source, composedText.toStdString().c_str());
+	} else if (!composingText.isEmpty()) {
+		//CefRange selectionRange;
+		int attr_start = 0;
+		for (auto &attr : event->attributes()) {
+			switch (attr.type) {
+			case QInputMethodEvent::TextFormat:
+				break;
+			case QInputMethodEvent::Cursor:
+				attr_start = attr.start;
+				break;
+			case QInputMethodEvent::Language:
+			case QInputMethodEvent::Ruby:
+			case QInputMethodEvent::Selection:
+				break;
+			default:
+				break;
+			}
+		}
+		obs_source_send_commit_composition(source, composingText.toStdString().c_str(), attr_start);
+	} else {
+		obs_source_send_cancel_composition(source);
+	}
+	return true;
+}
+
+bool OBSBasicInteraction::HandleInputMethodQuery(QInputMethodQueryEvent *event)
+{
+	switch (event->queries()) {
+	case Qt::ImCursorRectangle:
+		event->setValue(Qt::ImCursorRectangle, QVariant(compositionRect));
+		return true;
+	default:
+		return false;
+	}
+}
+
+void OBSBasicInteraction::SetCompositionRect(const QRect &rect)
+{
+	compositionRect = rect;
+	auto inputMethod = QGuiApplication::inputMethod();
+	if (inputMethod) {
+		inputMethod->update(Qt::ImCursorRectangle);
+	}
 }
 
 void OBSBasicInteraction::Init()

--- a/frontend/dialogs/OBSBasicInteraction.hpp
+++ b/frontend/dialogs/OBSBasicInteraction.hpp
@@ -37,6 +37,8 @@ private:
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	std::unique_ptr<OBSEventFilter> eventFilter;
+	bool sizeFollowWindow;
+	QRect compositionRect;
 
 	static void SourceRemoved(void *data, calldata_t *params);
 	static void SourceRenamed(void *data, calldata_t *params);
@@ -49,6 +51,9 @@ private:
 	bool HandleMouseWheelEvent(QWheelEvent *event);
 	bool HandleFocusEvent(QFocusEvent *event);
 	bool HandleKeyEvent(QKeyEvent *event);
+	bool HandleInputMethodEvent(QInputMethodEvent *event);
+	bool HandleInputMethodQuery(QInputMethodQueryEvent *event);
+	void SetCompositionRect(const QRect &rect);
 
 	OBSEventFilter *BuildEventFilter();
 
@@ -56,6 +61,8 @@ public:
 	OBSBasicInteraction(QWidget *parent, OBSSource source_);
 	~OBSBasicInteraction();
 
+	static void composiytionChanged(void *data, calldata_t *params);
+	QPoint getDisplayPos();
 	void Init();
 
 protected:

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -1097,6 +1097,42 @@ void obs_source_update_properties(obs_source_t *source)
 	obs_source_dosignal(source, NULL, "update_properties");
 }
 
+void obs_source_send_commit_text(obs_source_t *source, const char *text)
+{
+	if (!obs_source_valid(source, "obs_source_commit_text"))
+		return;
+
+	if (source->info.output_flags & OBS_SOURCE_INTERACTION) {
+		if (source->info.commit_text) {
+			source->info.commit_text(source->context.data, text);
+		}
+	}
+}
+
+void obs_source_send_commit_composition(obs_source_t *source, const char *text, int attr_start)
+{
+	if (!obs_source_valid(source, "obs_source_commit_text"))
+		return;
+
+	if (source->info.output_flags & OBS_SOURCE_INTERACTION) {
+		if (source->info.commit_composition) {
+			source->info.commit_composition(source->context.data, text, attr_start);
+		}
+	}
+}
+
+void obs_source_send_cancel_composition(obs_source_t *source)
+{
+	if (!obs_source_valid(source, "obs_source_commit_text"))
+		return;
+
+	if (source->info.output_flags & OBS_SOURCE_INTERACTION) {
+		if (source->info.cancel_composition) {
+			source->info.cancel_composition(source->context.data);
+		}
+	}
+}
+
 void obs_source_send_mouse_click(obs_source_t *source, const struct obs_mouse_event *event, int32_t type, bool mouse_up,
 				 uint32_t click_count)
 {

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -460,6 +460,30 @@ struct obs_source_info {
 	void (*key_click)(void *data, const struct obs_key_event *event, bool key_up);
 
 	/**
+	* Called when input method commits finalized text.
+	*
+	* @param data  Source data
+	* @param text  The finalized text content committed by the input method
+	*/
+	void (*commit_text)(void *data, const char *text);
+
+	/**
+	 * Called when input method commits ongoing composition text (e.g., candidate words in Pinyin IME).
+	 *
+	 * @param data             Source data
+	 * @param text             The current composition text being edited
+	 * @param attr_start       To build The selected range within the composition text
+	 */
+	void (*commit_composition)(void *data, const char *text, int attr_start);
+
+	/**
+	 * Called when input method cancels the current composition (e.g., user cancels input or switches input method).
+	 *
+	 * @param data  Source data
+	 */
+	void (*cancel_composition)(void *data);
+
+	/**
 	 * Called when the filter is removed from a source
 	 *
 	 * @param  data    Filter data

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1511,6 +1511,15 @@ EXPORT bool obs_source_add_active_child(obs_source_t *parent, obs_source_t *chil
  */
 EXPORT void obs_source_remove_active_child(obs_source_t *parent, obs_source_t *child);
 
+/** Sends an IME commit text event to a source. */
+EXPORT void obs_source_send_commit_text(obs_source_t *source, const char *text);
+
+/** Sends an IME commit composition event to a source. */
+EXPORT void obs_source_send_commit_composition(obs_source_t *source, const char *text, int attr_start);
+
+/** Sends an IME cancel composition event to a source. */
+EXPORT void obs_source_send_cancel_composition(obs_source_t *source);
+
 /** Sends a mouse down/up event to a source */
 EXPORT void obs_source_send_mouse_click(obs_source_t *source, const struct obs_mouse_event *event, int32_t type,
 					bool mouse_up, uint32_t click_count);


### PR DESCRIPTION
window and enable the browser source size to adapt to changes in the browser window size

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
This change adds input method switching support for browser sources, and implements a feature that allows the browser source page size to automatically adapt to changes of the browser interactive window size. Users can now freely adjust the browser source layout more conveniently.

### Motivation and Context
Currently, the OBS browser source does not support input method switching. When text input is required, users have to use an external browser to complete input operations and copy the URL back to OBS, which brings a poor and cumbersome experience.
In addition, the browser source content cannot follow the interactive window resizing, making size adjustment inconvenient.
This PR fixes the input method switching limitation and adds responsive window adaptation for browser source, significantly improving daily usability and flexibility.

### How Has This Been Tested?
Tested on Windows platform with multiple common system input methods.
Confirmed that input method switching works normally when focusing on browser source input areas.
Verified browser content scales and resizes correctly in real time when dragging or resizing the browser interactive window.
No crashes, rendering issues, performance regression or breaking changes to other existing source features.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.