### PR TITLE
CI: Update macOS runners and required Xcode version for project

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -41,7 +41,7 @@ jobs:
 
   macos:
     name: macOS 🍏 (clang-analyze)
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}
@@ -57,8 +57,8 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 16.4'
-          sudo xcode-select --switch /Applications/Xcode_16.4.app/Contents/Developer
+          print '::group::Enable Xcode 26.5'
+          sudo xcode-select --switch /Applications/Xcode_26.5.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -59,7 +59,7 @@ jobs:
 
   macos-build:
     name: macOS 🍏
-    runs-on: macos-15
+    runs-on: macos-26
     needs: check-event
     strategy:
       fail-fast: false
@@ -80,8 +80,8 @@ jobs:
           : Set Up Environment 🔧
           if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
-          print '::group::Enable Xcode 26.1'
-          sudo xcode-select --switch /Applications/Xcode_26.1.app/Contents/Developer
+          print '::group::Enable Xcode 26.5'
+          sudo xcode-select --switch /Applications/Xcode_26.5.app/Contents/Developer
           print '::endgroup::'
 
           print '::group::Clean Homebrew Environment'

--- a/.github/workflows/check-format.yaml
+++ b/.github/workflows/check-format.yaml
@@ -15,7 +15,7 @@ jobs:
           failCondition: error
 
   swift-format:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/dispatch.yaml
+++ b/.github/workflows/dispatch.yaml
@@ -39,7 +39,7 @@ jobs:
   services-validation:
     name: Validate Services 🕵️
     if: github.repository_owner == 'obsproject' && inputs.job == 'services'
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       checks: write
       contents: write
@@ -73,7 +73,7 @@ jobs:
   steam-upload:
     name: Upload Steam Builds 🚂
     if: github.repository_owner == 'obsproject' && inputs.job == 'steam'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/steam-upload

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -230,7 +230,7 @@ jobs:
     name: Upload Steam Builds 🚂
     needs: check-tag
     if: github.repository_owner == 'obsproject' && fromJSON(needs.check-tag.outputs.validTag)
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/steam-upload

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -139,7 +139,7 @@ jobs:
   create-appcast:
     name: Create Sparkle Appcast 🎙️
     if: github.repository_owner == 'obsproject' && github.ref_type == 'tag'
-    runs-on: macos-15
+    runs-on: macos-26
     needs: build-project
     strategy:
       fail-fast: false

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -13,7 +13,7 @@ jobs:
   services-availability:
     name: Check Service Availability 🛜
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-15
+    runs-on: macos-26
     permissions:
       checks: write
       contents: write
@@ -163,7 +163,7 @@ jobs:
     name: Upload Steam Builds 🚂
     needs: [build-project]
     if: github.repository_owner == 'obsproject'
-    runs-on: macos-15
+    runs-on: macos-26
     defaults:
       run:
         shell: zsh --no-rcs --errexit --pipefail {0}

--- a/cmake/macos/compilerconfig.cmake
+++ b/cmake/macos/compilerconfig.cmake
@@ -19,8 +19,8 @@ endif()
 
 # Ensure recent enough Xcode and platform SDK
 function(check_sdk_requirements)
-  set(obs_macos_minimum_sdk 15.0) # Keep in sync with Xcode
-  set(obs_macos_minimum_xcode 16.0) # Keep in sync with SDK
+  set(obs_macos_minimum_sdk 26.5) # Keep in sync with Xcode
+  set(obs_macos_minimum_xcode 26.5) # Keep in sync with SDK
   execute_process(
     COMMAND xcrun --sdk macosx --show-sdk-platform-version
     OUTPUT_VARIABLE obs_macos_current_sdk


### PR DESCRIPTION
### Description
Increases the Xcode version requirement for building OBS Studio on macOS to v26.5 and switch GitHub Actions runners to macOS 26.

### Motivation and Context
Per the usual release cadence, Xcode versions released around Q2 of the year following a macOS release will require that release to run, which also serves as preparation for the following macOS beta version which will usually be released to developers shortly after that.

To avoid falling too far behind, the project needs to keep up with Xcode updates, particularly as those will also include updates to the build toolchain and compilers used.

Supersedes and closes #13406
Supersedes and closes #13384

> [!NOTE]
> This does not change the deployment target of OBS Studio itself, which still targets macOS 12.

### How Has This Been Tested?
Tested with Xcode 26.5 on current macOS 26, as well as on GitHub Actions runners using `macos-26` image on separate fork.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
