### PR TITLE
frontend: Update invokeMethod to use function pointers

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1181,7 +1181,7 @@ static void ui_task_handler(obs_task_t task, void *param, bool wait)
 		/* to get clang-format to behave */
 		task(param);
 	};
-	QMetaObject::invokeMethod(App(), "Exec", wait ? WaitConnection() : Qt::AutoConnection, Q_ARG(VoidFunc, doTask));
+	QMetaObject::invokeMethod(App(), &OBSApp::Exec, wait ? WaitConnection() : Qt::AutoConnection, doTask);
 }
 
 bool OBSApp::OBSInit()

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1219,7 +1219,7 @@ static void ui_task_handler(obs_task_t task, void *param, bool wait)
 		/* to get clang-format to behave */
 		task(param);
 	};
-	QMetaObject::invokeMethod(App(), "Exec", wait ? WaitConnection() : Qt::AutoConnection, Q_ARG(VoidFunc, doTask));
+	QMetaObject::invokeMethod(App(), &OBSApp::Exec, wait ? WaitConnection() : Qt::AutoConnection, doTask);
 }
 
 bool OBSApp::OBSInit()

--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -133,7 +133,6 @@ private:
 
 private slots:
 	void commitData(QSessionManager &manager);
-	void addLogLine(int logLevel, const QString &message);
 	void themeFileChanged(const QString &);
 	void applicationShutdown() noexcept;
 
@@ -233,6 +232,7 @@ public:
 	void pluginManagerOpenDialog();
 
 public slots:
+	void addLogLine(int logLevel, const QString &message);
 	void Exec(VoidFunc func);
 	void processSigInt();
 	void processSigTerm();

--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -137,7 +137,6 @@ private:
 
 private slots:
 	void commitData(QSessionManager &manager);
-	void addLogLine(int logLevel, const QString &message);
 	void themeFileChanged(const QString &);
 	void applicationShutdown() noexcept;
 
@@ -244,6 +243,7 @@ public:
 	void pluginManagerOpenDialog();
 
 public slots:
+	void addLogLine(int logLevel, const QString &message);
 	void Exec(VoidFunc func);
 	void processSigInt();
 	void processSigTerm();

--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -64,11 +64,10 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_scene()
 void OBSStudioAPI::obs_frontend_set_current_scene(obs_source_t *scene)
 {
 	if (main->IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(main, "TransitionToScene", WaitConnection(),
-					  Q_ARG(OBSSource, OBSSource(scene)));
+		QMetaObject::invokeMethod(main, [this, scene]() { main->TransitionToScene(scene); }, WaitConnection());
 	} else {
-		QMetaObject::invokeMethod(main, "SetCurrentScene", WaitConnection(), Q_ARG(OBSSource, OBSSource(scene)),
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(main, qOverload<OBSSource, bool>(&OBSBasic::SetCurrentScene),
+					  WaitConnection(), scene, false);
 	}
 }
 
@@ -90,7 +89,7 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_transition()
 
 void OBSStudioAPI::obs_frontend_set_current_transition(obs_source_t *transition)
 {
-	QMetaObject::invokeMethod(main, "SetTransition", Q_ARG(OBSSource, OBSSource(transition)));
+	QMetaObject::invokeMethod(main, &OBSBasic::SetTransition, OBSSource(transition));
 }
 
 int OBSStudioAPI::obs_frontend_get_transition_duration()
@@ -100,17 +99,17 @@ int OBSStudioAPI::obs_frontend_get_transition_duration()
 
 void OBSStudioAPI::obs_frontend_set_transition_duration(int duration)
 {
-	QMetaObject::invokeMethod(main, "SetTransitionDuration", Q_ARG(int, duration));
+	QMetaObject::invokeMethod(main, &OBSBasic::SetTransitionDuration, duration);
 }
 
 void OBSStudioAPI::obs_frontend_release_tbar()
 {
-	QMetaObject::invokeMethod(main, "TBarReleased");
+	QMetaObject::invokeMethod(main, &OBSBasic::TBarReleased);
 }
 
 void OBSStudioAPI::obs_frontend_set_tbar_position(int position)
 {
-	QMetaObject::invokeMethod(main, "TBarChanged", Q_ARG(int, position));
+	QMetaObject::invokeMethod(main, &OBSBasic::TBarChanged, position);
 }
 
 int OBSStudioAPI::obs_frontend_get_tbar_position()
@@ -158,8 +157,9 @@ void OBSStudioAPI::obs_frontend_set_current_scene_collection(const char *collect
 bool OBSStudioAPI::obs_frontend_add_scene_collection(const char *name)
 {
 	bool success = false;
-	QMetaObject::invokeMethod(main, "CreateNewSceneCollection", WaitConnection(), Q_RETURN_ARG(bool, success),
-				  Q_ARG(QString, QT_UTF8(name)));
+	QMetaObject::invokeMethod(
+		main, [this, &success, name = QT_UTF8(name)]() { success = main->CreateNewSceneCollection(name); },
+		WaitConnection());
 	return success;
 }
 
@@ -205,27 +205,27 @@ void OBSStudioAPI::obs_frontend_set_current_profile(const char *profile)
 
 void OBSStudioAPI::obs_frontend_create_profile(const char *name)
 {
-	QMetaObject::invokeMethod(main, "CreateNewProfile", Q_ARG(QString, name));
+	QMetaObject::invokeMethod(main, &OBSBasic::CreateNewProfile, QString::fromUtf8(name));
 }
 
 void OBSStudioAPI::obs_frontend_duplicate_profile(const char *name)
 {
-	QMetaObject::invokeMethod(main, "CreateDuplicateProfile", Q_ARG(QString, name));
+	QMetaObject::invokeMethod(main, &OBSBasic::CreateDuplicateProfile, QString::fromUtf8(name));
 }
 
 void OBSStudioAPI::obs_frontend_delete_profile(const char *profile)
 {
-	QMetaObject::invokeMethod(main, "DeleteProfile", Q_ARG(QString, profile));
+	QMetaObject::invokeMethod(main, &OBSBasic::DeleteProfile, QString::fromUtf8(profile));
 }
 
 void OBSStudioAPI::obs_frontend_streaming_start()
 {
-	QMetaObject::invokeMethod(main, "StartStreaming");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartStreaming);
 }
 
 void OBSStudioAPI::obs_frontend_streaming_stop()
 {
-	QMetaObject::invokeMethod(main, "StopStreaming");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopStreaming);
 }
 
 bool OBSStudioAPI::obs_frontend_streaming_active()
@@ -235,12 +235,12 @@ bool OBSStudioAPI::obs_frontend_streaming_active()
 
 void OBSStudioAPI::obs_frontend_recording_start()
 {
-	QMetaObject::invokeMethod(main, "StartRecording");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartRecording);
 }
 
 void OBSStudioAPI::obs_frontend_recording_stop()
 {
-	QMetaObject::invokeMethod(main, "StopRecording");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopRecording);
 }
 
 bool OBSStudioAPI::obs_frontend_recording_active()
@@ -290,17 +290,17 @@ bool OBSStudioAPI::obs_frontend_recording_add_chapter(const char *name)
 
 void OBSStudioAPI::obs_frontend_replay_buffer_start()
 {
-	QMetaObject::invokeMethod(main, "StartReplayBuffer");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartReplayBuffer);
 }
 
 void OBSStudioAPI::obs_frontend_replay_buffer_save()
 {
-	QMetaObject::invokeMethod(main, "ReplayBufferSave");
+	QMetaObject::invokeMethod(main, &OBSBasic::ReplayBufferSave);
 }
 
 void OBSStudioAPI::obs_frontend_replay_buffer_stop()
 {
-	QMetaObject::invokeMethod(main, "StopReplayBuffer");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopReplayBuffer);
 }
 
 bool OBSStudioAPI::obs_frontend_replay_buffer_active()
@@ -447,7 +447,7 @@ void OBSStudioAPI::obs_frontend_open_projector(const char *type, int monitor, co
 		else if (astrcmpi(type, "Multiview") == 0)
 			proj.type = ProjectorType::Multiview;
 	}
-	QMetaObject::invokeMethod(main, "OpenSavedProjector", WaitConnection(), Q_ARG(SavedProjectorInfo *, &proj));
+	QMetaObject::invokeMethod(main, [this, &proj]() { main->OpenSavedProjector(&proj); }, WaitConnection());
 }
 
 void OBSStudioAPI::obs_frontend_save()
@@ -457,12 +457,12 @@ void OBSStudioAPI::obs_frontend_save()
 
 void OBSStudioAPI::obs_frontend_defer_save_begin()
 {
-	QMetaObject::invokeMethod(main, "DeferSaveBegin");
+	QMetaObject::invokeMethod(main, &OBSBasic::DeferSaveBegin);
 }
 
 void OBSStudioAPI::obs_frontend_defer_save_end()
 {
-	QMetaObject::invokeMethod(main, "DeferSaveEnd");
+	QMetaObject::invokeMethod(main, &OBSBasic::DeferSaveEnd);
 }
 
 void OBSStudioAPI::obs_frontend_add_save_callback(obs_frontend_save_cb callback, void *private_data)
@@ -534,7 +534,7 @@ void OBSStudioAPI::obs_frontend_set_preview_program_mode(bool enable)
 
 void OBSStudioAPI::obs_frontend_preview_program_trigger_transition()
 {
-	QMetaObject::invokeMethod(main, "TransitionClicked");
+	QMetaObject::invokeMethod(main, &OBSBasic::TransitionClicked);
 }
 
 bool OBSStudioAPI::obs_frontend_preview_enabled()
@@ -561,19 +561,19 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_preview_scene()
 void OBSStudioAPI::obs_frontend_set_current_preview_scene(obs_source_t *scene)
 {
 	if (main->IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(main, "SetCurrentScene", Q_ARG(OBSSource, OBSSource(scene)),
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(main, qOverload<OBSSource, bool>(&OBSBasic::SetCurrentScene),
+					  OBSSource(scene), false);
 	}
 }
 
 void OBSStudioAPI::obs_frontend_take_screenshot()
 {
-	QMetaObject::invokeMethod(main, "Screenshot");
+	QMetaObject::invokeMethod(main, &OBSBasic::Screenshot, nullptr);
 }
 
 void OBSStudioAPI::obs_frontend_take_source_screenshot(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "Screenshot", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::Screenshot, OBSSource(source));
 }
 
 obs_output_t *OBSStudioAPI::obs_frontend_get_virtualcam_output()
@@ -584,12 +584,12 @@ obs_output_t *OBSStudioAPI::obs_frontend_get_virtualcam_output()
 
 void OBSStudioAPI::obs_frontend_start_virtualcam()
 {
-	QMetaObject::invokeMethod(main, "StartVirtualCam");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartVirtualCam);
 }
 
 void OBSStudioAPI::obs_frontend_stop_virtualcam()
 {
-	QMetaObject::invokeMethod(main, "StopVirtualCam");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopVirtualCam);
 }
 
 bool OBSStudioAPI::obs_frontend_virtualcam_active()
@@ -604,22 +604,22 @@ void OBSStudioAPI::obs_frontend_reset_video()
 
 void OBSStudioAPI::obs_frontend_open_source_properties(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenProperties", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenProperties, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_source_filters(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenFilters", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenFilters, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_source_interaction(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenInteraction", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenInteraction, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item)
 {
-	QMetaObject::invokeMethod(main, "OpenEditTransform", Q_ARG(OBSSceneItem, OBSSceneItem(item)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenEditTransform, OBSSceneItem(item));
 }
 
 char *OBSStudioAPI::obs_frontend_get_current_record_output_path()

--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -66,11 +66,10 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_scene()
 void OBSStudioAPI::obs_frontend_set_current_scene(obs_source_t *scene)
 {
 	if (main->IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(main, "TransitionToScene", WaitConnection(),
-					  Q_ARG(OBSSource, OBSSource(scene)));
+		QMetaObject::invokeMethod(main, [this, scene]() { main->TransitionToScene(scene); }, WaitConnection());
 	} else {
-		QMetaObject::invokeMethod(main, "SetCurrentScene", WaitConnection(), Q_ARG(OBSSource, OBSSource(scene)),
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(main, qOverload<OBSSource, bool>(&OBSBasic::SetCurrentScene),
+					  WaitConnection(), scene, false);
 	}
 }
 
@@ -93,7 +92,7 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_transition()
 
 void OBSStudioAPI::obs_frontend_set_current_transition(obs_source_t *transition)
 {
-	QMetaObject::invokeMethod(main, "SetTransition", Q_ARG(OBSSource, OBSSource(transition)));
+	QMetaObject::invokeMethod(main, &OBSBasic::SetTransition, OBSSource(transition));
 }
 
 int OBSStudioAPI::obs_frontend_get_transition_duration()
@@ -103,17 +102,17 @@ int OBSStudioAPI::obs_frontend_get_transition_duration()
 
 void OBSStudioAPI::obs_frontend_set_transition_duration(int duration)
 {
-	QMetaObject::invokeMethod(main, "SetTransitionDuration", Q_ARG(int, duration));
+	QMetaObject::invokeMethod(main, &OBSBasic::SetTransitionDuration, duration);
 }
 
 void OBSStudioAPI::obs_frontend_release_tbar()
 {
-	QMetaObject::invokeMethod(main, "TBarReleased");
+	QMetaObject::invokeMethod(main, &OBSBasic::TBarReleased);
 }
 
 void OBSStudioAPI::obs_frontend_set_tbar_position(int position)
 {
-	QMetaObject::invokeMethod(main, "TBarChanged", Q_ARG(int, position));
+	QMetaObject::invokeMethod(main, &OBSBasic::TBarChanged, position);
 }
 
 int OBSStudioAPI::obs_frontend_get_tbar_position()
@@ -161,8 +160,9 @@ void OBSStudioAPI::obs_frontend_set_current_scene_collection(const char *collect
 bool OBSStudioAPI::obs_frontend_add_scene_collection(const char *name)
 {
 	bool success = false;
-	QMetaObject::invokeMethod(main, "CreateNewSceneCollection", WaitConnection(), Q_RETURN_ARG(bool, success),
-				  Q_ARG(QString, QT_UTF8(name)));
+	QMetaObject::invokeMethod(
+		main, [this, &success, name = QT_UTF8(name)]() { success = main->CreateNewSceneCollection(name); },
+		WaitConnection());
 	return success;
 }
 
@@ -208,27 +208,27 @@ void OBSStudioAPI::obs_frontend_set_current_profile(const char *profile)
 
 void OBSStudioAPI::obs_frontend_create_profile(const char *name)
 {
-	QMetaObject::invokeMethod(main, "CreateNewProfile", Q_ARG(QString, name));
+	QMetaObject::invokeMethod(main, &OBSBasic::CreateNewProfile, QString::fromUtf8(name));
 }
 
 void OBSStudioAPI::obs_frontend_duplicate_profile(const char *name)
 {
-	QMetaObject::invokeMethod(main, "CreateDuplicateProfile", Q_ARG(QString, name));
+	QMetaObject::invokeMethod(main, &OBSBasic::CreateDuplicateProfile, QString::fromUtf8(name));
 }
 
 void OBSStudioAPI::obs_frontend_delete_profile(const char *profile)
 {
-	QMetaObject::invokeMethod(main, "DeleteProfile", Q_ARG(QString, profile));
+	QMetaObject::invokeMethod(main, &OBSBasic::DeleteProfile, QString::fromUtf8(profile));
 }
 
 void OBSStudioAPI::obs_frontend_streaming_start()
 {
-	QMetaObject::invokeMethod(main, "StartStreaming");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartStreaming);
 }
 
 void OBSStudioAPI::obs_frontend_streaming_stop()
 {
-	QMetaObject::invokeMethod(main, "StopStreaming");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopStreaming);
 }
 
 bool OBSStudioAPI::obs_frontend_streaming_active()
@@ -238,12 +238,12 @@ bool OBSStudioAPI::obs_frontend_streaming_active()
 
 void OBSStudioAPI::obs_frontend_recording_start()
 {
-	QMetaObject::invokeMethod(main, "StartRecording");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartRecording);
 }
 
 void OBSStudioAPI::obs_frontend_recording_stop()
 {
-	QMetaObject::invokeMethod(main, "StopRecording");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopRecording);
 }
 
 bool OBSStudioAPI::obs_frontend_recording_active()
@@ -294,17 +294,17 @@ bool OBSStudioAPI::obs_frontend_recording_add_chapter(const char *name)
 
 void OBSStudioAPI::obs_frontend_replay_buffer_start()
 {
-	QMetaObject::invokeMethod(main, "StartReplayBuffer");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartReplayBuffer);
 }
 
 void OBSStudioAPI::obs_frontend_replay_buffer_save()
 {
-	QMetaObject::invokeMethod(main, "ReplayBufferSave");
+	QMetaObject::invokeMethod(main, &OBSBasic::ReplayBufferSave);
 }
 
 void OBSStudioAPI::obs_frontend_replay_buffer_stop()
 {
-	QMetaObject::invokeMethod(main, "StopReplayBuffer");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopReplayBuffer);
 }
 
 bool OBSStudioAPI::obs_frontend_replay_buffer_active()
@@ -455,7 +455,7 @@ void OBSStudioAPI::obs_frontend_open_projector(const char *type, int monitor, co
 			proj.type = ProjectorType::Multiview;
 		}
 	}
-	QMetaObject::invokeMethod(main, "OpenSavedProjector", WaitConnection(), Q_ARG(SavedProjectorInfo *, &proj));
+	QMetaObject::invokeMethod(main, [this, &proj]() { main->OpenSavedProjector(&proj); }, WaitConnection());
 }
 
 void OBSStudioAPI::obs_frontend_save()
@@ -465,12 +465,12 @@ void OBSStudioAPI::obs_frontend_save()
 
 void OBSStudioAPI::obs_frontend_defer_save_begin()
 {
-	QMetaObject::invokeMethod(main, "DeferSaveBegin");
+	QMetaObject::invokeMethod(main, &OBSBasic::DeferSaveBegin);
 }
 
 void OBSStudioAPI::obs_frontend_defer_save_end()
 {
-	QMetaObject::invokeMethod(main, "DeferSaveEnd");
+	QMetaObject::invokeMethod(main, &OBSBasic::DeferSaveEnd);
 }
 
 void OBSStudioAPI::obs_frontend_add_save_callback(obs_frontend_save_cb callback, void *private_data)
@@ -546,7 +546,7 @@ void OBSStudioAPI::obs_frontend_set_preview_program_mode(bool enable)
 
 void OBSStudioAPI::obs_frontend_preview_program_trigger_transition()
 {
-	QMetaObject::invokeMethod(main, "TransitionClicked");
+	QMetaObject::invokeMethod(main, &OBSBasic::TransitionClicked);
 }
 
 bool OBSStudioAPI::obs_frontend_preview_enabled()
@@ -574,19 +574,19 @@ obs_source_t *OBSStudioAPI::obs_frontend_get_current_preview_scene()
 void OBSStudioAPI::obs_frontend_set_current_preview_scene(obs_source_t *scene)
 {
 	if (main->IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(main, "SetCurrentScene", Q_ARG(OBSSource, OBSSource(scene)),
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(main, qOverload<OBSSource, bool>(&OBSBasic::SetCurrentScene),
+					  OBSSource(scene), false);
 	}
 }
 
 void OBSStudioAPI::obs_frontend_take_screenshot()
 {
-	QMetaObject::invokeMethod(main, "Screenshot");
+	QMetaObject::invokeMethod(main, &OBSBasic::Screenshot, nullptr);
 }
 
 void OBSStudioAPI::obs_frontend_take_source_screenshot(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "Screenshot", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::Screenshot, OBSSource(source));
 }
 
 obs_output_t *OBSStudioAPI::obs_frontend_get_virtualcam_output()
