### PR TITLE
Fix: Behavior of hotkeys more like other apps now

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1033,27 +1033,31 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 }
 
 static inline void handle_binding(obs_hotkey_binding_t *binding, uint32_t modifiers, bool no_press,
-				  bool strict_modifiers, bool *pressed)
+				  bool strict_modifiers)
 {
 	bool modifiers_match_ = modifiers_match(binding, modifiers, strict_modifiers);
 	bool modifiers_only = binding->key.key == OBS_KEY_NONE;
+	bool no_modifiers = binding->key.modifiers == 0;
 
-	if (!strict_modifiers && !binding->key.modifiers)
+	if (!strict_modifiers && no_modifiers)
 		binding->modifiers_match = true;
 
-	if (modifiers_only)
-		pressed = &modifiers_only;
-
-	if (!binding->key.modifiers && modifiers_only)
+	if (!modifiers_only && !is_pressed(binding->key.key))
 		goto reset;
 
-	if ((!binding->modifiers_match && !modifiers_only) || !modifiers_match_)
+	if (no_modifiers && modifiers_only)
 		goto reset;
 
-	if ((pressed && !*pressed) || (!pressed && !is_pressed(binding->key.key)))
+	if (!binding->modifiers_match && !modifiers_only)
 		goto reset;
 
-	if (binding->pressed || no_press)
+	if (!modifiers_match_)
+		goto reset;
+
+	if (binding->pressed)
+		return;
+
+	if (no_press)
 		return;
 
 	press_released_binding(binding);
@@ -1127,7 +1131,7 @@ static inline bool query_hotkey(void *data, size_t idx, obs_hotkey_binding_t *bi
 	UNUSED_PARAMETER(idx);
 
 	struct obs_query_hotkeys_helper *param = (struct obs_query_hotkeys_helper *)data;
-	handle_binding(binding, param->modifiers, param->no_press, param->strict_modifiers, NULL);
+	handle_binding(binding, param->modifiers, param->no_press, param->strict_modifiers);
 
 	return true;
 }

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -990,13 +990,12 @@ void obs_enum_hotkey_bindings(obs_hotkey_binding_enum_func func, void *data)
 	unlock();
 }
 
-static inline bool modifiers_match(obs_hotkey_binding_t *binding, uint32_t modifiers_, bool strict_modifiers)
+static inline bool input_match_modifiers(uint32_t input_modifiers, uint32_t hotkey_modifiers, bool is_strict)
 {
-	uint32_t modifiers = binding->key.modifiers;
-	if (!strict_modifiers)
-		return (modifiers & modifiers_) == modifiers;
+	if (is_strict)
+		return input_modifiers == hotkey_modifiers;
 	else
-		return modifiers == modifiers_;
+		return (input_modifiers & hotkey_modifiers) == hotkey_modifiers;
 }
 
 static inline bool is_pressed(obs_key_t key)
