### PR TITLE
frontend: Replace string-based exceptions with std::runtime_error

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1051,7 +1051,7 @@ void OBSApp::AppInit()
 
 	QAccessible::installFactory(alignmentSelectorFactory);
 
-		if (!MakeUserDirs())
+	if (!MakeUserDirs())
 		throw std::runtime_error("Failed to create required user directories");
 	if (!InitGlobalConfig())
 		throw std::runtime_error("Failed to initialize global config");

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1045,6 +1045,14 @@ static void move_basic_to_scene_collections(void)
 	}
 }
 
+
+static QString GetInitErrorString(const char *lookup, const char *fallback)
+{
+	if (App() && App()->GetTextLookup())
+		return QTStr(lookup);
+	return QString::fromUtf8(fallback);
+}
+
 void OBSApp::AppInit()
 {
 	ProfileScope("OBSApp::AppInit");
@@ -1052,13 +1060,29 @@ void OBSApp::AppInit()
 	QAccessible::installFactory(alignmentSelectorFactory);
 
 	if (!MakeUserDirs())
-		throw std::runtime_error("Failed to create required user directories");
+		throw std::runtime_error(
+			GetInitErrorString(
+				"Init.Error.UserDirs",
+				"Failed to create required user directories")
+				.toStdString());
 	if (!InitGlobalConfig())
-		throw std::runtime_error("Failed to initialize global config");
+		throw std::runtime_error(
+			GetInitErrorString(
+				"Init.Error.GlobalConfig",
+				"Failed to initialize global config")
+				.toStdString());
 	if (!InitLocale())
-		throw std::runtime_error("Failed to load locale");
+		throw std::runtime_error(
+			GetInitErrorString(
+				"Init.Error.Locale",
+				"Failed to load locale")
+				.toStdString());
 	if (!InitTheme())
-		throw std::runtime_error("Failed to load theme");
+		throw std::runtime_error(
+			GetInitErrorString(
+				"Init.Error.Theme",
+				"Failed to load theme")
+				.toStdString());
 
 	config_set_default_string(userConfig, "Basic", "Profile", Str("Untitled"));
 	config_set_default_string(userConfig, "Basic", "ProfileDir", Str("Untitled"));
@@ -1097,7 +1121,11 @@ void OBSApp::AppInit()
 	move_basic_to_scene_collections();
 
 	if (!MakeUserProfileDirs())
-		throw std::runtime_error("Failed to create profile directories");
+		throw std::runtime_error(
+			GetInitErrorString(
+				"Init.Error.ProfileDirs",
+				"Failed to create profile directories")
+				.toStdString());
 }
 
 void OBSApp::checkForUncleanShutdown()

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1051,14 +1051,14 @@ void OBSApp::AppInit()
 
 	QAccessible::installFactory(alignmentSelectorFactory);
 
-	if (!MakeUserDirs())
-		throw "Failed to create required user directories";
+		if (!MakeUserDirs())
+		throw std::runtime_error("Failed to create required user directories");
 	if (!InitGlobalConfig())
-		throw "Failed to initialize global config";
+		throw std::runtime_error("Failed to initialize global config");
 	if (!InitLocale())
-		throw "Failed to load locale";
+		throw std::runtime_error("Failed to load locale");
 	if (!InitTheme())
-		throw "Failed to load theme";
+		throw std::runtime_error("Failed to load theme");
 
 	config_set_default_string(userConfig, "Basic", "Profile", Str("Untitled"));
 	config_set_default_string(userConfig, "Basic", "ProfileDir", Str("Untitled"));

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1097,7 +1097,7 @@ void OBSApp::AppInit()
 	move_basic_to_scene_collections();
 
 	if (!MakeUserProfileDirs())
-		throw "Failed to create profile directories";
+		throw std::runtime_error("Failed to create profile directories");
 }
 
 void OBSApp::checkForUncleanShutdown()
@@ -1641,11 +1641,11 @@ vector<pair<string, string>> GetLocaleNames()
 {
 	string path;
 	if (!GetDataFilePath("locale.ini", path))
-		throw "Could not find locale.ini path";
+		throw std::runtime_error("Could not find locale.ini path");
 
 	ConfigFile ini;
 	if (ini.Open(path.c_str(), CONFIG_OPEN_EXISTING) != 0)
-		throw "Could not open locale.ini";
+		throw std::runtime_error("Could not open locale.ini");
 
 	size_t sections = config_num_sections(ini);
 

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1045,7 +1045,6 @@ static void move_basic_to_scene_collections(void)
 	}
 }
 