@@ -597,12 +597,12 @@ obs_output_t *OBSStudioAPI::obs_frontend_get_virtualcam_output()
 
 void OBSStudioAPI::obs_frontend_start_virtualcam()
 {
-	QMetaObject::invokeMethod(main, "StartVirtualCam");
+	QMetaObject::invokeMethod(main, &OBSBasic::StartVirtualCam);
 }
 
 void OBSStudioAPI::obs_frontend_stop_virtualcam()
 {
-	QMetaObject::invokeMethod(main, "StopVirtualCam");
+	QMetaObject::invokeMethod(main, &OBSBasic::StopVirtualCam);
 }
 
 bool OBSStudioAPI::obs_frontend_virtualcam_active()
@@ -617,22 +617,22 @@ void OBSStudioAPI::obs_frontend_reset_video()
 
 void OBSStudioAPI::obs_frontend_open_source_properties(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenProperties", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenProperties, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_source_filters(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenFilters", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenFilters, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_source_interaction(obs_source_t *source)
 {
-	QMetaObject::invokeMethod(main, "OpenInteraction", Q_ARG(OBSSource, OBSSource(source)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenInteraction, OBSSource(source));
 }
 
 void OBSStudioAPI::obs_frontend_open_sceneitem_edit_transform(obs_sceneitem_t *item)
 {
-	QMetaObject::invokeMethod(main, "OpenEditTransform", Q_ARG(OBSSceneItem, OBSSceneItem(item)));
+	QMetaObject::invokeMethod(main, &OBSBasic::OpenEditTransform, OBSSceneItem(item));
 }
 
 char *OBSStudioAPI::obs_frontend_get_current_record_output_path()

--- a/frontend/components/MediaControls.cpp
+++ b/frontend/components/MediaControls.cpp
@@ -10,37 +10,37 @@
 void MediaControls::OBSMediaStopped(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "SetRestartState");
+	QMetaObject::invokeMethod(media, &MediaControls::SetRestartState);
 }
 
 void MediaControls::OBSMediaPlay(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "SetPlayingState");
+	QMetaObject::invokeMethod(media, &MediaControls::SetPlayingState);
 }
 
 void MediaControls::OBSMediaPause(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "SetPausedState");
+	QMetaObject::invokeMethod(media, &MediaControls::SetPausedState);
 }
 
 void MediaControls::OBSMediaStarted(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "SetPlayingState");
+	QMetaObject::invokeMethod(media, &MediaControls::SetPlayingState);
 }
 
 void MediaControls::OBSMediaNext(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "UpdateSlideCounter");
+	QMetaObject::invokeMethod(media, &MediaControls::UpdateSlideCounter);
 }
 
 void MediaControls::OBSMediaPrevious(void *data, calldata_t *)
 {
 	MediaControls *media = static_cast<MediaControls *>(data);
-	QMetaObject::invokeMethod(media, "UpdateSlideCounter");
+	QMetaObject::invokeMethod(media, &MediaControls::UpdateSlideCounter);
 }
 
 MediaControls::MediaControls(QWidget *parent) : QWidget(parent), ui(new Ui::MediaControls)

--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -259,57 +259,57 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 
 void OBSAdvAudioCtrl::OBSSourceActivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, true));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceActiveChanged, true);
 }
 
 void OBSAdvAudioCtrl::OBSSourceDeactivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, false));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceActiveChanged, false);
 }
 
 void OBSAdvAudioCtrl::OBSSourceFlagsChanged(void *param, calldata_t *calldata)
 {
 	uint32_t flags = (uint32_t)calldata_int(calldata, "flags");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceFlagsChanged", Q_ARG(uint32_t, flags));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceFlagsChanged, flags);
 }
 
 void OBSAdvAudioCtrl::OBSSourceVolumeChanged(void *param, calldata_t *calldata)
 {
 	float volume = (float)calldata_float(calldata, "volume");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceVolumeChanged", Q_ARG(float, volume));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceVolumeChanged, volume);
 }
 
 void OBSAdvAudioCtrl::OBSSourceSyncChanged(void *param, calldata_t *calldata)
 {
 	int64_t offset = calldata_int(calldata, "offset");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceSyncChanged", Q_ARG(int64_t, offset));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceSyncChanged, offset);
 }
 
 void OBSAdvAudioCtrl::OBSSourceMonitoringTypeChanged(void *param, calldata_t *calldata)
 {
 	int type = calldata_int(calldata, "type");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMonitoringTypeChanged",
-				  Q_ARG(int, type));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceMonitoringTypeChanged,
+				  type);
 }
 
 void OBSAdvAudioCtrl::OBSSourceMixersChanged(void *param, calldata_t *calldata)
 {
 	uint32_t mixers = (uint32_t)calldata_int(calldata, "mixers");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMixersChanged",
-				  Q_ARG(uint32_t, mixers));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceMixersChanged, mixers);
 }
 
 void OBSAdvAudioCtrl::OBSSourceBalanceChanged(void *param, calldata_t *calldata)
 {
 	int balance = (float)calldata_float(calldata, "balance") * 100.0f;
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceBalanceChanged", Q_ARG(int, balance));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceBalanceChanged,
+				  balance);
 }
 
 void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
 {
 	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
 
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SetSourceName", Q_ARG(QString, newName));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SetSourceName, newName);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -266,57 +266,57 @@ void OBSAdvAudioCtrl::ShowAudioControl(QGridLayout *layout)
 
 void OBSAdvAudioCtrl::OBSSourceActivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, true));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceActiveChanged, true);
 }
 
 void OBSAdvAudioCtrl::OBSSourceDeactivated(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceActiveChanged", Q_ARG(bool, false));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceActiveChanged, false);
 }
 
 void OBSAdvAudioCtrl::OBSSourceFlagsChanged(void *param, calldata_t *calldata)
 {
 	uint32_t flags = (uint32_t)calldata_int(calldata, "flags");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceFlagsChanged", Q_ARG(uint32_t, flags));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceFlagsChanged, flags);
 }
 
 void OBSAdvAudioCtrl::OBSSourceVolumeChanged(void *param, calldata_t *calldata)
 {
 	float volume = (float)calldata_float(calldata, "volume");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceVolumeChanged", Q_ARG(float, volume));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceVolumeChanged, volume);
 }
 
 void OBSAdvAudioCtrl::OBSSourceSyncChanged(void *param, calldata_t *calldata)
 {
 	int64_t offset = calldata_int(calldata, "offset");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceSyncChanged", Q_ARG(int64_t, offset));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceSyncChanged, offset);
 }
 
 void OBSAdvAudioCtrl::OBSSourceMonitoringTypeChanged(void *param, calldata_t *calldata)
 {
 	int type = calldata_int(calldata, "type");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMonitoringTypeChanged",
-				  Q_ARG(int, type));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceMonitoringTypeChanged,
+				  type);
 }
 
 void OBSAdvAudioCtrl::OBSSourceMixersChanged(void *param, calldata_t *calldata)
 {
 	uint32_t mixers = (uint32_t)calldata_int(calldata, "mixers");
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceMixersChanged",
-				  Q_ARG(uint32_t, mixers));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceMixersChanged, mixers);
 }
 
 void OBSAdvAudioCtrl::OBSSourceBalanceChanged(void *param, calldata_t *calldata)
 {
 	int balance = (float)calldata_float(calldata, "balance") * 100.0f;
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SourceBalanceChanged", Q_ARG(int, balance));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SourceBalanceChanged,
+				  balance);
 }
 
 void OBSAdvAudioCtrl::OBSSourceRenamed(void *param, calldata_t *calldata)
 {
 	QString newName = QT_UTF8(calldata_string(calldata, "new_name"));
 
-	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), "SetSourceName", Q_ARG(QString, newName));
+	QMetaObject::invokeMethod(static_cast<OBSAdvAudioCtrl *>(param), &OBSAdvAudioCtrl::SetSourceName, newName);
 }
 
 /* ------------------------------------------------------------------------- */

--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -196,12 +196,11 @@ void SourceTreeItem::ReconnectSignals()
 		obs_scene_t *curScene = (obs_scene_t *)calldata_ptr(cd, "scene");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_->tree, "Remove", Q_ARG(OBSSceneItem, curItem),
-						  Q_ARG(OBSScene, curScene));
+			QMetaObject::invokeMethod(this_->tree, &SourceTree::Remove, curItem, curScene);
 			curItem = nullptr;
 		}
 		if (!curItem)
-			QMetaObject::invokeMethod(this_, "Clear");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Clear);
 	};
 
 	auto itemVisible = [](void *data, calldata_t *cd) {
@@ -210,7 +209,7 @@ void SourceTreeItem::ReconnectSignals()
 		bool visible = calldata_bool(cd, "visible");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "VisibilityChanged", Q_ARG(bool, visible));
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::VisibilityChanged, visible);
 	};
 
 	auto itemLocked = [](void *data, calldata_t *cd) {
@@ -219,7 +218,7 @@ void SourceTreeItem::ReconnectSignals()
 		bool locked = calldata_bool(cd, "locked");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "LockedChanged", Q_ARG(bool, locked));
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::LockedChanged, locked);
 	};
 
 	auto itemSelect = [](void *data, calldata_t *cd) {
@@ -227,7 +226,7 @@ void SourceTreeItem::ReconnectSignals()
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Select");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Select);
 	};
 
 	auto itemDeselect = [](void *data, calldata_t *cd) {
@@ -235,12 +234,12 @@ void SourceTreeItem::ReconnectSignals()
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem)
-			QMetaObject::invokeMethod(this_, "Deselect");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Deselect);
 	};
 
 	auto reorderGroup = [](void *data, calldata_t *) {
 		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
-		QMetaObject::invokeMethod(this_->tree, "ReorderItems");
+		QMetaObject::invokeMethod(this_->tree, &SourceTree::ReorderItems);
 	};
 
 	obs_scene_t *scene = obs_sceneitem_get_scene(sceneitem);
@@ -267,7 +266,7 @@ void SourceTreeItem::ReconnectSignals()
 		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
-		QMetaObject::invokeMethod(this_->tree, "RefreshItems");
+		QMetaObject::invokeMethod(this_->tree, &SourceTree::RefreshItems);
 	};
 
 	obs_source_t *source = obs_sceneitem_get_source(sceneitem);
@@ -446,11 +445,11 @@ bool SourceTreeItem::eventFilter(QObject *object, QEvent *event)
 		return false;
 
 	if (LineEditCanceled(event)) {
-		QMetaObject::invokeMethod(this, "ExitEditMode", Qt::QueuedConnection, Q_ARG(bool, false));
+		QMetaObject::invokeMethod(this, &SourceTreeItem::ExitEditMode, Qt::QueuedConnection, false);
 		return true;
 	}
 	if (LineEditChanged(event)) {
-		QMetaObject::invokeMethod(this, "ExitEditMode", Qt::QueuedConnection, Q_ARG(bool, true));
+		QMetaObject::invokeMethod(this, &SourceTreeItem::ExitEditMode, Qt::QueuedConnection, true);
 		return true;
 	}
 

--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -199,12 +199,11 @@ void SourceTreeItem::ReconnectSignals()
 		obs_scene_t *curScene = (obs_scene_t *)calldata_ptr(cd, "scene");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_->tree, "Remove", Q_ARG(OBSSceneItem, curItem),
-						  Q_ARG(OBSScene, curScene));
+			QMetaObject::invokeMethod(this_->tree, &SourceTree::Remove, curItem, curScene);
 			curItem = nullptr;
 		}
 		if (!curItem) {
-			QMetaObject::invokeMethod(this_, "Clear");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Clear);
 		}
 	};
 
@@ -214,7 +213,7 @@ void SourceTreeItem::ReconnectSignals()
 		bool visible = calldata_bool(cd, "visible");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_, "VisibilityChanged", Q_ARG(bool, visible));
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::VisibilityChanged, visible);
 		}
 	};
 
@@ -224,7 +223,7 @@ void SourceTreeItem::ReconnectSignals()
 		bool locked = calldata_bool(cd, "locked");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_, "LockedChanged", Q_ARG(bool, locked));
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::LockedChanged, locked);
 		}
 	};
 
@@ -233,7 +232,7 @@ void SourceTreeItem::ReconnectSignals()
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_, "Select");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Select);
 		}
 	};
 
@@ -242,13 +241,13 @@ void SourceTreeItem::ReconnectSignals()
 		obs_sceneitem_t *curItem = (obs_sceneitem_t *)calldata_ptr(cd, "item");
 
 		if (curItem == this_->sceneitem) {
-			QMetaObject::invokeMethod(this_, "Deselect");
+			QMetaObject::invokeMethod(this_, &SourceTreeItem::Deselect);
 		}
 	};
 
 	auto reorderGroup = [](void *data, calldata_t *) {
 		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
-		QMetaObject::invokeMethod(this_->tree, "ReorderItems");
+		QMetaObject::invokeMethod(this_->tree, &SourceTree::ReorderItems);
 	};
 
 	obs_scene_t *scene = obs_sceneitem_get_scene(sceneitem);
@@ -275,7 +274,7 @@ void SourceTreeItem::ReconnectSignals()
 		SourceTreeItem *this_ = static_cast<SourceTreeItem *>(data);
 		this_->DisconnectSignals();
 		this_->sceneitem = nullptr;
-		QMetaObject::invokeMethod(this_->tree, "RefreshItems");
+		QMetaObject::invokeMethod(this_->tree, &SourceTree::RefreshItems);
 	};
 
 	obs_source_t *source = obs_sceneitem_get_source(sceneitem);
@@ -457,11 +456,11 @@ bool SourceTreeItem::eventFilter(QObject *object, QEvent *event)
 	}
 
 	if (LineEditCanceled(event)) {
-		QMetaObject::invokeMethod(this, "ExitEditMode", Qt::QueuedConnection, Q_ARG(bool, false));
+		QMetaObject::invokeMethod(this, &SourceTreeItem::ExitEditMode, Qt::QueuedConnection, false);
 		return true;
 	}
 	if (LineEditChanged(event)) {
-		QMetaObject::invokeMethod(this, "ExitEditMode", Qt::QueuedConnection, Q_ARG(bool, true));
+		QMetaObject::invokeMethod(this, &SourceTreeItem::ExitEditMode, Qt::QueuedConnection, true);
 		return true;
 	}
 

--- a/frontend/components/SourceTreeModel.cpp
+++ b/frontend/components/SourceTreeModel.cpp
@@ -300,7 +300,7 @@ void SourceTreeModel::AddGroup()
 	st->UpdateWidget(createIndex(0, 0, nullptr), group);
 	UpdateGroupState(true);
 
-	QMetaObject::invokeMethod(st, "Edit", Qt::QueuedConnection, Q_ARG(int, 0));
+	QMetaObject::invokeMethod(st, &SourceTree::Edit, Qt::QueuedConnection, 0);
 }
 
 void SourceTreeModel::GroupSelectedItems(QModelIndexList &indices)
@@ -343,7 +343,7 @@ void SourceTreeModel::GroupSelectedItems(QModelIndexList &indices)
 	/* that's created automatically.                                     */
 
 	int newIdx = indices[0].row();
-	QMetaObject::invokeMethod(st, "NewGroupEdit", Qt::QueuedConnection, Q_ARG(int, newIdx));
+	QMetaObject::invokeMethod(st, &SourceTree::NewGroupEdit, Qt::QueuedConnection, newIdx);
 }
 
 void SourceTreeModel::UngroupSelectedGroups(QModelIndexList &indices)

--- a/frontend/components/SourceTreeModel.cpp
+++ b/frontend/components/SourceTreeModel.cpp
@@ -308,7 +308,7 @@ void SourceTreeModel::AddGroup()
 	st->UpdateWidget(createIndex(0, 0, nullptr), group);
 	UpdateGroupState(true);
 
-	QMetaObject::invokeMethod(st, "Edit", Qt::QueuedConnection, Q_ARG(int, 0));
+	QMetaObject::invokeMethod(st, &SourceTree::Edit, Qt::QueuedConnection, 0);
 }
 
 void SourceTreeModel::GroupSelectedItems(QModelIndexList &indices)
@@ -353,7 +353,7 @@ void SourceTreeModel::GroupSelectedItems(QModelIndexList &indices)
 	/* that's created automatically.                                     */
 
 	int newIdx = indices[0].row();
-	QMetaObject::invokeMethod(st, "NewGroupEdit", Qt::QueuedConnection, Q_ARG(int, newIdx));
+	QMetaObject::invokeMethod(st, &SourceTree::NewGroupEdit, Qt::QueuedConnection, newIdx);
 }
 
 void SourceTreeModel::UngroupSelectedGroups(QModelIndexList &indices)

--- a/frontend/components/VisibilityItemWidget.cpp
+++ b/frontend/components/VisibilityItemWidget.cpp
@@ -36,7 +36,7 @@ void VisibilityItemWidget::OBSSourceEnabled(void *param, calldata_t *data)
 	VisibilityItemWidget *window = static_cast<VisibilityItemWidget *>(param);
 	bool enabled = calldata_bool(data, "enabled");
 
-	QMetaObject::invokeMethod(window, "SourceEnabled", Q_ARG(bool, enabled));
+	QMetaObject::invokeMethod(window, &VisibilityItemWidget::SourceEnabled, enabled);
 }
 
 void VisibilityItemWidget::SourceEnabled(bool enabled)

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -41,7 +41,7 @@ void showUnassignedWarning(const char *name)
 		}
 	};
 
-	QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+	QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 }
 } // namespace
 
@@ -169,37 +169,38 @@ void VolumeControl::obsVolumeChanged(void *data, float)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
 
-	QMetaObject::invokeMethod(volControl, "changeVolume", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, &VolumeControl::changeVolume, Qt::QueuedConnection);
 }
 
 void VolumeControl::obsVolumeMuted(void *data, calldata_t *)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
 
-	QMetaObject::invokeMethod(volControl, "updateMixerState", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, &VolumeControl::updateMixerState, Qt::QueuedConnection);
 }
 
 void VolumeControl::obsMixersOrMonitoringChanged(void *data, calldata_t *)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
-	QMetaObject::invokeMethod(volControl, "updateMixerState", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, &VolumeControl::updateMixerState, Qt::QueuedConnection);
 }
 
 void VolumeControl::obsSourceActivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "sourceActiveChanged", Qt::QueuedConnection,
-				  Q_ARG(bool, true));
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::sourceActiveChanged,
+				  Qt::QueuedConnection, true);
 }
 
 void VolumeControl::obsSourceDeactivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "sourceActiveChanged", Qt::QueuedConnection,
-				  Q_ARG(bool, false));
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::sourceActiveChanged,
+				  Qt::QueuedConnection, false);
 }
 
 void VolumeControl::obsSourceDestroy(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "handleSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::handleSourceDestroyed,
+				  Qt::QueuedConnection);
 }
 
 void VolumeControl::setLayoutVertical(bool vertical)

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -41,7 +41,7 @@ void showUnassignedWarning(const char *name)
 		}
 	};
 
-	QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+	QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 }
 } // namespace
 
@@ -198,7 +198,7 @@ void VolumeControl::obsVolumeChanged(void *data, float)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
 
-	QMetaObject::invokeMethod(volControl, "changeVolume", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, &VolumeControl::changeVolume, Qt::QueuedConnection);
 }
 
 void VolumeControl::obsVolumeMuted(void *data, calldata_t *params)
@@ -206,13 +206,13 @@ void VolumeControl::obsVolumeMuted(void *data, calldata_t *params)
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
 	bool muted = calldata_bool(params, "muted");
 
-	QMetaObject::invokeMethod(volControl, "onMuteChanged", Qt::QueuedConnection, Q_ARG(bool, muted));
+	QMetaObject::invokeMethod(volControl, &VolumeControl::onMuteChanged, Qt::QueuedConnection, muted);
 }
 
 void VolumeControl::obsMixersChanged(void *data, calldata_t *)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
-	QMetaObject::invokeMethod(volControl, "processMixerState", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, &VolumeControl::processMixerState, Qt::QueuedConnection);
 }
 
 void VolumeControl::obsMonitoringChanged(void *data, calldata_t *params)
@@ -220,24 +220,25 @@ void VolumeControl::obsMonitoringChanged(void *data, calldata_t *params)
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
 	auto type = static_cast<int>(calldata_int(params, "type"));
 
