### PR TITLE
libobs: Reject hotkey bindings on Mouse1/Mouse2

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -455,8 +455,21 @@ static inline void load_modifier(uint32_t *modifiers, obs_data_t *data, const ch
 		*modifiers |= flag;
 }
 
+static inline bool valid_binding(obs_key_combination_t combo)
+{
+	if (combo.key < OBS_KEY_NONE || combo.key >= OBS_KEY_LAST_VALUE)
+		return false;
+	if (obs_key_combination_is_empty(combo))
+		return false;
+
+	return combo.key != OBS_KEY_MOUSE1 && combo.key != OBS_KEY_MOUSE2;
+}
+
 static inline void create_binding(obs_hotkey_t *hotkey, obs_key_combination_t combo)
 {
+	if (!valid_binding(combo))
+		return;
+
 	obs_hotkey_binding_t *binding = da_push_back_new(obs->hotkeys.bindings);
 	if (!binding)
 		return;
@@ -479,7 +492,7 @@ static inline void load_binding(obs_hotkey_t *hotkey, obs_data_t *data)
 	load_modifier(modifiers, data, "command", INTERACT_COMMAND_KEY);
 
 	combo.key = obs_key_from_name(obs_data_get_string(data, "key"));
-	if (!modifiers && (combo.key == OBS_KEY_NONE || combo.key >= OBS_KEY_LAST_VALUE))
+	if (!*modifiers && (combo.key == OBS_KEY_NONE || combo.key >= OBS_KEY_LAST_VALUE))
 		return;
 
 	create_binding(hotkey, combo);


### PR DESCRIPTION
### Description
This PR prevents loading hotkeys on Mouse1/Mouse2 by adding a guard in `create_binding()`.

### Motivation and Context
Hotkeys should not be bound on Mouse1/Mouse2 (left and right mouse buttons) since this will interrupt normal frontend clicks.

The hotkeys UI prevents setting hotkeys for these two buttons, but it is still possible to load such hotkeys by manually editing scene collection JSON or by a third-party plugin calling obs_hotkey_load_bindings().

This fixes issue #13403.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Tested by adding hotkeys bound to Mouse1/Mouse2 in scene collection JSON:

```json
"hotkeys": {
       "libobs.mute": [{"key": "OBS_KEY_MOUSE1"}],
       "libobs.unmute": [{"key": "OBS_KEY_MOUSE2"}]
}
```

Verified that the hotkeys do not show up in Settings > Hotkeys.

Also verified that hotkeys on non-blocked keys (e.g. Mouse3) are not affected.

Tested on MacOS 26.3.1 (a)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [X] My code is not on the master branch.
- [X] My code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
