### PR TITLE
rtmp-services: Add Stream24

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 285,
+    "version": 286,
     "files": [
         {
             "name": "services.json",
-            "version": 285
+            "version": 286
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -3586,6 +3586,27 @@
             "supported video codecs": [
                 "h264"
             ]
+        },
+        {
+            "name": "Stream24",
+            "more_info_link": "https://stream24.io",
+            "stream_key_link": "https://app.stream24.io",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://app.stream24.io/live"
+                }
+            ],
+            "supported video codecs": [
+                "h264"
+            ],
+            "recommended": {
+                "keyint": 2,
+                "profile": "high",
+                "max video bitrate": 6000,
+                "max audio bitrate": 160,
+                "bframes": 2
+            }
         }
     ]
 }


### PR DESCRIPTION
### Description
Adds Stream24 to the RTMP services list. Stream24 is a professional 
multistreaming SaaS platform that enables simultaneous live broadcasting 
to YouTube, Facebook, Twitch, TikTok, Instagram, X (Twitter), LinkedIn, 
and more from a single RTMP ingest.

- Ingest URL: rtmp://app.stream24.io/live
- Stream key: personal key from user dashboard at app.stream24.io
- Documentation: https://stream24.io/support

I am the founder and operator of Stream24. This submission is made on 
behalf of the service.

### Motivation and Context
OBS users currently have to select "Custom" and manually enter the 
Stream24 RTMP URL. Adding Stream24 to the services list removes that 
friction and auto-fills the server URL for users.

### How Has This Been Tested?
- RTMP ingest URL tested with OBS Studio on macOS and Windows
- Stream key authentication verified against live platform
- services.json validated at jsonlint.com — valid JSON confirmed
- package.json version incremented from 285 to 286

### Types of changes
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.