-	QMetaObject::invokeMethod(volControl, "onMonitoringChanged", Qt::QueuedConnection, Q_ARG(int, type));
+	QMetaObject::invokeMethod(volControl, &VolumeControl::onMonitoringChanged, Qt::QueuedConnection, type);
 }
 
 void VolumeControl::obsSourceActivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceActiveChanged", Qt::QueuedConnection,
-				  Q_ARG(bool, true));
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::onSourceActiveChanged,
+				  Qt::QueuedConnection, true);
 }
 
 void VolumeControl::obsSourceDeactivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceActiveChanged", Qt::QueuedConnection,
-				  Q_ARG(bool, false));
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::onSourceActiveChanged,
+				  Qt::QueuedConnection, false);
 }
 
 void VolumeControl::obsSourceDestroy(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), &VolumeControl::onSourceDestroyed,
+				  Qt::QueuedConnection);
 }
 
 void VolumeControl::setLayoutVertical(bool vertical)

--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -364,7 +364,7 @@ VolumeMeter::~VolumeMeter()
 void VolumeMeter::obsSourceDestroyed(void *data, calldata_t *)
 {
 	VolumeMeter *self = static_cast<VolumeMeter *>(data);
-	QMetaObject::invokeMethod(self, "handleSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(self, &VolumeMeter::handleSourceDestroyed, Qt::QueuedConnection);
 }
 
 void VolumeMeter::setLevels(const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],

--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -364,7 +364,7 @@ VolumeMeter::~VolumeMeter()
 void VolumeMeter::obsSourceDestroyed(void *data, calldata_t *)
 {
 	VolumeMeter *self = static_cast<VolumeMeter *>(data);
-	QMetaObject::invokeMethod(self, "onSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(self, &VolumeMeter::onSourceDestroyed, Qt::QueuedConnection);
 }
 
 void VolumeMeter::setLevels(const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],

--- a/frontend/components/VolumeName.cpp
+++ b/frontend/components/VolumeName.cpp
@@ -120,21 +120,21 @@ void VolumeName::obsSourceRenamed(void *data, calldata_t *params)
 	VolumeName *widget = static_cast<VolumeName *>(data);
 	const char *name = calldata_string(params, "new_name");
 
-	QMetaObject::invokeMethod(widget, "onRenamed", Qt::QueuedConnection, Q_ARG(QString, name));
+	QMetaObject::invokeMethod(widget, &VolumeName::onRenamed, Qt::QueuedConnection, QString::fromUtf8(name));
 }
 
 void VolumeName::obsSourceRemoved(void *data, calldata_t *)
 {
 	VolumeName *widget = static_cast<VolumeName *>(data);
 
-	QMetaObject::invokeMethod(widget, "onRemoved", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(widget, &VolumeName::onRemoved, Qt::QueuedConnection);
 }
 
 void VolumeName::obsSourceDestroyed(void *data, calldata_t *)
 {
 	VolumeName *widget = static_cast<VolumeName *>(data);
 
-	QMetaObject::invokeMethod(widget, "onDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(widget, &VolumeName::onDestroyed, Qt::QueuedConnection);
 }
 
 void VolumeName::resizeEvent(QResizeEvent *event)

--- a/frontend/components/VolumeName.cpp
+++ b/frontend/components/VolumeName.cpp
@@ -123,21 +123,21 @@ void VolumeName::obsSourceRenamed(void *data, calldata_t *params)
 	VolumeName *widget = static_cast<VolumeName *>(data);
 	const char *name = calldata_string(params, "new_name");
 
-	QMetaObject::invokeMethod(widget, "onRenamed", Qt::QueuedConnection, Q_ARG(QString, name));
+	QMetaObject::invokeMethod(widget, &VolumeName::onRenamed, Qt::QueuedConnection, QString::fromUtf8(name));
 }
 
 void VolumeName::obsSourceRemoved(void *data, calldata_t *)
 {
 	VolumeName *widget = static_cast<VolumeName *>(data);
 
-	QMetaObject::invokeMethod(widget, "onRemoved", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(widget, &VolumeName::onRemoved, Qt::QueuedConnection);
 }
 
 void VolumeName::obsSourceDestroyed(void *data, calldata_t *)
 {
 	VolumeName *widget = static_cast<VolumeName *>(data);
 
-	QMetaObject::invokeMethod(widget, "onDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(widget, &VolumeName::onDestroyed, Qt::QueuedConnection);
 }
 
 void VolumeName::resizeEvent(QResizeEvent *event)

--- a/frontend/dialogs/OBSBasicAdvAudio.cpp
+++ b/frontend/dialogs/OBSBasicAdvAudio.cpp
@@ -57,14 +57,14 @@ void OBSBasicAdvAudio::OBSSourceAdded(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceAdded, source);
 }
 
 void OBSBasicAdvAudio::OBSSourceRemoved(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceRemoved", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceRemoved, source);
 }
 
 void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
@@ -72,8 +72,8 @@ void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
 	if (obs_source_audio_active(source))
-		QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded",
-					  Q_ARG(OBSSource, source));
+		QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceAdded,
+					  source);
 }
 
 inline void OBSBasicAdvAudio::AddAudioSource(obs_source_t *source)

--- a/frontend/dialogs/OBSBasicAdvAudio.cpp
+++ b/frontend/dialogs/OBSBasicAdvAudio.cpp
@@ -60,14 +60,14 @@ void OBSBasicAdvAudio::OBSSourceAdded(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceAdded, source);
 }
 
 void OBSBasicAdvAudio::OBSSourceRemoved(void *param, calldata_t *calldata)
 {
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceRemoved", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceRemoved, source);
 }
 
 void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
@@ -75,8 +75,8 @@ void OBSBasicAdvAudio::OBSSourceActivated(void *param, calldata_t *calldata)
 	OBSSource source((obs_source_t *)calldata_ptr(calldata, "source"));
 
 	if (obs_source_audio_active(source)) {
-		QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), "SourceAdded",
-					  Q_ARG(OBSSource, source));
+		QMetaObject::invokeMethod(static_cast<OBSBasicAdvAudio *>(param), &OBSBasicAdvAudio::SourceAdded,
+					  source);
 	}
 }
 

--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -271,7 +271,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 
 void OBSBasicFilters::UpdateProperties(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(data)->view, "ReloadProperties");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(data)->view, &OBSPropertiesView::ReloadProperties);
 }
 
 void OBSBasicFilters::AddFilter(OBSSource filter, bool focus)
@@ -623,7 +623,7 @@ void OBSBasicFilters::OBSSourceFilterAdded(void *param, calldata_t *data)
 	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
-	QMetaObject::invokeMethod(window, "AddFilter", Q_ARG(OBSSource, OBSSource(filter)));
+	QMetaObject::invokeMethod(window, [window, filter]() { window->AddFilter(filter); });
 }
 
 void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
@@ -631,17 +631,17 @@ void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
 	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
-	QMetaObject::invokeMethod(window, "RemoveFilter", Q_ARG(OBSSource, OBSSource(filter)));
+	QMetaObject::invokeMethod(window, [window, filter]() { window->RemoveFilter(filter); });
 }
 
 void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "ReorderFilters");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::ReorderFilters);
 }
 
 void OBSBasicFilters::SourceRemoved(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::close);
 }
 
 void OBSBasicFilters::SourceRenamed(void *param, calldata_t *data)
@@ -649,7 +649,7 @@ void OBSBasicFilters::SourceRenamed(void *param, calldata_t *data)
 	const char *name = calldata_string(data, "new_name");
 	QString title = QTStr("Basic.Filters.Title").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::setWindowTitle, title);
 }
 
 void OBSBasicFilters::DrawPreview(void *data, uint32_t cx, uint32_t cy)

--- a/frontend/dialogs/OBSBasicFilters.cpp
+++ b/frontend/dialogs/OBSBasicFilters.cpp
@@ -276,7 +276,7 @@ void OBSBasicFilters::UpdatePropertiesView(int row, bool async)
 
 void OBSBasicFilters::UpdateProperties(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(data)->view, "ReloadProperties");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(data)->view, &OBSPropertiesView::ReloadProperties);
 }
 
 void OBSBasicFilters::AddFilter(OBSSource filter, bool focus)
@@ -640,7 +640,7 @@ void OBSBasicFilters::OBSSourceFilterAdded(void *param, calldata_t *data)
 	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
-	QMetaObject::invokeMethod(window, "AddFilter", Q_ARG(OBSSource, OBSSource(filter)));
+	QMetaObject::invokeMethod(window, &OBSBasicFilters::AddFilter, filter, true);
 }
 
 void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
@@ -648,17 +648,17 @@ void OBSBasicFilters::OBSSourceFilterRemoved(void *param, calldata_t *data)
 	OBSBasicFilters *window = static_cast<OBSBasicFilters *>(param);
 	obs_source_t *filter = (obs_source_t *)calldata_ptr(data, "filter");
 
-	QMetaObject::invokeMethod(window, "RemoveFilter", Q_ARG(OBSSource, OBSSource(filter)));
+	QMetaObject::invokeMethod(window, &OBSBasicFilters::RemoveFilter, filter);
 }
 
 void OBSBasicFilters::OBSSourceReordered(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "ReorderFilters");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::ReorderFilters);
 }
 
 void OBSBasicFilters::SourceRemoved(void *param, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::close);
 }
 
 void OBSBasicFilters::SourceRenamed(void *param, calldata_t *data)
@@ -666,7 +666,7 @@ void OBSBasicFilters::SourceRenamed(void *param, calldata_t *data)
 	const char *name = calldata_string(data, "new_name");
 	QString title = QTStr("Basic.Filters.Title").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicFilters *>(param), &OBSBasicFilters::setWindowTitle, title);
 }
 
 void OBSBasicFilters::DrawPreview(void *data, uint32_t cx, uint32_t cy)

--- a/frontend/dialogs/OBSBasicInteraction.cpp
+++ b/frontend/dialogs/OBSBasicInteraction.cpp
@@ -108,7 +108,7 @@ OBSEventFilter *OBSBasicInteraction::BuildEventFilter()
 
 void OBSBasicInteraction::SourceRemoved(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicInteraction *>(data), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicInteraction *>(data), &OBSBasicInteraction::close);
 }
 
 void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
@@ -116,7 +116,7 @@ void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
 	const char *name = calldata_string(params, "new_name");
 	QString title = QTStr("Basic.InteractionWindow").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicInteraction::setWindowTitle, title);
 }
 
 void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)

--- a/frontend/dialogs/OBSBasicInteraction.cpp
+++ b/frontend/dialogs/OBSBasicInteraction.cpp
@@ -109,7 +109,7 @@ OBSEventFilter *OBSBasicInteraction::BuildEventFilter()
 
 void OBSBasicInteraction::SourceRemoved(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicInteraction *>(data), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicInteraction *>(data), &OBSBasicInteraction::close);
 }
 
 void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
@@ -117,7 +117,7 @@ void OBSBasicInteraction::SourceRenamed(void *data, calldata_t *params)
 	const char *name = calldata_string(params, "new_name");
 	QString title = QTStr("Basic.InteractionWindow").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicInteraction::setWindowTitle, title);
 }
 
 void OBSBasicInteraction::DrawPreview(void *data, uint32_t cx, uint32_t cy)

--- a/frontend/dialogs/OBSBasicProperties.cpp
+++ b/frontend/dialogs/OBSBasicProperties.cpp
@@ -275,7 +275,7 @@ void OBSBasicProperties::previewTransitionClicked()
 
 void OBSBasicProperties::SourceRemoved(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicProperties::close);
 }
 
 void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)
@@ -283,12 +283,12 @@ void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)
 	const char *name = calldata_string(params, "new_name");
 	QString title = QTStr("Basic.PropertiesWindow").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicProperties::setWindowTitle, title);
 }
 
 void OBSBasicProperties::UpdateProperties(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data)->view, "ReloadProperties");
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data)->view, &OBSPropertiesView::ReloadProperties);
 }
 
 void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)

--- a/frontend/dialogs/OBSBasicProperties.cpp
+++ b/frontend/dialogs/OBSBasicProperties.cpp
@@ -276,7 +276,7 @@ void OBSBasicProperties::previewTransitionClicked()
 
 void OBSBasicProperties::SourceRemoved(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "close");
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicProperties::close);
 }
 
 void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)
@@ -284,12 +284,12 @@ void OBSBasicProperties::SourceRenamed(void *data, calldata_t *params)
 	const char *name = calldata_string(params, "new_name");
 	QString title = QTStr("Basic.PropertiesWindow").arg(QT_UTF8(name));
 
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), "setWindowTitle", Q_ARG(QString, title));
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data), &OBSBasicProperties::setWindowTitle, title);
 }
 
 void OBSBasicProperties::UpdateProperties(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data)->view, "ReloadProperties");
+	QMetaObject::invokeMethod(static_cast<OBSBasicProperties *>(data)->view, &OBSPropertiesView::ReloadProperties);
 }
 
 void OBSBasicProperties::on_buttonBox_clicked(QAbstractButton *button)

--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -80,7 +80,7 @@ void OBSBasicSourceSelect::OBSSourceAdded(void *data, calldata_t *calldata)
 	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
 	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
 
-	QMetaObject::invokeMethod(window, "SourceAdded", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(window, &OBSBasicSourceSelect::SourceAdded, source);
 }
 
 void OBSBasicSourceSelect::OBSSourceRemoved(void *data, calldata_t *calldata)
@@ -88,7 +88,7 @@ void OBSBasicSourceSelect::OBSSourceRemoved(void *data, calldata_t *calldata)
 	OBSBasicSourceSelect *window = static_cast<OBSBasicSourceSelect *>(data);
 	obs_source_t *source = (obs_source_t *)calldata_ptr(calldata, "source");
 
-	QMetaObject::invokeMethod(window, "SourceRemoved", Q_ARG(OBSSource, source));
+	QMetaObject::invokeMethod(window, &OBSBasicSourceSelect::SourceRemoved, source);
 }
 
 void OBSBasicSourceSelect::SourceAdded(OBSSource source)

--- a/frontend/dialogs/OBSBasicTransform.cpp
+++ b/frontend/dialogs/OBSBasicTransform.cpp
@@ -154,7 +154,7 @@ void OBSBasicTransform::setScene(OBSScene scene)
 
 void OBSBasicTransform::setItem(OBSSceneItem newItem)
 {
-	QMetaObject::invokeMethod(this, "setItemQt", Q_ARG(OBSSceneItem, OBSSceneItem(newItem)));
+	QMetaObject::invokeMethod(this, &OBSBasicTransform::setItemQt, OBSSceneItem(newItem));
 }
 
 void OBSBasicTransform::setEnabled(bool enable)
@@ -181,7 +181,7 @@ void OBSBasicTransform::OBSSceneItemTransform(void *param, calldata_t *data)
 	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item == window->item && !window->ignoreTransformSignal)
-		QMetaObject::invokeMethod(window, "refreshControls");
+		QMetaObject::invokeMethod(window, &OBSBasicTransform::refreshControls);
 }
 
 void OBSBasicTransform::OBSSceneItemRemoved(void *param, calldata_t *data)
@@ -220,7 +220,7 @@ void OBSBasicTransform::OBSSceneItemLocked(void *param, calldata_t *data)
 	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	bool locked = calldata_bool(data, "locked");
 
-	QMetaObject::invokeMethod(window, "setEnabled", Q_ARG(bool, !locked));
+	QMetaObject::invokeMethod(window, &OBSBasicTransform::setEnabled, !locked);
 }
 
 static const uint32_t indexToAlign[] = {OBS_ALIGN_TOP | OBS_ALIGN_LEFT,

--- a/frontend/dialogs/OBSBasicTransform.cpp
+++ b/frontend/dialogs/OBSBasicTransform.cpp
@@ -155,7 +155,7 @@ void OBSBasicTransform::setScene(OBSScene scene)
 
 void OBSBasicTransform::setItem(OBSSceneItem newItem)
 {
-	QMetaObject::invokeMethod(this, "setItemQt", Q_ARG(OBSSceneItem, OBSSceneItem(newItem)));
+	QMetaObject::invokeMethod(this, &OBSBasicTransform::setItemQt, OBSSceneItem(newItem));
 }
 
 void OBSBasicTransform::setEnabled(bool enable)
@@ -183,7 +183,7 @@ void OBSBasicTransform::OBSSceneItemTransform(void *param, calldata_t *data)
 	OBSSceneItem item = (obs_sceneitem_t *)calldata_ptr(data, "item");
 
 	if (item == window->item && !window->ignoreTransformSignal) {
-		QMetaObject::invokeMethod(window, "refreshControls");
+		QMetaObject::invokeMethod(window, &OBSBasicTransform::refreshControls);
 	}
 }
 
@@ -225,7 +225,7 @@ void OBSBasicTransform::OBSSceneItemLocked(void *param, calldata_t *data)
 	OBSBasicTransform *window = static_cast<OBSBasicTransform *>(param);
 	bool locked = calldata_bool(data, "locked");
 
-	QMetaObject::invokeMethod(window, "setEnabled", Q_ARG(bool, !locked));
+	QMetaObject::invokeMethod(window, &OBSBasicTransform::setEnabled, !locked);
 }
 
 static const uint32_t indexToAlign[] = {OBS_ALIGN_TOP | OBS_ALIGN_LEFT,

--- a/frontend/dialogs/OBSMissingFiles.cpp
+++ b/frontend/dialogs/OBSMissingFiles.cpp
@@ -66,8 +66,7 @@ OBSMissingFiles::OBSMissingFiles(obs_missing_files_t *files, QWidget *parent)
 	connect(filesModel, &MissingFilesModel::dataChanged, this, &OBSMissingFiles::dataChanged);
 
 	QModelIndex index = filesModel->createIndex(0, 1);
-	QMetaObject::invokeMethod(ui->tableView, "setCurrentIndex", Qt::QueuedConnection,
-				  Q_ARG(const QModelIndex &, index));
+	QMetaObject::invokeMethod(ui->tableView, &QTableView::setCurrentIndex, Qt::QueuedConnection, index);
 }
 
 OBSMissingFiles::~OBSMissingFiles()

--- a/frontend/dialogs/OBSRemux.cpp
+++ b/frontend/dialogs/OBSRemux.cpp
@@ -97,8 +97,7 @@ OBSRemux::OBSRemux(const char *path, QWidget *parent, bool autoRemux_)
 	connect(queueModel.data(), &RemuxQueueModel::rowsRemoved, this, &OBSRemux::rowCountChanged);
 
 	QModelIndex index = queueModel->createIndex(0, 1);
-	QMetaObject::invokeMethod(ui->tableView, "setCurrentIndex", Qt::QueuedConnection,
-				  Q_ARG(const QModelIndex &, index));
+	QMetaObject::invokeMethod(ui->tableView, &QTableView::setCurrentIndex, Qt::QueuedConnection, index);
 }
 
 bool OBSRemux::stopRemux()

--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -506,7 +506,7 @@ void OBSYoutubeActions::InitBroadcast()
 			if (success)
 				broadcast.id = this->selectedBroadcast;
 		};
-		QMetaObject::invokeMethod(&msgBox, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&msgBox, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 	QScopedPointer<QThread> thread(CreateQThread(action));
 	thread->start();
@@ -569,7 +569,7 @@ void OBSYoutubeActions::ReadyBroadcast()
 			if (success)
 				broadcast.id = this->selectedBroadcast;
 		};
-		QMetaObject::invokeMethod(&msgBox, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&msgBox, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 	QScopedPointer<QThread> thread(CreateQThread(action));
 	thread->start();

--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -519,7 +519,7 @@ void OBSYoutubeActions::InitBroadcast()
 				broadcast.id = this->selectedBroadcast;
 			}
 		};
-		QMetaObject::invokeMethod(&msgBox, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&msgBox, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 	QScopedPointer<QThread> thread(CreateQThread(action));
 	thread->start();
@@ -585,7 +585,7 @@ void OBSYoutubeActions::ReadyBroadcast()
 				broadcast.id = this->selectedBroadcast;
 			}
 		};
