### PR TITLE
Cmake: Sets minimum macOS SDK and XCode to 26.1. 

### DIFF
--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -19,8 +19,8 @@ endif()
 
 # Ensure recent enough Xcode and platform SDK
 function(check_sdk_requirements)
-  set(obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
-  set(obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
+  set(obs_macos_minimum_sdk 26.1) # Keep in sync with Xcode
+  set(obs_macos_minimum_xcode 26.1) # Keep in sync with SDK
   execute_process(
     COMMAND xcrun --sdk macosx --show-sdk-platform-version
     OUTPUT_VARIABLE obs_macos_current_sdk


### PR DESCRIPTION


<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description

There is a build issue in macOS with errors if the Xcode and Swift version is too old. This cmake config change sets the minimum macOS SDK and XCode version to 26.1. To match the CI mac build environment. XCode 16.3 builds but best to match the CI build system. This requires macOS 15.6 and above.

I am unable to find the docs for building the source.

### Motivation and Context

Related: #13384 

This fixes a build error when using macOS 14 and Xcode 16.1. 

### How Has This Been Tested?

```
cmake --preset macos
cd build_macos
xcodebuild                                                 \
  -configuration RelWithDebInfo \
  -scheme obs-studio                                       \
  -parallelizeTargets                                      \
  -destination "generic/platform=macOS,name=Any Mac"
 ```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [ x] My code is not on the master branch.
- [ x] My code has been tested.
- [ x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
