### PR TITLE
win-capture: Add Construct 3 window class to WGC match

### DIFF
--- a/plugins/win-capture/data/compatibility.json
+++ b/plugins/win-capture/data/compatibility.json
@@ -87,6 +87,34 @@
             "url": ""
         },
         {
+            "name": "Construct 3",
+            "translation_key": "Compatibility.WindowCapture.BitBlt.Applications.Based",
+            "severity": 0,
+            "executable": "",
+            "window_class": "WindowsWebview2Wrapper",
+            "window_title": "",
+            "match_flags": 4,
+            "game_capture": false,
+            "window_capture": true,
+            "window_capture_wgc": false,
+            "message": "Applications based on Chromium may not be capturable using the selected Capture Method (BitBlt).",
+            "url": ""
+        },
+        {
+            "name": "Construct 3",
+            "translation_key": "Compatibility.GameCapture.Blocked.Applications.Built",
+            "severity": 2,
+            "executable": "",
+            "window_class": "WindowsWebview2Wrapper",
+            "window_title": "",
+            "match_flags": 4,
+            "game_capture": true,
+            "window_capture": false,
+            "window_capture_wgc": false,
+            "message": "Games built on Chromium cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
+            "url": ""
+        },
+        {
             "name": "UWP",
             "translation_key": "Compatibility.WindowCapture.BitBlt.Applications",
             "severity": 0,

--- a/plugins/win-capture/data/package.json
+++ b/plugins/win-capture/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/win-capture/v1",
-    "version": 9,
+    "version": 10,
     "files": [
         {
             "name": "compatibility.json",
-            "version": 9
+            "version": 10
         }
     ]
 }

--- a/plugins/win-capture/data/package.json
+++ b/plugins/win-capture/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/win-capture/v1",
-    "version": 10,
+    "version": 11,
     "files": [
         {
             "name": "compatibility.json",
-            "version": 10
+            "version": 11
         }
     ]
 }

--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -121,16 +121,17 @@ static const char *wgc_whole_match_classes[] = {
 	"Windows.UI.Core.CoreWindow",
 	"WinUIDesktopWin32WindowClass",
 	"GAMINGSERVICESUI_HOSTING_WINDOW_CLASS",
-	"XLMAIN",            /* Microsoft Excel */
-	"PPTFrameClass",     /* Microsoft PowerPoint */
-	"screenClass",       /* Microsoft PowerPoint (Slide Show) */
-	"PodiumParent",      /* Microsoft PowerPoint (Presenter View) */
-	"OpusApp",           /* Microsoft Word */
-	"OMain",             /* Microsoft Access */
-	"Framework::CFrame", /* Microsoft OneNote */
-	"rctrl_renwnd32",    /* Microsoft Outlook */
-	"MSWinPub",          /* Microsoft Publisher */
-	"OfficeApp-Frame",   /* Microsoft 365 Software */
+	"XLMAIN",                 /* Microsoft Excel */
+	"PPTFrameClass",          /* Microsoft PowerPoint */
+	"screenClass",            /* Microsoft PowerPoint (Slide Show) */
+	"PodiumParent",           /* Microsoft PowerPoint (Presenter View) */
+	"OpusApp",                /* Microsoft Word */
+	"OMain",                  /* Microsoft Access */
+	"Framework::CFrame",      /* Microsoft OneNote */
+	"rctrl_renwnd32",         /* Microsoft Outlook */
+	"MSWinPub",               /* Microsoft Publisher */
+	"OfficeApp-Frame",        /* Microsoft 365 Software */
+	"WindowsWebview2Wrapper", /* Construct 3 Games */
 	"SDL_app",
 	NULL,
 };


### PR DESCRIPTION
### Description

Add `"WindowsWebview2Wrapper"` to `wgc_whole_match_classes[]` in `window-capture.c` so that OBS automatic mode selects WGC instead of BitBlt when capturing a window whose top-level class is `WindowsWebview2Wrapper`.

My aim is to fix an issue where capturing [games made in the Construct 3 engine](https://steamdb.info/tech/Engine/Construct/) defaults to the wrong mode (#13359)

I have tried to follow the precedent set in https://github.com/obsproject/obs-studio/pull/8617 and https://github.com/obsproject/obs-studio/pull/12327 as closely as possible, but this is my first contribution so please forgive any issues, I am happy to correct them.

Also add two entries to `compatibility.json` for `WindowsWebview2Wrapper`:
- A severity-0 window capture warning (BitBlt method selected) reusing the existing `Compatibility.WindowCapture.BitBlt.Applications.Based` key and Chromium message text (I used the existing key because WebView2 is Chromium-based after all).
- A severity-2 game capture blocked warning reusing the existing `Compatibility.GameCapture.Blocked.Applications.Built` key and Chromium message text, for the same reason.

The `name` field in both entries is `"Construct 3"` because `WindowsWebview2Wrapper` is the top-level host class Construct 3 registers for its exported WebView2 games. Although this isn't ideal because it sounds quite generic, my logic was that because it has to be an exact match, and also the fact that any other WebView2 application will also need to be captured using WGC, I can't foresee any issues.

### Motivation and Context

Construct 3 games embed the Microsoft WebView2 runtime, and although WebView2's internal child windows use the `Chrome_WidgetWin_1` class (which already matches the `"Chrome"` partial-match entry), the top-level host window class is defined by the dev. Construct 3 uses `WindowsWebview2Wrapper` which contains neither `"Chrome"` nor `"Mozilla"`, and it isn't in `wgc_whole_match_classes`, so OBS automatic mode falls through to BitBlt, which can't capture the WebView2 content, resulting in a white screen.

Adding `"WindowsWebview2Wrapper"` to the whole-match list was chosen over a new partial-match entry (e.g. `"WebView2"`) because there is no Microsoft-standard substring guaranteed to appear in host window class names (as I say it's defined by the app dev). I felt doing it this way is more specific.

Closes #13359 although only for Construct 3 games, Tauri and other Webview based apps would need a different approach.

### How Has This Been Tested?

Tested locally on Windows 11 with the Construct 3 game attached to #13359. With the capture method set to Automatic, OBS now selects WGC and the window preview captures correctly with content visible. The compatibility warning also shows correctly when BitBlt or Game Capture is selected manually.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [[clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format)](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**[style guidelines](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.