-		QMetaObject::invokeMethod(&msgBox, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&msgBox, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 	QScopedPointer<QThread> thread(CreateQThread(action));
 	thread->start();

--- a/frontend/docks/OBSDock.cpp
+++ b/frontend/docks/OBSDock.cpp
@@ -29,7 +29,7 @@ void OBSDock::closeEvent(QCloseEvent *event)
 
 	bool warned = config_get_bool(App()->GetUserConfig(), "General", "WarnedAboutClosingDocks");
 	if (!OBSBasic::Get()->isClosing() && !warned) {
-		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+		QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 	}
 
 	QDockWidget::closeEvent(event);

--- a/frontend/docks/YouTubeChatDock.cpp
+++ b/frontend/docks/YouTubeChatDock.cpp
@@ -23,8 +23,8 @@ void YoutubeChatDock::YoutubeCookieCheck()
 		if (loginStateChanged) {
 			OBSBasic *main = OBSBasic::Get();
 			if (main->GetYouTubeAppDock() != nullptr) {
-				QMetaObject::invokeMethod(main->GetYouTubeAppDock(), "SettingsUpdated",
-							  Qt::QueuedConnection, Q_ARG(bool, !currentlyLoggedIn));
+				QMetaObject::invokeMethod(main->GetYouTubeAppDock(), &YouTubeAppDock::SettingsUpdated,
+							  Qt::QueuedConnection, !currentlyLoggedIn);
 			}
 		}
 	};

--- a/frontend/importer/OBSImporter.cpp
+++ b/frontend/importer/OBSImporter.cpp
@@ -91,8 +91,7 @@ OBSImporter::OBSImporter(QWidget *parent) : QDialog(parent), optionsModel(new Im
 	ui->tableView->resizeColumnsToContents();
 
 	QModelIndex index = optionsModel->createIndex(optionsModel->rowCount() - 1, 2);
-	QMetaObject::invokeMethod(ui->tableView, "setCurrentIndex", Qt::QueuedConnection,
-				  Q_ARG(const QModelIndex &, index));
+	QMetaObject::invokeMethod(ui->tableView, &QTableView::setCurrentIndex, Qt::QueuedConnection, index);
 }
 
 void OBSImporter::addImportOption(QString path, bool automatic)

--- a/frontend/importer/OBSImporter.cpp
+++ b/frontend/importer/OBSImporter.cpp
@@ -92,8 +92,7 @@ OBSImporter::OBSImporter(QWidget *parent) : QDialog(parent), optionsModel(new Im
 	ui->tableView->resizeColumnsToContents();
 
 	QModelIndex index = optionsModel->createIndex(optionsModel->rowCount() - 1, 2);
-	QMetaObject::invokeMethod(ui->tableView, "setCurrentIndex", Qt::QueuedConnection,
-				  Q_ARG(const QModelIndex &, index));
+	QMetaObject::invokeMethod(ui->tableView, &QTableView::setCurrentIndex, Qt::QueuedConnection, index);
 }
 
 void OBSImporter::addImportOption(QString path, bool automatic)

--- a/frontend/oauth/TwitchAuth.cpp
+++ b/frontend/oauth/TwitchAuth.cpp
@@ -9,6 +9,7 @@
 #include <qt-wrappers.hpp>
 #include <ui-config.h>
 
+#include <QTimer>
 #include <QUuid>
 
 #include "moc_TwitchAuth.cpp"
@@ -421,9 +422,9 @@ void TwitchAuth::TryLoadSecondaryUIPanes()
 		}
 
 		if (!found) {
-			QMetaObject::invokeMethod(&this_->uiLoadTimer, "start");
+			QMetaObject::invokeMethod(this_, [this_]() { this_->uiLoadTimer.start(); });
 		} else {
-			QMetaObject::invokeMethod(this_, "LoadSecondaryUIPanes");
+			QMetaObject::invokeMethod(this_, &TwitchAuth::LoadSecondaryUIPanes);
 		}
 	};
 

--- a/frontend/oauth/TwitchAuth.cpp
+++ b/frontend/oauth/TwitchAuth.cpp
@@ -9,6 +9,7 @@
 #include <qt-wrappers.hpp>
 #include <ui-config.h>
 
+#include <QTimer>
 #include <QUuid>
 
 #include "moc_TwitchAuth.cpp"
@@ -440,9 +441,9 @@ void TwitchAuth::TryLoadSecondaryUIPanes()
 		}
 
 		if (!found) {
-			QMetaObject::invokeMethod(&this_->uiLoadTimer, "start");
+			QMetaObject::invokeMethod(this_, [this_]() { this_->uiLoadTimer.start(); });
 		} else {
-			QMetaObject::invokeMethod(this_, "LoadSecondaryUIPanes");
+			QMetaObject::invokeMethod(this_, &TwitchAuth::LoadSecondaryUIPanes);
 		}
 	};
 

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -115,8 +115,7 @@ static void LogString(fstream &logFile, const char *timeString, char *str, int l
 	logFile << msg << endl;
 	logfile_mutex.unlock();
 
-	QMetaObject::invokeMethod(App(), "addLogLine", Qt::QueuedConnection, Q_ARG(int, log_level),
-				  Q_ARG(QString, QString(msg.c_str())));
+	QMetaObject::invokeMethod(App(), &OBSApp::addLogLine, Qt::QueuedConnection, log_level, QString(msg.c_str()));
 }
 
 static inline void LogStringChunk(fstream &logFile, char *str, int log_level)

--- a/frontend/plugins/frontend-tools/scripts.cpp
+++ b/frontend/plugins/frontend-tools/scripts.cpp
@@ -623,7 +623,7 @@ static void script_log(void *, obs_script_t *script, int log_level, const char *
 		qmsg = QStringLiteral("[Unknown Script] %1").arg(message);
 	}
 
-	QMetaObject::invokeMethod(scriptLogWindow, "AddLogMsg", Q_ARG(int, log_level), Q_ARG(QString, qmsg));
+	QMetaObject::invokeMethod(scriptLogWindow, &ScriptLogWindow::AddLogMsg, log_level, qmsg);
 }
 
 extern "C" void InitScripts()

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -695,7 +695,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 		if (!(obs_source_get_output_flags(source) & OBS_SOURCE_AUDIO))
 			return;
 
-		QMetaObject::invokeMethod(settings, "ReloadAudioSources", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(settings, &OBSBasicSettings::ReloadAudioSources, Qt::QueuedConnection);
 	};
 	sourceCreated.Connect(obs_get_signal_handler(), "source_create", ReloadAudioSources, this);
 	channelChanged.Connect(obs_get_signal_handler(), "channel_change", ReloadAudioSources, this);
@@ -704,14 +704,14 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	auto ReloadHotkeys = [](void *data, calldata_t *) {
 		auto settings = static_cast<OBSBasicSettings *>(data);
-		QMetaObject::invokeMethod(settings, "ReloadHotkeys");
+		QMetaObject::invokeMethod(settings, [settings]() { settings->ReloadHotkeys(); });
 	};
 	hotkeyRegistered.Connect(obs_get_signal_handler(), "hotkey_register", ReloadHotkeys, this);
 
 	auto ReloadHotkeysIgnore = [](void *data, calldata_t *param) {
 		auto settings = static_cast<OBSBasicSettings *>(data);
 		auto key = static_cast<obs_hotkey_t *>(calldata_ptr(param, "key"));
-		QMetaObject::invokeMethod(settings, "ReloadHotkeys", Q_ARG(obs_hotkey_id, obs_hotkey_get_id(key)));
+		QMetaObject::invokeMethod(settings, &OBSBasicSettings::ReloadHotkeys, obs_hotkey_get_id(key));
 	};
 	hotkeyUnregistered.Connect(obs_get_signal_handler(), "hotkey_unregister", ReloadHotkeysIgnore, this);
 
@@ -2372,29 +2372,39 @@ void OBSBasicSettings::LoadAudioSources()
 		audioSourceSignals.emplace_back(
 			handler, "push_to_mute_changed",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setCheckedSilently",
-							  Q_ARG(bool, calldata_bool(param, "enabled")));
+				auto checkBox = static_cast<SilentUpdateCheckBox *>(data);
+				bool enabled = calldata_bool(param, "enabled");
+				QMetaObject::invokeMethod(checkBox, [checkBox, enabled]() {
+					checkBox->setCheckedSilently(enabled);
+				});
 			},
 			ptmCB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_mute_delay",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setValueSilently",
-							  Q_ARG(int, calldata_int(param, "delay")));
+				auto spinBox = static_cast<SilentUpdateSpinBox *>(data);
+				auto delay = static_cast<int>(calldata_int(param, "delay"));
+				QMetaObject::invokeMethod(spinBox,
+							  [spinBox, delay]() { spinBox->setValueSilently(delay); });
 			},
 			ptmSB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_talk_changed",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setCheckedSilently",
-							  Q_ARG(bool, calldata_bool(param, "enabled")));
+				auto checkBox = static_cast<SilentUpdateCheckBox *>(data);
+				bool enabled = calldata_bool(param, "enabled");
+				QMetaObject::invokeMethod(checkBox, [checkBox, enabled]() {
+					checkBox->setCheckedSilently(enabled);
+				});
 			},
 			pttCB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_talk_delay",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setValueSilently",
-							  Q_ARG(int, calldata_int(param, "delay")));
+				auto spinBox = static_cast<SilentUpdateSpinBox *>(data);
+				auto delay = static_cast<int>(calldata_int(param, "delay"));
+				QMetaObject::invokeMethod(spinBox,
+							  [spinBox, delay]() { spinBox->setValueSilently(delay); });
 			},
 			pttSB);
 
@@ -2405,9 +2415,9 @@ void OBSBasicSettings::LoadAudioSources()
 		label->setMinimumSize(QSize(170, 0));
 		label->setAlignment(Qt::AlignRight | Qt::AlignTrailing | Qt::AlignVCenter);
 		connect(label, &OBSSourceLabel::removed, this,
-			[=]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[=]() { QMetaObject::invokeMethod(this, &OBSBasicSettings::ReloadAudioSources); });
 		connect(label, &OBSSourceLabel::destroyed, this,
-			[=]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[=]() { QMetaObject::invokeMethod(this, &OBSBasicSettings::ReloadAudioSources); });
 
 		layout->addRow(label, form);
 		return true;
@@ -5314,8 +5324,8 @@ void OBSBasicSettings::SurroundWarning(int idx)
 		button = OBSMessageBox::question(this, QTStr(MULTI_CHANNEL_WARNING ".Title"), warningString);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->channelSetup, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastChannelSetupIdx));
+			QMetaObject::invokeMethod(ui->channelSetup, &QComboBox::setCurrentIndex, Qt::QueuedConnection,
+						  lastChannelSetupIdx);
 			return;
 		}
 	}
@@ -5357,14 +5367,14 @@ void OBSBasicSettings::LowLatencyBufferingChanged(bool checked)
 		auto button = OBSMessageBox::question(this, QTStr(LL_BUFFERING_WARNING ".Title"), warningStr);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->lowLatencyBuffering, "setChecked", Qt::QueuedConnection,
-						  Q_ARG(bool, false));
+			QMetaObject::invokeMethod(ui->lowLatencyBuffering, &QCheckBox::setChecked, Qt::QueuedConnection,
+						  false);
 			return;
 		}
 	}
 
-	QMetaObject::invokeMethod(this, "UpdateAudioWarnings", Qt::QueuedConnection);
-	QMetaObject::invokeMethod(this, "AudioChangedRestart");
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::UpdateAudioWarnings, Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::AudioChangedRestart);
 }
 
 void OBSBasicSettings::SimpleRecordingQualityLosslessWarning(int idx)
@@ -5388,8 +5398,8 @@ void OBSBasicSettings::SimpleRecordingQualityLosslessWarning(int idx)
 		button = OBSMessageBox::question(this, SIMPLE_OUTPUT_WARNING("Lossless.Title"), warningString);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->simpleOutRecQuality, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastSimpleRecQualityIdx));
+			QMetaObject::invokeMethod(ui->simpleOutRecQuality, &QComboBox::setCurrentIndex,
+						  Qt::QueuedConnection, lastSimpleRecQualityIdx);
 			return;
 		}
 	}

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -723,7 +723,7 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 			return;
 		}
 
-		QMetaObject::invokeMethod(settings, "ReloadAudioSources", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(settings, &OBSBasicSettings::ReloadAudioSources, Qt::QueuedConnection);
 	};
 	sourceCreated.Connect(obs_get_signal_handler(), "source_create", ReloadAudioSources, this);
 	channelChanged.Connect(obs_get_signal_handler(), "channel_change", ReloadAudioSources, this);
@@ -732,14 +732,14 @@ OBSBasicSettings::OBSBasicSettings(QWidget *parent)
 
 	auto ReloadHotkeys = [](void *data, calldata_t *) {
 		auto settings = static_cast<OBSBasicSettings *>(data);
-		QMetaObject::invokeMethod(settings, "ReloadHotkeys");
+		QMetaObject::invokeMethod(settings, &OBSBasicSettings::ReloadHotkeys, OBS_INVALID_HOTKEY_ID);
 	};
 	hotkeyRegistered.Connect(obs_get_signal_handler(), "hotkey_register", ReloadHotkeys, this);
 
 	auto ReloadHotkeysIgnore = [](void *data, calldata_t *param) {
 		auto settings = static_cast<OBSBasicSettings *>(data);
 		auto key = static_cast<obs_hotkey_t *>(calldata_ptr(param, "key"));
-		QMetaObject::invokeMethod(settings, "ReloadHotkeys", Q_ARG(obs_hotkey_id, obs_hotkey_get_id(key)));
+		QMetaObject::invokeMethod(settings, &OBSBasicSettings::ReloadHotkeys, obs_hotkey_get_id(key));
 	};
 	hotkeyUnregistered.Connect(obs_get_signal_handler(), "hotkey_unregister", ReloadHotkeysIgnore, this);
 
@@ -2442,29 +2442,33 @@ void OBSBasicSettings::LoadAudioSources()
 		audioSourceSignals.emplace_back(
 			handler, "push_to_mute_changed",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setCheckedSilently",
-							  Q_ARG(bool, calldata_bool(param, "enabled")));
+				auto checkBox = static_cast<SilentUpdateCheckBox *>(data);
+				bool enabled = calldata_bool(param, "enabled");
+				QMetaObject::invokeMethod(checkBox, &SilentUpdateCheckBox::setCheckedSilently, enabled);
 			},
 			ptmCB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_mute_delay",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setValueSilently",
-							  Q_ARG(int, calldata_int(param, "delay")));
+				auto spinBox = static_cast<SilentUpdateSpinBox *>(data);
+				auto delay = static_cast<int>(calldata_int(param, "delay"));
+				QMetaObject::invokeMethod(spinBox, &SilentUpdateSpinBox::setValueSilently, delay);
 			},
 			ptmSB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_talk_changed",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setCheckedSilently",
-							  Q_ARG(bool, calldata_bool(param, "enabled")));
+				auto checkBox = static_cast<SilentUpdateCheckBox *>(data);
+				bool enabled = calldata_bool(param, "enabled");
+				QMetaObject::invokeMethod(checkBox, &SilentUpdateCheckBox::setCheckedSilently, enabled);
 			},
 			pttCB);
 		audioSourceSignals.emplace_back(
 			handler, "push_to_talk_delay",
 			[](void *data, calldata_t *param) {
-				QMetaObject::invokeMethod(static_cast<QObject *>(data), "setValueSilently",
-							  Q_ARG(int, calldata_int(param, "delay")));
+				auto spinBox = static_cast<SilentUpdateSpinBox *>(data);
+				auto delay = static_cast<int>(calldata_int(param, "delay"));
+				QMetaObject::invokeMethod(spinBox, &SilentUpdateSpinBox::setValueSilently, delay);
 			},
 			pttSB);
 
@@ -2475,9 +2479,9 @@ void OBSBasicSettings::LoadAudioSources()
 		label->setMinimumSize(QSize(170, 0));
 		label->setAlignment(Qt::AlignRight | Qt::AlignTrailing | Qt::AlignVCenter);
 		connect(label, &OBSSourceLabel::removed, this,
-			[this]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[this]() { QMetaObject::invokeMethod(this, &OBSBasicSettings::ReloadAudioSources); });
 		connect(label, &OBSSourceLabel::destroyed, this,
-			[this]() { QMetaObject::invokeMethod(this, "ReloadAudioSources"); });
+			[this]() { QMetaObject::invokeMethod(this, &OBSBasicSettings::ReloadAudioSources); });
 
 		layout->addRow(label, form);
 		return true;
@@ -5572,8 +5576,8 @@ void OBSBasicSettings::SurroundWarning(int idx)
 		button = OBSMessageBox::question(this, QTStr(MULTI_CHANNEL_WARNING ".Title"), warningString);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->channelSetup, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastChannelSetupIdx));
+			QMetaObject::invokeMethod(ui->channelSetup, &QComboBox::setCurrentIndex, Qt::QueuedConnection,
+						  lastChannelSetupIdx);
 			return;
 		}
 	}
@@ -5616,14 +5620,14 @@ void OBSBasicSettings::LowLatencyBufferingChanged(bool checked)
 		auto button = OBSMessageBox::question(this, QTStr(LL_BUFFERING_WARNING ".Title"), warningStr);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->lowLatencyBuffering, "setChecked", Qt::QueuedConnection,
-						  Q_ARG(bool, false));
+			QMetaObject::invokeMethod(ui->lowLatencyBuffering, &QCheckBox::setChecked, Qt::QueuedConnection,
+						  false);
 			return;
 		}
 	}
 
-	QMetaObject::invokeMethod(this, "UpdateAudioWarnings", Qt::QueuedConnection);
-	QMetaObject::invokeMethod(this, "AudioChangedRestart");
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::UpdateAudioWarnings, Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::AudioChangedRestart);
 }
 
 void OBSBasicSettings::SimpleRecordingQualityLosslessWarning(int idx)
@@ -5648,8 +5652,8 @@ void OBSBasicSettings::SimpleRecordingQualityLosslessWarning(int idx)
 		button = OBSMessageBox::question(this, SIMPLE_OUTPUT_WARNING("Lossless.Title"), warningString);
 
 		if (button == QMessageBox::No) {
-			QMetaObject::invokeMethod(ui->simpleOutRecQuality, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastSimpleRecQualityIdx));
+			QMetaObject::invokeMethod(ui->simpleOutRecQuality, &QComboBox::setCurrentIndex,
+						  Qt::QueuedConnection, lastSimpleRecQualityIdx);
 			return;
 		}
 	}

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -234,7 +234,7 @@ void OBSBasicSettings::LoadStream1Settings()
 
 	loading = false;
 
-	QMetaObject::invokeMethod(this, "UpdateResFPSLimits", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::UpdateResFPSLimits, Qt::QueuedConnection);
 }
 
 #define SRT_PROTOCOL "srt"
@@ -1117,8 +1117,7 @@ void OBSBasicSettings::DisplayEnforceWarning(bool checked)
 #undef ENFORCE_WARNING
 
 	if (button == QMessageBox::No) {
-		QMetaObject::invokeMethod(ui->ignoreRecommended, "setChecked", Qt::QueuedConnection,
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(ui->ignoreRecommended, &QCheckBox::setChecked, Qt::QueuedConnection, false);
 		return;
 	}
 
@@ -1284,11 +1283,11 @@ bool OBSBasicSettings::UpdateResFPSLimits()
 
 		if (button == QMessageBox::No) {
 			if (idx != lastServiceIdx)
-				QMetaObject::invokeMethod(ui->service, "setCurrentIndex", Qt::QueuedConnection,
-							  Q_ARG(int, lastServiceIdx));
+				QMetaObject::invokeMethod(ui->service, &QComboBox::setCurrentIndex,
+							  Qt::QueuedConnection, lastServiceIdx);
 			else
-				QMetaObject::invokeMethod(ui->ignoreRecommended, "setChecked", Qt::QueuedConnection,
-							  Q_ARG(bool, true));
+				QMetaObject::invokeMethod(ui->ignoreRecommended, &QCheckBox::setChecked,
+							  Qt::QueuedConnection, true);
 			return false;
 		}
 	}
