### PR TITLE
frontend: Fix thumbnail update rate

### DIFF
--- a/frontend/utility/ThumbnailManager.cpp
+++ b/frontend/utility/ThumbnailManager.cpp
@@ -187,9 +187,9 @@ void ThumbnailManager::updateNextItem(size_t cycleDepth)
 		}
 	}
 
-	int nextIntervalMS = kMinimumThumbnailUpdateInterval;
-	if (!priorityQueue.empty() && !quickUpdate) {
-		nextIntervalMS = kThumbnailUpdateInterval;
+	int nextIntervalMS = kThumbnailUpdateInterval;
+	if (!priorityQueue.empty() || quickUpdate) {
+		nextIntervalMS = kMinimumThumbnailUpdateInterval;
 	}
 
 	updateTickInterval(nextIntervalMS);


### PR DESCRIPTION
### Description
Fixes thumbnails always updating at the priority speed instead of only when necessary.

### Motivation and Context
Thumbnails have a default update speed of 5000ms to maximize performance but are allowed to update every 100ms in certain cases, such as when first loading a thumbnail for a source that does not have one yet, or when something has explicitly requested an update.

The condition for handling the interval change was
```cpp
    if (!priorityQueue.empty() && !quickUpdate)
// -----^
```
when it should have been
```cpp
    if (priorityQueue.empty() && !quickUpdate)
```

PR fixes the logic but also inverts it to start with the default update interval.

### How Has This Been Tested?
👁

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
- Performance enhancement (non-breaking change which improves efficiency)
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
