### PR TITLE
linux-alsa: stop reopen thread before destroying abort_event

### DIFF
--- a/plugins/linux-alsa/alsa-input.c
+++ b/plugins/linux-alsa/alsa-input.c
@@ -154,6 +154,8 @@ void alsa_destroy(void *vptr)
 {
 	struct alsa_data *data = vptr;
 
+	_alsa_stop_reopen(data);
+
 	if (data->handle)
 		_alsa_close(data);
 


### PR DESCRIPTION
### Description
Was hitting an abort in glibc's`__pthread_mutex_cond_lock` from `os_event_timedwait` in the ALSA plugin's reopen thread.

### Motivation and Context

While running obs on on Ubuntu 26.04 (32.1.0-0ubuntu3), occassionally I would see crashes. I investigated one such crash using apport-retrace and came to the attached fix.

### How Has This Been Tested?

I rebuilt my changes against the affected Ubuntu version, and did my usual OBS workflow for a few days. No crashes found so far, whereas before it was common.

### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