@@ -1584,11 +1583,11 @@ bool OBSBasicSettings::ServiceSupportsCodecCheck()
 
 	if (button == QMessageBox::No) {
 		if (lastServiceIdx == 0 && lastServiceIdx == ui->service->currentIndex())
-			QMetaObject::invokeMethod(ui->customServer, "setText", Qt::QueuedConnection,
-						  Q_ARG(QString, lastCustomServer));
+			QMetaObject::invokeMethod(ui->customServer, &QLineEdit::setText, Qt::QueuedConnection,
+						  lastCustomServer);
 		else
-			QMetaObject::invokeMethod(ui->service, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastServiceIdx));
+			QMetaObject::invokeMethod(ui->service, &QComboBox::setCurrentIndex, Qt::QueuedConnection,
+						  lastServiceIdx);
 		return false;
 	}
 

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -241,7 +241,7 @@ void OBSBasicSettings::LoadStream1Settings()
 
 	loading = false;
 
-	QMetaObject::invokeMethod(this, "UpdateResFPSLimits", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasicSettings::UpdateResFPSLimits, Qt::QueuedConnection);
 }
 
 #define SRT_PROTOCOL "srt"
@@ -1140,8 +1140,7 @@ void OBSBasicSettings::DisplayEnforceWarning(bool checked)
 #undef ENFORCE_WARNING
 
 	if (button == QMessageBox::No) {
-		QMetaObject::invokeMethod(ui->ignoreRecommended, "setChecked", Qt::QueuedConnection,
-					  Q_ARG(bool, false));
+		QMetaObject::invokeMethod(ui->ignoreRecommended, &QCheckBox::setChecked, Qt::QueuedConnection, false);
 		return;
 	}
 
@@ -1317,11 +1316,11 @@ bool OBSBasicSettings::UpdateResFPSLimits()
 
 		if (button == QMessageBox::No) {
 			if (idx != lastServiceIdx) {
-				QMetaObject::invokeMethod(ui->service, "setCurrentIndex", Qt::QueuedConnection,
-							  Q_ARG(int, lastServiceIdx));
+				QMetaObject::invokeMethod(ui->service, &QComboBox::setCurrentIndex,
+							  Qt::QueuedConnection, lastServiceIdx);
 			} else {
-				QMetaObject::invokeMethod(ui->ignoreRecommended, "setChecked", Qt::QueuedConnection,
-							  Q_ARG(bool, true));
+				QMetaObject::invokeMethod(ui->ignoreRecommended, &QCheckBox::setChecked,
+							  Qt::QueuedConnection, true);
 			}
 			return false;
 		}
@@ -1636,11 +1635,11 @@ bool OBSBasicSettings::ServiceSupportsCodecCheck()
 
 	if (button == QMessageBox::No) {
 		if (lastServiceIdx == 0 && lastServiceIdx == ui->service->currentIndex()) {
-			QMetaObject::invokeMethod(ui->customServer, "setText", Qt::QueuedConnection,
-						  Q_ARG(QString, lastCustomServer));
+			QMetaObject::invokeMethod(ui->customServer, &QLineEdit::setText, Qt::QueuedConnection,
+						  lastCustomServer);
 		} else {
-			QMetaObject::invokeMethod(ui->service, "setCurrentIndex", Qt::QueuedConnection,
-						  Q_ARG(int, lastServiceIdx));
+			QMetaObject::invokeMethod(ui->service, &QComboBox::setCurrentIndex, Qt::QueuedConnection,
+						  lastServiceIdx);
 		}
 		return false;
 	}

--- a/frontend/settings/OBSHotkeyEdit.cpp
+++ b/frontend/settings/OBSHotkeyEdit.cpp
@@ -198,7 +198,7 @@ void OBSHotkeyEdit::InitSignalHandler()
 	layoutChanged = {obs_get_signal_handler(), "hotkey_layout_change",
 			 [](void *this_, calldata_t *) {
 				 auto edit = static_cast<OBSHotkeyEdit *>(this_);
-				 QMetaObject::invokeMethod(edit, "ReloadKeyLayout");
+				 QMetaObject::invokeMethod(edit, &OBSHotkeyEdit::ReloadKeyLayout);
 			 },
 			 this};
 }

--- a/frontend/settings/OBSHotkeyEdit.cpp
+++ b/frontend/settings/OBSHotkeyEdit.cpp
@@ -204,7 +204,7 @@ void OBSHotkeyEdit::InitSignalHandler()
 	layoutChanged = {obs_get_signal_handler(), "hotkey_layout_change",
 			 [](void *this_, calldata_t *) {
 				 auto edit = static_cast<OBSHotkeyEdit *>(this_);
-				 QMetaObject::invokeMethod(edit, "ReloadKeyLayout");
+				 QMetaObject::invokeMethod(edit, &OBSHotkeyEdit::ReloadKeyLayout);
 			 },
 			 this};
 }

--- a/frontend/settings/OBSHotkeyWidget.cpp
+++ b/frontend/settings/OBSHotkeyWidget.cpp
@@ -183,7 +183,7 @@ void OBSHotkeyWidget::BindingsChanged(void *data, calldata_t *param)
 	auto widget = static_cast<OBSHotkeyWidget *>(data);
 	auto key = static_cast<obs_hotkey_t *>(calldata_ptr(param, "key"));
 
-	QMetaObject::invokeMethod(widget, "HandleChangedBindings", Q_ARG(obs_hotkey_id, obs_hotkey_get_id(key)));
+	QMetaObject::invokeMethod(widget, &OBSHotkeyWidget::HandleChangedBindings, obs_hotkey_get_id(key));
 }
 
 void OBSHotkeyWidget::HandleChangedBindings(obs_hotkey_id id_)

--- a/frontend/settings/OBSHotkeyWidget.cpp
+++ b/frontend/settings/OBSHotkeyWidget.cpp
@@ -190,7 +190,7 @@ void OBSHotkeyWidget::BindingsChanged(void *data, calldata_t *param)
 	auto widget = static_cast<OBSHotkeyWidget *>(data);
 	auto key = static_cast<obs_hotkey_t *>(calldata_ptr(param, "key"));
 
-	QMetaObject::invokeMethod(widget, "HandleChangedBindings", Q_ARG(obs_hotkey_id, obs_hotkey_get_id(key)));
+	QMetaObject::invokeMethod(widget, &OBSHotkeyWidget::HandleChangedBindings, obs_hotkey_get_id(key));
 }
 
 void OBSHotkeyWidget::HandleChangedBindings(obs_hotkey_id id_)

--- a/frontend/utility/AutoUpdateThread.cpp
+++ b/frontend/utility/AutoUpdateThread.cpp
@@ -6,6 +6,7 @@
 #include <updater/manifest.hpp>
 #include <utility/WhatsNewInfoThread.hpp>
 #include <utility/update-helpers.hpp>
+#include <widgets/OBSBasic.hpp>
 
 #include <qt-wrappers.hpp>
 
@@ -133,8 +134,7 @@ void AutoUpdateThread::infoMsg(const QString &title, const QString &text)
 
 void AutoUpdateThread::info(const QString &title, const QString &text)
 {
-	QMetaObject::invokeMethod(this, "infoMsg", Qt::BlockingQueuedConnection, Q_ARG(QString, title),
-				  Q_ARG(QString, text));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::infoMsg, Qt::BlockingQueuedConnection, title, text);
 }
 
 int AutoUpdateThread::queryUpdateSlot(bool localManualUpdate, const QString &text)
@@ -147,8 +147,9 @@ int AutoUpdateThread::queryUpdate(bool localManualUpdate, const char *text_utf8)
 {
 	int ret = OBSUpdate::No;
 	QString text = text_utf8;
-	QMetaObject::invokeMethod(this, "queryUpdateSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, ret),
-				  Q_ARG(bool, localManualUpdate), Q_ARG(QString, text));
+	QMetaObject::invokeMethod(
+		this, [this, &ret, localManualUpdate, text]() { ret = queryUpdateSlot(localManualUpdate, text); },
+		Qt::BlockingQueuedConnection);
 	return ret;
 }
 
@@ -164,7 +165,8 @@ bool AutoUpdateThread::queryRepairSlot()
 bool AutoUpdateThread::queryRepair()
 {
 	bool ret = false;
-	QMetaObject::invokeMethod(this, "queryRepairSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, ret));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::queryRepairSlot, Qt::BlockingQueuedConnection,
+				  Q_RETURN_ARG(bool, ret));
 	return ret;
 }
 
@@ -177,7 +179,10 @@ try {
 	bool updatesAvailable = false;
 
 	struct FinishedTrigger {
-		inline ~FinishedTrigger() { QMetaObject::invokeMethod(App()->GetMainWindow(), "updateCheckFinished"); }
+		inline ~FinishedTrigger()
+		{
+			QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::updateCheckFinished);
+		}
 	} finishedTrigger;
 
 	/* ----------------------------------- *
@@ -325,7 +330,7 @@ try {
 	config_set_int(App()->GetAppConfig(), "General", "LastUpdateCheck", 0);
 	config_set_string(App()->GetAppConfig(), "General", "SkipUpdateVersion", "0");
 
-	QMetaObject::invokeMethod(App()->GetMainWindow(), "close");
+	QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::close);
 
 } catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());

--- a/frontend/utility/AutoUpdateThread.cpp
+++ b/frontend/utility/AutoUpdateThread.cpp
@@ -6,6 +6,7 @@
 #include <updater/manifest.hpp>
 #include <utility/WhatsNewInfoThread.hpp>
 #include <utility/update-helpers.hpp>
+#include <widgets/OBSBasic.hpp>
 
 #include <qt-wrappers.hpp>
 
@@ -138,8 +139,7 @@ void AutoUpdateThread::infoMsg(const QString &title, const QString &text)
 
 void AutoUpdateThread::info(const QString &title, const QString &text)
 {
-	QMetaObject::invokeMethod(this, "infoMsg", Qt::BlockingQueuedConnection, Q_ARG(QString, title),
-				  Q_ARG(QString, text));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::infoMsg, Qt::BlockingQueuedConnection, title, text);
 }
 
 int AutoUpdateThread::queryUpdateSlot(bool localManualUpdate, const QString &text)
@@ -152,8 +152,9 @@ int AutoUpdateThread::queryUpdate(bool localManualUpdate, const char *text_utf8)
 {
 	int ret = OBSUpdate::No;
 	QString text = text_utf8;
-	QMetaObject::invokeMethod(this, "queryUpdateSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, ret),
-				  Q_ARG(bool, localManualUpdate), Q_ARG(QString, text));
+	QMetaObject::invokeMethod(
+		this, [this, &ret, localManualUpdate, text]() { ret = queryUpdateSlot(localManualUpdate, text); },
+		Qt::BlockingQueuedConnection);
 	return ret;
 }
 
@@ -169,7 +170,8 @@ bool AutoUpdateThread::queryRepairSlot()
 bool AutoUpdateThread::queryRepair()
 {
 	bool ret = false;
-	QMetaObject::invokeMethod(this, "queryRepairSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, ret));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::queryRepairSlot, Qt::BlockingQueuedConnection,
+				  Q_RETURN_ARG(bool, ret));
 	return ret;
 }
 
@@ -182,7 +184,10 @@ try {
 	bool updatesAvailable = false;
 
 	struct FinishedTrigger {
-		inline ~FinishedTrigger() { QMetaObject::invokeMethod(App()->GetMainWindow(), "updateCheckFinished"); }
+		inline ~FinishedTrigger()
+		{
+			QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::updateCheckFinished);
+		}
 	} finishedTrigger;
 
 	/* ----------------------------------- *
@@ -344,7 +349,7 @@ try {
 	config_set_int(App()->GetAppConfig(), "General", "LastUpdateCheck", 0);
 	config_set_string(App()->GetAppConfig(), "General", "SkipUpdateVersion", "0");
 
-	QMetaObject::invokeMethod(App()->GetMainWindow(), "close");
+	QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::close);
 
 } catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());

--- a/frontend/utility/AutoUpdateThread.cpp
+++ b/frontend/utility/AutoUpdateThread.cpp
@@ -6,6 +6,7 @@
 #include <updater/manifest.hpp>
 #include <utility/WhatsNewInfoThread.hpp>
 #include <utility/update-helpers.hpp>
+#include <widgets/OBSBasic.hpp>
 
 #include <qt-wrappers.hpp>
 
@@ -138,8 +139,7 @@ void AutoUpdateThread::infoMsg(const QString &title, const QString &text)
 
 void AutoUpdateThread::info(const QString &title, const QString &text)
 {
-	QMetaObject::invokeMethod(this, "infoMsg", Qt::BlockingQueuedConnection, Q_ARG(QString, title),
-				  Q_ARG(QString, text));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::infoMsg, Qt::BlockingQueuedConnection, title, text);
 }
 
 int AutoUpdateThread::queryUpdateSlot(bool localManualUpdate, const QString &text)
@@ -152,8 +152,8 @@ int AutoUpdateThread::queryUpdate(bool localManualUpdate, const char *text_utf8)
 {
 	int ret = OBSUpdate::No;
 	QString text = text_utf8;
-	QMetaObject::invokeMethod(this, "queryUpdateSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(int, ret),
-				  Q_ARG(bool, localManualUpdate), Q_ARG(QString, text));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::queryUpdateSlot, Qt::BlockingQueuedConnection,
+				  qReturnArg(ret), localManualUpdate, text);
 	return ret;
 }
 
@@ -169,7 +169,8 @@ bool AutoUpdateThread::queryRepairSlot()
 bool AutoUpdateThread::queryRepair()
 {
 	bool ret = false;
-	QMetaObject::invokeMethod(this, "queryRepairSlot", Qt::BlockingQueuedConnection, Q_RETURN_ARG(bool, ret));
+	QMetaObject::invokeMethod(this, &AutoUpdateThread::queryRepairSlot, Qt::BlockingQueuedConnection,
+				  Q_RETURN_ARG(bool, ret));
 	return ret;
 }
 
@@ -182,7 +183,10 @@ try {
 	bool updatesAvailable = false;
 
 	struct FinishedTrigger {
-		inline ~FinishedTrigger() { QMetaObject::invokeMethod(App()->GetMainWindow(), "updateCheckFinished"); }
+		inline ~FinishedTrigger()
+		{
+			QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::updateCheckFinished);
+		}
 	} finishedTrigger;
 
 	/* ----------------------------------- *
@@ -344,7 +348,7 @@ try {
 	config_set_int(App()->GetAppConfig(), "General", "LastUpdateCheck", 0);
 	config_set_string(App()->GetAppConfig(), "General", "SkipUpdateVersion", "0");
 
-	QMetaObject::invokeMethod(App()->GetMainWindow(), "close");
+	QMetaObject::invokeMethod(OBSBasic::Get(), &OBSBasic::close);
 
 } catch (string &text) {
 	blog(LOG_WARNING, "%s: %s", __FUNCTION__, text.c_str());

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -31,7 +31,7 @@ void OBSStreamStarting(void *data, calldata_t *params)
 		return;
 
 	output->delayActive = true;
-	QMetaObject::invokeMethod(output->main, "StreamDelayStarting", Q_ARG(int, sec));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamDelayStarting, sec);
 }
 
 void OBSStreamStopping(void *data, calldata_t *params)
@@ -41,9 +41,9 @@ void OBSStreamStopping(void *data, calldata_t *params)
 
 	int sec = (int)obs_output_get_active_delay(obj);
 	if (sec == 0)
-		QMetaObject::invokeMethod(output->main, "StreamStopping");
+		QMetaObject::invokeMethod(output->main, &OBSBasic::StreamStopping);
 	else
-		QMetaObject::invokeMethod(output->main, "StreamDelayStopping", Q_ARG(int, sec));
+		QMetaObject::invokeMethod(output->main, &OBSBasic::StreamDelayStopping, sec);
 }
 
 void OBSStartStreaming(void *data, calldata_t * /* params */)
@@ -51,7 +51,7 @@ void OBSStartStreaming(void *data, calldata_t * /* params */)
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	output->streamingActive = true;
 	os_atomic_set_bool(&streaming_active, true);
-	QMetaObject::invokeMethod(output->main, "StreamingStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamingStart);
 }
 
 void OBSStopStreaming(void *data, calldata_t *params)
@@ -66,7 +66,7 @@ void OBSStopStreaming(void *data, calldata_t *params)
 	output->delayActive = false;
 	output->multitrackVideoActive = false;
 	os_atomic_set_bool(&streaming_active, false);
-	QMetaObject::invokeMethod(output->main, "StreamingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamingStop, code, arg_last_error);
 }
 
 void OBSStartRecording(void *data, calldata_t * /* params */)
@@ -75,7 +75,7 @@ void OBSStartRecording(void *data, calldata_t * /* params */)
 
 	output->recordingActive = true;
 	os_atomic_set_bool(&recording_active, true);
-	QMetaObject::invokeMethod(output->main, "RecordingStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingStart);
 }
 
 void OBSStopRecording(void *data, calldata_t *params)
@@ -89,13 +89,13 @@ void OBSStopRecording(void *data, calldata_t *params)
 	output->recordingActive = false;
 	os_atomic_set_bool(&recording_active, false);
 	os_atomic_set_bool(&recording_paused, false);
-	QMetaObject::invokeMethod(output->main, "RecordingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingStop, code, arg_last_error);
 }
 
 void OBSRecordStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "RecordStopping");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordStopping);
 }
 
 void OBSRecordFileChanged(void *data, calldata_t *params)
@@ -105,7 +105,7 @@ void OBSRecordFileChanged(void *data, calldata_t *params)
 
 	QString arg_last_file = QString::fromUtf8(output->lastRecordingPath.c_str());
 
-	QMetaObject::invokeMethod(output->main, "RecordingFileChanged", Q_ARG(QString, arg_last_file));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingFileChanged, arg_last_file);
 
 	output->lastRecordingPath = next_file;
 }
@@ -116,7 +116,7 @@ void OBSStartReplayBuffer(void *data, calldata_t * /* params */)
 
 	output->replayBufferActive = true;
 	os_atomic_set_bool(&replaybuf_active, true);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStart);
 }
 
 void OBSStopReplayBuffer(void *data, calldata_t *params)
@@ -126,19 +126,19 @@ void OBSStopReplayBuffer(void *data, calldata_t *params)
 
 	output->replayBufferActive = false;
 	os_atomic_set_bool(&replaybuf_active, false);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStop", Q_ARG(int, code));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStop, code);
 }
 
 void OBSReplayBufferStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStopping");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStopping);
 }
 
 void OBSReplayBufferSaved(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferSaved", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferSaved, Qt::QueuedConnection);
 }
 
 static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
@@ -147,7 +147,7 @@ static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
 
 	output->virtualCamActive = true;
 	os_atomic_set_bool(&virtualcam_active, true);
-	QMetaObject::invokeMethod(output->main, "OnVirtualCamStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::OnVirtualCamStart);
 }
 
 static void OBSStopVirtualCam(void *data, calldata_t *params)
@@ -157,7 +157,7 @@ static void OBSStopVirtualCam(void *data, calldata_t *params)
 
 	output->virtualCamActive = false;
 	os_atomic_set_bool(&virtualcam_active, false);
-	QMetaObject::invokeMethod(output->main, "OnVirtualCamStop", Q_ARG(int, code));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::OnVirtualCamStop, code);
 }
 
 static void OBSDeactivateVirtualCam(void *data, calldata_t * /* params */)

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -32,7 +32,7 @@ void OBSStreamStarting(void *data, calldata_t *params)
 	}
 
 	output->delayActive = true;
-	QMetaObject::invokeMethod(output->main, "StreamDelayStarting", Q_ARG(int, sec));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamDelayStarting, sec);
 }
 
 void OBSStreamStopping(void *data, calldata_t *params)
