### PR TITLE
win-capture: Add Edge/WebView2 to WGC partial match classes

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -111,10 +111,10 @@ struct window_capture {
 };
 
 static const char *wgc_partial_match_classes[] = {
-        "Chrome",
-        "Edge",
-        "Mozilla",
-        NULL,
+	"Chrome",
+	"Edge",
+	"Mozilla",
+	NULL,
 };
 
 static const char *wgc_whole_match_classes[] = {

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -111,9 +111,10 @@ struct window_capture {
 };
 
 static const char *wgc_partial_match_classes[] = {
-	"Chrome",
-	"Mozilla",
-	NULL,
+        "Chrome",
+        "Edge",
+        "Mozilla",
+        NULL,
 };
 
 static const char *wgc_whole_match_classes[] = {


### PR DESCRIPTION
Add 'Edge' to wgc_partial_match_classes so that WebView2-based applications default to WGC capture mode instead of BitBlt.

Fixes #13359

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
WebView2-based applications were defaulting to BitBlt capture instead of
WGC (Windows Graphics Capture) because their window class wasn't in the
detection list. Added "Edge" to wgc_partial_match_classes so these apps
use WGC capture automatically.

### Motivation and Context
Fixes #13359. Users of WebView2-based games (Construct 3, Tauri apps)
get a white screen with BitBlt capture. WGC correctly captures these
Chromium-based windows.
### How Has This Been Tested?
Compiled locally. The change is a one-line addition to an existing
detection list. Existing Chrome/Mozilla detection is unaffected.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