-
 static QString GetInitErrorString(const char *lookup, const char *fallback)
 {
 	if (App() && App()->GetTextLookup())
@@ -1061,28 +1060,17 @@ void OBSApp::AppInit()
 
 	if (!MakeUserDirs())
 		throw std::runtime_error(
-			GetInitErrorString(
-				"Init.Error.UserDirs",
-				"Failed to create required user directories")
+			GetInitErrorString("Init.Error.UserDirs", "Failed to create required user directories")
 				.toStdString());
 	if (!InitGlobalConfig())
 		throw std::runtime_error(
-			GetInitErrorString(
-				"Init.Error.GlobalConfig",
-				"Failed to initialize global config")
+			GetInitErrorString("Init.Error.GlobalConfig", "Failed to initialize global config")
 				.toStdString());
 	if (!InitLocale())
 		throw std::runtime_error(
-			GetInitErrorString(
-				"Init.Error.Locale",
-				"Failed to load locale")
-				.toStdString());
+			GetInitErrorString("Init.Error.Locale", "Failed to load locale").toStdString());
 	if (!InitTheme())
-		throw std::runtime_error(
-			GetInitErrorString(
-				"Init.Error.Theme",
-				"Failed to load theme")
-				.toStdString());
+		throw std::runtime_error(GetInitErrorString("Init.Error.Theme", "Failed to load theme").toStdString());
 
 	config_set_default_string(userConfig, "Basic", "Profile", Str("Untitled"));
 	config_set_default_string(userConfig, "Basic", "ProfileDir", Str("Untitled"));
@@ -1122,9 +1110,7 @@ void OBSApp::AppInit()
 
 	if (!MakeUserProfileDirs())
 		throw std::runtime_error(
-			GetInitErrorString(
-				"Init.Error.ProfileDirs",
-				"Failed to create profile directories")
+			GetInitErrorString("Init.Error.ProfileDirs", "Failed to create profile directories")
 				.toStdString());
 }
 

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1674,3 +1674,10 @@ PluginManager.Section.Manage.Title="Manage Enabled Plugins"
 
 # Custom Widget Localization
 Accessible.Widget.Name.AlignmentSelector="Alignment Selector"
+
+# Initialization Error Messages
+Init.Error.UserDirs="Failed to create required user directories"
+Init.Error.GlobalConfig="Failed to initialize global config"
+Init.Error.Locale="Failed to load locale"
+Init.Error.Theme="Failed to load theme"
+Init.Error.ProfileDirs="Failed to create profile directories"

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -661,9 +661,9 @@ static int run_program(fstream &logFile, int argc, char *argv[])
 
 		ret = program.exec();
 
-	} catch (const char *error) {
-		blog(LOG_ERROR, "%s", error);
-		OBSErrorBox(nullptr, "%s", error);
+	} catch (const std::exception &error) {
+		blog(LOG_ERROR, "%s", error.what());
+		OBSErrorBox(nullptr, "%s", error.what());
 	}
 
 	if (restart || restart_safe) {

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -831,7 +831,7 @@ int main(int argc, char *argv[])
 	using SignalHandlerCallback = decltype(OBSApp::sigIntSignalHandler);
 
 	auto setupSignalHandler = [](SignalHandlerCallback &callback, int signal) {
-		struct sigaction signalHandler {};
+		struct sigaction signalHandler{};
 		signalHandler.sa_handler = callback;
 		sigemptyset(&signalHandler.sa_mask);
 		signalHandler.sa_flags = 0;

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -831,7 +831,7 @@ int main(int argc, char *argv[])
 	using SignalHandlerCallback = decltype(OBSApp::sigIntSignalHandler);
 
 	auto setupSignalHandler = [](SignalHandlerCallback &callback, int signal) {
-		struct sigaction signalHandler{};
+		struct sigaction signalHandler {};
 		signalHandler.sa_handler = callback;
 		sigemptyset(&signalHandler.sa_mask);
 		signalHandler.sa_flags = 0;


### PR DESCRIPTION
Replace raw const char* throws in initialization with proper std::runtime_error exceptions. This allows localization of error messages and follows C++ best practices.

Fixes #13394

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
Replaced raw const char* throws in AppInit() with std::runtime_error exceptions. Updated the corresponding catch block in run_program() to catch std::exception instead of const char*.

### Motivation and Context
Raw string exceptions cannot be localized and are considered messy error handling. Using proper C++ exception types allows future localization of error messages and follows modern C++ best practices.

### How Has This Been Tested?
Ran clang-format-19 locally to ensure style compliance. CI builds are running across Ubuntu, macOS, and Windows platforms to verify compilation.

### Types of changes- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