@@ -42,9 +42,9 @@ void OBSStreamStopping(void *data, calldata_t *params)
 
 	int sec = (int)obs_output_get_active_delay(obj);
 	if (sec == 0) {
-		QMetaObject::invokeMethod(output->main, "StreamStopping");
+		QMetaObject::invokeMethod(output->main, &OBSBasic::StreamStopping);
 	} else {
-		QMetaObject::invokeMethod(output->main, "StreamDelayStopping", Q_ARG(int, sec));
+		QMetaObject::invokeMethod(output->main, &OBSBasic::StreamDelayStopping, sec);
 	}
 }
 
@@ -53,7 +53,7 @@ void OBSStartStreaming(void *data, calldata_t * /* params */)
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	output->streamingActive = true;
 	os_atomic_set_bool(&streaming_active, true);
-	QMetaObject::invokeMethod(output->main, "StreamingStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamingStart);
 }
 
 void OBSStopStreaming(void *data, calldata_t *params)
@@ -68,7 +68,7 @@ void OBSStopStreaming(void *data, calldata_t *params)
 	output->delayActive = false;
 	output->multitrackVideoActive = false;
 	os_atomic_set_bool(&streaming_active, false);
-	QMetaObject::invokeMethod(output->main, "StreamingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::StreamingStop, code, arg_last_error);
 }
 
 void OBSStartRecording(void *data, calldata_t * /* params */)
@@ -77,7 +77,7 @@ void OBSStartRecording(void *data, calldata_t * /* params */)
 
 	output->recordingActive = true;
 	os_atomic_set_bool(&recording_active, true);
-	QMetaObject::invokeMethod(output->main, "RecordingStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingStart);
 }
 
 void OBSStopRecording(void *data, calldata_t *params)
@@ -91,13 +91,13 @@ void OBSStopRecording(void *data, calldata_t *params)
 	output->recordingActive = false;
 	os_atomic_set_bool(&recording_active, false);
 	os_atomic_set_bool(&recording_paused, false);
-	QMetaObject::invokeMethod(output->main, "RecordingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingStop, code, arg_last_error);
 }
 
 void OBSRecordStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "RecordStopping");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordStopping);
 }
 
 void OBSRecordFileChanged(void *data, calldata_t *params)
@@ -107,7 +107,7 @@ void OBSRecordFileChanged(void *data, calldata_t *params)
 
 	QString arg_last_file = QString::fromUtf8(output->lastRecordingPath.c_str());
 
-	QMetaObject::invokeMethod(output->main, "RecordingFileChanged", Q_ARG(QString, arg_last_file));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::RecordingFileChanged, arg_last_file);
 
 	output->lastRecordingPath = next_file;
 }
@@ -118,7 +118,7 @@ void OBSStartReplayBuffer(void *data, calldata_t * /* params */)
 
 	output->replayBufferActive = true;
 	os_atomic_set_bool(&replaybuf_active, true);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStart);
 }
 
 void OBSStopReplayBuffer(void *data, calldata_t *params)
@@ -128,19 +128,19 @@ void OBSStopReplayBuffer(void *data, calldata_t *params)
 
 	output->replayBufferActive = false;
 	os_atomic_set_bool(&replaybuf_active, false);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStop", Q_ARG(int, code));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStop, code);
 }
 
 void OBSReplayBufferStopping(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferStopping");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferStopping);
 }
 
 void OBSReplayBufferSaved(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	QMetaObject::invokeMethod(output->main, "ReplayBufferSaved", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(output->main, &OBSBasic::ReplayBufferSaved, Qt::QueuedConnection);
 }
 
 static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
@@ -149,7 +149,7 @@ static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
 
 	output->virtualCamActive = true;
 	os_atomic_set_bool(&virtualcam_active, true);
-	QMetaObject::invokeMethod(output->main, "OnVirtualCamStart");
+	QMetaObject::invokeMethod(output->main, &OBSBasic::OnVirtualCamStart);
 }
 
 static void OBSStopVirtualCam(void *data, calldata_t *params)
@@ -159,7 +159,7 @@ static void OBSStopVirtualCam(void *data, calldata_t *params)
 
 	output->virtualCamActive = false;
 	os_atomic_set_bool(&virtualcam_active, false);
-	QMetaObject::invokeMethod(output->main, "OnVirtualCamStop", Q_ARG(int, code));
+	QMetaObject::invokeMethod(output->main, &OBSBasic::OnVirtualCamStop, code);
 }
 
 static void OBSDeactivateVirtualCam(void *data, calldata_t * /* params */)

--- a/frontend/utility/ExtraBrowsersModel.hpp
+++ b/frontend/utility/ExtraBrowsersModel.hpp
@@ -20,7 +20,7 @@ public:
 	inline ExtraBrowsersModel(QObject *parent = nullptr) : QAbstractTableModel(parent)
 	{
 		Reset();
-		QMetaObject::invokeMethod(this, "Init", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &ExtraBrowsersModel::Init, Qt::QueuedConnection);
 	}
 
 	int rowCount(const QModelIndex &parent = QModelIndex()) const override;

--- a/frontend/utility/ScreenshotObj.cpp
+++ b/frontend/utility/ScreenshotObj.cpp
@@ -303,7 +303,7 @@ static void ScreenshotTick(void *param, float)
 		break;
 	case STAGE_COPY_AND_SAVE:
 		data->Copy();
-		QMetaObject::invokeMethod(data, "Save");
+		QMetaObject::invokeMethod(data, &ScreenshotObj::Save);
 		obs_remove_tick_callback(ScreenshotTick, data);
 		break;
 	}

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -1016,8 +1016,8 @@ void AudioMixer::obsSourceActivated(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updateControlVisibility",
-					  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::updateControlVisibility,
+					  Qt::QueuedConnection, QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1028,8 +1028,8 @@ void AudioMixer::obsSourceDeactivated(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updateControlVisibility",
-					  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::updateControlVisibility,
+					  Qt::QueuedConnection, QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1041,8 +1041,8 @@ void AudioMixer::obsSourceAudioActivated(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO && audioActive) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "addSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::addSource, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1053,8 +1053,8 @@ void AudioMixer::obsSourceAudioDeactivated(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "removeSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::removeSource,
+					  Qt::QueuedConnection, QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1066,8 +1066,8 @@ void AudioMixer::obsSourceCreate(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO && audioActive) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "addSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::addSource, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1078,14 +1078,15 @@ void AudioMixer::obsSourceRemove(void *data, calldata_t *params)
 
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "removeSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::removeSource,
+					  Qt::QueuedConnection, QString::fromUtf8(uuidPointer));
 	}
 }
 
 void AudioMixer::obsSourceRename(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "queueLayoutUpdate", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::queueLayoutUpdate,
+				  Qt::QueuedConnection);
 }
 
 void AudioMixer::obsSceneItemVisibleChange(void *data, calldata_t *params)
@@ -1103,11 +1104,11 @@ void AudioMixer::obsSceneItemVisibleChange(void *data, calldata_t *params)
 	uint32_t flags = obs_source_get_output_flags(source);
 
 	if (flags & OBS_SOURCE_AUDIO) {
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updatePreviewSources",
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::updatePreviewSources,
 					  Qt::QueuedConnection);
 
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updateControlVisibility",
-					  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), &AudioMixer::updateControlVisibility,
+					  Qt::QueuedConnection, QString::fromUtf8(uuidPointer));
 	}
 }

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -1017,9 +1017,8 @@ void AudioMixer::obsSourceActivated(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "updateControlVisibility", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::updateControlVisibility, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1031,9 +1030,8 @@ void AudioMixer::obsSourceDeactivated(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "updateControlVisibility", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::updateControlVisibility, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1046,9 +1044,8 @@ void AudioMixer::obsSourceAudioActivated(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO && audioActive) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "addSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::addSource, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1060,9 +1057,8 @@ void AudioMixer::obsSourceAudioDeactivated(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "updateControlVisibility", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::updateControlVisibility, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1075,9 +1071,8 @@ void AudioMixer::obsSourceCreate(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO && audioActive) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "addSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::addSource, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1089,9 +1084,8 @@ void AudioMixer::obsSourceRemove(void *data, calldata_t *params)
 	if (flags & OBS_SOURCE_AUDIO) {
 		auto mixer = static_cast<AudioMixer *>(data);
 		auto uuidPointer = obs_source_get_uuid(source);
-
-		QMetaObject::invokeMethod(mixer, "removeSource", Qt::QueuedConnection,
-					  Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::removeSource, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }
 
@@ -1099,7 +1093,7 @@ void AudioMixer::obsSourceRename(void *data, calldata_t *)
 {
 	auto mixer = static_cast<AudioMixer *>(data);
 
-	QMetaObject::invokeMethod(mixer, "queueLayoutUpdate", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(mixer, &AudioMixer::queueLayoutUpdate, Qt::QueuedConnection);
 }
 
 void AudioMixer::obsSceneItemVisibleChange(void *data, calldata_t *params)
@@ -1117,11 +1111,12 @@ void AudioMixer::obsSceneItemVisibleChange(void *data, calldata_t *params)
 	uint32_t flags = obs_source_get_output_flags(source);
 
 	if (flags & OBS_SOURCE_AUDIO) {
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updatePreviewSources",
-					  Qt::QueuedConnection);
+		auto mixer = static_cast<AudioMixer *>(data);
+
+		QMetaObject::invokeMethod(mixer, &AudioMixer::updatePreviewSources, Qt::QueuedConnection);
 
 		auto uuidPointer = obs_source_get_uuid(source);
-		QMetaObject::invokeMethod(static_cast<AudioMixer *>(data), "updateControlVisibility",
-					  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
+		QMetaObject::invokeMethod(mixer, &AudioMixer::updateControlVisibility, Qt::QueuedConnection,
+					  QString::fromUtf8(uuidPointer));
 	}
 }

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -922,14 +922,14 @@ void OBSBasic::InitOBSCallbacks()
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_add",
 		[](void *data, calldata_t *) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "UpdateEditMenu",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::UpdateEditMenu,
 						  Qt::QueuedConnection);
 		},
 		this);
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_remove",
 		[](void *data, calldata_t *) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "UpdateEditMenu",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::UpdateEditMenu,
 						  Qt::QueuedConnection);
 		},
 		this);
@@ -1129,10 +1129,9 @@ void OBSBasic::OBSInit()
 	previewEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow", "PreviewEnabled");
 
 	if (!previewEnabled && !IsPreviewProgramMode())
-		QMetaObject::invokeMethod(this, "EnablePreviewDisplay", Qt::QueuedConnection,
-					  Q_ARG(bool, previewEnabled));
+		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, previewEnabled);
 	else if (!previewEnabled && IsPreviewProgramMode())
-		QMetaObject::invokeMethod(this, "EnablePreviewDisplay", Qt::QueuedConnection, Q_ARG(bool, true));
+		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, true);
 
 	disableSaving--;
 
@@ -1266,7 +1265,7 @@ void OBSBasic::OBSInit()
 	}
 
 	if (!first_run && !has_last_version && !Active())
-		QMetaObject::invokeMethod(this, "on_autoConfigure_triggered", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::on_autoConfigure_triggered, Qt::QueuedConnection);
 
 #if (defined(_WIN32) || defined(__APPLE__)) && (OBS_RELEASE_CANDIDATE > 0 || OBS_BETA > 0)
 	/* Automatically set branch to "beta" the first time a pre-release build is run. */
@@ -2004,9 +2003,9 @@ void OBSBasic::closeWindow()
 
 	emit mainWindowClosed();
 
-	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(App(), &OBSApp::quit, Qt::QueuedConnection);
 #else
-	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(App(), &OBSApp::quit, Qt::QueuedConnection);
 #endif
 }
 

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -937,14 +937,14 @@ void OBSBasic::InitOBSCallbacks()
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_add",
 		[](void *data, calldata_t *) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "UpdateEditMenu",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::UpdateEditMenu,
 						  Qt::QueuedConnection);
 		},
 		this);
 	signalHandlers.emplace_back(
 		obs_get_signal_handler(), "source_filter_remove",
 		[](void *data, calldata_t *) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "UpdateEditMenu",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::UpdateEditMenu,
 						  Qt::QueuedConnection);
 		},
 		this);
@@ -1149,10 +1149,9 @@ void OBSBasic::OBSInit()
 	previewEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow", "PreviewEnabled");
 
 	if (!previewEnabled && !IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, "EnablePreviewDisplay", Qt::QueuedConnection,
-					  Q_ARG(bool, previewEnabled));
+		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, previewEnabled);
 	} else if (!previewEnabled && IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, "EnablePreviewDisplay", Qt::QueuedConnection, Q_ARG(bool, true));
+		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, true);
 	}
 
 	disableSaving--;
@@ -1293,7 +1292,7 @@ void OBSBasic::OBSInit()
 	}
 
 	if (!first_run && !has_last_version && !Active()) {
-		QMetaObject::invokeMethod(this, "on_autoConfigure_triggered", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::on_autoConfigure_triggered, Qt::QueuedConnection);
 	}
 
 #if (defined(_WIN32) || defined(__APPLE__)) && (OBS_RELEASE_CANDIDATE > 0 || OBS_BETA > 0)
@@ -2052,9 +2051,9 @@ void OBSBasic::closeWindow()
 
 	emit mainWindowClosed();
 
-	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(App(), &OBSApp::quit, Qt::QueuedConnection);
 #else
-	QMetaObject::invokeMethod(App(), "quit", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(App(), &OBSApp::quit, Qt::QueuedConnection);
 #endif
 }
 

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -641,9 +641,8 @@ private slots:
 
 	void logUploadFinished(const QString &text, const QString &error, OBS::LogFileType uploadType);
 
-	void updateCheckFinished();
-
 public slots:
+	void updateCheckFinished();
 	void on_actionAdvAudioProperties_triggered();
 
 public:

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -654,9 +654,8 @@ private slots:
 
 	void logUploadFinished(const std::string &text, const std::string &error, OBS::LogFileType uploadType);
 
-	void updateCheckFinished();
-
 public slots:
+	void updateCheckFinished();
 	void on_actionAdvAudioProperties_triggered();
 
 public:

--- a/frontend/widgets/OBSBasicStatusBar.cpp
+++ b/frontend/widgets/OBSBasicStatusBar.cpp
@@ -368,14 +368,14 @@ void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
 	int seconds = (int)calldata_int(params, "timeout_sec");
-	QMetaObject::invokeMethod(statusBar, "Reconnect", Q_ARG(int, seconds));
+	QMetaObject::invokeMethod(statusBar, &OBSBasicStatusBar::Reconnect, seconds);
 }
 
 void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data, calldata_t *)
 {
 	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
-	QMetaObject::invokeMethod(statusBar, "ReconnectSuccess");
+	QMetaObject::invokeMethod(statusBar, &OBSBasicStatusBar::ReconnectSuccess);
 }
 
 void OBSBasicStatusBar::Reconnect(int seconds)

--- a/frontend/widgets/OBSBasicStatusBar.cpp
+++ b/frontend/widgets/OBSBasicStatusBar.cpp
@@ -389,14 +389,14 @@ void OBSBasicStatusBar::OBSOutputReconnect(void *data, calldata_t *params)
 	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
 	int seconds = (int)calldata_int(params, "timeout_sec");
-	QMetaObject::invokeMethod(statusBar, "Reconnect", Q_ARG(int, seconds));
+	QMetaObject::invokeMethod(statusBar, &OBSBasicStatusBar::Reconnect, seconds);
 }
 
 void OBSBasicStatusBar::OBSOutputReconnectSuccess(void *data, calldata_t *)
 {
 	OBSBasicStatusBar *statusBar = static_cast<OBSBasicStatusBar *>(data);
 
-	QMetaObject::invokeMethod(statusBar, "ReconnectSuccess");
+	QMetaObject::invokeMethod(statusBar, &OBSBasicStatusBar::ReconnectSuccess);
 }
 
 void OBSBasicStatusBar::Reconnect(int seconds)

--- a/frontend/widgets/OBSBasic_Canvases.cpp
+++ b/frontend/widgets/OBSBasic_Canvases.cpp
@@ -20,7 +20,7 @@
 void OBSBasic::CanvasRemoved(void *data, calldata_t *params)
 {
 	obs_canvas_t *canvas = static_cast<obs_canvas_t *>(calldata_ptr(params, "canvas"));
-	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveCanvas", Q_ARG(OBSCanvas, OBSCanvas(canvas)));
+	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::RemoveCanvas, canvas);
 }
 
 const OBS::Canvas &OBSBasic::AddCanvas(const std::string &name, obs_video_info *ovi, int flags)

--- a/frontend/widgets/OBSBasic_ContextToolbar.cpp
+++ b/frontend/widgets/OBSBasic_ContextToolbar.cpp
@@ -101,7 +101,7 @@ static bool is_network_media_source(obs_source_t *source, const char *id)
 
 void OBSBasic::UpdateContextBarDeferred(bool force)
 {
-	QMetaObject::invokeMethod(this, "UpdateContextBar", Qt::QueuedConnection, Q_ARG(bool, force));
+	QMetaObject::invokeMethod(this, &OBSBasic::UpdateContextBar, Qt::QueuedConnection, force);
 }
 
 void OBSBasic::SourceToolBarActionsSetEnabled()

--- a/frontend/widgets/OBSBasic_ContextToolbar.cpp
+++ b/frontend/widgets/OBSBasic_ContextToolbar.cpp
@@ -105,7 +105,7 @@ static bool is_network_media_source(obs_source_t *source, const char *id)
 
 void OBSBasic::UpdateContextBarDeferred(bool force)
 {
-	QMetaObject::invokeMethod(this, "UpdateContextBar", Qt::QueuedConnection, Q_ARG(bool, force));
+	QMetaObject::invokeMethod(this, &OBSBasic::UpdateContextBar, Qt::QueuedConnection, force);
 }
 
 void OBSBasic::SourceToolBarActionsSetEnabled()

--- a/frontend/widgets/OBSBasic_Hotkeys.cpp
+++ b/frontend/widgets/OBSBasic_Hotkeys.cpp
@@ -84,7 +84,7 @@ void OBSBasic::ProcessHotkey(obs_hotkey_id id, bool pressed)
 void OBSBasic::HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed)
 {
 	OBSBasic &basic = *static_cast<OBSBasic *>(data);
-	QMetaObject::invokeMethod(&basic, "ProcessHotkey", Q_ARG(obs_hotkey_id, id), Q_ARG(bool, pressed));
+	QMetaObject::invokeMethod(&basic, &OBSBasic::ProcessHotkey, id, pressed);
 }
 
 void OBSBasic::CreateHotkeys()
@@ -245,7 +245,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto transition = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed)
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "TransitionClicked",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::TransitionClicked,
 						  Qt::QueuedConnection);
 	};
 
@@ -254,7 +254,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto resetStats = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed)
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "ResetStatsHotkey",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::ResetStatsHotkey,
 						  Qt::QueuedConnection);
 	};
 
@@ -264,7 +264,8 @@ void OBSBasic::CreateHotkeys()
 
 	auto screenshot = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed)
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "Screenshot", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::Screenshot,
+						  Qt::QueuedConnection, nullptr);
 	};
 
 	screenshotHotkey = obs_hotkey_register_frontend("OBSBasic.Screenshot", Str("Screenshot"), screenshot, this);
@@ -272,7 +273,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto screenshotSource = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed)
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "ScreenshotSelectedSource",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::ScreenshotSelectedSource,
 						  Qt::QueuedConnection);
 	};
 

--- a/frontend/widgets/OBSBasic_Hotkeys.cpp
+++ b/frontend/widgets/OBSBasic_Hotkeys.cpp
@@ -84,7 +84,7 @@ void OBSBasic::ProcessHotkey(obs_hotkey_id id, bool pressed)
 void OBSBasic::HotkeyTriggered(void *data, obs_hotkey_id id, bool pressed)
 {
 	OBSBasic &basic = *static_cast<OBSBasic *>(data);
-	QMetaObject::invokeMethod(&basic, "ProcessHotkey", Q_ARG(obs_hotkey_id, id), Q_ARG(bool, pressed));
+	QMetaObject::invokeMethod(&basic, &OBSBasic::ProcessHotkey, id, pressed);
 }
 
 void OBSBasic::CreateHotkeys()
