### PR TITLE
libobs, frontend: Add functions to save json with defaults

### DIFF
--- a/docs/sphinx/reference-settings.rst
+++ b/docs/sphinx/reference-settings.rst
@@ -121,10 +121,57 @@ General Functions
 
 ---------------------
 
+.. function:: bool obs_data_save_json_with_defaults(obs_data_t *data, const char *file)
+
+   Saves the data to a file as Json text and includes default values.
+
+   :param file: The file to save to
+   :return:     *true* if successful, *false* otherwise
+
+---------------------
+
 .. function:: bool obs_data_save_json_safe(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
 
    Saves the data to a file as Json text, and if overwriting an old
    file, backs up that old file to help prevent potential file
+   corruption.
+
+   :param file:       The file to save to
+   :param backup_ext: The backup extension to use for the overwritten
+                      file if it exists
+   :return:           *true* if successful, *false* otherwise
+
+---------------------
+
+.. function:: bool obs_data_save_json_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
+
+   Saves the data, including defaults, to a file as Json text, and if
+   overwriting an old file, backs up that old file to help prevent potential
+   file corruption.
+
+   :param file:       The file to save to
+   :param backup_ext: The backup extension to use for the overwritten
+                      file if it exists
+   :return:           *true* if successful, *false* otherwise
+
+---------------------
+
+.. function:: bool obs_data_save_json_pretty_safe(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
+
+   Saves the data to a file as formatted Json text, and if overwriting an old
+   file, backs up that old file to help prevent potential file corruption.
+
+   :param file:       The file to save to
+   :param backup_ext: The backup extension to use for the overwritten
+                      file if it exists
+   :return:           *true* if successful, *false* otherwise
+
+---------------------
+
+.. function:: bool obs_data_save_json_pretty_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
+
+   Saves the data, including defaults, to a file as formatted Json text, and if
+   overwriting an old file, backs up that old file to help prevent potential file
    corruption.
 
    :param file:       The file to save to

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -688,7 +688,8 @@ void OBSBasic::on_actionExportSceneCollection_triggered()
 		}
 
 		obs_data_set_array(collection, "sources", newSources);
-		obs_data_save_json_pretty_safe(collection, destinationFile.u8string().c_str(), "tmp", "bak");
+		obs_data_save_json_pretty_safe_with_defaults(collection, destinationFile.u8string().c_str(), "tmp",
+							     "bak");
 	}
 }
 
@@ -977,7 +978,7 @@ void OBSBasic::Save(SceneCollection &collection)
 	obs_data_set_int(saveData, "version", sceneCollectionVersion);
 
 	const std::string collectionFileName = collection.getFilePathString();
-	bool success = obs_data_save_json_pretty_safe(saveData, collectionFileName.c_str(), "tmp", "bak");
+	bool success = obs_data_save_json_pretty_safe_with_defaults(saveData, collectionFileName.c_str(), "tmp", "bak");
 
 	if (!success) {
 		blog(LOG_ERROR, "Could not save scene data to %s", collectionFileName.c_str());
@@ -1284,8 +1285,8 @@ void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
 			backupFilePath.replace_extension(".json.v1");
 
 			if (!std::filesystem::exists(backupFilePath)) {
-				bool success = obs_data_save_json_pretty_safe(data, backupFilePath.u8string().c_str(),
-									      "tmp", nullptr);
+				bool success = obs_data_save_json_pretty_safe_with_defaults(
+					data, backupFilePath.u8string().c_str(), "tmp", nullptr);
 
 				if (!success) {
 					blog(LOG_WARNING,

--- a/libobs/obs-data.c
+++ b/libobs/obs-data.c
@@ -755,6 +755,17 @@ bool obs_data_save_json(obs_data_t *data, const char *file)
 	return false;
 }
 
+bool obs_data_save_json_with_defaults(obs_data_t *data, const char *file)
+{
+	const char *json = obs_data_get_json_with_defaults(data);
+
+	if (json && *json) {
+		return os_quick_write_utf8_file(file, json, strlen(json), false);
+	}
+
+	return false;
+}
+
 bool obs_data_save_json_safe(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
 {
 	const char *json = obs_data_get_json(data);
@@ -766,9 +777,33 @@ bool obs_data_save_json_safe(obs_data_t *data, const char *file, const char *tem
 	return false;
 }
 
+bool obs_data_save_json_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext,
+					   const char *backup_ext)
+{
+	const char *json = obs_data_get_json_with_defaults(data);
+
+	if (json && *json) {
+		return os_quick_write_utf8_file_safe(file, json, strlen(json), false, temp_ext, backup_ext);
+	}
+
+	return false;
+}
+
 bool obs_data_save_json_pretty_safe(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext)
 {
 	const char *json = obs_data_get_json_pretty(data);
+
+	if (json && *json) {
+		return os_quick_write_utf8_file_safe(file, json, strlen(json), false, temp_ext, backup_ext);
+	}
+
+	return false;
+}
+
+bool obs_data_save_json_pretty_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext,
+						  const char *backup_ext)
+{
+	const char *json = obs_data_get_json_pretty_with_defaults(data);
 
 	if (json && *json) {
 		return os_quick_write_utf8_file_safe(file, json, strlen(json), false, temp_ext, backup_ext);

--- a/libobs/obs-data.h
+++ b/libobs/obs-data.h
@@ -70,9 +70,14 @@ EXPORT const char *obs_data_get_json_pretty(obs_data_t *data);
 EXPORT const char *obs_data_get_json_pretty_with_defaults(obs_data_t *data);
 EXPORT const char *obs_data_get_last_json(obs_data_t *data);
 EXPORT bool obs_data_save_json(obs_data_t *data, const char *file);
+EXPORT bool obs_data_save_json_with_defaults(obs_data_t *data, const char *file);
 EXPORT bool obs_data_save_json_safe(obs_data_t *data, const char *file, const char *temp_ext, const char *backup_ext);
+EXPORT bool obs_data_save_json_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext,
+						  const char *backup_ext);
 EXPORT bool obs_data_save_json_pretty_safe(obs_data_t *data, const char *file, const char *temp_ext,
 					   const char *backup_ext);
+EXPORT bool obs_data_save_json_pretty_safe_with_defaults(obs_data_t *data, const char *file, const char *temp_ext,
+							 const char *backup_ext);
 
 EXPORT void obs_data_apply(obs_data_t *target, obs_data_t *apply_data);
 


### PR DESCRIPTION
### Description
This saves the default OBS data. With this, we don't have to create new versions of objects when we want to change the default settings.

### Motivation and Context
Continuation of https://github.com/obsproject/obs-studio/pull/10693

### How Has This Been Tested?
Created a new source, made sure I didn't change any settings, and made sure the settings were saved to the json file.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
