### PR TITLE
mac-avcapture: Lock device outside session config

### DIFF
--- a/plugins/mac-avcapture/OBSAVCapture.m
+++ b/plugins/mac-avcapture/OBSAVCapture.m
@@ -517,14 +517,14 @@ static const UInt32 kMaxFrameRateRangesInDescription = 10;
         }
     }
 
-    [self.session beginConfiguration];
-
     self.isDeviceLocked = [self.deviceInput.device lockForConfiguration:error];
 
     if (!self.isDeviceLocked) {
         [self AVCaptureLog:LOG_WARNING withFormat:@"Could not lock device for configuration"];
         return NO;
     }
+
+    [self.session beginConfiguration];
 
     [self AVCaptureLog:LOG_INFO
             withFormat:@"Capturing '%@' (%@):\n"


### PR DESCRIPTION
### Description

Move `lockForConfiguration:` out of the session config batch in `configureSession`. The lock isn't a session operation and the old order leaked an unbalanced `beginConfiguration` on lock failure, which eventually crashed OBS on `startRunning`.

### Motivation and Context

`lockForConfiguration:` can fail on a USB hot-plug while the device is still settling. With the lock inside `beginConfiguration` / `commitConfiguration`, the early return on failure left the session mid-config. The next `deviceConnected:` opens more nested begin/commit pairs but the outer one stays uncommitted, then `startRunning` throws:

> If you've called -beginConfiguration, you must call -commitConfiguration before invoking -startRunning or -stopRunning, otherwise an NSGenericException is thrown.

(`AVCaptureSession.h`)

OBS doesn't catch it and aborts. Repros frequently on a Mac Studio M1 Ultra (macOS 26.4.1, OBS 32.1.2) with a camera on a switched USB hub.

Log: https://obsproject.com/logs/8S3wBZPQ2vtcOcmB
Crash: https://obsproject.com/logs/crashes/R51BD5uJRNxyCSqe

Supersedes #13426.

### How Has This Been Tested?

Building locally. Will update before marking ready for review.

### Types of changes

- Bug fix

### Checklist

- [x] I have read the contributing document.
- [x] My code has been run through clang-format.
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
