### PR TITLE
obs-ffmpeg: Fix NVIDIA encoder memory leak on recording stop

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-nvenc.c
@@ -217,6 +217,10 @@ static void nvenc_destroy(void *data)
 {
 	struct nvenc_encoder *enc = data;
 	ffmpeg_video_encoder_free(&enc->ffve);
+#ifdef __linux__
+	cuda_free_surfaces(enc);
+	cuda_ctx_free(enc);
+#endif
 	da_free(enc->header);
 	da_free(enc->sei);
 	bfree(enc);


### PR DESCRIPTION
Add missing cuda_free_surfaces and cuda_ctx_free calls in nvenc_destroy to prevent GPU memory leak when starting and stopping recordings.

Fixes #13446

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
The obs-ffmpeg NVENC encoder's destroy function was not freeing
CUDA surfaces and context, causing GPU memory to leak on every
start/stop recording cycle.

### Motivation and Context
Users on Linux with NVIDIA GPUs experience continuous GPU memory
leakage every time they start and stop a recording. Over multiple
cycles, this causes OBS to be terminated by the system OOM killer.

The standalone obs-nvenc plugin properly frees CUDA surfaces and
context in its destroy function, but the FFmpeg-based NVENC encoder
does not. This fix adds the missing cleanup calls to bring
obs-ffmpeg in line with obs-nvenc.
### How Has This Been Tested?
CI builds across all platforms. The standalone obs-nvenc plugin
already calls these cleanup functions in its destroy path.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [ ] My code is not on the master branch.
- [ ] My code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
