### PR TITLE
frontend: Cleanup output active variables

### DIFF
--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -6,12 +6,6 @@
 
 #include <qt-wrappers.hpp>
 
-extern volatile bool streaming_active;
-extern volatile bool recording_active;
-extern volatile bool recording_paused;
-extern volatile bool replaybuf_active;
-extern volatile bool virtualcam_active;
-
 template<typename T>
 inline size_t GetCallbackIdx(std::vector<OBSStudioCallback<T>> &callbacks, T callback, void *private_data)
 {
@@ -230,7 +224,7 @@ void OBSStudioAPI::obs_frontend_streaming_stop()
 
 bool OBSStudioAPI::obs_frontend_streaming_active()
 {
-	return os_atomic_load_bool(&streaming_active);
+	return main->outputHandler->StreamingActive();
 }
 
 void OBSStudioAPI::obs_frontend_recording_start()
@@ -245,7 +239,7 @@ void OBSStudioAPI::obs_frontend_recording_stop()
 
 bool OBSStudioAPI::obs_frontend_recording_active()
 {
-	return os_atomic_load_bool(&recording_active);
+	return main->outputHandler->RecordingActive();
 }
 
 void OBSStudioAPI::obs_frontend_recording_pause(bool pause)
@@ -255,12 +249,12 @@ void OBSStudioAPI::obs_frontend_recording_pause(bool pause)
 
 bool OBSStudioAPI::obs_frontend_recording_paused()
 {
-	return os_atomic_load_bool(&recording_paused);
+	return main->outputHandler->RecordingPaused();
 }
 
 bool OBSStudioAPI::obs_frontend_recording_split_file()
 {
-	if (os_atomic_load_bool(&recording_active) && !os_atomic_load_bool(&recording_paused)) {
+	if (main->outputHandler->RecordingActive() || !main->outputHandler->RecordingPaused()) {
 		proc_handler_t *ph = obs_output_get_proc_handler(main->outputHandler->fileOutput);
 		uint8_t stack[128];
 		calldata cd;
@@ -275,7 +269,7 @@ bool OBSStudioAPI::obs_frontend_recording_split_file()
 
 bool OBSStudioAPI::obs_frontend_recording_add_chapter(const char *name)
 {
-	if (!os_atomic_load_bool(&recording_active) || os_atomic_load_bool(&recording_paused))
+	if (!main->outputHandler->RecordingActive() || main->outputHandler->RecordingPaused())
 		return false;
 
 	proc_handler_t *ph = obs_output_get_proc_handler(main->outputHandler->fileOutput);
@@ -305,7 +299,7 @@ void OBSStudioAPI::obs_frontend_replay_buffer_stop()
 
 bool OBSStudioAPI::obs_frontend_replay_buffer_active()
 {
-	return os_atomic_load_bool(&replaybuf_active);
+	return main->outputHandler->ReplayBufferActive();
 }
 
 void *OBSStudioAPI::obs_frontend_add_tools_menu_qaction(const char *name)
@@ -594,7 +588,7 @@ void OBSStudioAPI::obs_frontend_stop_virtualcam()
 
 bool OBSStudioAPI::obs_frontend_virtualcam_active()
 {
-	return os_atomic_load_bool(&virtualcam_active);
+	return main->outputHandler->VirtualCamActive();
 }
 
 void OBSStudioAPI::obs_frontend_reset_video()

--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -936,6 +936,11 @@ bool AdvancedOutput::RecordingActive() const
 	return obs_output_active(fileOutput);
 }
 
+bool AdvancedOutput::RecordingPaused() const
+{
+	return obs_output_paused(fileOutput);
+}
+
 bool AdvancedOutput::ReplayBufferActive() const
 {
 	return obs_output_active(replayBuffer);

--- a/frontend/utility/AdvancedOutput.hpp
+++ b/frontend/utility/AdvancedOutput.hpp
@@ -42,6 +42,7 @@ struct AdvancedOutput : BasicOutputHandler {
 	virtual void StopReplayBuffer(bool force) override;
 	virtual bool StreamingActive() const override;
 	virtual bool RecordingActive() const override;
+	virtual bool RecordingPaused() const override;
 	virtual bool ReplayBufferActive() const override;
 	bool allowsMultiTrack();
 };

--- a/frontend/utility/BasicOutputHandler.cpp
+++ b/frontend/utility/BasicOutputHandler.cpp
@@ -15,12 +15,6 @@ using namespace std;
 
 extern bool EncoderAvailable(const char *encoder);
 
-volatile bool streaming_active = false;
-volatile bool recording_active = false;
-volatile bool recording_paused = false;
-volatile bool replaybuf_active = false;
-volatile bool virtualcam_active = false;
-
 void OBSStreamStarting(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
@@ -30,7 +24,6 @@ void OBSStreamStarting(void *data, calldata_t *params)
 	if (sec == 0)
 		return;
 
-	output->delayActive = true;
 	QMetaObject::invokeMethod(output->main, "StreamDelayStarting", Q_ARG(int, sec));
 }
 
@@ -49,8 +42,6 @@ void OBSStreamStopping(void *data, calldata_t *params)
 void OBSStartStreaming(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-	output->streamingActive = true;
-	os_atomic_set_bool(&streaming_active, true);
 	QMetaObject::invokeMethod(output->main, "StreamingStart");
 }
 
@@ -62,19 +53,13 @@ void OBSStopStreaming(void *data, calldata_t *params)
 
 	QString arg_last_error = QString::fromUtf8(last_error);
 
-	output->streamingActive = false;
-	output->delayActive = false;
 	output->multitrackVideoActive = false;
-	os_atomic_set_bool(&streaming_active, false);
 	QMetaObject::invokeMethod(output->main, "StreamingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
 }
 
 void OBSStartRecording(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-
-	output->recordingActive = true;
-	os_atomic_set_bool(&recording_active, true);
 	QMetaObject::invokeMethod(output->main, "RecordingStart");
 }
 
@@ -85,10 +70,6 @@ void OBSStopRecording(void *data, calldata_t *params)
 	const char *last_error = calldata_string(params, "last_error");
 
 	QString arg_last_error = QString::fromUtf8(last_error);
-
-	output->recordingActive = false;
-	os_atomic_set_bool(&recording_active, false);
-	os_atomic_set_bool(&recording_paused, false);
 	QMetaObject::invokeMethod(output->main, "RecordingStop", Q_ARG(int, code), Q_ARG(QString, arg_last_error));
 }
 
@@ -113,9 +94,6 @@ void OBSRecordFileChanged(void *data, calldata_t *params)
 void OBSStartReplayBuffer(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-
-	output->replayBufferActive = true;
-	os_atomic_set_bool(&replaybuf_active, true);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferStart");
 }
 
@@ -123,9 +101,6 @@ void OBSStopReplayBuffer(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	int code = (int)calldata_int(params, "code");
-
-	output->replayBufferActive = false;
-	os_atomic_set_bool(&replaybuf_active, false);
 	QMetaObject::invokeMethod(output->main, "ReplayBufferStop", Q_ARG(int, code));
 }
 
@@ -144,9 +119,6 @@ void OBSReplayBufferSaved(void *data, calldata_t * /* params */)
 static void OBSStartVirtualCam(void *data, calldata_t * /* params */)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
-
-	output->virtualCamActive = true;
-	os_atomic_set_bool(&virtualcam_active, true);
 	QMetaObject::invokeMethod(output->main, "OnVirtualCamStart");
 }
 
@@ -154,9 +126,6 @@ static void OBSStopVirtualCam(void *data, calldata_t *params)
 {
 	BasicOutputHandler *output = static_cast<BasicOutputHandler *>(data);
 	int code = (int)calldata_int(params, "code");
-
-	output->virtualCamActive = false;
-	os_atomic_set_bool(&virtualcam_active, false);
 	QMetaObject::invokeMethod(output->main, "OnVirtualCamStop", Q_ARG(int, code));
 }
 

--- a/frontend/utility/BasicOutputHandler.hpp
+++ b/frontend/utility/BasicOutputHandler.hpp
@@ -21,11 +21,6 @@ struct BasicOutputHandler {
 	OBSOutputAutoRelease streamOutput;
 	OBSOutputAutoRelease replayBuffer;
 	OBSOutputAutoRelease virtualCam;
-	bool streamingActive = false;
-	bool recordingActive = false;
-	bool delayActive = false;
-	bool replayBufferActive = false;
-	bool virtualCamActive = false;
 	OBSBasic *main;
 
 	std::unique_ptr<MultitrackVideoOutput> multitrackVideo;
@@ -82,6 +77,7 @@ struct BasicOutputHandler {
 	virtual void StopVirtualCam();
 	virtual bool StreamingActive() const = 0;
 	virtual bool RecordingActive() const = 0;
+	virtual bool RecordingPaused() const = 0;
 	virtual bool ReplayBufferActive() const { return false; }
 	virtual bool VirtualCamActive() const;
 
@@ -92,11 +88,7 @@ struct BasicOutputHandler {
 	virtual void DestroyVirtualCamView();
 	virtual void DestroyVirtualCameraScene();
 
-	inline bool Active() const
-	{
-		return streamingActive || recordingActive || delayActive || replayBufferActive || virtualCamActive ||
-		       multitrackVideoActive;
-	}
+	inline bool Active() const { return obs_video_active(); }
 
 protected:
 	void SetupAutoRemux(const char *&container);

--- a/frontend/utility/SimpleOutput.cpp
+++ b/frontend/utility/SimpleOutput.cpp
@@ -755,7 +755,7 @@ void SimpleOutput::UpdateRecording()
 	int idx2 = 0;
 	const char *quality = config_get_string(main->Config(), "SimpleOutput", "RecQuality");
 
-	if (replayBufferActive || recordingActive)
+	if (ReplayBufferActive() || RecordingActive())
 		return;
 
 	if (usingRecordingPreset) {
@@ -924,6 +924,11 @@ bool SimpleOutput::StreamingActive() const
 bool SimpleOutput::RecordingActive() const
 {
 	return obs_output_active(fileOutput);
+}
+
+bool SimpleOutput::RecordingPaused() const
+{
+	return obs_output_paused(fileOutput);
 }
 
 bool SimpleOutput::ReplayBufferActive() const

--- a/frontend/utility/SimpleOutput.hpp
+++ b/frontend/utility/SimpleOutput.hpp
@@ -59,5 +59,6 @@ struct SimpleOutput : BasicOutputHandler {
 	virtual void StopReplayBuffer(bool force) override;
 	virtual bool StreamingActive() const override;
 	virtual bool RecordingActive() const override;
+	virtual bool RecordingPaused() const override;
 	virtual bool ReplayBufferActive() const override;
 };

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -724,7 +724,7 @@ private:
 				trayIcon->setIcon(QIcon::fromTheme("obs-tray", trayIconFile));
 			}
 		} else if (outputHandler->Active() && trayIcon && trayIcon->isVisible()) {
-			if (os_atomic_load_bool(&recording_paused)) {
+			if (outputHandler->RecordingPaused()) {
 #ifdef __APPLE__
 				QIcon trayIconFile = QIcon(":/res/images/obs_paused_macos.svg");
 				trayIconFile.setIsMask(true);

--- a/frontend/widgets/OBSBasicStatusBar.cpp
+++ b/frontend/widgets/OBSBasicStatusBar.cpp
@@ -263,11 +263,10 @@ void OBSBasicStatusBar::UpdateStreamTime()
 	}
 }
 
-extern volatile bool recording_paused;
-
 void OBSBasicStatusBar::UpdateRecordTime()
 {
-	bool paused = os_atomic_load_bool(&recording_paused);
+	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+	bool paused = main->outputHandler->RecordingPaused();
 
 	if (!paused) {
 		totalRecordSeconds++;
@@ -286,13 +285,15 @@ void OBSBasicStatusBar::UpdateRecordTime()
 
 void OBSBasicStatusBar::UpdateRecordTimeLabel()
 {
+	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+
 	int seconds = totalRecordSeconds % 60;
 	int totalMinutes = totalRecordSeconds / 60;
 	int minutes = totalMinutes % 60;
 	int hours = totalMinutes / 60;
 
 	QString text = QString::asprintf("%02d:%02d:%02d", hours, minutes, seconds);
-	if (os_atomic_load_bool(&recording_paused)) {
+	if (main->outputHandler->RecordingPaused()) {
 		text += QStringLiteral(" (PAUSED)");
 	}
 
@@ -550,6 +551,8 @@ static QPixmap GetPixmap(const QString &filename)
 
 void OBSBasicStatusBar::UpdateIcons()
 {
+	OBSBasic *main = qobject_cast<OBSBasic *>(parent());
+
 	disconnectedPixmap = GetPixmap("network-disconnected.svg");
 	inactivePixmap = GetPixmap("network-inactive.svg");
 
@@ -558,7 +561,7 @@ void OBSBasicStatusBar::UpdateIcons()
 	recordingInactivePixmap = GetPixmap("recording-inactive.svg");
 	recordingPauseInactivePixmap = GetPixmap("recording-pause-inactive.svg");
 
-	bool streaming = obs_frontend_streaming_active();
+	bool streaming = main->outputHandler && main->outputHandler->StreamingActive();
 
 	if (!streaming) {
 		statusWidget->ui->streamIcon->setPixmap(streamingInactivePixmap);
@@ -568,7 +571,7 @@ void OBSBasicStatusBar::UpdateIcons()
 			statusWidget->ui->statusIcon->setPixmap(disconnectedPixmap);
 	}
 
-	bool recording = obs_frontend_recording_active();
+	bool recording = main->outputHandler && main->outputHandler->RecordingActive();
 
 	if (!recording)
 		statusWidget->ui->recordIcon->setPixmap(recordingInactivePixmap);

--- a/frontend/widgets/OBSBasic_Recording.cpp
+++ b/frontend/widgets/OBSBasic_Recording.cpp
@@ -42,8 +42,6 @@ void OBSBasic::on_actionShow_Recordings_triggered()
 #define RECORDING_START "==== Recording Start ==============================================="
 #define RECORDING_STOP "==== Recording Stop ================================================"
 
-extern volatile bool replaybuf_active;
-
 void OBSBasic::AutoRemux(QString input, bool no_show)
 {
 	auto config = Config();
@@ -272,15 +270,12 @@ bool OBSBasic::RecordingActive()
 
 void OBSBasic::PauseRecording()
 {
-	if (!isRecordingPausable || !outputHandler || !outputHandler->fileOutput ||
-	    os_atomic_load_bool(&recording_paused))
+	if (!isRecordingPausable || !outputHandler || !outputHandler->fileOutput || outputHandler->RecordingPaused())
 		return;
 
 	obs_output_t *output = outputHandler->fileOutput;
 
 	if (obs_output_pause(output, true)) {
-		os_atomic_set_bool(&recording_paused, true);
-
 		emit RecordingPaused();
 
 		ui->statusbar->RecordingPaused();
@@ -298,22 +293,19 @@ void OBSBasic::PauseRecording()
 
 		OnEvent(OBS_FRONTEND_EVENT_RECORDING_PAUSED);
 
-		if (os_atomic_load_bool(&replaybuf_active))
+		if (outputHandler->ReplayBufferActive())
 			ShowReplayBufferPauseWarning();
 	}
 }
 
 void OBSBasic::UnpauseRecording()
 {
-	if (!isRecordingPausable || !outputHandler || !outputHandler->fileOutput ||
-	    !os_atomic_load_bool(&recording_paused))
+	if (!isRecordingPausable || !outputHandler || !outputHandler->fileOutput || !outputHandler->RecordingPaused())
 		return;
 
 	obs_output_t *output = outputHandler->fileOutput;
 
 	if (obs_output_pause(output, false)) {
-		os_atomic_set_bool(&recording_paused, false);
-
 		emit RecordingUnpaused();
 
 		ui->statusbar->RecordingUnpaused();

--- a/frontend/widgets/OBSBasic_ReplayBuffer.cpp
+++ b/frontend/widgets/OBSBasic_ReplayBuffer.cpp
@@ -90,7 +90,7 @@ void OBSBasic::StartReplayBuffer()
 
 	SaveProject();
 
-	if (outputHandler->StartReplayBuffer() && os_atomic_load_bool(&recording_paused)) {
+	if (outputHandler->StartReplayBuffer() && outputHandler->RecordingPaused()) {
 		ShowReplayBufferPauseWarning();
 	}
 }


### PR DESCRIPTION
### Description
The active variables aren't needed because of the obs_output_active() functions. Also the atomic bools shouldn't be needed because the active variable inside the outputs is already atomic.

### Motivation and Context
Unneeded variables

### How Has This Been Tested?
Run outputs to make sure they still worked properly

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
