### PR TITLE
plugins/text-freetype2: Clean up file access code

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -407,7 +407,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	size_t filesize;
 	size_t cur_pos;
 	size_t bytes_read;
-	char bvalue;
 	uint32_t log_lines;
 	uint32_t line_breaks = 0;
 	char *tmp_read = NULL;
@@ -427,16 +426,40 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	log_lines = srcdata->log_lines;
 
 	while (line_breaks <= log_lines && cur_pos != 0) {
-		cur_pos--;
+		char input[1024];
+
+		size_t count = (cur_pos > sizeof(input)) ? sizeof(input) : cur_pos;
+		cur_pos -= count;
 		os_fseeki64(tmp_file, (int64_t)cur_pos, SEEK_SET);
 
-		bytes_read = fread(&bvalue, 1, 1, tmp_file);
-		if (bytes_read == 1 && bvalue == '\n')
-			line_breaks++;
+		bytes_read = fread(input, 1, count, tmp_file);
+		if (bytes_read != count) {
+			blog(LOG_WARNING, "Somehow text-freetype2 did not read the "
+					  "intended count even though we know "
+					  "the file size should be safe.");
+			cur_pos = filesize;
+			break;
+		}
+
+		for (size_t i = 0; i < count; i++) {
+			char ch = input[count - i - 1];
+			if (ch == '\n') {
+				if (++line_breaks > log_lines) {
+					cur_pos += count - i;
+					break;
+				}
+			}
+		}
 	}
 
-	if (cur_pos != 0)
-		cur_pos++;
+	if (srcdata->text != NULL) {
+		bfree(srcdata->text);
+		srcdata->text = NULL;
+	}
+
+	if (cur_pos == filesize) {
+		return;
+	}
 
 	os_fseeki64(tmp_file, (int64_t)cur_pos, SEEK_SET);
 
@@ -444,10 +467,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	bytes_read = fread(tmp_read, 1, filesize - cur_pos, tmp_file);
 	fclose(tmp_file);
 
-	if (srcdata->text != NULL) {
-		bfree(srcdata->text);
-		srcdata->text = NULL;
-	}
 	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
 	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
 

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -367,6 +367,14 @@ static void remove_cr(wchar_t *source)
 	source[j] = '\0';
 }
 
