### PR TITLE
frontend: Fix a crash when user cancels to save changes in settings

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -1612,7 +1612,10 @@ void OBSBasicSettings::LoadResolutionLists()
 	RecalcOutputResPixels(outputResString.c_str());
 	ResetDownscales(cx, cy);
 
-	ui->outputResolution->lineEdit()->setText(outputResString.c_str());
+	// No guarantee that outputResolution is editable, e.g., Facebook Live.
+	if (ui->outputResolution->isEditable()) {
+		ui->outputResolution->lineEdit()->setText(outputResString.c_str());
+	}
 
 	std::tuple<int, int> aspect = aspect_ratio(cx, cy);
 


### PR DESCRIPTION
### Description
Settings > Video > Output (Scaled) Resolution is a `QComboBox`, which has a dropdown and may be editable or not. If some settings make it not editable meanwhile change its value, when user tries to close settings window and select "No". OBS always tries to write preview value back, even if it is not editable now. This will cause a crush.

This PR adds a check of `nullptr` so it won't cause a crush anymore.

### Motivation and Context
#13367

### How Has This Been Tested?
1. Switch Settings > Stream > Service to "YouTube - RTMPS".
2. Write "3840x2160" in Settings > Video > Output (Scaled) Resolution .
3. Switch Settings > Stream > Service to "Facebook Live".
4. In the pop-up window, select "Yes" to accept changing resolution to 1920x1080.
5. Click X to close settings window.
6. In the pop-up window, select "No" to cancel saving changes.
7. OBS won't crash anymore.
8. Open the settings again. The settings don't change, as it wasn't be changed.

- OS: Windows 10
- OBS Studio version: 32.1.2

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
