### PR TITLE
frontend: Fix OAuth and dock state save corruption

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -60,6 +60,7 @@
 #include <QThread>
 #include <QWidgetAction>
 
+#include <mutex>
 #ifdef _WIN32
 #include <sstream>
 #endif
@@ -106,6 +107,10 @@ extern bool cef_js_avail;
 
 extern void DestroyPanelCookieManager();
 extern void CheckExistingCookieId();
+
+namespace {
+std::once_flag saveOnceFlag;
+}
 
 static void AddExtraModulePaths()
 {
@@ -1849,16 +1854,19 @@ void OBSBasic::saveAll()
 				  saveGeometry().toBase64().constData());
 	}
 
-	Auth::Save();
-	SaveProjectNow();
+	std::call_once(saveOnceFlag, [this]() {
+		Auth::Save();
+		SaveProjectNow();
 
-	config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState", saveState().toBase64().constData());
+		config_set_string(App()->GetUserConfig(), "BasicWindow", "DockState",
+				  saveState().toBase64().constData());
 
 #ifdef BROWSER_AVAILABLE
-	if (cef) {
-		SaveExtraBrowserDocks();
-	}
+		if (cef) {
+			SaveExtraBrowserDocks();
+		}
 #endif
+	});
 
 	config_set_int(App()->GetAppConfig(), "General", "LastVersion", LIBOBS_API_VER);
 	config_save_safe(App()->GetAppConfig(), "tmp", nullptr);


### PR DESCRIPTION
### Description
Wraps functionality that saves OAuth data and browser dock state in a `std::call_once` block to ensure that regardless of how often `OBSBasic::saveAll` is called the data is only saved once and partial data does not overwrite the config values on consecutive calls (at which the state of the OAuth data and browser docks cannot be considered "complete" anymore).

### Motivation and Context
When the app is quit on macOS, the underlying process is either triggered by an application-level "Quit" event or by a main window "close" event.

If the application-level "Quit" event is the trigger, `OBSBasic::saveAll` is called twice: 
1. By Qt's session manager (via `OBSApp::commitData`).
2. By the main window's close event handled by `OBSBasic::closeWindow`.

However if the main window is closed first (and is the first to call "saveAll") the underlying OAuth data object is destroyed after the data has been saved. When the second "saveAll" call takes place, it encounters a `nullptr` for the auth object, which makes `Auth::Save` effectively remove any OAuth configuration from the settings file (undoing prior work).

At the other end, if the application quits first, some dock windows might have been explicitly closed by Qt before the main window is closed and thus the second call to `saveAll` will overwrite valid browser dock state data with incomplete data (any dock that has been closed by Qt before will not be present in that data).

Wrapping the code responsible for saving OAuth and browser dock state data in a `std::call_once` block should ensure that this data is only written once and by whoever gets to call `saveAll` first (at which point state data is still considered "complete").

Fixes #13440
Fixes #13099

### How Has This Been Tested?
Tested on macOS 26 by having a YouTube service connection active and several browser and non-browser docks detached and placed at specific positions on screen.

Terminated OBS by menu item, dock menu, and by closing the main window, confirmed that both service connection and dock state and position were correctly restored when OBS was relaunched.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
