### PR TITLE
mac-avcapture: Catch NSException from startRunning

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -313,15 +313,27 @@ static const UInt32 kMaxFrameRateRangesInDescription = 10;
 
 - (void)startCaptureSession
 {
-    if (!self.session.running) {
+    if (self.session.running) {
+        return;
+    }
+
+    @try {
         [self.session startRunning];
+    } @catch (NSException *exception) {
+        [self AVCaptureLog:LOG_ERROR withFormat:@"-[AVCaptureSession startRunning] raised %@: %@", exception.name,
+                                                exception.reason ?: @"(no reason)"];
     }
 }
 
 - (void)stopCaptureSession
 {
     if (self.session.running) {
-        [self.session stopRunning];
+        @try {
+            [self.session stopRunning];
+        } @catch (NSException *exception) {
+            [self AVCaptureLog:LOG_ERROR withFormat:@"-[AVCaptureSession stopRunning] raised %@: %@", exception.name,
+                                                    exception.reason ?: @"(no reason)"];
+        }
     }
 
     if (self.captureInfo->isFastPath) {


### PR DESCRIPTION
### Description

Wrap `-[AVCaptureSession startRunning]` and `stopRunning` in `@try/@catch`. The unhandled NSException currently aborts OBS.

### Motivation and Context

Reproduces frequently on macOS 26.4.1 / OBS 32.1.2 when a camera on a switched USB hub hot-plugs while OBS is running. Crash trace ends in `startRunning` -> `objc_exception_throw` -> `abort`. With the guard in place the source error-logs and recovers on the next `deviceConnected:` notification.

This behaviour is documented in Apple's AVFoundation SDK header (`AVCaptureSession.h`, discussion on `beginConfiguration` / `commitConfiguration`):

> -beginConfiguration / -commitConfiguration are AVCaptureSession's mechanism for batching multiple configuration operations on a running session into atomic updates. [...] If you've called -beginConfiguration, you must call -commitConfiguration before invoking -startRunning or -stopRunning, otherwise an NSGenericException is thrown.

Log: https://obsproject.com/logs/8S3wBZPQ2vtcOcmB
Crash: https://obsproject.com/logs/crashes/R51BD5uJRNxyCSqe

### How Has This Been Tested?

Not built locally yet. Will test against the CI artifact before requesting merge.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- [x] I have read the contributing document.
- [x] My code has been run through clang-format.
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
