### PR TITLE
obs-webrtc: Allow B-frames for AV1

### DIFF
--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -208,6 +208,7 @@ void AdvancedOutput::UpdateStreamSettings()
 	if (applyServiceSettings) {
 		int bitrate = (int)obs_data_get_int(settings, "bitrate");
 		int keyint_sec = (int)obs_data_get_int(settings, "keyint_sec");
+		obs_data_set_string(settings, "codec", obs_get_encoder_codec(streamEncoder));
 		obs_service_apply_encoder_settings(main->GetService(), settings, nullptr);
 		if (!enforceBitrate) {
 			int maxVideoBitrate;

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -326,6 +326,7 @@ void SimpleOutput::Update()
 	obs_data_set_string(audioSettings, "rate_control", "CBR");
 	obs_data_set_int(audioSettings, "bitrate", audioBitrate);
 
+	obs_data_set_string(videoSettings, "codec", obs_get_encoder_codec(encoder_id));
 	obs_service_apply_encoder_settings(main->GetService(), videoSettings, audioSettings);
 
 	if (!enforceBitrate) {

--- a/plugins/obs-webrtc/whip-service.cpp
+++ b/plugins/obs-webrtc/whip-service.cpp
@@ -28,7 +28,11 @@ void WHIPService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 {
 	// For now, ensure maximum compatibility with webrtc peers
 	if (video_settings) {
-		obs_data_set_int(video_settings, "bf", 0);
+		const char *codec = obs_data_get_string(video_settings, "codec");
+		bool isAv1 = strcmp(codec, "av1") == 0;
+		if (!isAv1) {
+			obs_data_set_int(video_settings, "bf", 0);
+		}
 		obs_data_set_bool(video_settings, "repeat_headers", true);
 	}
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description

This change allows to use AV1 B-frames for the WHIP output.

### Motivation and Context

Current browsers do have problems with B-frames in WebRTC, however this limitation only applies to H264 and HEVC.
When used with AV1 they do not cause problems.
Therefore OBS should not force disable B-frames if the video codec is AV1.

### How Has This Been Tested?

Started a WHIP stream with different codecs and made sure the number of b-frames in the log looks correct.

Watched an AV1 stream with b-frames using Broadcast Box in a browser.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
 - Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
