### PR TITLE
Fix trailing comma in OBSShader causing a build error in mac

### DIFF
--- a/libobs-metal/OBSShader.swift
+++ b/libobs-metal/OBSShader.swift
@@ -542,7 +542,7 @@ class OBSShader {
                 textures: [],
                 samplers: [],
                 arguments: [],
-                gsFunction: function,
+                gsFunction: function
             )
 
             for j in 0..<function.pointee.params.num {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
There is a build error on mac which the error only shows up in xcode not the command line. The trailing comma in OBSShader in libobs-metal causes an "unexpected separator" error. 

<img width="1893" height="1111" alt="Screenshot 2026-05-02 014858" src="https://github.com/user-attachments/assets/2f386964-1f99-4415-bdce-919146206387" />

Related: #13383

### Motivation and Context
Discovered trying to build for macos. Under macOS 14 and XCode 16.1

### How Has This Been Tested?
```
cmake --preset macos
cd build_macos
xcodebuild                                                 \
  -configuration RelWithDebInfo \
  -scheme obs-studio                                       \
  -parallelizeTargets                                      \
  -destination "generic/platform=macOS,name=Any Mac"
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [ x] My code is not on the master branch.
- [ x] My code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
