### PR TITLE
frontend: Adjust shutdown logic more

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1916,7 +1916,7 @@ void OBSApp::processSigQuit()
 void OBSApp::commitData(QSessionManager &manager)
 {
 	OBSBasic *main = OBSBasic::Get();
-	if (main) {
+	if (main && !main->isClosing()) {
 		main->saveAll();
 
 		if (manager.allowsInteraction() && main->shouldPromptForClose()) {

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1266,20 +1266,6 @@ bool OBSApp::OBSInit()
 
 	mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 
-#ifndef __APPLE__
-	connect(QApplication::instance(), &QApplication::aboutToQuit, this, [this]() {
-		if (mainWindow) {
-			QPointer<OBSBasic> basicWindow = static_cast<OBSBasic *>(mainWindow.get());
-
-			basicWindow->closeWindow();
-		}
-
-		if (libobs_initialized) {
-			applicationShutdown();
-		}
-	});
-#endif
-
 	mainWindow->OBSInit();
 
 	connect(OBSBasic::Get(), &OBSBasic::mainWindowClosed, crashHandler_.get(),

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1267,20 +1267,6 @@ bool OBSApp::OBSInit()
 
 	mainWindow->setAttribute(Qt::WA_DeleteOnClose, true);
 
-#ifndef __APPLE__
-	connect(QApplication::instance(), &QApplication::aboutToQuit, this, [this]() {
-		if (mainWindow) {
-			QPointer<OBSBasic> basicWindow = static_cast<OBSBasic *>(mainWindow.get());
-
-			basicWindow->closeWindow();
-		}
-
-		if (libobs_initialized) {
-			applicationShutdown();
-		}
-	});
-#endif
-
 	mainWindow->OBSInit();
 
 	connect(OBSBasic::Get(), &OBSBasic::mainWindowClosed, crashHandler_.get(),

--- a/frontend/utility/NativeEventFilter_Windows.cpp
+++ b/frontend/utility/NativeEventFilter_Windows.cpp
@@ -37,16 +37,16 @@ bool NativeEventFilter::nativeEventFilter(const QByteArray &eventType, void *mes
 
 		switch (msg->message) {
 		case WM_QUERYENDSESSION:
-			main->saveAll();
-			if (msg->lParam == ENDSESSION_CRITICAL) {
-				break;
+			if (msg->lParam & ENDSESSION_CRITICAL) {
+				main->saveAll();
+				return false;
 			}
 
 			if (main->shouldPromptForClose()) {
 				if (result) {
 					*result = FALSE;
 				}
-				QTimer::singleShot(1, main, &OBSBasic::close);
+				QMetaObject::invokeMethod(main, "close", Qt::QueuedConnection);
 				return true;
 			}
 

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1385,12 +1385,7 @@ void OBSBasic::OnFirstLoad()
 		on_actionViewCurrentLog_triggered();
 }
 
-OBSBasic::~OBSBasic()
-{
-	if (!isClosing()) {
-		closeWindow();
-	}
-}
+OBSBasic::~OBSBasic() {}
 
 void OBSBasic::applicationShutdown() noexcept
 {


### PR DESCRIPTION
### Description
Removes our connections to Qt's aboutToQuit signal as well better handling the deferred close to the main window for WM_QUERYENDSESSION.

### Motivation and Context
Trying to fix shutdown crashes more. The aboutToQuit connections were set up early in my original shutdown logic PR and now that we have a nativeEventFilter for the Windows MSGs (Which is exactly the same thing aboutToQuit gets fired from), it no longer appears to be necessary (And indeed was causing some issues on macOS) and may only be causing problems in some cases.

We're still seeing some situations where OBSBasic is getting destroyed while already shutting down that may be attributable to this.

### How Has This Been Tested?
Shut down OBS various times, including with/without outputs active, and tried logging out in both scenarios.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
