### PR TITLE
Add Girls Gone Game streaming service

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3586,6 +3586,27 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Girls Gone Game",
+            "common": false,
+            "more_info_link": "https://girlsgonegame.com",
+            "stream_key_link": "https://girlsgonegame.com/streamer-dashboard/key",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmps://47e4f15676e4.global-contribute.live-video.net:443/app"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 160,
+                "x264opts": "scenecut=0"
+            },
+            "supported video codecs": [
+                "h264"
+            ]
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds Girls Gone Game (https://girlsgonegame.com) as a service in `services.json` so streamers can select "Girls Gone Game" from the Service dropdown instead of using "Custom" with a manually-pasted URL and key.

The platform is a live-streaming service for female streamers. Streaming is backed by AWS IVS (Interactive Video Service) using Standard latency channels.

### Motivation and Context
Reduces friction for streamers onboarding to the platform. Today they have to copy/paste both the RTMPS server URL and stream key into OBS's "Custom" service. Many streamers are non-technical and find that error-prone. Native integration also means OBS can surface our recommended encoder settings automatically.

### How Has This Been Tested?
- JSON validates against the v5 schema in this repo.
- Diff is a clean 21-line addition with no edits to existing entries.
- Test stream key available on request to a maintainer for ingest verification.
- Verified locally that OBS picks up the new service entry from the dropdown.

### Types of changes
- [x] New service support (`services.json` entry only — no code changes)

### Service details
- **Protocol:** RTMPS
- **Ingest endpoint:** `rtmps://47e4f15676e4.global-contribute.live-video.net:443/app`
- **Backend:** AWS IVS Standard channels (h264, max 6 Mbps video / 160 kbps audio, 2s keyframe)
- **`recommended` settings** match the AWS IVS documented input limits.