### PR TITLE
shared/properties-view: Remove unused signals

### DIFF
--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -155,8 +155,6 @@ void OBSPropertiesView::RefreshProperties()
 		QLabel *noPropertiesLabel = new QLabel(NO_PROPERTIES_STRING);
 		layout->addWidget(noPropertiesLabel);
 	}
-
-	emit PropertiesRefreshed();
 }
 
 void OBSPropertiesView::SetScrollPos(int h, int v, int old_hend, int old_vend)
@@ -242,7 +240,6 @@ void OBSPropertiesView::SetDisabled(bool disabled)
 
 void OBSPropertiesView::resizeEvent(QResizeEvent *event)
 {
-	emit PropertiesResized();
 	VScrollArea::resizeEvent(event);
 }
 

--- a/shared/properties-view/properties-view.hpp
+++ b/shared/properties-view/properties-view.hpp
@@ -138,9 +138,7 @@ public slots:
 	void SignalChanged();
 
 signals:
-	void PropertiesResized();
 	void Changed();
-	void PropertiesRefreshed();
 
 public:
 	OBSPropertiesView(OBSData settings, obs_object_t *obj, PropertiesReloadCallback reloadCallback,


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Removes unused signals.

The `PropertiesRefreshed()` signal is no longer used anywhere since #8041 and can be removed. While I can't say for sure when `PropertiesResized()` was last used (a git commit search suggests it was in 2015, see e93ca4cd10adbd14b12ca2b717bd3ac06522dd2d), there are no uses of it now.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Stumbled across PropertiesRefreshed while working on something else.
Code cleanup is nice.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
App still compiles and runs (macOS 26).
Searched the codebase for both signals.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
