### PR TITLE
shared/media-playback: make the decoder accept custom FFmpeg options

### DIFF
--- a/shared/media-playback/media-playback/decode.c
+++ b/shared/media-playback/media-playback/decode.c
@@ -89,7 +89,16 @@ static int mp_open_codec(struct mp_decode *d, bool hw)
 	    c->codec_id != AV_CODEC_ID_JPEG2000 && c->codec_id != AV_CODEC_ID_MPEG4 && c->codec_id != AV_CODEC_ID_WEBP)
 		c->thread_count = 0;
 
-	ret = avcodec_open2(c, d->codec, NULL);
+	AVDictionary *opts = NULL;
+	if (d->m->ffmpeg_options) {
+		int parse_ret = av_dict_parse_string(&opts, d->m->ffmpeg_options, "=", " ", 0);
+		if (parse_ret)
+			blog(LOG_WARNING, "Failed to parse FFmpeg options for decoder: %s\n%s", av_err2str(parse_ret),
+			     d->m->ffmpeg_options);
+	}
+
+	ret = avcodec_open2(c, d->codec, opts ? &opts : NULL);
+	av_dict_free(&opts);
 	if (ret < 0)
 		goto fail;
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Previously, OBS only passed the custom `ffmpeg_options` string to the demuxer (format context) during the stream handshake in `media.c`. The codec/decoder initialization in `decode.c` did not receive them.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I was chasing lowest latency by adding FFmpeg options in Media Source, and I found some options do not have any effect in OBS but work in `ffplay`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Windows 10
- MSVC build.
- FFmpeg options: `flags=low_delay probesize=32 analyzeduration=0`
    The first one is for AVCodec, and the last two options are for AVFormat.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
