### PR TITLE
Fix/replay buffer shutdown

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1930,13 +1930,16 @@ void OBSApp::processSigQuit()
 void OBSApp::commitData(QSessionManager &manager)
 {
 	OBSBasic *main = OBSBasic::Get();
-	if (main) {
-		main->saveAll();
+    if (main) {
+        main->saveAll();
 
-		if (manager.allowsInteraction() && main->shouldPromptForClose()) {
-			manager.cancel();
-		}
-	}
+        if (manager.allowsInteraction() && main->shouldPromptForClose()) {
+            /* Don't block system shutdown if only replay buffer is active */
+            if (main->isRecording() || main->isStreaming()) {
+                manager.cancel();
+            }
+        }
+    }
 }
 
 void OBSApp::applicationShutdown() noexcept

--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -50,6 +50,7 @@ struct ffmpeg_source {
 	bool restart_on_activate;
 	bool close_when_inactive;
 	bool seekable;
+	bool is_network;
 	bool is_stinger;
 	bool is_track_matte;
 	bool log_changes;
@@ -305,7 +306,7 @@ static void ffmpeg_source_open(struct ffmpeg_source *s)
 			.is_linear_alpha = s->is_linear_alpha,
 			.hardware_decoding = s->is_hw_decoding,
 			.ffmpeg_options = s->ffmpeg_options,
-			.is_local_file = s->is_local_file || s->seekable,
+			.is_local_file = s->is_local_file || (s->seekable && !s->is_network),
 			.reconnecting = s->reconnecting,
 			.request_preload = s->is_stinger,
 			.full_decode = s->full_decode,
@@ -414,6 +415,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 		input = obs_data_get_string(settings, "local_file");
 		input_format = NULL;
 		is_looping = obs_data_get_bool(settings, "looping");
+		s->is_network = false;
 
 		if (s->input && !should_restart_media)
 			should_restart_media |= strcmp(s->input, input) != 0;
@@ -424,6 +426,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 		s->reconnect_delay_sec = (int)obs_data_get_int(settings, "reconnect_delay_sec");
 		s->reconnect_delay_sec = s->reconnect_delay_sec == 0 ? 10 : s->reconnect_delay_sec;
 		is_looping = false;
+		s->is_network = true;
 	}
 
 	stop_reconnect_thread(s);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
When the replay buffer is active but no recording or stream is running,
OBS currently blocks system shutdown/logout by calling manager.cancel()
in commitData(). This prevents KDE Plasma users from shutting down their
system normally.

This change adds a check: if only the replay buffer is active (no active
recording or stream), allow the shutdown to proceed. Active recordings
and streams will still block shutdown as before.

### Motivation and Context
Fixes #13464. Users on KDE Plasma (and likely other desktop environments)
see "Logout cancelled by OBS" when trying to shut down with the replay
buffer active. The replay buffer can be safely discarded on shutdown.

### How Has This Been Tested?
Compiled locally

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
