### PR TITLE
plugins: Fix missing file descriptors

### DIFF
--- a/plugins/obs-vst/CMakeLists.txt
+++ b/plugins/obs-vst/CMakeLists.txt
@@ -42,6 +42,8 @@ target_link_libraries(
 )
 
 if(OS_WINDOWS)
+  configure_file(cmake/windows/obs-module.rc.in obs-vst.rc)
+  target_sources(obs-vst PRIVATE obs-vst.rc)
   set_property(TARGET obs-vst APPEND PROPERTY AUTORCC_OPTIONS --format-version 1)
 endif()
 

--- a/plugins/obs-vst/cmake/windows/obs-module.rc.in
+++ b/plugins/obs-vst/cmake/windows/obs-module.rc.in
@@ -1,0 +1,24 @@
+1 VERSIONINFO
+FILEVERSION ${OBS_VERSION_MAJOR},${OBS_VERSION_MINOR},${OBS_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "${OBS_COMPANY_NAME}"
+      VALUE "FileDescription", "OBS VST2 module"
+      VALUE "FileVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "ProductName", "${OBS_PRODUCT_NAME}"
+      VALUE "ProductVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "Comments", "${OBS_COMMENTS}"
+      VALUE "LegalCopyright", "${OBS_LEGAL_COPYRIGHT}"
+      VALUE "InternalName", "obs-vst"
+      VALUE "OriginalFilename", "obs-vst"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END

--- a/plugins/obs-webrtc/CMakeLists.txt
+++ b/plugins/obs-webrtc/CMakeLists.txt
@@ -19,4 +19,9 @@ target_sources(
 
 target_link_libraries(obs-webrtc PRIVATE OBS::libobs LibDataChannel::LibDataChannel CURL::libcurl)
 
+if(OS_WINDOWS)
+  configure_file(cmake/windows/obs-module.rc.in obs-webrtc.rc)
+  target_sources(obs-webrtc PRIVATE obs-webrtc.rc)
+endif()
+
 set_target_properties_obs(obs-webrtc PROPERTIES FOLDER plugins PREFIX "")

--- a/plugins/obs-webrtc/cmake/windows/obs-module.rc.in
+++ b/plugins/obs-webrtc/cmake/windows/obs-module.rc.in
@@ -6,7 +6,7 @@ BEGIN
     BLOCK "040904B0"
     BEGIN
       VALUE "CompanyName", "${OBS_COMPANY_NAME}"
-      VALUE "FileDescription", "OBS output module"
+      VALUE "FileDescription", "OBS WebRTC module"
       VALUE "FileVersion", "${OBS_VERSION_CANONICAL}"
       VALUE "ProductName", "${OBS_PRODUCT_NAME}"
       VALUE "ProductVersion", "${OBS_VERSION_CANONICAL}"

--- a/plugins/win-capture/CMakeLists.txt
+++ b/plugins/win-capture/CMakeLists.txt
@@ -76,6 +76,9 @@ target_link_libraries(
 # Remove once jansson has been fixed on obs-deps
 target_link_options(win-capture PRIVATE /IGNORE:4098)
 
+configure_file(cmake/windows/obs-module.rc.in win-capture.rc)
+target_sources(win-capture PRIVATE win-capture.rc)
+
 set_target_properties_obs(win-capture PROPERTIES FOLDER plugins/win-capture PREFIX "")
 
 add_subdirectory(graphics-hook)

--- a/plugins/win-capture/cmake/windows/obs-module.rc.in
+++ b/plugins/win-capture/cmake/windows/obs-module.rc.in
@@ -1,0 +1,24 @@
+1 VERSIONINFO
+FILEVERSION ${OBS_VERSION_MAJOR},${OBS_VERSION_MINOR},${OBS_VERSION_PATCH},0
+BEGIN
+  BLOCK "StringFileInfo"
+  BEGIN
+    BLOCK "040904B0"
+    BEGIN
+      VALUE "CompanyName", "${OBS_COMPANY_NAME}"
+      VALUE "FileDescription", "OBS Windows Capture module"
+      VALUE "FileVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "ProductName", "${OBS_PRODUCT_NAME}"
+      VALUE "ProductVersion", "${OBS_VERSION_CANONICAL}"
+      VALUE "Comments", "${OBS_COMMENTS}"
+      VALUE "LegalCopyright", "${OBS_LEGAL_COPYRIGHT}"
+      VALUE "InternalName", "win-capture"
+      VALUE "OriginalFilename", "win-capture"
+    END
+  END
+
+  BLOCK "VarFileInfo"
+  BEGIN
+    VALUE "Translation", 0x0409, 0x04B0
+  END
+END


### PR DESCRIPTION
### Description

Apply same changes from #1944 to obs-webrtc, obs-vst, and win-capture.

<img width="275" height="308" alt="image" src="https://github.com/user-attachments/assets/52c0f1b6-55b0-4eed-b8fe-35c8f99dd212" />
<img width="240" height="306" alt="image" src="https://github.com/user-attachments/assets/8b047621-c87f-4e07-baba-2ad4c79e75b5" />
<img width="243" height="304" alt="image" src="https://github.com/user-attachments/assets/e8bd65cd-daa9-4fa7-8b1e-b5b8ed677668" />




### Motivation and Context

Unversioned files are unhelpful, and this makes our DLLs consistent.

Noticed these were missing while comparing the same for https://github.com/obsproject/obs-browser/pull/525.

### How Has This Been Tested?

Built on Windows 10, inspected the file details.

### Types of changes

 - Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
