### PR TITLE
obs-outputs: File splitting improvements for Hybrid MP4/MOV

### DIFF
--- a/plugins/obs-outputs/mp4-mux.c
+++ b/plugins/obs-outputs/mp4-mux.c
@@ -2501,18 +2501,30 @@ static void process_packets(struct mp4_mux *mux, struct mp4_track *track, uint64
 	if (!count)
 		return;
 
-	/* Only iterate upt to penultimate packet so we can determine duration
-	 * for all processed packets. */
-	for (size_t i = 0; i < count - 1; i++) {
+	/* Unless it is the final flush, only iterate up to penultimate packet so we can determine duration for all
+	 * processed packets. */
+	const bool final_flush = mux->next_frag_pts == 0;
+	const size_t end_offset = final_flush ? 0 : 1;
+
+	for (size_t i = 0; i < count - end_offset; i++) {
 		struct encoder_packet *pkt = get_pkt_at(&track->packets, i);
 
-		if (mux->next_frag_pts && packet_pts_usec(pkt) >= mux->next_frag_pts)
+		if (!final_flush && packet_pts_usec(pkt) >= mux->next_frag_pts)
 			break;
 
-		struct encoder_packet *next = get_pkt_at(&track->packets, i + 1);
+		uint32_t duration;
+		if (i < count - 1) {
+			/* If a next packet is available: Duration is just distance between current and next DTS. */
+			struct encoder_packet *next = get_pkt_at(&track->packets, i + 1);
+			duration = (uint32_t)(next->dts - pkt->dts);
+		} else {
+			/* If this is the last packet, and we're doing a final flush: Reuse the previous duration */
+			if (!track->fragment_samples.num)
+				break; /* no previous sample */
 
-		/* Duration is just distance between current and next DTS. */
-		uint32_t duration = (uint32_t)(next->dts - pkt->dts);
+			duration = track->fragment_samples.array[track->fragment_samples.num - 1].duration;
+		}
+
 		uint32_t sample_count = 1;
 		uint32_t size = (uint32_t)pkt->size;
 		int32_t offset = (int32_t)(pkt->pts - pkt->dts);

--- a/plugins/obs-outputs/mp4-output.c
+++ b/plugins/obs-outputs/mp4-output.c
@@ -51,6 +51,7 @@ struct mp4_output {
 	struct serializer serializer;
 
 	bool enable_bpm;
+	bool received_first_keyframe;
 
 	volatile bool active;
 	volatile bool stopping;
@@ -348,8 +349,11 @@ static inline bool should_split(struct mp4_output *out, struct encoder_packet *p
 		return true;
 
 	/* reached maximum duration */
-	if (out->max_time > 0 && packet->dts_usec - out->start_time >= out->max_time)
-		return true;
+	if (out->max_time > 0) {
+		const int64_t current_runtime = packet->dts_usec - out->start_time;
+		/* Allow a small error in timestamps (up to 1 ms). */
+		return llabs(out->max_time - current_runtime) < 1000LL;
+	}
 
 	return false;
 }
@@ -530,6 +534,13 @@ static void mp4_output_packet(void *data, struct encoder_packet *packet)
 			mp4_output_actual_stop(out, 0);
 			goto unlock;
 		}
+	}
+
+	/* Correct start time for b-frames */
+	if (!out->received_first_keyframe && packet->type == OBS_ENCODER_VIDEO && packet->track_idx == 0 &&
+	    packet->keyframe) {
+		out->start_time = packet->dts_usec;
+		out->received_first_keyframe = true;
 	}
 
 	if (out->split_file_enabled) {


### PR DESCRIPTION
### Description

Fixes file splitting by ensurnig the last frame of each part is not dropped, and b-frames are accounted for in the timer

### Motivation and Context

Address part of #13374.

Originally, before file splitting was introduced, I made the choice to simple ignore the last frame in the packet queue of the muxer, because frame N+1 is required to properly determine the duration and I figured nobody would notice if their recording is one frame short.

However, when using frame splitting this would result in the last frame before a split being dropped. To fix this, we can simply reuse the previous sample's duration for the final sample in a file. Since OBS only does CFR, they should all be identical anyway.

Additionally I discovered while testing that the first split would always be one GOP too long (e.g. 1m2s instead of 1m) due to the fact that b-frames and negative start DTSes were not accounted for. This is also fixed in this PR.

### How Has This Been Tested?

Recorded some files, looked at them frame-by-frame to confirm none are missing now.

### Types of changes

- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
