### PR TITLE
vlc-video: Fix some enum names

### DIFF
--- a/plugins/vlc-video/vlc-video-plugin.h
+++ b/plugins/vlc-video/vlc-video-plugin.h
@@ -12,6 +12,12 @@ typedef SSIZE_T ssize_t;
 #include <vlc/libvlc_media_player.h>
 #include <vlc/libvlc_media_list_player.h>
 
+#include <vlc/libvlc_version.h>
+#if LIBVLC_VERSION_MAJOR < 4
+#define libvlc_Stopping               libvlc_Ended
+#define libvlc_MediaPlayerStopping    libvlc_MediaPlayerEndReached
+#endif
+
 extern libvlc_instance_t *libvlc;
 extern uint64_t time_start;
 

--- a/plugins/vlc-video/vlc-video-source.c
+++ b/plugins/vlc-video/vlc-video-source.c
@@ -778,7 +778,7 @@ static enum obs_media_state vlcs_get_state(void *data)
 		return OBS_MEDIA_STATE_PAUSED;
 	case libvlc_Stopped:
 		return OBS_MEDIA_STATE_STOPPED;
-	case libvlc_Ended:
+	case libvlc_Stopping:
 		return OBS_MEDIA_STATE_ENDED;
 	case libvlc_Error:
 		return OBS_MEDIA_STATE_ERROR;
@@ -956,7 +956,7 @@ static void *vlcs_create(obs_data_t *settings, obs_source_t *source)
 
 	libvlc_event_manager_t *event_manager;
 	event_manager = libvlc_media_player_event_manager_(c->media_player);
-	libvlc_event_attach_(event_manager, libvlc_MediaPlayerEndReached, vlcs_stopped, c);
+	libvlc_event_attach_(event_manager, libvlc_MediaPlayerStopping, vlcs_stopped, c);
 	libvlc_event_attach_(event_manager, libvlc_MediaPlayerOpening, vlcs_started, c);
 
 	proc_handler_t *ph = obs_source_get_proc_handler(source);


### PR DESCRIPTION
VLC 4 changes the respective names of libvlc_Ended and libvlc_MediaPlayerEndReached to libvlc_Stopping and libvlc_MediaPlayerStopping.

For reference, see this merge request from 2022
   https://code.videolan.org/videolan/vlc/-/merge_requests/1565

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This change updates the enum names to correspond with VLC 4. Additionally, there's a small compatibility block for older versions.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With VLC 4, a couple of enum names have been changed, resulting in build failures when attempting to compile OBS against that version.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
This patch has been tested to compile against OBS 32.1.0 and a pre-release version of VLC 4.0.0 on a Gentoo Linux box of mine.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
