### PR TITLE
win-capture: Restore linked audio when shown

### DIFF
--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -309,7 +309,7 @@ static inline float hook_rate_to_float(enum hook_rate rate)
 	}
 }
 
-static void stop_capture(struct game_capture *gc)
+static void stop_capture(struct game_capture *gc, bool clear_audio)
 {
 	ipc_pipe_server_free(&gc->pipe);
 
@@ -354,7 +354,7 @@ static void stop_capture(struct game_capture *gc)
 	if (gc->active)
 		info("capture stopped");
 
-	// if it was previously capturing, send an unhooked signal
+	/* if it was previously capturing, send an unhooked signal */
 	if (gc->capturing) {
 		gc->capturing = false;
 		signal_handler_t *sh = obs_source_get_signal_handler(gc->source);
@@ -363,8 +363,13 @@ static void stop_capture(struct game_capture *gc)
 		signal_handler_signal(sh, "unhooked", &data);
 		calldata_free(&data);
 
-		// Also update audio source to stop capturing
-		if (gc->audio_source)
+		/*
+		 * Clear linked WASAPI only on real unhooks. When the source is
+		 * merely no longer showing (scene transition finished), keep
+		 * the window target so Activate() can resume audio as soon as
+		 * the source is shown again, without waiting for hook_ready.
+		 */
+		if (clear_audio && gc->audio_source)
 			reconfigure_audio_source(gc->audio_source, NULL);
 	}
 
@@ -387,7 +392,7 @@ static inline void free_config(struct game_capture_config *config)
 static void game_capture_destroy(void *data)
 {
 	struct game_capture *gc = data;
-	stop_capture(gc);
+	stop_capture(gc, true);
 
 	if (gc->audio_source)
 		destroy_audio_source(gc->source, &gc->audio_source);
@@ -567,7 +572,7 @@ static void game_capture_update(void *data, obs_data_t *settings)
 
 	if (!gc->initial_config) {
 		if (reset_capture) {
-			stop_capture(gc);
+			stop_capture(gc, true);
 		}
 	} else {
 		gc->initial_config = false;
@@ -1185,7 +1190,7 @@ static void try_hook(struct game_capture *gc)
 		}
 
 		if (!init_hook(gc)) {
-			stop_capture(gc);
+			stop_capture(gc, true);
 		}
 	} else {
 		gc->active = false;
@@ -1712,7 +1717,7 @@ static void game_capture_tick(void *data, float seconds)
 	if (!obs_source_showing(gc->source)) {
 		if (gc->showing) {
 			if (gc->active)
-				stop_capture(gc);
+				stop_capture(gc, false);
 			gc->showing = false;
 		}
 		return;
@@ -1723,10 +1728,10 @@ static void game_capture_tick(void *data, float seconds)
 
 	if (gc->hook_stop && object_signalled(gc->hook_stop)) {
 		debug("hook stop signal received");
-		stop_capture(gc);
+		stop_capture(gc, true);
 	}
 	if (gc->active && deactivate) {
-		stop_capture(gc);
+		stop_capture(gc, true);
 	}
 
 	if (gc->active && !gc->hook_ready && gc->process_id) {
@@ -1745,7 +1750,7 @@ static void game_capture_tick(void *data, float seconds)
 
 		} else if (!gc->capturing) {
 			gc->retry_interval = ERROR_RETRY_INTERVAL * hook_rate_to_float(gc->config.hook_rate);
-			stop_capture(gc);
+			stop_capture(gc, true);
 		}
 	}
 
@@ -1782,7 +1787,7 @@ static void game_capture_tick(void *data, float seconds)
 		}
 		if (result != CAPTURE_RETRY && !gc->capturing) {
 			gc->retry_interval = ERROR_RETRY_INTERVAL * hook_rate_to_float(gc->config.hook_rate);
-			stop_capture(gc);
+			stop_capture(gc, true);
 		}
 	}
 
@@ -1799,7 +1804,7 @@ static void game_capture_tick(void *data, float seconds)
 		if (!capture_valid(gc)) {
 			info("capture window no longer exists, "
 			     "terminating capture");
-			stop_capture(gc);
+			stop_capture(gc, true);
 		} else {
 			if (gc->copy_texture) {
 				obs_enter_graphics();


### PR DESCRIPTION
stop_capture() clears the linked WASAPI target on unhook; audio was only reconfigured again from hook_ready, which can lag behind obs_source_showing during a scene fade. Reconfigure on the first tick we are shown again using gc->window or gc->next_window so process audio can mix with the transition.

Fixes https://github.com/obsproject/obs-studio/issues/13326


### Description
When Game Capture uses Capture Audio (BETA), the private WASAPI source is cleared in stop_capture() (on unhook) via reconfigure_audio_source(..., NULL). Linked audio was only pointed at the game window again from the hook_ready path. That can run after obs_source_showing is already true during a scene fade, so transition audio had nothing to mix until the hook finished—often matching “silent until the fade ends, then full volume.” Video could still fade because it does not depend on that timing.

On the first tick game capture is shown again (else if (!gc->showing) in game_capture_tick), the change reconfigures the linked WASAPI when Capture Audio is enabled and a valid HWND exists (gc->window or gc->next_window), using IsWindow() before calling reconfigure_audio_source.

### Motivation and Context
Fixes [obs-studio#13326](https://github.com/obsproject/obs-studio/issues/13326): audio does not fade in on a Fade scene transition when using Game Capture with Capture Audio (BETA); using Game Capture without capture audio plus a separate Application Audio Capture works because that path is not tied to hook teardown/reconfigure timing.

Standalone Application Audio does not go through game capture’s stop_capture / deferred hook_ready reconfigure, which is why the integrated path behaved differently.


### How Has This Been Tested?
 Two scenes: Scene A with Game Capture + Capture Audio (BETA) on a running game; Scene B empty; global Fade transition (~3000 ms). Scene A -> B -> A and confirm audio ramps with the fade instead of popping at the end.

 Toggle Capture Audio off/on; rename the Game Capture source; confirm no crash or obvious regression.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
