### PR TITLE
fix: Supress a Settings UI Streching

### DIFF
--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -3285,7 +3285,7 @@
                            <item row="0" column="1">
                             <widget class="QStackedWidget" name="advStreamTrackWidget">
                              <property name="sizePolicy">
-                              <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
                                <horstretch>0</horstretch>
                                <verstretch>0</verstretch>
                               </sizepolicy>


### PR DESCRIPTION
change `advStreamTrackWidget`'s vsizetype from `Preferred` to `Fixed` which prevent this item stretching in vertical direction

### Description
Settings > Output > Output Mode: Advance > Streaming > Streaming Settings > Audio Track
The options would stretch in vertical direction when the window is very height. Now it has a fixed height.

before:
<img width="1228" height="1556" alt="image" src="https://github.com/user-attachments/assets/c85aef25-c8cd-4c58-9d24-e26416bf94c7" />

after:
<img width="1228" height="1546" alt="image" src="https://github.com/user-attachments/assets/a738d2ef-4aee-4e38-9579-a1875016d6a6" />

### Motivation and Context
Issue: /issues/13286

### How Has This Been Tested?
I run it on my Windows 10 laptop and I see it works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