+static void load_text_from_utf8_buf(struct ft2_source *srcdata, const char *utf8_text, size_t len)
+{
+	size_t wlen = os_utf8_to_wcs(utf8_text, len, NULL, 0);
+	srcdata->text = bzalloc((wlen + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(utf8_text, len, srcdata->text, (wlen + 1));
+	remove_cr(srcdata->text);
+}
+
 void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 {
 	FILE *tmp_file = NULL;
@@ -394,10 +402,8 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
 
-	remove_cr(srcdata->text);
+	load_text_from_utf8_buf(srcdata, tmp_read, bytes_read);
 	bfree(tmp_read);
 }
 
@@ -467,10 +473,7 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	bytes_read = fread(tmp_read, 1, filesize - cur_pos, tmp_file);
 	fclose(tmp_file);
 
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
-
-	remove_cr(srcdata->text);
+	load_text_from_utf8_buf(srcdata, tmp_read, bytes_read);
 	bfree(tmp_read);
 }
 

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -404,11 +404,13 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 void read_from_end(struct ft2_source *srcdata, const char *filename)
 {
 	FILE *tmp_file = NULL;
-	uint32_t filesize = 0, cur_pos = 0, log_lines = 0;
-	char *tmp_read = NULL;
-	uint16_t value = 0, line_breaks = 0;
+	size_t filesize;
+	size_t cur_pos;
 	size_t bytes_read;
 	char bvalue;
+	uint32_t log_lines;
+	uint32_t line_breaks = 0;
+	char *tmp_read = NULL;
 
 	tmp_file = fopen(filename, "rb");
 	if (tmp_file == NULL) {
@@ -420,13 +422,13 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	}
 
 	fseek(tmp_file, 0, SEEK_END);
-	filesize = (uint32_t)ftell(tmp_file);
+	filesize = (size_t)os_ftelli64(tmp_file);
 	cur_pos = filesize;
 	log_lines = srcdata->log_lines;
 
 	while (line_breaks <= log_lines && cur_pos != 0) {
 		cur_pos--;
-		fseek(tmp_file, cur_pos, SEEK_SET);
+		os_fseeki64(tmp_file, (int64_t)cur_pos, SEEK_SET);
 
 		bytes_read = fread(&bvalue, 1, 1, tmp_file);
 		if (bytes_read == 1 && bvalue == '\n')
@@ -436,8 +438,7 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	if (cur_pos != 0)
 		cur_pos++;
 
-	fseek(tmp_file, cur_pos, SEEK_SET);
-
+	os_fseeki64(tmp_file, (int64_t)cur_pos, SEEK_SET);
 
 	tmp_read = bzalloc((filesize - cur_pos) + 1);
 	bytes_read = fread(tmp_read, filesize - cur_pos, 1, tmp_file);

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -372,7 +372,6 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	FILE *tmp_file = NULL;
 	uint32_t filesize = 0;
 	char *tmp_read = NULL;
-	uint16_t header = 0;
 	size_t bytes_read;
 
 	tmp_file = os_fopen(filename, "rb");
@@ -385,24 +384,6 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	}
 	fseek(tmp_file, 0, SEEK_END);
 	filesize = (uint32_t)ftell(tmp_file);
-	fseek(tmp_file, 0, SEEK_SET);
-	bytes_read = fread(&header, 1, 2, tmp_file);
-
-	if (bytes_read == 2 && header == 0xFEFF) {
-		// File is already in UTF-16 format
-		if (srcdata->text != NULL) {
-			bfree(srcdata->text);
-			srcdata->text = NULL;
-		}
-		srcdata->text = bzalloc(filesize);
-		bytes_read = fread(srcdata->text, filesize - 2, 1, tmp_file);
-
-		bfree(tmp_read);
-		fclose(tmp_file);
-
-		return;
-	}
-
 	fseek(tmp_file, 0, SEEK_SET);
 
 	tmp_read = bzalloc(filesize + 1);
@@ -429,8 +410,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	size_t bytes_read;
 	char bvalue;
 
-	bool utf16 = false;
-
 	tmp_file = fopen(filename, "rb");
 	if (tmp_file == NULL) {
 		if (!srcdata->file_load_failed) {
@@ -439,10 +418,6 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 		}
 		return;
 	}
-	bytes_read = fread(&value, 1, 2, tmp_file);
-
-	if (bytes_read == 2 && value == 0xFEFF)
-		utf16 = true;
 
 	fseek(tmp_file, 0, SEEK_END);
 	filesize = (uint32_t)ftell(tmp_file);
@@ -450,42 +425,19 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	log_lines = srcdata->log_lines;
 
 	while (line_breaks <= log_lines && cur_pos != 0) {
-		if (!utf16)
-			cur_pos--;
-		else
-			cur_pos -= 2;
+		cur_pos--;
 		fseek(tmp_file, cur_pos, SEEK_SET);
 
-		if (!utf16) {
-			bytes_read = fread(&bvalue, 1, 1, tmp_file);
-			if (bytes_read == 1 && bvalue == '\n')
-				line_breaks++;
-		} else {
-			bytes_read = fread(&value, 1, 2, tmp_file);
-			if (bytes_read == 2 && value == L'\n')
-				line_breaks++;
-		}
+		bytes_read = fread(&bvalue, 1, 1, tmp_file);
+		if (bytes_read == 1 && bvalue == '\n')
+			line_breaks++;
 	}
 
 	if (cur_pos != 0)
-		cur_pos += (utf16) ? 2 : 1;
+		cur_pos++;
 
 	fseek(tmp_file, cur_pos, SEEK_SET);
 
-	if (utf16) {
-		if (srcdata->text != NULL) {
-			bfree(srcdata->text);
-			srcdata->text = NULL;
-		}
-		srcdata->text = bzalloc(filesize - cur_pos);
-		bytes_read = fread(srcdata->text, (filesize - cur_pos), 1, tmp_file);
-
-		remove_cr(srcdata->text);
-		bfree(tmp_read);
-		fclose(tmp_file);
-
-		return;
-	}
 
 	tmp_read = bzalloc((filesize - cur_pos) + 1);
 	bytes_read = fread(tmp_read, filesize - cur_pos, 1, tmp_file);

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -356,15 +356,16 @@ time_t get_modified_timestamp(char *filename)
 	return stats.st_mtime;
 }
 
-static void remove_cr(wchar_t *source)
+static inline void remove_cr_and_zeroes(wchar_t *source, size_t len)
 {
-	int j = 0;
-	for (int i = 0; source[i] != '\0'; ++i) {
-		if (source[i] != L'\r') {
+	size_t j = 0;
+	for (size_t i = 0; i < len; i++) {
+		wchar_t ch = source[i];
+		if (ch != L'\0' && ch != L'\r') {
 			source[j++] = source[i];
 		}
 	}
-	source[j] = '\0';
+	source[j] = L'\0';
 }
 
 static void load_text_from_utf8_buf(struct ft2_source *srcdata, const char *utf8_text, size_t len)
@@ -372,7 +373,7 @@ static void load_text_from_utf8_buf(struct ft2_source *srcdata, const char *utf8
 	size_t wlen = os_utf8_to_wcs(utf8_text, len, NULL, 0);
 	srcdata->text = bzalloc((wlen + 1) * sizeof(wchar_t));
 	os_utf8_to_wcs(utf8_text, len, srcdata->text, (wlen + 1));
-	remove_cr(srcdata->text);
+	remove_cr_and_zeroes(srcdata->text, wlen);
 }
 
 void load_text_from_file(struct ft2_source *srcdata, const char *filename)

--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -387,7 +387,7 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	fseek(tmp_file, 0, SEEK_SET);
 
 	tmp_read = bzalloc(filesize + 1);
-	bytes_read = fread(tmp_read, filesize, 1, tmp_file);
+	bytes_read = fread(tmp_read, 1, filesize, tmp_file);
 	fclose(tmp_file);
 
 	if (srcdata->text != NULL) {
@@ -441,7 +441,7 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 	os_fseeki64(tmp_file, (int64_t)cur_pos, SEEK_SET);
 
 	tmp_read = bzalloc((filesize - cur_pos) + 1);
-	bytes_read = fread(tmp_read, filesize - cur_pos, 1, tmp_file);
+	bytes_read = fread(tmp_read, 1, filesize - cur_pos, tmp_file);
 	fclose(tmp_file);
 
 	if (srcdata->text != NULL) {


### PR DESCRIPTION
### Description
This PR contains numerous fixes for file access with the text-freetype2 text source:

1. Remove redundant/deprecated Windows-only UTF16 code -- the freetype2 text source is deprecated on Windows and no one, even on Windows, is actually going to use UTF16 BOM text files. I don't know why that code was even there. Just completely pointless code.
2. Fix fread() parameter usage, it was using size instead of count for the number of bytes to read, which technically still works but is backwards from how its intended to be used.
3. Optimize "log mode" file reads. It was calling countless fread() calls **one single character at a time** while trying to find the appropriate place to start reading from. Once I saw this situation I couldn't just not fix it. It was insane. I changed it to read in reasonable chunks of 1k bytes and analyze that data chunk by chunk instead.
4. Minor refactor of file reading code. Some unnecessarily duplicated code. Probably more out there in the rest of the source but I'm keeping it to the file-related code for this PR for now to prevent my sanity levels from dropping too low.
5. Ignore null bytes when reading text files, which was what I was _originally_ trying to just fix, but which lead me down a rabbit hole of other issues in the surrounding code.

Fixes obsproject/obs-studio#7595

### Motivation and Context
In my journey of investigating #7595 (that many have proposed fixes to over the years), I realized that there was quite a few things to fix with file reading. This is the culmination of those fixes.

There are probably more things that could probably be fixed in text-freetype2 -- I would argue the source needs to be completely rewritten from scratch with a text renderer that also handles text shaping properly -- but I would prefer to keep it focused on just fixing the issue properly, and fixing a few related issues and not like, bike shed the god forsaken text-freetype2 source to death.

If someone wants to rewrite this thing then please do, this thing needs a bulldozer. I just want to get the issues and those other PRs closed to remove some ancient gunk from our repository.

### How Has This Been Tested?
Tested on Linux. Tested file reading to ensure that it worked, tested log mode to ensure that it also still worked properly.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- Performance enhancement (non-breaking change which improves efficiency)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation. (N/A)
