### PR TITLE
frontend: Set up theme watcher during init

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -827,7 +827,7 @@ bool OBSApp::SetTheme(const QString &name)
 	if (!theme)
 		return false;
 
-	if (themeWatcher) {
+	if (themeWatcher && themeWatcher->files().size() > 0) {
 		themeWatcher->blockSignals(true);
 		themeWatcher->removePaths(themeWatcher->files());
 	}
@@ -1027,18 +1027,22 @@ bool OBSApp::InitTheme()
 #endif
 	}
 
+	if (config_get_bool(userConfig, "Appearance", "AutoReload")) {
+		if (themeWatcher) {
+			themeWatcher->deleteLater();
+		}
+
+		// Set up Qt file watcher to automatically reload themes.
+		themeWatcher = new QFileSystemWatcher(this);
+		connect(themeWatcher, &QFileSystemWatcher::fileChanged, this, &OBSApp::themeFileChanged);
+	}
+
 	if (!SetTheme(themeName)) {
 		blog(LOG_ERROR,
 		     "Loading default theme \"%s\" failed, falling back to "
 		     "system theme as last resort.",
 		     QT_TO_UTF8(themeName));
 		return SetTheme("com.obsproject.System");
-	}
-
-	if (config_get_bool(userConfig, "Appearance", "AutoReload")) {
-		/* Set up Qt file watcher to automatically reload themes */
-		themeWatcher = new QFileSystemWatcher(this);
-		connect(themeWatcher.get(), &QFileSystemWatcher::fileChanged, this, &OBSApp::themeFileChanged);
 	}
 
 	return true;


### PR DESCRIPTION
### Description
Unfortunately an oversight in #13259 means that the themeWatcher never gets the initial file paths during startup, so the AutoReload functionality that it enables only starts working after the theme is changed once.

Moves the themeWatcher initialization up before the theme is initially set up, and adds a guard for `themeWatcher->files().size()` to address the original warning still.

### Motivation and Context
Fix theme AutoReload not working.

### How Has This Been Tested?
Compiled, ran OBS, tested editing theme files.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