@@ -249,7 +249,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto transition = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "TransitionClicked",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::TransitionClicked,
 						  Qt::QueuedConnection);
 		}
 	};
@@ -259,7 +259,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto resetStats = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "ResetStatsHotkey",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::ResetStatsHotkey,
 						  Qt::QueuedConnection);
 		}
 	};
@@ -270,7 +270,8 @@ void OBSBasic::CreateHotkeys()
 
 	auto screenshot = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "Screenshot", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::Screenshot,
+						  Qt::QueuedConnection, nullptr);
 		}
 	};
 
@@ -279,7 +280,7 @@ void OBSBasic::CreateHotkeys()
 
 	auto screenshotSource = [](void *data, obs_hotkey_id, obs_hotkey_t *, bool pressed) {
 		if (pressed) {
-			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "ScreenshotSelectedSource",
+			QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::ScreenshotSelectedSource,
 						  Qt::QueuedConnection);
 		}
 	};

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -472,7 +472,7 @@ void OBSBasic::on_actionAlwaysOnTop_triggered()
 	CloseDialogs();
 #endif
 
-	QMetaObject::invokeMethod(this, "ToggleAlwaysOnTop", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasic::ToggleAlwaysOnTop, Qt::QueuedConnection);
 }
 
 void OBSBasic::ToggleAlwaysOnTop()

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -492,7 +492,7 @@ void OBSBasic::on_actionAlwaysOnTop_triggered()
 	CloseDialogs();
 #endif
 
-	QMetaObject::invokeMethod(this, "ToggleAlwaysOnTop", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasic::ToggleAlwaysOnTop, Qt::QueuedConnection);
 }
 
 void OBSBasic::ToggleAlwaysOnTop()

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -60,7 +60,7 @@ void OBSBasic::ShowReplayBufferPauseWarning()
 
 	bool warned = config_get_bool(App()->GetUserConfig(), "General", "WarnedAboutReplayBufferPausing");
 	if (!warned) {
-		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+		QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 	}
 }
 

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -61,7 +61,7 @@ void OBSBasic::ShowReplayBufferPauseWarning()
 
 	bool warned = config_get_bool(App()->GetUserConfig(), "General", "WarnedAboutReplayBufferPausing");
 	if (!warned) {
-		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+		QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 	}
 }
 

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1442,23 +1442,23 @@ retryScene:
 
 	if (opt_start_streaming && !safe_mode) {
 		blog(LOG_INFO, "Starting stream due to command line parameter");
-		QMetaObject::invokeMethod(this, "StartStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming, Qt::QueuedConnection);
 		opt_start_streaming = false;
 	}
 
 	if (opt_start_recording && !safe_mode) {
 		blog(LOG_INFO, "Starting recording due to command line parameter");
-		QMetaObject::invokeMethod(this, "StartRecording", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartRecording, Qt::QueuedConnection);
 		opt_start_recording = false;
 	}
 
 	if (opt_start_replaybuffer && !safe_mode) {
-		QMetaObject::invokeMethod(this, "StartReplayBuffer", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartReplayBuffer, Qt::QueuedConnection);
 		opt_start_replaybuffer = false;
 	}
 
 	if (opt_start_virtualcam && !safe_mode) {
-		QMetaObject::invokeMethod(this, "StartVirtualCam", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartVirtualCam, Qt::QueuedConnection);
 		opt_start_virtualcam = false;
 	}
 
@@ -1491,7 +1491,7 @@ void OBSBasic::SaveProject()
 		return;
 
 	projectChanged = true;
-	QMetaObject::invokeMethod(this, "SaveProjectDeferred", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasic::SaveProjectDeferred, Qt::QueuedConnection);
 }
 
 void OBSBasic::SaveProjectDeferred()

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1483,23 +1483,23 @@ retryScene:
 
 	if (opt_start_streaming && !safe_mode) {
 		blog(LOG_INFO, "Starting stream due to command line parameter");
-		QMetaObject::invokeMethod(this, "StartStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming, Qt::QueuedConnection);
 		opt_start_streaming = false;
 	}
 
 	if (opt_start_recording && !safe_mode) {
 		blog(LOG_INFO, "Starting recording due to command line parameter");
-		QMetaObject::invokeMethod(this, "StartRecording", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartRecording, Qt::QueuedConnection);
 		opt_start_recording = false;
 	}
 
 	if (opt_start_replaybuffer && !safe_mode) {
-		QMetaObject::invokeMethod(this, "StartReplayBuffer", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartReplayBuffer, Qt::QueuedConnection);
 		opt_start_replaybuffer = false;
 	}
 
 	if (opt_start_virtualcam && !safe_mode) {
-		QMetaObject::invokeMethod(this, "StartVirtualCam", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartVirtualCam, Qt::QueuedConnection);
 		opt_start_virtualcam = false;
 	}
 
@@ -1536,7 +1536,7 @@ void OBSBasic::SaveProject()
 	}
 
 	projectChanged = true;
-	QMetaObject::invokeMethod(this, "SaveProjectDeferred", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSBasic::SaveProjectDeferred, Qt::QueuedConnection);
 }
 
 void OBSBasic::SaveProjectDeferred()

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -175,8 +175,7 @@ void OBSBasic::SourceCreated(void *data, calldata_t *params)
 	obs_source_t *source = (obs_source_t *)calldata_ptr(params, "source");
 
 	if (obs_scene_from_source(source) != NULL)
-		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "AddScene", WaitConnection(),
-					  Q_ARG(OBSSource, OBSSource(source)));
+		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::AddScene, WaitConnection(), source);
 }
 
 void OBSBasic::SourceRemoved(void *data, calldata_t *params)
@@ -184,8 +183,7 @@ void OBSBasic::SourceRemoved(void *data, calldata_t *params)
 	obs_source_t *source = (obs_source_t *)calldata_ptr(params, "source");
 
 	if (obs_scene_from_source(source) != NULL)
-		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveScene",
-					  Q_ARG(OBSSource, OBSSource(source)));
+		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::RemoveScene, source);
 }
 
 void OBSBasic::SourceRenamed(void *data, calldata_t *params)
@@ -194,8 +192,8 @@ void OBSBasic::SourceRenamed(void *data, calldata_t *params)
 	const char *newName = calldata_string(params, "new_name");
 	const char *prevName = calldata_string(params, "prev_name");
 
-	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RenameSources", Q_ARG(OBSSource, source),
-				  Q_ARG(QString, QT_UTF8(newName)), Q_ARG(QString, QT_UTF8(prevName)));
+	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::RenameSources, source, QT_UTF8(newName),
+				  QT_UTF8(prevName));
 
 	blog(LOG_INFO, "Source '%s' renamed to '%s'", prevName, newName);
 }

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -202,8 +202,7 @@ void OBSBasic::SourceCreated(void *data, calldata_t *params)
 	obs_source_t *source = (obs_source_t *)calldata_ptr(params, "source");
 
 	if (obs_scene_from_source(source) != NULL) {
-		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "AddScene", WaitConnection(),
-					  Q_ARG(OBSSource, OBSSource(source)));
+		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::AddScene, WaitConnection(), source);
 	}
 }
 
@@ -212,8 +211,7 @@ void OBSBasic::SourceRemoved(void *data, calldata_t *params)
 	obs_source_t *source = (obs_source_t *)calldata_ptr(params, "source");
 
 	if (obs_scene_from_source(source) != NULL) {
-		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RemoveScene",
-					  Q_ARG(OBSSource, OBSSource(source)));
+		QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::RemoveScene, source);
 	}
 }
 
@@ -223,8 +221,8 @@ void OBSBasic::SourceRenamed(void *data, calldata_t *params)
 	const char *newName = calldata_string(params, "new_name");
 	const char *prevName = calldata_string(params, "prev_name");
 
-	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), "RenameSources", Q_ARG(OBSSource, source),
-				  Q_ARG(QString, QT_UTF8(newName)), Q_ARG(QString, QT_UTF8(prevName)));
+	QMetaObject::invokeMethod(static_cast<OBSBasic *>(data), &OBSBasic::RenameSources, source, QT_UTF8(newName),
+				  QT_UTF8(prevName));
 
 	blog(LOG_INFO, "Source '%s' renamed to '%s'", prevName, newName);
 }

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -471,7 +471,7 @@ void OBSBasic::SceneReordered(void *data, calldata_t *params)
 
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
 
-	QMetaObject::invokeMethod(window, "ReorderSources", Q_ARG(OBSScene, OBSScene(scene)));
+	QMetaObject::invokeMethod(window, &OBSBasic::ReorderSources, OBSScene(scene));
 }
 
 void OBSBasic::SceneRefreshed(void *data, calldata_t *params)
@@ -480,7 +480,7 @@ void OBSBasic::SceneRefreshed(void *data, calldata_t *params)
 
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
 
-	QMetaObject::invokeMethod(window, "RefreshSources", Q_ARG(OBSScene, OBSScene(scene)));
+	QMetaObject::invokeMethod(window, &OBSBasic::RefreshSources, OBSScene(scene));
 }
 
 void OBSBasic::SceneItemAdded(void *data, calldata_t *params)
@@ -489,7 +489,7 @@ void OBSBasic::SceneItemAdded(void *data, calldata_t *params)
 
 	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(params, "item");
 
-	QMetaObject::invokeMethod(window, "AddSceneItem", Q_ARG(OBSSceneItem, OBSSceneItem(item)));
+	QMetaObject::invokeMethod(window, &OBSBasic::AddSceneItem, OBSSceneItem(item));
 }
 
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current, QListWidgetItem *)

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -484,7 +484,7 @@ void OBSBasic::SceneReordered(void *data, calldata_t *params)
 
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
 
-	QMetaObject::invokeMethod(window, "ReorderSources", Q_ARG(OBSScene, OBSScene(scene)));
+	QMetaObject::invokeMethod(window, &OBSBasic::ReorderSources, OBSScene(scene));
 }
 
 void OBSBasic::SceneRefreshed(void *data, calldata_t *params)
@@ -493,7 +493,7 @@ void OBSBasic::SceneRefreshed(void *data, calldata_t *params)
 
 	obs_scene_t *scene = (obs_scene_t *)calldata_ptr(params, "scene");
 
-	QMetaObject::invokeMethod(window, "RefreshSources", Q_ARG(OBSScene, OBSScene(scene)));
+	QMetaObject::invokeMethod(window, &OBSBasic::RefreshSources, OBSScene(scene));
 }
 
 void OBSBasic::SceneItemAdded(void *data, calldata_t *params)
@@ -502,7 +502,7 @@ void OBSBasic::SceneItemAdded(void *data, calldata_t *params)
 
 	obs_sceneitem_t *item = (obs_sceneitem_t *)calldata_ptr(params, "item");
 
-	QMetaObject::invokeMethod(window, "AddSceneItem", Q_ARG(OBSSceneItem, OBSSceneItem(item)));
+	QMetaObject::invokeMethod(window, &OBSBasic::AddSceneItem, OBSSceneItem(item));
 }
 
 void OBSBasic::on_scenes_currentItemChanged(QListWidgetItem *current, QListWidgetItem *)

--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -65,7 +65,7 @@ void OBSBasic::StartStreaming()
 			no_broadcast.exec();
 
 			if (no_broadcast.clickedButton() == SetupBroadcast)
-				QMetaObject::invokeMethod(this, "SetupBroadcast");
+				QMetaObject::invokeMethod(this, &OBSBasic::SetupBroadcast);
 			return;
 		}
 	}
@@ -367,7 +367,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 	if (!broadcastActive)
 		SetBroadcastFlowEnabled(auth && auth->broadcastFlow());
 	if (should_reconnect)
-		QMetaObject::invokeMethod(this, "StartStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming, Qt::QueuedConnection);
 }
 
 void OBSBasic::StreamActionTriggered()

--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -67,7 +67,7 @@ void OBSBasic::StartStreaming()
 			no_broadcast.exec();
 
 			if (no_broadcast.clickedButton() == SetupBroadcast) {
-				QMetaObject::invokeMethod(this, "SetupBroadcast");
+				QMetaObject::invokeMethod(this, &OBSBasic::SetupBroadcast);
 			}
 			return;
 		}
@@ -384,7 +384,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 		SetBroadcastFlowEnabled(auth && auth->broadcastFlow());
 	}
 	if (should_reconnect) {
-		QMetaObject::invokeMethod(this, "StartStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming, Qt::QueuedConnection);
 	}
 }
 

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -96,7 +96,7 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 		OBSBasic *main = OBSBasic::Get();
 
 		if (pressed)
-			QMetaObject::invokeMethod(main, "TriggerQuickTransition", Qt::QueuedConnection, Q_ARG(int, id));
+			QMetaObject::invokeMethod(main, &OBSBasic::TriggerQuickTransition, Qt::QueuedConnection, id);
 	};
 
 	qt->hotkey = obs_hotkey_register_frontend(hotkeyId->array, QT_TO_UTF8(hotkeyName), quickTransition,
@@ -129,17 +129,17 @@ void OBSBasic::InitTransition(obs_source_t *transition)
 {
 	auto onTransitionStart = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionStarted", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionStarted, Qt::QueuedConnection);
 	};
 
 	auto onTransitionStop = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionStopped", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionStopped, Qt::QueuedConnection);
 	};
 
 	auto onTransitionFullStop = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionFullyStopped", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionFullyStopped, Qt::QueuedConnection);
 	};
 
 	signal_handler_t *handler = obs_source_get_signal_handler(transition);
@@ -1097,8 +1097,7 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 	duration->setValue(qt ? qt->duration : 300);
 
 	if (qt) {
-		connect(duration, (void(QSpinBox::*)(int)) & QSpinBox::valueChanged, this,
-			&OBSBasic::QuickTransitionChangeDuration);
+		connect(duration, &QSpinBox::valueChanged, this, &OBSBasic::QuickTransitionChangeDuration);
 	}
 
 	action = menu->addAction(QTStr("FadeToBlack"));

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -99,7 +99,7 @@ void OBSBasic::AddQuickTransitionHotkey(QuickTransition *qt)
 		OBSBasic *main = OBSBasic::Get();
 
 		if (pressed) {
-			QMetaObject::invokeMethod(main, "TriggerQuickTransition", Qt::QueuedConnection, Q_ARG(int, id));
+			QMetaObject::invokeMethod(main, &OBSBasic::TriggerQuickTransition, Qt::QueuedConnection, id);
 		}
 	};
 
@@ -133,17 +133,17 @@ void OBSBasic::InitTransition(obs_source_t *transition)
 {
 	auto onTransitionStart = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionStarted", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionStarted, Qt::QueuedConnection);
 	};
 
 	auto onTransitionStop = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionStopped", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionStopped, Qt::QueuedConnection);
 	};
 
 	auto onTransitionFullStop = [](void *data, calldata_t *) {
 		OBSBasic *window = (OBSBasic *)data;
-		QMetaObject::invokeMethod(window, "TransitionFullyStopped", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(window, &OBSBasic::TransitionFullyStopped, Qt::QueuedConnection);
 	};
 
 	signal_handler_t *handler = obs_source_get_signal_handler(transition);
@@ -1144,8 +1144,7 @@ QMenu *OBSBasic::CreateTransitionMenu(QWidget *parent, QuickTransition *qt)
 	duration->setValue(qt ? qt->duration : 300);
 
 	if (qt) {
-		connect(duration, (void (QSpinBox::*)(int))&QSpinBox::valueChanged, this,
-			&OBSBasic::QuickTransitionChangeDuration);
+		connect(duration, &QSpinBox::valueChanged, this, &OBSBasic::QuickTransitionChangeDuration);
 	}
 
 	action = menu->addAction(QTStr("FadeToBlack"));

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -56,7 +56,7 @@ void OBSBasic::YouTubeActionDialogOk(const QString &broadcast_id, const QString 
 	emit BroadcastStreamReady(broadcastReady);
 
 	if (start_now)
-		QMetaObject::invokeMethod(this, "StartStreaming");
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming);
 }
 
 void OBSBasic::YoutubeStreamCheck(const std::string &key)
@@ -64,7 +64,7 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 	YoutubeApiWrappers *apiYouTube(dynamic_cast<YoutubeApiWrappers *>(GetAuth()));
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
-		QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::ForceStopStreaming, Qt::QueuedConnection);
 		youtubeStreamCheckThread->deleteLater();
 		blog(LOG_ERROR, "==========================================");
 		blog(LOG_ERROR, "%s: Uh, hey, we got here", __FUNCTION__);
@@ -78,13 +78,13 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 
 	while (StreamingActive()) {
 		if (timeout == 14) {
-			QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::ForceStopStreaming, Qt::QueuedConnection);
 			break;
 		}
 
 		if (!apiYouTube->FindStream(id, json)) {
-			QMetaObject::invokeMethod(this, "DisplayStreamStartError", Qt::QueuedConnection);
-			QMetaObject::invokeMethod(this, "StopStreaming", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::DisplayStreamStartError, Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::StopStreaming, Qt::QueuedConnection);
 			break;
 		}
 
@@ -124,7 +124,7 @@ void OBSBasic::ShowYouTubeAutoStartWarning()
 
 	bool warned = config_get_bool(App()->GetUserConfig(), "General", "WarnedAboutYouTubeAutoStart");
 	if (!warned) {
-		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+		QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 	}
 }
 #endif
@@ -187,7 +187,7 @@ void OBSBasic::BroadcastButtonClicked()
 		broadcastReady = false;
 
 		autoStopBroadcast = true;
-		QMetaObject::invokeMethod(this, "StopStreaming");
+		QMetaObject::invokeMethod(this, &OBSBasic::StopStreaming);
 		emit BroadcastStreamReady(broadcastReady);
 		SetBroadcastFlowEnabled(true);
 	}

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -50,7 +50,7 @@ void OBSBasic::YouTubeActionDialogOk(const std::string &broadcastId, const std::
 	emit BroadcastStreamReady(broadcastReady);
 
 	if (startNow) {
-		QMetaObject::invokeMethod(this, "StartStreaming");
+		QMetaObject::invokeMethod(this, &OBSBasic::StartStreaming);
 	}
 }
 
@@ -59,7 +59,7 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 	YoutubeApiWrappers *apiYouTube(dynamic_cast<YoutubeApiWrappers *>(GetAuth()));
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
-		QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(this, &OBSBasic::ForceStopStreaming, Qt::QueuedConnection);
 		youtubeStreamCheckThread->deleteLater();
 		blog(LOG_ERROR, "==========================================");
 		blog(LOG_ERROR, "%s: Uh, hey, we got here", __FUNCTION__);
@@ -73,13 +73,13 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 
 	while (StreamingActive()) {
 		if (timeout == 14) {
-			QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::ForceStopStreaming, Qt::QueuedConnection);
 			break;
 		}
 
 		if (!apiYouTube->FindStream(id, json)) {
-			QMetaObject::invokeMethod(this, "DisplayStreamStartError", Qt::QueuedConnection);
-			QMetaObject::invokeMethod(this, "StopStreaming", Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::DisplayStreamStartError, Qt::QueuedConnection);
+			QMetaObject::invokeMethod(this, &OBSBasic::StopStreaming, Qt::QueuedConnection);
 			break;
 		}
 
@@ -119,7 +119,7 @@ void OBSBasic::ShowYouTubeAutoStartWarning()
 
 	bool warned = config_get_bool(App()->GetUserConfig(), "General", "WarnedAboutYouTubeAutoStart");
 	if (!warned) {
-		QMetaObject::invokeMethod(App(), "Exec", Qt::QueuedConnection, Q_ARG(VoidFunc, msgBox));
+		QMetaObject::invokeMethod(App(), &OBSApp::Exec, Qt::QueuedConnection, msgBox);
 	}
 }
 #endif
