### PR TITLE
plugins/compressor: Fix ducking trigger when sidechain source is muted

### DIFF
--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -415,7 +415,6 @@ static void compressor_tick(void *data, float seconds)
 static struct obs_audio_data *compressor_filter_audio(void *data, struct obs_audio_data *audio)
 {
 	struct compressor_data *cd = data;
-
 	const uint32_t num_samples = audio->frames;
 	if (num_samples == 0)
 		return audio;
@@ -423,13 +422,29 @@ static struct obs_audio_data *compressor_filter_audio(void *data, struct obs_aud
 	float **samples = (float **)audio->data;
 
 	pthread_mutex_lock(&cd->sidechain_update_mutex);
-	obs_weak_source_t *weak_sidechain = cd->weak_sidechain;
+	obs_source_t *sidechain = cd->weak_sidechain ? obs_weak_source_get_source(cd->weak_sidechain) : NULL;
+	bool has_sidechain_config = (cd->weak_sidechain != NULL);
 	pthread_mutex_unlock(&cd->sidechain_update_mutex);
 
-	if (weak_sidechain)
+	bool sidechain_active = (sidechain && obs_source_active(sidechain) && !obs_source_muted(sidechain));
+
+	if (sidechain_active) {
 		analyze_sidechain(cd, num_samples);
-	else
+	} else if (has_sidechain_config) {
+		// SIDECHAIN MUTE/INACTIVE: Apply smooth decay
+		const float release_gain = cd->release_gain;
+		for (uint32_t i = 0; i < num_samples; ++i) {
+			cd->envelope = release_gain * cd->envelope;
+			if (i < cd->envelope_buf_len)
+				cd->envelope_buf[i] = cd->envelope;
+		}
+	} else {
+		// NO SIDECHAIN: Standard self-compression
 		analyze_envelope(cd, samples, num_samples);
+	}
+
+	if (sidechain)
+		obs_source_release(sidechain);
 
 	process_compression(cd, samples, num_samples);
 	return audio;

--- a/plugins/obs-filters/compressor-filter.c
+++ b/plugins/obs-filters/compressor-filter.c
@@ -353,6 +353,18 @@ static void analyze_sidechain(struct compressor_data *cd, const uint32_t num_sam
 	cd->envelope = cd->envelope_buf[num_samples - 1];
 }
 
+static inline void apply_natural_release(struct compressor_data *cd, const uint32_t num_samples)
+{
+	if (cd->envelope_buf_len < num_samples)
+		resize_env_buffer(cd, num_samples);
+
+	const float release_gain = cd->release_gain;
+	for (uint32_t i = 0; i < num_samples; ++i) {
+		cd->envelope = release_gain * cd->envelope;
+		cd->envelope_buf[i] = cd->envelope;
+	}
+}
+
 static inline void process_compression(const struct compressor_data *cd, float **samples, uint32_t num_samples)
 {
 	for (size_t i = 0; i < num_samples; ++i) {
@@ -432,12 +444,7 @@ static struct obs_audio_data *compressor_filter_audio(void *data, struct obs_aud
 		analyze_sidechain(cd, num_samples);
 	} else if (has_sidechain_config) {
 		// SIDECHAIN MUTE/INACTIVE: Apply smooth decay
-		const float release_gain = cd->release_gain;
-		for (uint32_t i = 0; i < num_samples; ++i) {
-			cd->envelope = release_gain * cd->envelope;
-			if (i < cd->envelope_buf_len)
-				cd->envelope_buf[i] = cd->envelope;
-		}
+		apply_natural_release(cd, num_samples);
 	} else {
 		// NO SIDECHAIN: Standard self-compression
 		analyze_envelope(cd, samples, num_samples);


### PR DESCRIPTION
### Description
This PR addresses the issue where the compressor continues to duck audio based on its last known envelope state when the sidechain source is muted or becomes inactive. The implementation introduces a graceful release decay using the configured release time when the sidechain source is unavailable or muted, preventing sudden volume jumps and ensuring consistent gain behavior. It also preserves standard self-compression functionality when no sidechain is configured.

### Motivation and Context
This change fixes #13170.
Currently, when a sidechain source is muted in the OBS audio mixer, the compressor retains its previous gain reduction level instead of releasing. This results in audio remaining "ducked" even when the sidechain is muted or inactive. This fix ensures that the compressor behaves predictably by treating an inactive/muted sidechain as a signal for a natural release curve.

### How Has This Been Tested?
I have verified this fix on a local build of OBS Studio.
- Test Case 1 (Sidechain): Created an audio output source with the Compressor filter using a sidechain. Observed that muting the sidechain source now triggers a smooth release decay instead of holding the gain reduction.
- Test Case 2 (Standard): Created an audio input source (microphone) with a Compressor filter without a sidechain. Verified that standard self-compression remains fully functional and unaffected by these changes.
- Environment: 
    - OS: Kubuntu 26.04 LTS
    - KDE Plasma: 6.6.4 | Kernel: 7.0.0-15-generic
    - Hardware: AMD Ryzen 7 4800H, NVIDIA GTX 1660 Ti

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.