### PR TITLE
obs-webrtc: Add 512Kb limit for WHIP Responses

### DIFF
--- a/plugins/obs-webrtc/whip-utils.h
+++ b/plugins/obs-webrtc/whip-utils.h
@@ -9,6 +9,8 @@
 #define do_log(level, format, ...) \
 	blog(level, "[obs-webrtc] [whip_output: '%s'] " format, obs_output_get_name(output), ##__VA_ARGS__)
 
+constexpr size_t maxHttpResponseSize = 512 * 1024;
+
 static uint32_t generate_random_u32()
 {
 	std::random_device rd;
@@ -44,6 +46,9 @@ static size_t curl_writefunction(char *data, size_t size, size_t nmemb, void *pr
 	auto read_buffer = static_cast<std::string *>(priv_data);
 
 	size_t real_size = size * nmemb;
+	if (read_buffer->size() + real_size > maxHttpResponseSize) {
+		return CURL_WRITEFUNC_ERROR;
+	}
 
 	read_buffer->append(data, real_size);
 	return real_size;


### PR DESCRIPTION
### Description
Add a 512Kb limit on HTTP Responses from WHIP servers. 

### Motivation and Context
Fail earlier before we pass into libdatachannel.

### How Has This Been Tested?
Tested against https://b.siobud.com so happy case still works.

Ran broadcast box locally and added lots of padding and confirmed error handling works.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