@@ -1035,7 +1034,7 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 static inline void handle_binding(obs_hotkey_binding_t *binding, uint32_t modifiers, bool no_press,
 				  bool strict_modifiers)
 {
-	bool modifiers_match_ = modifiers_match(binding, modifiers, strict_modifiers);
+	bool modifiers_match_ = input_match_modifiers(binding->key.modifiers, modifiers, strict_modifiers);
 	bool modifiers_only = binding->key.key == OBS_KEY_NONE;
 	bool no_modifiers = binding->key.modifiers == 0;
 
@@ -1082,7 +1081,7 @@ static inline bool inject_hotkey(void *data, size_t idx, obs_hotkey_binding_t *b
 	UNUSED_PARAMETER(idx);
 	struct obs_hotkey_internal_inject *event = data;
 
-	if (modifiers_match(binding, event->hotkey.modifiers, event->strict_modifiers)) {
+	if (input_match_modifiers(binding->key.modifiers, event->hotkey.modifiers, event->strict_modifiers)) {
 		bool pressed = binding->key.key == event->hotkey.key && event->pressed;
 		if (binding->key.key == OBS_KEY_NONE)
 			pressed = true;

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -1031,43 +1031,48 @@ static inline void release_pressed_binding(obs_hotkey_binding_t *binding)
 		obs->hotkeys.router_func(obs->hotkeys.router_func_data, hotkey->id, false);
 }
 
-static inline void handle_binding(obs_hotkey_binding_t *binding, uint32_t modifiers, bool no_press,
-				  bool strict_modifiers)
+static inline void handle_binding(obs_hotkey_binding_t *binding, uint32_t input_modifiers, bool no_press,
+				  bool is_strict)
 {
-	bool modifiers_match_ = input_match_modifiers(binding->key.modifiers, modifiers, strict_modifiers);
-	bool modifiers_only = binding->key.key == OBS_KEY_NONE;
-	bool no_modifiers = binding->key.modifiers == 0;
-
-	if (!strict_modifiers && no_modifiers)
-		binding->modifiers_match = true;
-
-	if (!modifiers_only && !is_pressed(binding->key.key))
-		goto reset;
-
-	if (no_modifiers && modifiers_only)
-		goto reset;
-
-	if (!binding->modifiers_match && !modifiers_only)
-		goto reset;
-
-	if (!modifiers_match_)
-		goto reset;
-
-	if (binding->pressed)
-		return;
-
 	if (no_press)
 		return;
 
-	press_released_binding(binding);
-	return;
+	uint32_t hotkey_modifiers = binding->key.modifiers;
+	obs_key_t hotkey_key = binding->key.key;
 
-reset:
-	binding->modifiers_match = modifiers_match_;
-	if (!binding->pressed)
+	bool has_modifiers = hotkey_modifiers != 0;
+	bool has_key = hotkey_key != OBS_KEY_NONE;
+	assert(has_modifiers || has_key);
+
+	bool modifiers_matched = true;
+	if (has_modifiers)
+		modifiers_matched = input_match_modifiers(input_modifiers, hotkey_modifiers, is_strict);
+
+	bool prev_pressing_key = binding->pressing_key;
+	bool key_matched = true;
+	if (has_key)
+		key_matched = binding->pressing_key = is_pressed(hotkey_key);
+
+	// Check if the pressed hotkey release in this query
+	bool all_matched = modifiers_matched && key_matched;
+	if (binding->pressed) {
+		if (all_matched)
+			return;
+
+		release_pressed_binding(binding);
+		return;
+	}
+
+	// Check if the released hotkey is pressed in this query
+	// Key should be pressed after modifiers
+	if (prev_pressing_key)
 		return;
 
-	release_pressed_binding(binding);
+	// Not pressed
+	if (!all_matched)
+		return;
+
+	press_released_binding(binding);
 }
 
 struct obs_hotkey_internal_inject {
@@ -1087,7 +1092,6 @@ static inline bool inject_hotkey(void *data, size_t idx, obs_hotkey_binding_t *b
 			pressed = true;
 
 		if (pressed) {
-			binding->modifiers_match = true;
 			if (!binding->pressed)
 				press_released_binding(binding);
 		}

--- a/libobs/obs-internal.h
+++ b/libobs/obs-internal.h
@@ -256,8 +256,8 @@ void obs_hotkeys_free(void);
 
 struct obs_hotkey_binding {
 	obs_key_combination_t key;
+	bool pressing_key;
 	bool pressed;
-	bool modifiers_match;
 
 	obs_hotkey_id hotkey_id;
 	obs_hotkey_t *hotkey;


### PR DESCRIPTION
### Description
Hotkeys could trigger in unexpected way before:
- When holding a hotkey combination, press a modifier key (<kbd>Ctrl</kbd>, <kbd>Alt</kbd>, <kbd>Shift</kbd>, <kbd>Win</kbd> for Windows, <kbd>⌘</kbd> for macOS, and super key for Linux) would trigger the hotkey.
- A hotkey with modifier keys and a common key can be triggered no matter press modifier keys first or last. For most of apps, hotkey should only be triggered when modifier keys be pressed first.

### Motivation and Context
https://github.com/obsproject/obs-studio/issues/13091

### How Has This Been Tested?
I ran it on my Windows 10 laptop and see it works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
