### PR TITLE
Fix typos: 4 doubled-word + 1 misspelling

### DIFF
--- a/docs/sphinx/reference-outputs.rst
+++ b/docs/sphinx/reference-outputs.rst
@@ -1010,7 +1010,7 @@ Functions used by outputs
    the output stopped unexpectedly.  This is typically used if for
    example the server was disconnected for some reason, or if there was
    an error saving to file.  The output will trigger the "stop" signal
-   with the the desired code to indicate that the output has stopped
+   with the desired code to indicate that the output has stopped
    successfully.  See :ref:`output_signal_handler_reference` for more
    information on output signals.
 

--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -1015,7 +1015,7 @@ General Source Functions
 .. function:: bool obs_source_configurable(const obs_source_t *source)
               bool obs_is_source_configurable(const char *id)
 
-   :return: *true* if the the source has custom properties, *false*
+   :return: *true* if the source has custom properties, *false*
             otherwise
 
 ---------------------
@@ -1973,7 +1973,7 @@ Functions used by transitions
    Helper function used for transitioning audio.  Typically you'd call
    this in the obs_source_info.audio_render callback with its
    parameters, and use the mix_a_callback and mix_b_callback to
-   determine the the audio fading of source A and source B.
+   determine the audio fading of source A and source B.
 
    Relevant data types used with this function:
 

--- a/frontend/utility/system-info-posix.cpp
+++ b/frontend/utility/system-info-posix.cpp
@@ -409,7 +409,7 @@ void get_drm_cards(std::vector<drm_card_info> &cards)
  * with multiple GPUs (including the CPU iGPU), the GPU that
  * OBS is currently using must be placed first in the list, so
  * that composition_gpu_index=0 is valid. composition_gpu_index
- * is set to to ovi.adapter which is always 0 apparently.
+ * is set to ovi.adapter which is always 0 apparently.
  *
  * system_gpu_data() does the following:
  *   1. Gather information about the GPU being used by OBS

--- a/plugins/obs-webrtc/whip-output.cpp
+++ b/plugins/obs-webrtc/whip-output.cpp
@@ -6,7 +6,7 @@
 /*
  * Sets the maximum size for a video fragment. Effective range is
  * 576-1470, with a lower value equating to more packets created,
- * but also better network compatability.
+ * but also better network compatibility.
  */
 static uint16_t MAX_VIDEO_FRAGMENT_SIZE = 1200;
 


### PR DESCRIPTION
Five small typo fixes — no behavior change.

**Doubled-word fixes:**
- `frontend/utility/system-info-posix.cpp`: "set to to ovi.adapter" → "set to ovi.adapter"
- `docs/sphinx/reference-sources.rst` (2 instances): "the the source" / "the the audio fading" → single "the"
- `docs/sphinx/reference-outputs.rst`: "the the desired code" → "the desired code"

**Misspelling:**
- `plugins/obs-webrtc/whip-output.cpp`: "compatability" → "compatibility"

The three Sphinx fixes are in the user-facing API reference docs rendered on https://obsproject.com/docs/.