### PR TITLE
frontend: Handle stuck upload dialog for crash logs

### DIFF
--- a/frontend/utility/CrashHandler.cpp
+++ b/frontend/utility/CrashHandler.cpp
@@ -287,6 +287,7 @@ void CrashHandler::uploadCrashLogToServer()
 
 	if (crashLogFileContent.empty()) {
 		blog(LOG_WARNING, "Most recent crash log file was empty or unavailable for reading");
+		emit crashLogUploadFailed(QTStr("LogUploadDialog.Errors.NoLogFile"));
 		return;
 	}
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->
### Description
<!--- Describe your changes in detail. -->
When a crash log file was empty or unavailable for reading, CrashHandler::uploadCrashLogToServer() returned early without emitting a failure signal.
As a result, LogUploadDialog remained stuck in the loading state because neither the success nor failure path was triggered.
Emit crashLogUploadFailed() before returning when the crash log content is empty so the dialog transitions to the existing error state correctly.
<!--- If this change includes UI elements, please include screenshots. -->

**Previous Dialog**
<img width="676" height="317" alt="Screenshot 2026-05-07 at 10 07 14 PM" src="https://github.com/user-attachments/assets/5bd8223e-d4a9-47b3-abc0-feef6ad351f8" />
**Current Dialog**
<img width="657" height="317" alt="Screenshot 2026-05-07 at 10 08 07 PM" src="https://github.com/user-attachments/assets/e13cf813-ed5f-460f-aed0-781c03fa0f41" />

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes issue #13401.

When no valid crash log file was available, the upload dialog remained indefinitely in the loading state instead of transitioning to an error state.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS using a locally built OBS instance.

Temporarily forced crashLogFileContent.empty() to reproduce the failure path and verified that the dialog correctly transitions to the existing error state instead of remaining stuck in the loading state.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
