### PR TITLE
frontend, libobs: Fix volume control state desync

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -95,10 +95,11 @@ VolumeControl::VolumeControl(obs_source_t *source, QWidget *parent, bool vertica
 
 	volumeMeter = new VolumeMeter(this, source);
 
-	bool muted = obs_source_muted(source);
+	obsMuted = obs_source_muted(source);
 	bool unassigned = isSourceUnassigned(source);
+	obsMonitoringType = obs_source_get_monitoring_type(source);
 
-	volumeMeter->setMuted(muted || unassigned);
+	volumeMeter->setMuted(obsMuted || unassigned);
 
 	setLayoutVertical(vertical);
 	setName(sourceName);
@@ -107,10 +108,8 @@ VolumeControl::VolumeControl(obs_source_t *source, QWidget *parent, bool vertica
 
 	obsSignals.reserve(9);
 	obsSignals.emplace_back(obs_source_get_signal_handler(source), "mute", obsVolumeMuted, this);
-	obsSignals.emplace_back(obs_source_get_signal_handler(source), "audio_mixers", obsMixersOrMonitoringChanged,
-				this);
-	obsSignals.emplace_back(obs_source_get_signal_handler(source), "audio_monitoring", obsMixersOrMonitoringChanged,
-				this);
+	obsSignals.emplace_back(obs_source_get_signal_handler(source), "audio_mixers", obsMixersChanged, this);
+	obsSignals.emplace_back(obs_source_get_signal_handler(source), "audio_monitoring", obsMonitoringChanged, this);
 	obsSignals.emplace_back(obs_source_get_signal_handler(source), "activate", VolumeControl::obsSourceActivated,
 				this);
 	obsSignals.emplace_back(obs_source_get_signal_handler(source), "deactivate",
@@ -151,7 +150,7 @@ VolumeControl::VolumeControl(obs_source_t *source, QWidget *parent, bool vertica
 	// Call volume changed once to init the slider position and label
 	changeVolume();
 
-	updateMixerState();
+	processMixerState();
 }
 
 VolumeControl::~VolumeControl()
@@ -202,17 +201,26 @@ void VolumeControl::obsVolumeChanged(void *data, float)
 	QMetaObject::invokeMethod(volControl, "changeVolume", Qt::QueuedConnection);
 }
 
-void VolumeControl::obsVolumeMuted(void *data, calldata_t *)
+void VolumeControl::obsVolumeMuted(void *data, calldata_t *params)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
+	bool muted = calldata_bool(params, "muted");
 
-	QMetaObject::invokeMethod(volControl, "updateMixerState", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, "onMuteChanged", Qt::QueuedConnection, Q_ARG(bool, muted));
 }
 
-void VolumeControl::obsMixersOrMonitoringChanged(void *data, calldata_t *)
+void VolumeControl::obsMixersChanged(void *data, calldata_t *)
 {
 	VolumeControl *volControl = static_cast<VolumeControl *>(data);
-	QMetaObject::invokeMethod(volControl, "updateMixerState", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(volControl, "processMixerState", Qt::QueuedConnection);
+}
+
+void VolumeControl::obsMonitoringChanged(void *data, calldata_t *params)
+{
+	VolumeControl *volControl = static_cast<VolumeControl *>(data);
+	auto type = static_cast<int>(calldata_int(params, "type"));
+
+	QMetaObject::invokeMethod(volControl, "onMonitoringChanged", Qt::QueuedConnection, Q_ARG(int, type));
 }
 
 void VolumeControl::obsSourceActivated(void *data, calldata_t *)
@@ -594,6 +602,18 @@ void VolumeControl::setLocked(bool locked)
 	emit main->mixerStatusChanged(uuid);
 }
 
+void VolumeControl::onMuteChanged(bool muted)
+{
+	obsMuted = muted;
+	processMixerState();
+}
+
+void VolumeControl::onMonitoringChanged(int type)
+{
+	obsMonitoringType = static_cast<obs_monitoring_type>(type);
+	processMixerState();
+}
+
 void VolumeControl::updateCategoryLabel()
 {
 	QString labelText = QTStr("Basic.AudioMixer.Category.Active");
@@ -724,14 +744,15 @@ void VolumeControl::setMonitoring(obs_monitoring_type type)
 
 void VolumeControl::sourceActiveChanged(bool active)
 {
-	setUseDisabledColors(!active);
+	processMixerState();
+
 	mixerStatus().set(VolumeControl::MixerStatus::Active, active);
 
 	OBSBasic *main = OBSBasic::Get();
 	emit main->mixerStatusChanged(uuid);
 }
 
-void VolumeControl::updateMixerState()
+void VolumeControl::processMixerState()
 {
 	OBSSource source = OBSGetStrongRef(weakSource());
 	if (!source) {
@@ -739,9 +760,7 @@ void VolumeControl::updateMixerState()
 		return;
 	}
 
-	bool muted = obs_source_muted(source);
 	bool unassigned = isSourceUnassigned(source);
-	obs_monitoring_type monitoringType = obs_source_get_monitoring_type(source);
 
 	bool isActive = obs_source_active(source) && obs_source_audio_active(source);
 
@@ -751,9 +770,9 @@ void VolumeControl::updateMixerState()
 	QSignalBlocker blockMute(muteButton);
 	QSignalBlocker blockMonitor(monitorButton);
 
-	bool showAsMuted = muted || monitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY;
-	bool showAsMonitored = !muted && monitoringType != OBS_MONITORING_TYPE_NONE;
-	bool showAsUnassigned = !muted && unassigned;
+	bool showAsMuted = obsMuted || obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY;
+	bool showAsMonitored = obsMonitoringType != OBS_MONITORING_TYPE_NONE;
+	bool showAsUnassigned = !obsMuted && unassigned;
 
 	volumeMeter->setMuted((showAsMuted || showAsUnassigned) && !showAsMonitored);
 	setUseDisabledColors(showAsMuted || !isActive);
@@ -805,11 +824,10 @@ void VolumeControl::handleMuteButton(bool mute)
 	// The Mute and Monitor buttons in the volume mixer work as a pseudo quad-state toggle.
 	// Both buttons must be in their "off" state in order to actually process it as a mute.
 	// Otherwise, clicking "Mute" with monitoring enabled will toggle the monitoring type.
-	obs_monitoring_type monitoringType = obs_source_get_monitoring_type(source);
 
-	if (mute && monitoringType == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT) {
+	if (mute && obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT) {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
-	} else if (!mute && monitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
+	} else if (!mute && obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
 	} else {
 		setMuted(mute);
@@ -825,19 +843,16 @@ void VolumeControl::handleMonitorButton(bool enableMonitoring)
 
 	// The Mute and Monitor buttons in the volume mixer work as a pseudo quad-state toggle.
 	// The source is only ever actually "Muted" if Monitoring is set to None.
-	obs_monitoring_type monitoringType = obs_source_get_monitoring_type(source);
-
-	bool muted = obs_source_muted(source);
 
 	if (!enableMonitoring) {
 		setMonitoring(OBS_MONITORING_TYPE_NONE);
-		if (monitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
+		if (obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
 			setMuted(true);
 		}
-	} else if (enableMonitoring && muted) {
+	} else if (enableMonitoring && obsMuted) {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
 		setMuted(false);
-	} else if (enableMonitoring && !muted) {
+	} else if (enableMonitoring && !obsMuted) {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
 	}
 }

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -816,43 +816,27 @@ void VolumeControl::processMixerState()
 
 void VolumeControl::handleMuteButton(bool mute)
 {
-	OBSSource source = OBSGetStrongRef(weakSource());
-	if (!source) {
-		return;
-	}
+	setMuted(mute);
 
-	// The Mute and Monitor buttons in the volume mixer work as a pseudo quad-state toggle.
-	// Both buttons must be in their "off" state in order to actually process it as a mute.
-	// Otherwise, clicking "Mute" with monitoring enabled will toggle the monitoring type.
-
-	if (mute && obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT) {
-		setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
-	} else if (!mute && obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
-		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
-	} else {
-		setMuted(mute);
+	if (obsMonitoringType != OBS_MONITORING_TYPE_NONE) {
+		if (mute) {
+			setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
+		} else {
+			setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
+		}
 	}
 }
 
 void VolumeControl::handleMonitorButton(bool enableMonitoring)
 {
-	OBSSource source = OBSGetStrongRef(weakSource());
-	if (!source) {
+	if (!enableMonitoring) {
+		setMonitoring(OBS_MONITORING_TYPE_NONE);
 		return;
 	}
 
-	// The Mute and Monitor buttons in the volume mixer work as a pseudo quad-state toggle.
-	// The source is only ever actually "Muted" if Monitoring is set to None.
-
-	if (!enableMonitoring) {
-		setMonitoring(OBS_MONITORING_TYPE_NONE);
-		if (obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
-			setMuted(true);
-		}
-	} else if (enableMonitoring && obsMuted) {
+	if (obsMuted) {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
-		setMuted(false);
-	} else if (enableMonitoring && !obsMuted) {
+	} else {
 		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
 	}
 }

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -225,19 +225,19 @@ void VolumeControl::obsMonitoringChanged(void *data, calldata_t *params)
 
 void VolumeControl::obsSourceActivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "sourceActiveChanged", Qt::QueuedConnection,
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceActiveChanged", Qt::QueuedConnection,
 				  Q_ARG(bool, true));
 }
 
 void VolumeControl::obsSourceDeactivated(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "sourceActiveChanged", Qt::QueuedConnection,
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceActiveChanged", Qt::QueuedConnection,
 				  Q_ARG(bool, false));
 }
 
 void VolumeControl::obsSourceDestroy(void *data, calldata_t *)
 {
-	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "handleSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(static_cast<VolumeControl *>(data), "onSourceDestroyed", Qt::QueuedConnection);
 }
 
 void VolumeControl::setLayoutVertical(bool vertical)
@@ -742,7 +742,7 @@ void VolumeControl::setMonitoring(obs_monitoring_type type)
 					   std::bind(undo_redo, std::placeholders::_1, type), uuid, uuid);
 }
 
-void VolumeControl::sourceActiveChanged(bool active)
+void VolumeControl::onSourceActiveChanged(bool active)
 {
 	processMixerState();
 

--- a/frontend/components/VolumeControl.hpp
+++ b/frontend/components/VolumeControl.hpp
@@ -71,6 +71,8 @@ private:
 	OBSWeakSource weakSource_;
 	const char *uuid;
 	std::vector<OBSSignal> obsSignals;
+	obs_monitoring_type obsMonitoringType;
+	bool obsMuted;
 
 	QBoxLayout *mainLayout;
 	QLabel *categoryLabel;
@@ -98,7 +100,8 @@ private:
 
 	static void obsVolumeChanged(void *param, float db);
 	static void obsVolumeMuted(void *data, calldata_t *calldata);
-	static void obsMixersOrMonitoringChanged(void *data, calldata_t *);
+	static void obsMixersChanged(void *data, calldata_t *);
+	static void obsMonitoringChanged(void *data, calldata_t *);
 	static void obsSourceActivated(void *data, calldata_t *params);
 	static void obsSourceDeactivated(void *data, calldata_t *params);
 	static void obsSourceDestroy(void *data, calldata_t *params);
@@ -115,7 +118,7 @@ public slots:
 	void sourceActiveChanged(bool active);
 	void setUseDisabledColors(bool greyscale);
 	void setLocked(bool locked);
-	void updateMixerState();
+	void processMixerState();
 
 private slots:
 	void renameSource();
@@ -128,6 +131,8 @@ private slots:
 	void setName(QString name);
 
 	void handleSourceDestroyed() { deleteLater(); }
+	void onMuteChanged(bool muted);
+	void onMonitoringChanged(int type);
 
 signals:
 	void unhideAll();

--- a/frontend/components/VolumeControl.hpp
+++ b/frontend/components/VolumeControl.hpp
@@ -115,7 +115,6 @@ private:
 	void setMonitoring(obs_monitoring_type type);
 
 public slots:
-	void sourceActiveChanged(bool active);
 	void setUseDisabledColors(bool greyscale);
 	void setLocked(bool locked);
 	void processMixerState();
@@ -130,9 +129,10 @@ private slots:
 	void updateText();
 	void setName(QString name);
 
-	void handleSourceDestroyed() { deleteLater(); }
+	void onSourceActiveChanged(bool active);
 	void onMuteChanged(bool muted);
 	void onMonitoringChanged(int type);
+	void onSourceDestroyed() { deleteLater(); }
 
 signals:
 	void unhideAll();

--- a/frontend/components/VolumeMeter.cpp
+++ b/frontend/components/VolumeMeter.cpp
@@ -364,7 +364,7 @@ VolumeMeter::~VolumeMeter()
 void VolumeMeter::obsSourceDestroyed(void *data, calldata_t *)
 {
 	VolumeMeter *self = static_cast<VolumeMeter *>(data);
-	QMetaObject::invokeMethod(self, "handleSourceDestroyed", Qt::QueuedConnection);
+	QMetaObject::invokeMethod(self, "onSourceDestroyed", Qt::QueuedConnection);
 }
 
 void VolumeMeter::setLevels(const float magnitude[MAX_AUDIO_CHANNELS], const float peak[MAX_AUDIO_CHANNELS],

--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -371,7 +371,6 @@ void AudioMixer::updateControlVisibility(QString uuid)
 	bool show = getMixerVisibilityForControl(control);
 
 	if (show) {
-		control->updateMixerState();
 		control->show();
 	} else {
 		control->hide();

--- a/libobs/audio-monitoring/osx/coreaudio-output.c
+++ b/libobs/audio-monitoring/osx/coreaudio-output.c
@@ -61,7 +61,8 @@ static void on_audio_pause(void *data, calldata_t *calldata)
 	pthread_mutex_unlock(&monitor->mutex);
 }
 
-static void on_audio_playback(void *param, obs_source_t *source, const struct audio_data *audio_data, bool muted)
+static void on_audio_playback(void *param, obs_source_t *source, const struct audio_data *audio_data,
+			      bool muted __unused)
 {
 	struct audio_monitor *monitor = param;
 	float vol = source->user_volume;
@@ -88,17 +89,13 @@ static void on_audio_playback(void *param, obs_source_t *source, const struct au
 
 	bytes = sizeof(float) * monitor->channels * resample_frames;
 
-	if (muted) {
-		memset(resample_data[0], 0, bytes);
-	} else {
-		/* apply volume */
-		if (!close_float(vol, 1.0f, EPSILON)) {
-			register float *cur = (float *)resample_data[0];
-			register float *end = cur + resample_frames * monitor->channels;
+	/* apply volume */
+	if (!close_float(vol, 1.0f, EPSILON)) {
+		register float *cur = (float *)resample_data[0];
+		register float *end = cur + resample_frames * monitor->channels;
 
-			while (cur < end)
-				*(cur++) *= vol;
-		}
+		while (cur < end)
+			*(cur++) *= vol;
 	}
 
 	pthread_mutex_lock(&monitor->mutex);

--- a/libobs/audio-monitoring/pulse/pulseaudio-output.c
+++ b/libobs/audio-monitoring/pulse/pulseaudio-output.c
@@ -229,6 +229,8 @@ finish:
 
 static void on_audio_playback(void *param, obs_source_t *source, const struct audio_data *audio_data, bool muted)
 {
+	UNUSED_PARAMETER(muted);
+
 	struct audio_monitor *monitor = param;
 	float vol = source->user_volume;
 	size_t bytes;
@@ -252,12 +254,8 @@ static void on_audio_playback(void *param, obs_source_t *source, const struct au
 
 	bytes = monitor->bytes_per_frame * resample_frames;
 
-	if (muted) {
-		memset(resample_data[0], 0, bytes);
-	} else {
-		if (!close_float(vol, 1.0f, EPSILON)) {
-			process_volume(monitor, vol, resample_data, resample_frames);
-		}
+	if (!close_float(vol, 1.0f, EPSILON)) {
+		process_volume(monitor, vol, resample_data, resample_frames);
 	}
 
 	deque_push_back(&monitor->new_data, resample_data[0], bytes);

--- a/libobs/audio-monitoring/win32/wasapi-output.c
+++ b/libobs/audio-monitoring/win32/wasapi-output.c
@@ -278,6 +278,8 @@ static void audio_monitor_free_for_reconnect(struct audio_monitor *monitor)
 
 static void on_audio_playback(void *param, obs_source_t *source, const struct audio_data *audio_data, bool muted)
 {
+	UNUSED_PARAMETER(muted);
+
 	struct audio_monitor *monitor = param;
 	uint8_t *resample_data[MAX_AV_PLANES];
 	float vol = source->user_volume;
@@ -325,19 +327,17 @@ static void on_audio_playback(void *param, obs_source_t *source, const struct au
 		goto free_for_reconnect;
 	}
 
-	if (!muted) {
-		/* apply volume */
-		if (!close_float(vol, 1.0f, EPSILON)) {
-			register float *cur = (float *)resample_data[0];
-			register float *end = cur + resample_frames * monitor->channels;
+	/* apply volume */
+	if (!close_float(vol, 1.0f, EPSILON)) {
+		register float *cur = (float *)resample_data[0];
+		register float *end = cur + resample_frames * monitor->channels;
 
-			while (cur < end)
-				*(cur++) *= vol;
-		}
-		memcpy(output, resample_data[0], resample_frames * monitor->channels * sizeof(float));
+		while (cur < end)
+			*(cur++) *= vol;
 	}
+	memcpy(output, resample_data[0], resample_frames * monitor->channels * sizeof(float));
 
-	hr = render->lpVtbl->ReleaseBuffer(render, resample_frames, muted ? AUDCLNT_BUFFERFLAGS_SILENT : 0);
+	hr = render->lpVtbl->ReleaseBuffer(render, resample_frames, 0);
 	if (FAILED(hr)) {
 		goto free_for_reconnect;
 	}


### PR DESCRIPTION
### Description
This PR accomplishes two goals:
1. Fixes the volume control button state getting desynced when using plugins/scripts to change mute/monitoring
2. Makes it so monitoring while muted is handled directly in libobs instead of the frontend

### Motivation and Context
1. This fixes #13246. libobs sends the signals for the relevant state changes before the state is actually applied to the object. This means if you respond to a signal for `mute` by calling `obs_source_muted()` you are going to get a stale value at best or a race condition at worst. Instead the VolumeControl now updates a local value using the new value from the signal, so that the up to date value can be used for updating the mixer state.

2. Currently in the new audio mixer, the ability to hear a monitored source when it was muted was handled via frontend logic. This logic would consider the UI input and only actually mute a source if monitoring was disabled. This led to some inconsistencies when things like the Advanced Audio Properties window or websockets tried to update these settings, as they would not flow through that logic.

This approach was taken as I naively assumed that a muted source would never even make it to the part of the audio pipeline where monitoring would be considered. However after further investigation thanks to @PatTheMav, we gleaned that monitoring itself is done via audio callback and had specific handling _for_ the muted state already.

### How Has This Been Tested?
Changed the mute and monitoring state of multiple audio sources via the mixer, the Advanced Audio Properties window, and via obs-websockets.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
