### PR TITLE
libobs: Fix initialize peak values using absolute value in get peak functions

### DIFF
--- a/libobs/obs-audio-controls.c
+++ b/libobs/obs-audio-controls.c
@@ -328,7 +328,7 @@ static float get_true_peak(__m128 previous_samples, const float *samples, size_t
 	const __m128 p3 = _mm_set_ps(-0.103943f, 0.233872f, 0.935489f, -0.155915f);
 
 	__m128 work = previous_samples;
-	__m128 peak = previous_samples;
+	__m128 peak = abs_ps(previous_samples);
 	for (size_t i = 0; (i + 3) < nr_samples; i += 4) {
 		__m128 new_work = _mm_load_ps(&samples[i]);
 		__m128 intrp_samples;
@@ -365,7 +365,7 @@ static float get_true_peak(__m128 previous_samples, const float *samples, size_t
  */
 static float get_sample_peak(__m128 previous_samples, const float *samples, size_t nr_samples)
 {
-	__m128 peak = previous_samples;
+	__m128 peak = abs_ps(previous_samples);
 	for (size_t i = 0; (i + 3) < nr_samples; i += 4) {
 		__m128 new_work = _mm_load_ps(&samples[i]);
 		peak = _mm_max_ps(peak, abs_ps(new_work));


### PR DESCRIPTION
### Description
Bug fix in libobs audio controls.
- In `get_true_peak` function, `peak` was initialized with the signed value of `previous_samples` but the function should return the absolute peak value of `previous_samples`, `samples` and `interp_samples` . So I initialized it with absolute value of `previous_samples` .
- In `get_sample_peak`, `peak` was initialized with the signed value of `previous_samples` but the function should return the absolute peak value of `previous_samples` and `samples`. So I initialized it with absolute value of `previous_samples` .

### Motivation and Context
The volmeter (true-peak and sample-peak paths) must consider the absolute magnitude of the four carried samples from the previous buffer when computing the peak for the current buffer. Initializing the peak accumulator with signed values led to incorrect final peak values in some cases. Fixing the initialization to use absolute values makes peak detection correct across buffer boundaries.

### How Has This Been Tested?
- Reviewed the full git range diff and validated that changes are limited to `libobs/obs-audio-controls.c` .
- Verified no function signatures, struct layouts, or public interfaces were modified. 

Testing environment:
-  OS: Windows
- Repository: local obs-studio checkout

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation (None needed)