### PR TITLE
frontend: Fix nested menu styling

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -686,10 +686,6 @@ QMenu {
     outline: none;
 }
 
-QMenu {
-    border: 1px solid var(--border_color);
-}
-
 QListWidget::item,
 SourceTreeItem {
     padding: var(--padding_large) var(--padding_large);
@@ -717,6 +713,12 @@ QListWidget::item {
 SourceTreeItem {
     border-radius: var(--border_radius);
     color: var(--text);
+}
+
+QMenu,
+QMenu > QMenu {
+    border: 1px solid var(--border_color);
+    padding: var(--spacing_base);
 }
 
 /* Temporary fix for plugins affected by fix in #11555 */


### PR DESCRIPTION
### Description
Fixes a regression in the audio mixer update that broke the styling of nested QMenus

| Before | After |
| ----- | ----- |
| <img width="402" height="386" alt="image" src="https://github.com/user-attachments/assets/09bcc71a-af8c-44e6-8481-eeb0e82482ec" /> | <img width="362" height="370" alt="image" src="https://github.com/user-attachments/assets/486416b8-d4b0-4a07-9cfd-e4c0517eaa4a" /> |


### Motivation and Context
Want consistent appearance of menus.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
