### PR TITLE
frontend: Duplicate browser cookies when profile is duplicated

### DIFF
--- a/frontend/widgets/OBSBasic_Browser.cpp
+++ b/frontend/widgets/OBSBasic_Browser.cpp
@@ -223,7 +223,7 @@ void DeleteCookies()
 #endif
 }
 
-void DuplicateCurrentCookieProfile(ConfigFile &config)
+void DuplicateCurrentCookieProfile()
 {
 #ifdef BROWSER_AVAILABLE
 	if (cef) {
@@ -260,7 +260,6 @@ void DuplicateCurrentCookieProfile(ConfigFile &config)
 			}
 		}
 
-		config_set_string(config, "Panels", "CookieId", cookie_id.c_str());
 		config_set_string(main->Config(), "Panels", "CookieId", new_id.c_str());
 	}
 #else

--- a/frontend/widgets/OBSBasic_Profiles.cpp
+++ b/frontend/widgets/OBSBasic_Profiles.cpp
@@ -37,7 +37,7 @@ constexpr std::string_view OBSProfileSettingsFile = "basic.ini";
 extern bool restart;
 
 extern void DestroyPanelCookieManager();
-extern void DuplicateCurrentCookieProfile(ConfigFile &config);
+extern void DuplicateCurrentCookieProfile();
 extern void CheckExistingCookieId();
 extern void DeleteCookies();
 
@@ -102,6 +102,8 @@ void OBSBasic::SetupDuplicateProfile(const std::string &profileName)
 	}
 
 	ActivateProfile(newProfile);
+
+	DuplicateCurrentCookieProfile();
 
 	blog(LOG_INFO, "Created profile '%s' (duplicate, %s)", newProfile.name.c_str(),
 	     newProfile.directoryName.c_str());


### PR DESCRIPTION
### Description

Regenerate Cookie ID and copy existing cookies into a new folder when duplicating a profile.

Without this change, cookies are reused across profiles, so logging out of one logs out of both. This causes very unpredictable behaviour.

### Motivation and Context

* Fix regression introduced by #11055

Reproduction Steps:

1. Login via OAuth into a Twitch account
2. Notice all OAuth docks work and `config\obs-studio\plugin_config\obs-browser\obs_profile_cookies` contains 1 directory.
3. Duplicate Profile
4. Close OBS
5. Notice `config\obs-studio\plugin_config\obs-browser\obs_profile_cookies` didn't gain a second directory.
6. Close OBS
7. Notice the new and old profile's `basic.ini` have the same `[Panels] CookieId`

### How Has This Been Tested?

1. Create a Profile named `CopyCookies1`
2. Login to OAuth via Twitch
3. Duplicate Profile named `CopyCookies2`
4. Close OBS
5. Verify a new `obs_profile_cookies` subdirectory was created that matches the value in `CopyCookies2`'s `basic.ini` and that the `[Twitch]` section remains identical in both.
6. Re-open OBS, notice Twitch docks correctly work

<img width="598" height="104" alt="image" src="https://github.com/user-attachments/assets/3c8f8654-b6bd-4dbd-adba-b6e6d5c2b25f" />

<img width="482" height="73" alt="image" src="https://github.com/user-attachments/assets/253ab585-f5b9-4e86-bbf9-379455e30891" />

Tested on Windows 10.

### Types of changes

 - Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
