### PR TITLE
frontend: Fix wrong dock sizes at startup

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1219,6 +1219,12 @@ void OBSBasic::OBSInit()
 		NewYouTubeAppDock();
 #endif
 
+	// Workaround for QTBUG-46620
+	// https://qt-project.atlassian.net/browse/QTBUG-46620
+	if (isMaximized()) {
+		setGeometry(window()->screen()->availableGeometry());
+	}
+
 	const char *dockStateStr = config_get_string(App()->GetUserConfig(), "BasicWindow", "DockState");
 
 	if (!dockStateStr) {


### PR DESCRIPTION
### Description
Fixes docks being the wrong size during startup if OBS was maximized.

This appears to be some consequence of docks being added dynamically to the main window and restoring the window state when it was saved as maximized.

As such, this only seems to happen when you have the stats dock enabled or you have a browser dock. Closing OBS when it's maximized will result in the docks being different sizes next startup.

Appears to be https://qt-project.atlassian.net/browse/QTBUG-46620 and this PR implements a version of the fix noted in the comments there.

### Motivation and Context
Fixes #13278

### How Has This Been Tested?
Closed and opened OBS multiple times after setting the stats dock and some browser docks to various sizes and confirmed it was the same next launch.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
