### PR TITLE
frontend: Add spacing to properties hint icon

### DIFF
--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -809,6 +809,10 @@ OBSBasicSettings #PropertiesContainer {
     background-color: var(--bg_base);
 }
 
+OBSPropertiesView IconLabel {
+    margin-left: var(--spacing_large);
+}
+
 /* Dock Widget */
 OBSDock > QWidget {
     background: var(--bg_base);


### PR DESCRIPTION
### Description
Adds spacing to the hint icon in the PropertiesView for items that have a long description.

### Motivation and Context
Icon is cramped.

| **Before** | **After** |
| ---- | ---- |
| <img width="383" height="115" alt="image" src="https://github.com/user-attachments/assets/c86e72f3-9bbd-499c-8cea-5059159979b6" /> | <img width="363" height="113" alt="image" src="https://github.com/user-attachments/assets/ef4784c0-38a0-4eb5-a018-d0938101af60" /> |


### How Has This Been Tested?
👁

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
