### PR TITLE
plugins/nvenc: Allow UI options to override lookahead and AQ fix

### DIFF
--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -295,8 +295,7 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings)
 	/* lookahead */
 
 	const bool use_profile_lookahead = config->rcParams.enableLookahead;
-	bool lookahead = nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD) &&
-			 (enc->props.lookahead || use_profile_lookahead);
+	bool lookahead = nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_LOOKAHEAD) && enc->props.lookahead;
 
 	if (lookahead) {
 		rc_lookahead = use_profile_lookahead ? config->rcParams.lookaheadDepth : 8;
@@ -329,7 +328,18 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings)
 		}
 	}
 
-	enc->config.rcParams.disableIadapt = enc->props.disable_scenecut;
+	if (!lookahead) {
+		config->rcParams.enableLookahead = 0;
+		config->rcParams.lookaheadDepth = 0;
+		config->rcParams.disableIadapt = 1;
+		config->rcParams.disableBadapt = 1;
+	}
+
+	/* disable adaptive Iframes when scenecut is disabled */
+
+	if (enc->props.disable_scenecut) {
+		enc->config.rcParams.disableIadapt = 1;
+	}
 
 	/* psycho aq */
 
@@ -337,6 +347,10 @@ static bool init_encoder_base(struct nvenc_data *enc, obs_data_t *settings)
 		config->rcParams.enableAQ = 1;
 		config->rcParams.aqStrength = 8;
 		config->rcParams.enableTemporalAQ = nv_get_cap(enc, NV_ENC_CAPS_SUPPORT_TEMPORAL_AQ);
+	} else {
+		config->rcParams.enableAQ = 0;
+		config->rcParams.aqStrength = 0;
+		config->rcParams.enableTemporalAQ = 0;
 	}
 
 	/* -------------------------- */


### PR DESCRIPTION
## Description

Some NVENC H264 presets, such as P6 and P7 enforce lookahead and Adaptive Quantization.
When a User selected these presets there was no chance to disable lookahead and AQ.

This pull request ensures the UI option to be usable even if the preset enables it.

### Motivation and Context

If OBS exposes these options to the User, the encoder should respect the user's choice even when the selected preset enables them by default.

Tests show that in low bitrate situations like Twitch streaming with 6000-8000 Kbps and heavy movement and lots of objects, using lookahead can result in worse quality.

### How Has This Been Tested?

Tested with the NVENC H.264 encoder using P6 and P7 presets.

- P6/P7 can still be used normally.
- Lookahead is enabled when checked in the UI.
- Lookahead is disabled when unchecked in the UI
- Adaptive quantization is enabled when checked in the UI.
- Adaptive quantization is disabled when unchecked in the UI.

- Environment:
    - OS: Windows 11
    - Hardware: AMD Ryzen 9 9950x3d, NVIDIA RTX 5080

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.