### PR TITLE
frontend: Force Intel-based installations to update to Apple Silicon version on macOS

### DIFF
--- a/frontend/utility/OBSSparkle.mm
+++ b/frontend/utility/OBSSparkle.mm
@@ -1,11 +1,20 @@
 #import "OBSSparkle.hpp"
 #import "OBSUpdateDelegate.h"
 
+#import <util/platform.h>
+
 OBSSparkle::OBSSparkle(const char *branch, QAction *checkForUpdatesAction)
 {
     @autoreleasepool {
         updaterDelegate = [[OBSUpdateDelegate alloc] init];
         updaterDelegate.branch = [NSString stringWithUTF8String:branch];
+
+        if (os_get_emulation_status()) {
+            updaterDelegate.feedUrl = @"https://obsproject.com/osx_update/updates_arm64_v2.xml";
+        } else {
+            updaterDelegate.feedUrl = nil;
+        }
+
         updaterDelegate.updaterController =
             [[SPUStandardUpdaterController alloc] initWithStartingUpdater:YES updaterDelegate:updaterDelegate
                                                        userDriverDelegate:nil];

--- a/frontend/utility/OBSUpdateDelegate.h
+++ b/frontend/utility/OBSUpdateDelegate.h
@@ -25,6 +25,7 @@
 @interface OBSUpdateDelegate : NSObject <SPUUpdaterDelegate> {
 }
 @property (copy) NSString *_Nonnull branch;
+@property (copy) NSString *_Nullable feedUrl;
 @property (nonatomic) SPUStandardUpdaterController *_Nonnull updaterController;
 
 - (nonnull NSSet<NSString *> *)allowedChannelsForUpdater:(nonnull SPUUpdater *)updater;
@@ -33,5 +34,5 @@
                       ofObject:(id _Nullable)object
                         change:(NSDictionary<NSKeyValueChangeKey, id> *_Nullable)change
                        context:(void *_Nullable)context;
-
+- (nullable NSString *)feedURLStringForUpdater:(SPUUpdater *_Nullable)updater;
 @end

--- a/frontend/utility/OBSUpdateDelegate.mm
+++ b/frontend/utility/OBSUpdateDelegate.mm
@@ -30,6 +30,11 @@
     }
 }
 
+- (NSString *)feedURLStringForUpdater:(SPUUpdater *)updater
+{
+    return self.feedUrl;
+}
+
 - (void)dealloc
 {
     @autoreleasepool {


### PR DESCRIPTION
### Description
Forces Sparkle to use the Apple Silicon app cast URL when checking for new versions on OBS Studio if the app runs via Rosetta on an M-series Mac.

The intent is that an emulated version of OBS Studio will be provided with a native variant of the update and thus overwrite the existing copy on the users drive. Upon relaunch of the app (handled by Sparkle itself) the user should then be running the native variant.

### Motivation and Context
Rosetta is a transitional technology to support users during architecture transitions on Apple platforms and allow developers a grace period to provide working software to users on new architectures while work on a native version continues.

OBS Studio was available natively on Apple Silicon while the M1 chips were current already, and the plugin template had also been updated a long time ago.

Some users might however not be aware of different processor architectures and thus would not know or understand that they might have downloaded the "wrong" version of OBS Studio or might have migrated from an Intel-based Mac to a more recent Apple Silicon-base machine and thus just updated their existing copy of OBS Studio.

Rosetta will be deprecated in macOS 27:

> Rosetta is currently available for any Mac with Apple silicon, and it will remain available through the forthcoming macOS 27 — the next major macOS release. Starting with computers using macOS 28, Rosetta functionality will be available only for certain older, unmaintained games that rely on Intel-based frameworks.

Thus it's important to use this deprecation as a kick-off to move as many users as possible off the Intel-based variant of OBS Studio before macOS 28 is released.

### How Has This Been Tested?
Locally tested by inspecting code execution (confirming that alternative app cast URLs are used by Sparkle), changing app cast URL at runtime for non-emulated variants, further tests will be done with Intel builds provided by CI.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
