### PR TITLE
cmake: Switch preset to VS 2026

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -164,7 +164,7 @@
       },
       "architecture": "x64,version=10.0.22621.0",
       "binaryDir": "${sourceDir}/build_x64",
-      "generator": "Visual Studio 17 2022",
+      "generator": "Visual Studio 18 2026",
       "cacheVariables": {
         "GPU_PRIORITY_VAL": {"type": "STRING", "value": "$penv{GPU_PRIORITY_VAL}"},
         "VIRTUALCAM_GUID": {"type": "STRING", "value": "A3FCE0F5-3493-419F-958A-ABA1250EC20B"},


### PR DESCRIPTION
### Description
Updates the Visual Studio generator in CMakePresets.json from Visual Studio 2022 to Visual Studio 2026. This would be a breaking change for anyone still on Visual Studio 2022 and would require them to update.

### Motivation and Context
In order to build from source using the newest version of Visual Studio this line had to be updated. Many people may still be on Visual Studio 2022 but I am not sure that this version is still available to download from Microsoft. At some point in the future this will eventually need to be updated.

### How Has This Been Tested?
I used it myself to build OBS from source on Windows 11 using Visual Studio 2026 Enterprise Edition.

### Types of changes
- Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