@@ -187,7 +187,7 @@ void OBSBasic::BroadcastButtonClicked()
 		broadcastReady = false;
 
 		autoStopBroadcast = true;
-		QMetaObject::invokeMethod(this, "StopStreaming");
+		QMetaObject::invokeMethod(this, &OBSBasic::StopStreaming);
 		emit BroadcastStreamReady(broadcastReady);
 		SetBroadcastFlowEnabled(true);
 	}

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -205,16 +205,16 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 void OBSProjector::OBSSourceRenamed(void *data, calldata_t *params)
 {
 	OBSProjector *window = static_cast<OBSProjector *>(data);
-	QString oldName = calldata_string(params, "prev_name");
-	QString newName = calldata_string(params, "new_name");
+	QString oldName = QString::fromUtf8(calldata_string(params, "prev_name"));
+	QString newName = QString::fromUtf8(calldata_string(params, "new_name"));
 
-	QMetaObject::invokeMethod(window, "RenameProjector", Q_ARG(QString, oldName), Q_ARG(QString, newName));
+	QMetaObject::invokeMethod(window, &OBSProjector::RenameProjector, oldName, newName);
 }
 
 void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)
 {
 	OBSProjector *window = static_cast<OBSProjector *>(data);
-	QMetaObject::invokeMethod(window, "EscapeTriggered");
+	QMetaObject::invokeMethod(window, &OBSProjector::EscapeTriggered);
 }
 
 void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)

--- a/frontend/widgets/OBSProjector.cpp
+++ b/frontend/widgets/OBSProjector.cpp
@@ -215,16 +215,16 @@ void OBSProjector::OBSRender(void *data, uint32_t cx, uint32_t cy)
 void OBSProjector::OBSSourceRenamed(void *data, calldata_t *params)
 {
 	OBSProjector *window = static_cast<OBSProjector *>(data);
-	QString oldName = calldata_string(params, "prev_name");
-	QString newName = calldata_string(params, "new_name");
+	QString oldName = QString::fromUtf8(calldata_string(params, "prev_name"));
+	QString newName = QString::fromUtf8(calldata_string(params, "new_name"));
 
-	QMetaObject::invokeMethod(window, "RenameProjector", Q_ARG(QString, oldName), Q_ARG(QString, newName));
+	QMetaObject::invokeMethod(window, &OBSProjector::RenameProjector, oldName, newName);
 }
 
 void OBSProjector::OBSSourceDestroyed(void *data, calldata_t *)
 {
 	OBSProjector *window = static_cast<OBSProjector *>(data);
-	QMetaObject::invokeMethod(window, "EscapeTriggered");
+	QMetaObject::invokeMethod(window, &OBSProjector::EscapeTriggered);
 }
 
 void OBSProjector::mouseDoubleClickEvent(QMouseEvent *event)

--- a/frontend/wizards/AutoConfigTestPage.cpp
+++ b/frontend/wizards/AutoConfigTestPage.cpp
@@ -104,7 +104,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	TestMode testMode;
 	testMode.SetVideo(128, 128, 60, 1);
 
-	QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, 0));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, 0);
 
 	/*
 	 * create encoders
@@ -112,7 +112,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	 * test for 10 seconds
 	 */
 
-	QMetaObject::invokeMethod(this, "UpdateMessage", Q_ARG(QString, QStringLiteral("")));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage, QStringLiteral(""));
 
 	/* -----------------------------------*/
 	/* create obs objects                 */
@@ -245,7 +245,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 
 		/* If none, fail */
 		if (!output_type) {
-			QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_BW_NO_OUTPUT)));
+			QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_BW_NO_OUTPUT));
 			return;
 		}
 	}
@@ -320,9 +320,9 @@ void AutoConfigTestPage::TestBandwidthThread()
 		stopped = false;
 
 		int per = int((i + 1) * 100 / servers.size());
-		QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, per));
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_BW_CONNECTING).arg(server.name.c_str())));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, per);
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_BW_CONNECTING).arg(server.name.c_str()));
 
 		obs_data_set_string(service_settings, "server", server.address.c_str());
 		obs_service_update(service, service_settings);
@@ -346,8 +346,8 @@ void AutoConfigTestPage::TestBandwidthThread()
 		if (!connected)
 			continue;
 
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_BW_SERVER).arg(server.name.c_str())));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_BW_SERVER).arg(server.name.c_str()));
 
 		/* ignore first 2.5 seconds due to possible buffering skewing
 		 * the result */
@@ -393,7 +393,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	}
 
 	if (!success) {
-		QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_BW_CONNECT_FAIL)));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_BW_CONNECT_FAIL));
 		return;
 	}
 
@@ -417,7 +417,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	wiz->serverName = std::move(bestServerName);
 	wiz->idealBitrate = bestBitrate;
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 /* this is used to estimate the lower bitrate limit for a given
@@ -477,7 +477,7 @@ static void CalcBaseRes(int &baseCX, int &baseCY)
 bool AutoConfigTestPage::TestSoftwareEncoding()
 {
 	TestMode testMode;
-	QMetaObject::invokeMethod(this, "UpdateMessage", Q_ARG(QString, QStringLiteral("")));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage, QStringLiteral(""));
 
 	/* -----------------------------------*/
 	/* create obs objects                 */
@@ -575,7 +575,7 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 
 	auto testRes = [&](int cy, int fps_num, int fps_den, bool force) {
 		int per = ++i * 100 / count;
-		QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, per));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, per);
 
 		if (cy > baseCY)
 			return true;
@@ -616,15 +616,15 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 
 		QString fpsStr = (fps_den > 1) ? QString::number(fps, 'f', 2) : QString::number(fps, 'g', 2);
 
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_RES_VAL).arg(cxStr, cyStr, fpsStr)));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_RES_VAL).arg(cxStr, cyStr, fpsStr));
 
 		unique_lock<mutex> ul(m);
 		if (cancel)
 			return false;
 
 		if (!obs_output_start(output)) {
-			QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_RES_FAIL)));
+			QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_RES_FAIL));
 			return false;
 		}
 
@@ -866,7 +866,7 @@ void AutoConfigTestPage::TestStreamEncoderThread()
 	if (preferHardware && !softwareTested && wiz->hardwareEncodingAvailable)
 		FindIdealHardwareResolution();
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 void AutoConfigTestPage::TestRecordingEncoderThread()
@@ -904,7 +904,7 @@ void AutoConfigTestPage::TestRecordingEncoderThread()
 		}
 	}
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 #define ENCODER_TEXT(x) "Basic.Settings.Output.Simple.Encoder." x

--- a/frontend/wizards/AutoConfigTestPage.cpp
+++ b/frontend/wizards/AutoConfigTestPage.cpp
@@ -103,7 +103,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	TestMode testMode;
 	testMode.SetVideo(128, 128, 60, 1);
 
-	QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, 0));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, 0);
 
 	/*
 	 * create encoders
@@ -111,7 +111,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	 * test for 10 seconds
 	 */
 
-	QMetaObject::invokeMethod(this, "UpdateMessage", Q_ARG(QString, QStringLiteral("")));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage, QStringLiteral(""));
 
 	/* -----------------------------------*/
 	/* create obs objects                 */
@@ -247,7 +247,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 
 		/* If none, fail */
 		if (!output_type) {
-			QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_BW_NO_OUTPUT)));
+			QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_BW_NO_OUTPUT));
 			return;
 		}
 	}
@@ -322,9 +322,9 @@ void AutoConfigTestPage::TestBandwidthThread()
 		stopped = false;
 
 		int per = int((i + 1) * 100 / servers.size());
-		QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, per));
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_BW_CONNECTING).arg(server.name.c_str())));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, per);
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_BW_CONNECTING).arg(server.name.c_str()));
 
 		obs_data_set_string(service_settings, "server", server.address.c_str());
 		obs_service_update(service, service_settings);
@@ -351,8 +351,8 @@ void AutoConfigTestPage::TestBandwidthThread()
 			continue;
 		}
 
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_BW_SERVER).arg(server.name.c_str())));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_BW_SERVER).arg(server.name.c_str()));
 
 		/* ignore first 2.5 seconds due to possible buffering skewing
 		 * the result */
@@ -401,7 +401,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	}
 
 	if (!success) {
-		QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_BW_CONNECT_FAIL)));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_BW_CONNECT_FAIL));
 		return;
 	}
 
@@ -425,7 +425,7 @@ void AutoConfigTestPage::TestBandwidthThread()
 	wiz->serverName = std::move(bestServerName);
 	wiz->idealBitrate = bestBitrate;
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 /* this is used to estimate the lower bitrate limit for a given
@@ -485,7 +485,7 @@ static void CalcBaseRes(int &baseCX, int &baseCY)
 bool AutoConfigTestPage::TestSoftwareEncoding()
 {
 	TestMode testMode;
-	QMetaObject::invokeMethod(this, "UpdateMessage", Q_ARG(QString, QStringLiteral("")));
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage, QStringLiteral(""));
 
 	/* -----------------------------------*/
 	/* create obs objects                 */
@@ -583,7 +583,7 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 
 	auto testRes = [&](int cy, int fps_num, int fps_den, bool force) {
 		int per = ++i * 100 / count;
-		QMetaObject::invokeMethod(this, "Progress", Q_ARG(int, per));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::Progress, per);
 
 		if (cy > baseCY) {
 			return true;
@@ -628,8 +628,8 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 
 		QString fpsStr = (fps_den > 1) ? QString::number(fps, 'f', 2) : QString::number(fps, 'g', 2);
 
-		QMetaObject::invokeMethod(this, "UpdateMessage",
-					  Q_ARG(QString, QTStr(TEST_RES_VAL).arg(cxStr, cyStr, fpsStr)));
+		QMetaObject::invokeMethod(this, &AutoConfigTestPage::UpdateMessage,
+					  QTStr(TEST_RES_VAL).arg(cxStr, cyStr, fpsStr));
 
 		unique_lock<mutex> ul(m);
 		if (cancel) {
@@ -637,7 +637,7 @@ bool AutoConfigTestPage::TestSoftwareEncoding()
 		}
 
 		if (!obs_output_start(output)) {
-			QMetaObject::invokeMethod(this, "Failure", Q_ARG(QString, QTStr(TEST_RES_FAIL)));
+			QMetaObject::invokeMethod(this, &AutoConfigTestPage::Failure, QTStr(TEST_RES_FAIL));
 			return false;
 		}
 
@@ -913,7 +913,7 @@ void AutoConfigTestPage::TestStreamEncoderThread()
 		FindIdealHardwareResolution();
 	}
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 void AutoConfigTestPage::TestRecordingEncoderThread()
@@ -953,7 +953,7 @@ void AutoConfigTestPage::TestRecordingEncoderThread()
 		}
 	}
 
-	QMetaObject::invokeMethod(this, "NextStage");
+	QMetaObject::invokeMethod(this, &AutoConfigTestPage::NextStage);
 }
 
 #define ENCODER_TEXT(x) "Basic.Settings.Output.Simple.Encoder." x

--- a/plugins/frontend-tools/scripts.cpp
+++ b/plugins/frontend-tools/scripts.cpp
@@ -634,7 +634,7 @@ static void script_log(void *, obs_script_t *script, int log_level, const char *
 		qmsg = QStringLiteral("[Unknown Script] %1").arg(message);
 	}
 
-	QMetaObject::invokeMethod(scriptLogWindow, "AddLogMsg", Q_ARG(int, log_level), Q_ARG(QString, qmsg));
+	QMetaObject::invokeMethod(scriptLogWindow, &ScriptLogWindow::AddLogMsg, log_level, qmsg);
 }
 
 extern "C" void InitScripts()

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -204,7 +204,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, obs_object_t *obj, Prope
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesReloadCallback reloadCallback,
@@ -220,7 +220,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesRel
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_, PropertiesReloadCallback reloadCallback_,
@@ -233,7 +233,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_, Prope
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 void OBSPropertiesView::SetDisabled(bool disabled)
@@ -1395,8 +1395,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 	stack->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	combo->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	auto comboIndexChanged = static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged);
-	connect(combo, comboIndexChanged, stack, [=](int index) {
+	connect(combo, &QComboBox::currentIndexChanged, stack, [=](int index) {
 		bool out_of_bounds = index >= stack->count();
 		auto idx = out_of_bounds ? stack->count() - 1 : index;
 		stack->setCurrentIndex(idx);
@@ -1408,29 +1407,28 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		emit info->ControlChanged();
 	});
 
-	connect(widget->simpleFPS, comboIndexChanged, info, [=](int) {
+	connect(widget->simpleFPS, &QComboBox::currentIndexChanged, info, [=](int) {
 		if (widget->updating)
 			return;
 
 		emit info->ControlChanged();
 	});
 
-	connect(widget->fpsRange, comboIndexChanged, info, [=](int) {
+	connect(widget->fpsRange, &QComboBox::currentIndexChanged, info, [=](int) {
 		if (widget->updating)
 			return;
 
 		UpdateFPSLabels(widget);
 	});
 
-	auto sbValueChanged = static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged);
-	connect(widget->numEdit, sbValueChanged, info, [=](int) {
+	connect(widget->numEdit, &QSpinBox::valueChanged, info, [=](int) {
 		if (widget->updating)
 			return;
 
 		emit info->ControlChanged();
 	});
 
-	connect(widget->denEdit, sbValueChanged, info, [=](int) {
+	connect(widget->denEdit, &QSpinBox::valueChanged, info, [=](int) {
 		if (widget->updating)
 			return;
 
@@ -1950,7 +1948,7 @@ void WidgetInfo::ButtonClicked()
 	OBSObject strongObj = view->GetObject();
 	void *obj = strongObj ? strongObj.Get() : view->rawObj;
 	if (obs_property_button_clicked(property, obj)) {
-		QMetaObject::invokeMethod(view, "RefreshProperties", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(view, &OBSPropertiesView::RefreshProperties, Qt::QueuedConnection);
 	}
 }
 
@@ -2052,7 +2050,7 @@ void WidgetInfo::ControlChanged()
 
 	if (obs_property_modified(property, view->settings)) {
 		view->lastFocused = setting;
-		QMetaObject::invokeMethod(view, "RefreshProperties", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(view, &OBSPropertiesView::RefreshProperties, Qt::QueuedConnection);
 	}
 }
 

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -206,7 +206,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, obs_object_t *obj, Prope
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesReloadCallback reloadCallback,
@@ -221,7 +221,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, void *obj, PropertiesRel
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_, PropertiesReloadCallback reloadCallback_,
@@ -233,7 +233,7 @@ OBSPropertiesView::OBSPropertiesView(OBSData settings_, const char *type_, Prope
 	  minSize(minSize_)
 {
 	setFrameShape(QFrame::NoFrame);
-	QMetaObject::invokeMethod(this, "ReloadProperties", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(this, &OBSPropertiesView::ReloadProperties, Qt::QueuedConnection);
 }
 
 void OBSPropertiesView::SetDisabled(bool disabled)
@@ -1438,8 +1438,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 	stack->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	combo->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	auto comboIndexChanged = static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged);
-	connect(combo, comboIndexChanged, stack, [=](int index) {
+	connect(combo, &QComboBox::currentIndexChanged, stack, [=](int index) {
 		bool out_of_bounds = index >= stack->count();
 		auto idx = out_of_bounds ? stack->count() - 1 : index;
 		stack->setCurrentIndex(idx);
@@ -1452,7 +1451,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		emit info->ControlChanged();
 	});
 
-	connect(widget->simpleFPS, comboIndexChanged, info, [=](int) {
+	connect(widget->simpleFPS, &QComboBox::currentIndexChanged, info, [=](int) {
 		if (widget->updating) {
 			return;
 		}
@@ -1460,7 +1459,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		emit info->ControlChanged();
 	});
 
-	connect(widget->fpsRange, comboIndexChanged, info, [=](int) {
+	connect(widget->fpsRange, &QComboBox::currentIndexChanged, info, [=](int) {
 		if (widget->updating) {
 			return;
 		}
@@ -1468,8 +1467,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		UpdateFPSLabels(widget);
 	});
 
-	auto sbValueChanged = static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged);
-	connect(widget->numEdit, sbValueChanged, info, [=](int) {
+	connect(widget->numEdit, &QSpinBox::valueChanged, info, [=](int) {
 		if (widget->updating) {
 			return;
 		}
@@ -1477,7 +1475,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 		emit info->ControlChanged();
 	});
 
-	connect(widget->denEdit, sbValueChanged, info, [=](int) {
+	connect(widget->denEdit, &QSpinBox::valueChanged, info, [=](int) {
 		if (widget->updating) {
 			return;
 		}
@@ -2028,7 +2026,7 @@ void WidgetInfo::ButtonClicked()
 	OBSObject strongObj = view->GetObject();
 	void *obj = strongObj ? strongObj.Get() : view->rawObj;
 	if (obs_property_button_clicked(property, obj)) {
-		QMetaObject::invokeMethod(view, "RefreshProperties", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(view, &OBSPropertiesView::RefreshProperties, Qt::QueuedConnection);
 	}
 }
 
@@ -2136,7 +2134,7 @@ void WidgetInfo::ControlChanged()
 
 	if (obs_property_modified(property, view->settings)) {
 		view->lastFocused = setting;
-		QMetaObject::invokeMethod(view, "RefreshProperties", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(view, &OBSPropertiesView::RefreshProperties, Qt::QueuedConnection);
 	}
 }
 

--- a/shared/properties-view/properties-view.hpp
+++ b/shared/properties-view/properties-view.hpp
@@ -59,7 +59,7 @@ public:
 	{
 		if (update_timer) {
 			update_timer->stop();
-			QMetaObject::invokeMethod(update_timer, "timeout");
+			QMetaObject::invokeMethod(update_timer, &QTimer::stop);
 			update_timer->deleteLater();
 		}
 	}

--- a/shared/qt/wrappers/qt-wrappers.cpp
+++ b/shared/qt/wrappers/qt-wrappers.cpp
@@ -216,7 +216,7 @@ void ExecuteFuncSafeBlock(std::function<void()> func)
 
 	auto wait = [&]() {
 		func();
-		QMetaObject::invokeMethod(&eventLoop, "quit", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&eventLoop, &QEventLoop::quit, Qt::QueuedConnection);
 	};
 
 	os_atomic_inc_long(&insideEventLoop);
@@ -237,7 +237,7 @@ void ExecuteFuncSafeBlockMsgBox(std::function<void()> func, const QString &title
 
 	auto wait = [&]() {
 		func();
-		QMetaObject::invokeMethod(&dlg, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&dlg, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 
 	os_atomic_inc_long(&insideEventLoop);

--- a/shared/qt/wrappers/qt-wrappers.cpp
+++ b/shared/qt/wrappers/qt-wrappers.cpp
@@ -225,7 +225,7 @@ void ExecuteFuncSafeBlock(std::function<void()> func)
 
 	auto wait = [&]() {
 		func();
-		QMetaObject::invokeMethod(&eventLoop, "quit", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&eventLoop, &QEventLoop::quit, Qt::QueuedConnection);
 	};
 
 	os_atomic_inc_long(&insideEventLoop);
@@ -246,7 +246,7 @@ void ExecuteFuncSafeBlockMsgBox(std::function<void()> func, const QString &title
 
 	auto wait = [&]() {
 		func();
-		QMetaObject::invokeMethod(&dlg, "accept", Qt::QueuedConnection);
+		QMetaObject::invokeMethod(&dlg, &QMessageBox::accept, Qt::QueuedConnection);
 	};
 
 	os_atomic_inc_long(&insideEventLoop);


### PR DESCRIPTION
### Description
Updates all frontend uses of `invokeMethod` with function pointers or lambdas.

> [!IMPORTANT]  
> This PR is blocked until we drop support for Ubuntu 24.04 as this style of calling invokeMethod is not supported on Qt 6.5

### Motivation and Context
Makes it easier to update or refactor code without having to worry about string references to slot functions.

### How Has This Been Tested?
Compiled OBS and performed a few basic tests. I have not tested thoroughly yet.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
