### PR TITLE
rtmp-services: Add Girls Gone Game

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 285,
+    "version": 286,
     "files": [
         {
             "name": "services.json",
-            "version": 285
+            "version": 286
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1341,6 +1341,30 @@
             ]
         },
         {
+            "name": "Girls Gone Game",
+            "more_info_link": "https://www.girlsgonegame.com",
+            "stream_key_link": "https://www.girlsgonegame.com/streamer/profile",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmps://47e4f15676e4.global-contribute.live-video.net:443/app/"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 160,
+                "supported resolutions": [
+                    "1920x1080",
+                    "1280x720"
+                ],
+                "max fps": 30
+            },
+            "supported video codecs": [
+                "h264"
+            ]
+        },
+        {
             "name": "Lahzenegar - StreamG | لحظه‌نگار - استریمجی",
             "servers": [
                 {


### PR DESCRIPTION
### Description

Included new service for Girls Gone Game streaming.

### Motivation and Context

Girls Gone Game is a dedicated community for female gamers, and having our own OBS spot would give our members a simple, one-click way to start streaming without the technical headache. The platform launched in beta in February 2026 and officially on April 15, 2026, and currently has 25 active streamers producing roughly 40 hours of streams per week. This streamlined setup helps our girls focus on their content.

### How Has This Been Tested?

I installed services.json using a MacBookPro running macOS 24.4.1 and OBS 32.1.2 (64bit)
I can confirm that "Girls Gone Game" appeared in the Service drop-down
I was able to select the new service, and confirmed the server was populated correctly
I started a test stream with a valid stream key
I was able to verify via AWS CLI, and I was able to view a live stream

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have read the contributing document
- [x] My code is not on the master branch
- [x] The code has been tested
- [x] All commit messages are properly formatted and commits squashed where appropriate