### PR TITLE
frontend: Skip saveAll after closeWindow

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1931,7 +1931,9 @@ void OBSApp::commitData(QSessionManager &manager)
 {
 	OBSBasic *main = OBSBasic::Get();
 	if (main) {
-		main->saveAll();
+		if (!main->isClosing()) {
+			main->saveAll();
+		}
 
 		if (manager.allowsInteraction() && main->shouldPromptForClose()) {
 			manager.cancel();

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1849,7 +1849,9 @@ void OBSBasic::saveAll()
 				  saveGeometry().toBase64().constData());
 	}
 
-	Auth::Save();
+	if (!authDestroyedAfterSaveAll.load(std::memory_order_acquire)) {
+		Auth::Save();
+	}
 	SaveProjectNow();
 
 	config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState", saveState().toBase64().constData());
@@ -1971,6 +1973,7 @@ void OBSBasic::closeWindow()
 	saveAll();
 
 	auth.reset();
+	authDestroyedAfterSaveAll.store(true, std::memory_order_release);
 
 #ifdef BROWSER_AVAILABLE
 	ClearExtraBrowserDocks();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -340,6 +340,7 @@ signals:
 	 */
 private:
 	std::shared_ptr<Auth> auth;
+	std::atomic<bool> authDestroyedAfterSaveAll = false;
 
 public:
 	inline Auth *GetAuth() { return auth.get(); }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description

On the exit of OBS frontend, commitData can be called after closeWindow. Since closeWindow releases OBSBasic's resources, saveAll on commitData may write corrupted configuration.

This change adds a guard flag to prevent saveAll from saving destroyed auth settings.

### Motivation and Context

Creating a profile, connecting to YouTube, and closing the OBS frontend immediately results in removing Auth.Type in the profile's basic.ini. This is problematic for users because they cannot persist their connection with some specific procedure.

### How Has This Been Tested?

I have built it on my head branch on macOS Tahoe (arm64). I confirmed that create, connect, close flow saves correct configuration, and it is fixed to persist YouTube connection between runs.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
