### PR TITLE
frontend: replace Auth with YoutubeApiWrappers for YouTube callers

### DIFF
--- a/frontend/cmake/feature-youtube.cmake
+++ b/frontend/cmake/feature-youtube.cmake
@@ -19,6 +19,9 @@ if(
       oauth/YoutubeAuth.hpp
       utility/YoutubeApiWrappers.cpp
       utility/YoutubeApiWrappers.hpp
+      utility/YoutubeApiClient.hpp
+      utility/YoutubeApiClient.cpp
+      utility/YoutubeApiTypes.hpp
   )
 
   target_enable_feature(obs-studio "YouTube API connection" YOUTUBE_ENABLED)

--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -17,11 +17,11 @@ const QString SchedulDateAndTimeFormat = "yyyy-MM-dd'T'hh:mm:ss'Z'";
 const QString RepresentSchedulDateAndTimeFormat = "dddd, MMMM d, yyyy h:m";
 const QString IndexOfGamingCategory = "20";
 
-OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth, bool broadcastReady)
+OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, YoutubeApiWrappers &apiYouTube, bool broadcastReady)
 	: QDialog(parent),
 	  ui(new Ui::OBSYoutubeActions),
-	  apiYouTube(dynamic_cast<YoutubeApiWrappers *>(auth)),
-	  workerThread(new WorkerThread(apiYouTube)),
+	  apiYouTube(&apiYouTube),
+	  workerThread(new WorkerThread(&apiYouTube)),
 	  broadcastReady(broadcastReady)
 {
 	setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
@@ -121,12 +121,6 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth, bool broadcast
 
 	connect(ui->selectFileButton, &QPushButton::clicked, this, thumbSelectionHandler);
 	connect(ui->thumbnailPreview, &ClickableLabel::clicked, this, thumbSelectionHandler);
-
-	if (!apiYouTube) {
-		blog(LOG_DEBUG, "YouTube API auth NOT found.");
-		Cancel();
-		return;
-	}
 
 	const char *name = config_get_string(OBSBasic::Get()->Config(), "YouTube", "ChannelName");
 	this->setWindowTitle(QTStr("YouTube.Actions.WindowTitle").arg(name));

--- a/frontend/dialogs/OBSYoutubeActions.hpp
+++ b/frontend/dialogs/OBSYoutubeActions.hpp
@@ -47,7 +47,7 @@ protected:
 	void ShowErrorDialog(QWidget *parent, QString text);
 
 public:
-	explicit OBSYoutubeActions(QWidget *parent, Auth *auth, bool broadcastReady);
+	explicit OBSYoutubeActions(QWidget *parent, YoutubeApiWrappers &apiYouTube, bool broadcastReady);
 	virtual ~OBSYoutubeActions() override;
 
 	bool Valid() { return valid; };

--- a/frontend/settings/OBSBasicSettings_Stream.cpp
+++ b/frontend/settings/OBSBasicSettings_Stream.cpp
@@ -808,7 +808,7 @@ OBSService OBSBasicSettings::SpawnTempService()
 
 void OBSBasicSettings::OnOAuthStreamKeyConnected()
 {
-	OAuthStreamKey *a = reinterpret_cast<OAuthStreamKey *>(auth.get());
+	OAuthStreamKey *a = dynamic_cast<OAuthStreamKey *>(auth.get());
 
 	if (a) {
 		bool validKey = !a->key().empty();

--- a/frontend/utility/YoutubeApiClient.cpp
+++ b/frontend/utility/YoutubeApiClient.cpp
@@ -1,0 +1,519 @@
+#include "YoutubeApiClient.hpp"
+
+#include <utility>
+
+#include <utility/RemoteTextThread.hpp>
+#include <utility/obf.h>
+
+#include <qt-wrappers.hpp>
+#include <ui-config.h>
+
+#include <QFile>
+#include <QMimeDatabase>
+#include <QLocale>
+#include <QUrl>
+
+using namespace json11;
+
+namespace {
+using std::string_view_literals::operator""sv;
+
+constexpr auto youtubeLiveStreamUrl = "https://www.googleapis.com/youtube/v3/liveStreams"sv;
+constexpr auto youtubeLiveBroadcastUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts"sv;
+constexpr auto youtubeLiveBroadcastTransitionUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts/transition"sv;
+constexpr auto youtubeLiveBroadcastBindUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts/bind"sv;
+
+constexpr auto youtubeLiveChannelUrl = "https://www.googleapis.com/youtube/v3/channels"sv;
+constexpr auto youtubeLiveTokenUrl = "https://oauth2.googleapis.com/token"sv;
+constexpr auto youtubeLiveVideoCategoriesUrl = "https://www.googleapis.com/youtube/v3/videoCategories"sv;
+constexpr auto youtubeLiveVideosUrl = "https://www.googleapis.com/youtube/v3/videos"sv;
+constexpr auto youtubeLiveThumbnailUrl = "https://www.googleapis.com/upload/youtube/v3/thumbnails/set"sv;
+
+constexpr auto defaultBroadcastsPerQuery = 50; // acceptable values are 0 to 50, inclusive
+} // namespace
+
+bool YoutubeApiClient::GetTranslatedError(QString &error_message)
+{
+	const QString errorKey = "YouTube.Errors." + lastErrorReason.toUtf8();
+	const QString translated = QTStr(QT_TO_UTF8(errorKey));
+	// No translation found
+	if (translated.startsWith("YouTube.Errors.")) {
+		return false;
+	}
+	error_message = translated;
+	return true;
+}
+
+YoutubeApiClient::YoutubeApiClient(TokenAccess tokenAccess) : m_tokenAccess(std::move(tokenAccess)) {}
+
+bool YoutubeApiClient::TryInsertCommand(const char *url, const char *content_type, std::string request_type,
+					const char *data, Json &json_out, long *error_code, int data_size)
+{
+	long httpStatusCode = 0;
+
+#ifdef _DEBUG
+	blog(LOG_DEBUG, "YouTube API command URL: %s", url);
+	if (data && data[0] == '{') { // only log JSON data
+		blog(LOG_DEBUG, "YouTube API command data: %s", data);
+	}
+#endif
+	std::string token = m_tokenAccess.accessToken();
+	if (token.empty()) {
+		return false;
+	}
+	std::string output;
+	std::string error;
+	// Increase timeout by the time it takes to transfer `data_size` at 1 Mbps
+	int timeout = 60 + data_size / 125000;
+	bool success = GetRemoteFile(url, output, error, &httpStatusCode, content_type, request_type, data,
+				     {"Authorization: Bearer " + token}, nullptr, timeout, false, data_size);
+	if (error_code) {
+		*error_code = httpStatusCode;
+	}
+
+	if (!success || output.empty()) {
+		if (!error.empty()) {
+			blog(LOG_WARNING, "YouTube API request failed: %s", error.c_str());
+		}
+		return false;
+	}
+
+	json_out = Json::parse(output, error);
+#ifdef _DEBUG
+	blog(LOG_DEBUG, "YouTube API command answer: %s", json_out.dump().c_str());
+#endif
+	if (!error.empty()) {
+		return false;
+	}
+	return httpStatusCode < 400;
+}
+
+bool YoutubeApiClient::UpdateAccessToken()
+{
+	std::string refresh_token = m_tokenAccess.refreshToken();
+	if (refresh_token.empty()) {
+		return false;
+	}
+
+	std::string clientid = YOUTUBE_CLIENTID;
+	std::string secret = YOUTUBE_SECRET;
+	deobfuscate_str(&clientid[0], YOUTUBE_CLIENTID_HASH);
+	deobfuscate_str(&secret[0], YOUTUBE_SECRET_HASH);
+
+	std::string r_token = QUrl::toPercentEncoding(refresh_token.c_str()).toStdString();
+	const QString data_template = "client_id=%1"
+				      "&client_secret=%2"
+				      "&refresh_token=%3"
+				      "&grant_type=refresh_token";
+	const QString data =
+		data_template.arg(QString(clientid.c_str()), QString(secret.c_str()), QString(r_token.c_str()));
+	Json json_out;
+	bool success = TryInsertCommand(youtubeLiveTokenUrl.data(), "application/x-www-form-urlencoded", "",
+					QT_TO_UTF8(data), json_out);
+
+	if (!success || json_out.object_items().find("error") != json_out.object_items().end()) {
+		return false;
+	}
+	const std::string token = json_out["access_token"].string_value();
+	m_tokenAccess.setAccessToken(token);
+	return !token.empty();
+}
+
+bool YoutubeApiClient::InsertCommand(const char *url, const char *content_type, std::string request_type,
+				     const char *data, Json &json_out, int data_size)
+{
+	long error_code;
+	bool success = TryInsertCommand(url, content_type, request_type, data, json_out, &error_code, data_size);
+
+	if (error_code == 401) {
+		// Attempt to update access token and try again
+		if (!UpdateAccessToken()) {
+			return false;
+		}
+		success = TryInsertCommand(url, content_type, request_type, data, json_out, &error_code, data_size);
+	}
+
+	if (json_out.object_items().find("error") != json_out.object_items().end()) {
+		blog(LOG_ERROR, "YouTube API error:\n\tHTTP status: %ld\n\tURL: %s\n\tJSON: %s", error_code, url,
+		     json_out.dump().c_str());
+
+		lastError = json_out["error"]["code"].int_value();
+		lastErrorReason = QString(json_out["error"]["errors"][0]["reason"].string_value().c_str());
+		lastErrorMessage = QString(json_out["error"]["message"].string_value().c_str());
+
+		// The existence of an error implies non-success even if the HTTP status code disagrees.
+		success = false;
+	}
+	return success;
+}
+
+bool YoutubeApiClient::GetChannelDescription(ChannelDescription &channel_description)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+
+	const std::string url =
+		std::string(youtubeLiveChannelUrl) + "?part=snippet,contentDetails,statistics&mine=true";
+	Json json_out;
+	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
+		return false;
+	}
+
+	if (json_out["pageInfo"]["totalResults"].int_value() == 0) {
+		lastErrorMessage = QTStr("YouTube.Auth.NoChannels");
+		return false;
+	}
+
+	channel_description.id = QString(json_out["items"][0]["id"].string_value().c_str());
+	channel_description.title = QString(json_out["items"][0]["snippet"]["title"].string_value().c_str());
+	return channel_description.id.isEmpty() ? false : true;
+}
+
+bool YoutubeApiClient::InsertBroadcast(BroadcastDescription &broadcast)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	const std::string url = std::string(youtubeLiveBroadcastUrl) + "?part=snippet,status,contentDetails";
+	const Json data = Json::object{
+		{"snippet",
+		 Json::object{
+			 {"title", QT_TO_UTF8(broadcast.title)},
+			 {"description", QT_TO_UTF8(broadcast.description)},
+			 {"scheduledStartTime", QT_TO_UTF8(broadcast.schedul_date_time)},
+		 }},
+		{"status",
+		 Json::object{
+			 {"privacyStatus", QT_TO_UTF8(broadcast.privacy)},
+			 {"selfDeclaredMadeForKids", broadcast.made_for_kids},
+		 }},
+		{"contentDetails",
+		 Json::object{
+			 {"latencyPreference", QT_TO_UTF8(broadcast.latency)},
+			 {"enableAutoStart", broadcast.auto_start},
+			 {"enableAutoStop", broadcast.auto_stop},
+			 {"enableDvr", broadcast.dvr},
+			 {"projection", QT_TO_UTF8(broadcast.projection)},
+			 {
+				 "monitorStream",
+				 Json::object{
+					 {"enableMonitorStream", false},
+				 },
+			 },
+		 }},
+	};
+	Json json_out;
+	if (!InsertCommand(url.c_str(), "application/json", "", data.dump().c_str(), json_out)) {
+		return false;
+	}
+	broadcast.id = QString(json_out["id"].string_value().c_str());
+	return broadcast.id.isEmpty() ? false : true;
+}
+
+bool YoutubeApiClient::InsertStream(StreamDescription &stream)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	const std::string url = std::string(youtubeLiveStreamUrl) + "?part=snippet,cdn,status,contentDetails";
+	const Json data = Json::object{
+		{"snippet",
+		 Json::object{
+			 {"title", QT_TO_UTF8(stream.title)},
+		 }},
+		{"cdn",
+		 Json::object{
+			 {"frameRate", "variable"},
+			 {"ingestionType", "rtmp"},
+			 {"resolution", "variable"},
+		 }},
+		{"contentDetails", Json::object{{"isReusable", false}}},
+	};
+	Json json_out;
+	if (!InsertCommand(url.c_str(), "application/json", "", data.dump().c_str(), json_out)) {
+		return false;
+	}
+	stream.id = QString(json_out["id"].string_value().c_str());
+	stream.name = QString(json_out["cdn"]["ingestionInfo"]["streamName"].string_value().c_str());
+	return stream.id.isEmpty() ? false : true;
+}
+
+bool YoutubeApiClient::BindStream(const QString broadcast_id, const QString stream_id)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	// TODO: Use std::format with std::string instead of QString::arg with C++20
+	const QString url_template = QString(youtubeLiveBroadcastBindUrl.data()) +
+				     "?id=%1&streamId=%2&part=id,snippet,contentDetails,status";
+	const QString url = url_template.arg(broadcast_id, stream_id);
+	const Json data = Json::object{};
+	this->broadcastId = broadcast_id;
+	Json json_out;
+	return InsertCommand(QT_TO_UTF8(url), "application/json", "", data.dump().c_str(), json_out);
+}
+
+bool YoutubeApiClient::GetBroadcastsList(Json &json_out, const QString &page, const QString &status)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	std::string url = std::string(youtubeLiveBroadcastUrl) +
+			  "?part=snippet,contentDetails,status&broadcastType=all&maxResults=" +
+			  std::to_string(defaultBroadcastsPerQuery);
+
+	if (status.isEmpty()) {
+		url += "&mine=true";
+	} else {
+		url += "&broadcastStatus=" + status.toStdString();
+	}
+
+	if (!page.isEmpty()) {
+		url += "&pageToken=" + page.toStdString();
+	}
+	return InsertCommand(url.c_str(), "application/json", "", nullptr, json_out);
+}
+
+bool YoutubeApiClient::GetVideoCategoriesList(QVector<CategoryDescription> &category_list_out)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	// TODO: Use std::format with C++20
+	const QString url_template =
+		QString(youtubeLiveVideoCategoriesUrl.data()) + "?part=snippet&regionCode=%1&hl=%2";
+
+	/*
+	 * All OBS locale regions aside from "US" are missing category id 29
+	 * ("Nonprofits & Activism"), but it is still available to channels
+	 * set to those regions via the YouTube Studio website.
+	 * To work around this inconsistency with the API all locales will
+	 * use the "US" region and only set the language part for localisation.
+	 * It is worth noting that none of the regions available on YouTube
+	 * feature any category not also available to the "US" region.
+	 */
+	QString url = url_template.arg("US", QLocale().name());
+
+	Json json_out;
+	if (!InsertCommand(QT_TO_UTF8(url), "application/json", "", nullptr, json_out)) {
+		if (lastErrorReason != "unsupportedLanguageCode" && lastErrorReason != "invalidLanguage") {
+			return false;
+		}
+		// Try again with en-US if YouTube error indicates an unsupported locale
+		url = url_template.arg("US", "en_US");
+		if (!InsertCommand(QT_TO_UTF8(url), "application/json", "", nullptr, json_out)) {
+			return false;
+		}
+	}
+	category_list_out = {};
+	for (auto &j : json_out["items"].array_items()) {
+		// Assignable only.
+		if (j["snippet"]["assignable"].bool_value()) {
+			category_list_out.push_back(
+				{j["id"].string_value().c_str(), j["snippet"]["title"].string_value().c_str()});
+		}
+	}
+	return category_list_out.isEmpty() ? false : true;
+}
+
+bool YoutubeApiClient::SetVideoCategory(const QString &video_id, const QString &video_title,
+					const QString &video_description, const QString &categorie_id)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	const std::string url = std::string(youtubeLiveVideosUrl) + "?part=snippet";
+	const Json data = Json::object{
+		{"id", QT_TO_UTF8(video_id)},
+		{"snippet",
+		 Json::object{
+			 {"title", QT_TO_UTF8(video_title)},
+			 {"description", QT_TO_UTF8(video_description)},
+			 {"categoryId", QT_TO_UTF8(categorie_id)},
+		 }},
+	};
+	Json json_out;
+	return InsertCommand(url.c_str(), "application/json", "PUT", data.dump().c_str(), json_out);
+}
+
+bool YoutubeApiClient::SetVideoThumbnail(const QString &video_id, const QString &thumbnail_file)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+
+	// Make sure the file hasn't been deleted since originally selecting it
+	if (!QFile::exists(thumbnail_file)) {
+		lastErrorMessage = QTStr("YouTube.Actions.Error.FileMissing");
+		return false;
+	}
+
+	QFile thumbFile(thumbnail_file);
+	if (!thumbFile.open(QFile::ReadOnly)) {
+		lastErrorMessage = QTStr("YouTube.Actions.Error.FileOpeningFailed");
+		return false;
+	}
+
+	const QByteArray fileContents = thumbFile.readAll();
+	const QString mime = QMimeDatabase().mimeTypeForData(fileContents).name();
+
+	const std::string url = std::string(youtubeLiveThumbnailUrl) + "?videoId=" + video_id.toStdString();
+	Json json_out;
+	return InsertCommand(url.c_str(), QT_TO_UTF8(mime), "POST", fileContents.constData(), json_out,
+			     fileContents.size());
+}
+
+bool YoutubeApiClient::StartBroadcast(const QString &broadcast_id)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+
+	Json json_out;
+	if (!FindBroadcast(broadcast_id, json_out)) {
+		return false;
+	}
+
+	auto lifeCycleStatus = json_out["items"][0]["status"]["lifeCycleStatus"].string_value();
+
+	if (lifeCycleStatus == "live" || lifeCycleStatus == "liveStarting") {
+		// Broadcast is already (going to be) live
+		return true;
+	} else if (lifeCycleStatus == "testStarting") {
+		// User will need to wait a few seconds before attempting to start broadcast
+		lastErrorMessage = QTStr("YouTube.Actions.Error.BroadcastTestStarting");
+		lastErrorReason.clear();
+		return false;
+	}
+
+	// Only reset if broadcast has monitoring enabled and is not already in "testing" mode
+	auto monitorStreamEnabled =
+		json_out["items"][0]["contentDetails"]["monitorStream"]["enableMonitorStream"].bool_value();
+	if (lifeCycleStatus != "testing" && monitorStreamEnabled && !ResetBroadcast(broadcast_id, json_out)) {
+		return false;
+	}
+
+	// TODO: Use std::format with C++20
+	const QString url_template =
+		QString(youtubeLiveBroadcastTransitionUrl.data()) + "?id=%1&broadcastStatus=%2&part=status";
+	const QString live = url_template.arg(broadcast_id, "live");
+	bool success = InsertCommand(QT_TO_UTF8(live), "application/json", "POST", "{}", json_out);
+	// Return a success if the command failed, but was redundant (broadcast already live)
+	return success || lastErrorReason == "redundantTransition";
+}
+
+bool YoutubeApiClient::StartLatestBroadcast()
+{
+	return StartBroadcast(this->broadcastId);
+}
+
+bool YoutubeApiClient::StopBroadcast(const QString &broadcast_id)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+
+	const QString url_template =
+		QString(youtubeLiveBroadcastTransitionUrl.data()) + "?id=%1&broadcastStatus=complete&part=status";
+	const QString url = url_template.arg(broadcast_id);
+	Json json_out;
+	bool success = InsertCommand(QT_TO_UTF8(url), "application/json", "POST", "{}", json_out);
+	// Return a success if the command failed, but was redundant (broadcast already stopped)
+	return success || lastErrorReason == "redundantTransition";
+}
+
+bool YoutubeApiClient::StopLatestBroadcast()
+{
+	return StopBroadcast(this->broadcastId);
+}
+
+void YoutubeApiClient::SetBroadcastId(const QString &broadcast_id)
+{
+	this->broadcastId = broadcast_id;
+}
+
+QString YoutubeApiClient::GetBroadcastId()
+{
+	return broadcastId;
+}
+
+bool YoutubeApiClient::ResetBroadcast(const QString &broadcast_id, json11::Json &json_out)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+
+	auto snippet = json_out["items"][0]["snippet"];
+	auto status = json_out["items"][0]["status"];
+	auto contentDetails = json_out["items"][0]["contentDetails"];
+	auto monitorStream = contentDetails["monitorStream"];
+
+	const Json data = Json::object{
+		{"id", QT_TO_UTF8(broadcast_id)},
+		{"snippet",
+		 Json::object{
+			 {"title", snippet["title"]},
+			 {"description", snippet["description"]},
+			 {"scheduledStartTime", snippet["scheduledStartTime"]},
+			 {"scheduledEndTime", snippet["scheduledEndTime"]},
+		 }},
+		{"status",
+		 Json::object{
+			 {"privacyStatus", status["privacyStatus"]},
+			 {"madeForKids", status["madeForKids"]},
+			 {"selfDeclaredMadeForKids", status["selfDeclaredMadeForKids"]},
+		 }},
+		{"contentDetails",
+		 Json::object{
+			 {
+				 "monitorStream",
+				 Json::object{
+					 {"enableMonitorStream", false},
+					 {"broadcastStreamDelayMs", monitorStream["broadcastStreamDelayMs"]},
+				 },
+			 },
+			 {"enableAutoStart", contentDetails["enableAutoStart"]},
+			 {"enableAutoStop", contentDetails["enableAutoStop"]},
+			 {"enableClosedCaptions", contentDetails["enableClosedCaptions"]},
+			 {"enableDvr", contentDetails["enableDvr"]},
+			 {"enableContentEncryption", contentDetails["enableContentEncryption"]},
+			 {"enableEmbed", contentDetails["enableEmbed"]},
+			 {"recordFromStart", contentDetails["recordFromStart"]},
+			 {"startWithSlate", contentDetails["startWithSlate"]},
+		 }},
+	};
+
+	const std::string put = std::string(youtubeLiveBroadcastUrl) + "?part=id,snippet,contentDetails,status";
+	return InsertCommand(put.c_str(), "application/json", "PUT", data.dump().c_str(), json_out);
+}
+
+bool YoutubeApiClient::FindBroadcast(const QString &id, json11::Json &json_out)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	std::string url = std::string(youtubeLiveBroadcastUrl) +
+			  "?part=id,snippet,contentDetails,status&broadcastType=all&maxResults=1";
+	url += "&id=" + id.toStdString();
+
+	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
+		return false;
+	}
+
+	auto items = json_out["items"].array_items();
+	if (items.size() != 1) {
+		lastErrorMessage = QTStr("YouTube.Actions.Error.BroadcastNotFound");
+		return false;
+	}
+
+	return true;
+}
+
+bool YoutubeApiClient::FindStream(const QString &id, json11::Json &json_out)
+{
+	lastErrorMessage.clear();
+	lastErrorReason.clear();
+	std::string url = std::string(youtubeLiveStreamUrl) + "?part=id,snippet,cdn,status&maxResults=1";
+	url += "&id=" + id.toStdString();
+
+	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
+		return false;
+	}
+
+	auto items = json_out["items"].array_items();
+	if (items.size() != 1) {
+		lastErrorMessage = "No active broadcast found.";
+		return false;
+	}
+
+	return true;
+}

--- a/frontend/utility/YoutubeApiClient.hpp
+++ b/frontend/utility/YoutubeApiClient.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "YoutubeApiTypes.hpp"
+
+#include <json11.hpp>
+
+#include <functional>
+#include <string>
+
+#include <QString>
+#include <QVector>
+
+class YoutubeApiClient {
+public:
+	struct TokenAccess {
+		std::function<std::string()> accessToken;
+		std::function<std::string()> refreshToken;
+		std::function<void(std::string)> setAccessToken;
+	};
+	explicit YoutubeApiClient(TokenAccess tokenAccess);
+
+	bool GetChannelDescription(ChannelDescription &channel_description);
+	bool InsertBroadcast(BroadcastDescription &broadcast);
+	bool InsertStream(StreamDescription &stream);
+	bool BindStream(const QString broadcastId, const QString stream_id);
+	bool GetBroadcastsList(json11::Json &json_out, const QString &page, const QString &status);
+	bool GetVideoCategoriesList(QVector<CategoryDescription> &category_list_out);
+	bool SetVideoCategory(const QString &video_id, const QString &video_title, const QString &video_description,
+			      const QString &categorie_id);
+	bool SetVideoThumbnail(const QString &video_id, const QString &thumbnail_file);
+	bool StartBroadcast(const QString &broadcastId);
+	bool StopBroadcast(const QString &broadcastId);
+	bool ResetBroadcast(const QString &broadcastId, json11::Json &json_out);
+	bool StartLatestBroadcast();
+	bool StopLatestBroadcast();
+
+	void SetBroadcastId(const QString &broadcastId);
+	QString GetBroadcastId();
+
+	bool FindBroadcast(const QString &id, json11::Json &json_out);
+	bool FindStream(const QString &id, json11::Json &json_out);
+
+	QString GetLastError() const { return lastErrorMessage; };
+	bool GetTranslatedError(QString &error_message);
+
+private:
+	bool TryInsertCommand(const char *url, const char *content_type, std::string request_type, const char *data,
+			      json11::Json &ret, long *error_code = nullptr, int data_size = 0);
+	bool UpdateAccessToken();
+	bool InsertCommand(const char *url, const char *content_type, std::string request_type, const char *data,
+			   json11::Json &ret, int data_size = 0);
+
+private:
+	TokenAccess m_tokenAccess;
+	QString broadcastId;
+	int lastError = 0;
+	QString lastErrorMessage;
+	QString lastErrorReason;
+};

--- a/frontend/utility/YoutubeApiTypes.hpp
+++ b/frontend/utility/YoutubeApiTypes.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <QString>
+
+struct ChannelDescription {
+	QString id;
+	QString title;
+};
+
+struct StreamDescription {
+	QString id;
+	QString name;
+	QString title;
+};
+
+struct CategoryDescription {
+	QString id;
+	QString title;
+};
+
+struct BroadcastDescription {
+	QString id;
+	QString title;
+	QString description;
+	QString privacy;
+	CategoryDescription category;
+	QString latency;
+	bool made_for_kids;
+	bool auto_start;
+	bool auto_stop;
+	bool dvr;
+	bool schedul_for_later;
+	QString schedul_date_time;
+	QString projection;
+};

--- a/frontend/utility/YoutubeApiWrappers.cpp
+++ b/frontend/utility/YoutubeApiWrappers.cpp
@@ -1,40 +1,19 @@
 #include "YoutubeApiWrappers.hpp"
 
-#include <utility/RemoteTextThread.hpp>
-#include <utility/obf.h>
 #include <widgets/OBSBasic.hpp>
 
 #include <qt-wrappers.hpp>
-#include <ui-config.h>
-
-#include <QFile>
-#include <QMimeDatabase>
+#include <algorithm>
+#include <utility>
 
 #include "moc_YoutubeApiWrappers.cpp"
 
 using namespace json11;
 
-namespace {
-using std::string_view_literals::operator""sv;
-
-constexpr auto youtubeLiveStreamUrl = "https://www.googleapis.com/youtube/v3/liveStreams"sv;
-constexpr auto youtubeLiveBroadcastUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts"sv;
-constexpr auto youtubeLiveBroadcastTransitionUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts/transition"sv;
-constexpr auto youtubeLiveBroadcastBindUrl = "https://www.googleapis.com/youtube/v3/liveBroadcasts/bind"sv;
-
-constexpr auto youtubeLiveChannelUrl = "https://www.googleapis.com/youtube/v3/channels"sv;
-constexpr auto youtubeLiveTokenUrl = "https://oauth2.googleapis.com/token"sv;
-constexpr auto youtubeLiveVideoCategoriesUrl = "https://www.googleapis.com/youtube/v3/videoCategories"sv;
-constexpr auto youtubeLiveVideosUrl = "https://www.googleapis.com/youtube/v3/videos"sv;
-constexpr auto youtubeLiveThumbnailUrl = "https://www.googleapis.com/upload/youtube/v3/thumbnails/set"sv;
-
-constexpr auto defaultBroadcastsPerQuery = 50; // acceptable values are 0 to 50, inclusive
-} // namespace
-
 bool IsYouTubeService(const std::string &service)
 {
-	auto it = find_if(youtubeServices.begin(), youtubeServices.end(),
-			  [&service](const Auth::Def &yt) { return service == yt.service; });
+	auto it = std::find_if(youtubeServices.begin(), youtubeServices.end(),
+			       [&service](const Auth::Def &yt) { return service == yt.service; });
 	return it != youtubeServices.end();
 }
 bool IsUserSignedIntoYT()
@@ -51,483 +30,106 @@ bool IsUserSignedIntoYT()
 
 bool YoutubeApiWrappers::GetTranslatedError(QString &error_message)
 {
-	const QString errorKey = "YouTube.Errors." + lastErrorReason.toUtf8();
-	const QString translated = QTStr(QT_TO_UTF8(errorKey));
-	// No translation found
-	if (translated.startsWith("YouTube.Errors.")) {
-		return false;
-	}
-	error_message = translated;
-	return true;
+	return apiClient.GetTranslatedError(error_message);
 }
 
-YoutubeApiWrappers::YoutubeApiWrappers(const Def &d) : YoutubeAuth(d) {}
-
-bool YoutubeApiWrappers::TryInsertCommand(const char *url, const char *content_type, std::string request_type,
-					  const char *data, Json &json_out, long *error_code, int data_size)
+QString YoutubeApiWrappers::GetLastError() const
 {
-	long httpStatusCode = 0;
-
-#ifdef _DEBUG
-	blog(LOG_DEBUG, "YouTube API command URL: %s", url);
-	if (data && data[0] == '{') { // only log JSON data
-		blog(LOG_DEBUG, "YouTube API command data: %s", data);
-	}
-#endif
-	if (token.empty()) {
-		return false;
-	}
-	std::string output;
-	std::string error;
-	// Increase timeout by the time it takes to transfer `data_size` at 1 Mbps
-	int timeout = 60 + data_size / 125000;
-	bool success = GetRemoteFile(url, output, error, &httpStatusCode, content_type, request_type, data,
-				     {"Authorization: Bearer " + token}, nullptr, timeout, false, data_size);
-	if (error_code) {
-		*error_code = httpStatusCode;
-	}
-
-	if (!success || output.empty()) {
-		if (!error.empty()) {
-			blog(LOG_WARNING, "YouTube API request failed: %s", error.c_str());
-		}
-		return false;
-	}
-
-	json_out = Json::parse(output, error);
-#ifdef _DEBUG
-	blog(LOG_DEBUG, "YouTube API command answer: %s", json_out.dump().c_str());
-#endif
-	if (!error.empty()) {
-		return false;
-	}
-	return httpStatusCode < 400;
+	return apiClient.GetLastError();
 }
 
-bool YoutubeApiWrappers::UpdateAccessToken()
+YoutubeApiWrappers::YoutubeApiWrappers(const Def &d)
+	: YoutubeAuth(d),
+	  apiClient({
+		  [this]() { return token; },
+		  [this]() { return refresh_token; },
+		  [this](std::string newToken) { token = std::move(newToken); },
+	  })
 {
-	if (refresh_token.empty()) {
-		return false;
-	}
-
-	std::string clientid = YOUTUBE_CLIENTID;
-	std::string secret = YOUTUBE_SECRET;
-	deobfuscate_str(&clientid[0], YOUTUBE_CLIENTID_HASH);
-	deobfuscate_str(&secret[0], YOUTUBE_SECRET_HASH);
-
-	std::string r_token = QUrl::toPercentEncoding(refresh_token.c_str()).toStdString();
-	const QString data_template = "client_id=%1"
-				      "&client_secret=%2"
-				      "&refresh_token=%3"
-				      "&grant_type=refresh_token";
-	const QString data =
-		data_template.arg(QString(clientid.c_str()), QString(secret.c_str()), QString(r_token.c_str()));
-	Json json_out;
-	bool success = TryInsertCommand(youtubeLiveTokenUrl.data(), "application/x-www-form-urlencoded", "",
-					QT_TO_UTF8(data), json_out);
-
-	if (!success || json_out.object_items().find("error") != json_out.object_items().end()) {
-		return false;
-	}
-	token = json_out["access_token"].string_value();
-	return token.empty() ? false : true;
-}
-
-bool YoutubeApiWrappers::InsertCommand(const char *url, const char *content_type, std::string request_type,
-				       const char *data, Json &json_out, int data_size)
-{
-	long error_code;
-	bool success = TryInsertCommand(url, content_type, request_type, data, json_out, &error_code, data_size);
-
-	if (error_code == 401) {
-		// Attempt to update access token and try again
-		if (!UpdateAccessToken()) {
-			return false;
-		}
-		success = TryInsertCommand(url, content_type, request_type, data, json_out, &error_code, data_size);
-	}
-
-	if (json_out.object_items().find("error") != json_out.object_items().end()) {
-		blog(LOG_ERROR, "YouTube API error:\n\tHTTP status: %ld\n\tURL: %s\n\tJSON: %s", error_code, url,
-		     json_out.dump().c_str());
-
-		lastError = json_out["error"]["code"].int_value();
-		lastErrorReason = QString(json_out["error"]["errors"][0]["reason"].string_value().c_str());
-		lastErrorMessage = QString(json_out["error"]["message"].string_value().c_str());
-
-		// The existence of an error implies non-success even if the HTTP status code disagrees.
-		success = false;
-	}
-	return success;
 }
 
 bool YoutubeApiWrappers::GetChannelDescription(ChannelDescription &channel_description)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-
-	const std::string url =
-		std::string(youtubeLiveChannelUrl) + "?part=snippet,contentDetails,statistics&mine=true";
-	Json json_out;
-	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
-		return false;
-	}
-
-	if (json_out["pageInfo"]["totalResults"].int_value() == 0) {
-		lastErrorMessage = QTStr("YouTube.Auth.NoChannels");
-		return false;
-	}
-
-	channel_description.id = QString(json_out["items"][0]["id"].string_value().c_str());
-	channel_description.title = QString(json_out["items"][0]["snippet"]["title"].string_value().c_str());
-	return channel_description.id.isEmpty() ? false : true;
+	return apiClient.GetChannelDescription(channel_description);
 }
 
 bool YoutubeApiWrappers::InsertBroadcast(BroadcastDescription &broadcast)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	const std::string url = std::string(youtubeLiveBroadcastUrl) + "?part=snippet,status,contentDetails";
-	const Json data = Json::object{
-		{"snippet",
-		 Json::object{
-			 {"title", QT_TO_UTF8(broadcast.title)},
-			 {"description", QT_TO_UTF8(broadcast.description)},
-			 {"scheduledStartTime", QT_TO_UTF8(broadcast.schedul_date_time)},
-		 }},
-		{"status",
-		 Json::object{
-			 {"privacyStatus", QT_TO_UTF8(broadcast.privacy)},
-			 {"selfDeclaredMadeForKids", broadcast.made_for_kids},
-		 }},
-		{"contentDetails",
-		 Json::object{
-			 {"latencyPreference", QT_TO_UTF8(broadcast.latency)},
-			 {"enableAutoStart", broadcast.auto_start},
-			 {"enableAutoStop", broadcast.auto_stop},
-			 {"enableDvr", broadcast.dvr},
-			 {"projection", QT_TO_UTF8(broadcast.projection)},
-			 {
-				 "monitorStream",
-				 Json::object{
-					 {"enableMonitorStream", false},
-				 },
-			 },
-		 }},
-	};
-	Json json_out;
-	if (!InsertCommand(url.c_str(), "application/json", "", data.dump().c_str(), json_out)) {
-		return false;
-	}
-	broadcast.id = QString(json_out["id"].string_value().c_str());
-	return broadcast.id.isEmpty() ? false : true;
+	return apiClient.InsertBroadcast(broadcast);
 }
 
 bool YoutubeApiWrappers::InsertStream(StreamDescription &stream)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	const std::string url = std::string(youtubeLiveStreamUrl) + "?part=snippet,cdn,status,contentDetails";
-	const Json data = Json::object{
-		{"snippet",
-		 Json::object{
-			 {"title", QT_TO_UTF8(stream.title)},
-		 }},
-		{"cdn",
-		 Json::object{
-			 {"frameRate", "variable"},
-			 {"ingestionType", "rtmp"},
-			 {"resolution", "variable"},
-		 }},
-		{"contentDetails", Json::object{{"isReusable", false}}},
-	};
-	Json json_out;
-	if (!InsertCommand(url.c_str(), "application/json", "", data.dump().c_str(), json_out)) {
-		return false;
-	}
-	stream.id = QString(json_out["id"].string_value().c_str());
-	stream.name = QString(json_out["cdn"]["ingestionInfo"]["streamName"].string_value().c_str());
-	return stream.id.isEmpty() ? false : true;
+	return apiClient.InsertStream(stream);
 }
 
 bool YoutubeApiWrappers::BindStream(const QString broadcast_id, const QString stream_id)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	// TODO: Use std::format with std::string instead of QString::arg with C++20
-	const QString url_template = QString(youtubeLiveBroadcastBindUrl.data()) +
-				     "?id=%1&streamId=%2&part=id,snippet,contentDetails,status";
-	const QString url = url_template.arg(broadcast_id, stream_id);
-	const Json data = Json::object{};
-	this->broadcast_id = broadcast_id;
-	Json json_out;
-	return InsertCommand(QT_TO_UTF8(url), "application/json", "", data.dump().c_str(), json_out);
+	return apiClient.BindStream(broadcast_id, stream_id);
 }
 
 bool YoutubeApiWrappers::GetBroadcastsList(Json &json_out, const QString &page, const QString &status)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	std::string url = std::string(youtubeLiveBroadcastUrl) +
-			  "?part=snippet,contentDetails,status&broadcastType=all&maxResults=" +
-			  std::to_string(defaultBroadcastsPerQuery);
-
-	if (status.isEmpty()) {
-		url += "&mine=true";
-	} else {
-		url += "&broadcastStatus=" + status.toStdString();
-	}
-
-	if (!page.isEmpty()) {
-		url += "&pageToken=" + page.toStdString();
-	}
-	return InsertCommand(url.c_str(), "application/json", "", nullptr, json_out);
+	return apiClient.GetBroadcastsList(json_out, page, status);
 }
 
 bool YoutubeApiWrappers::GetVideoCategoriesList(QVector<CategoryDescription> &category_list_out)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	// TODO: Use std::format with C++20
-	const QString url_template =
-		QString(youtubeLiveVideoCategoriesUrl.data()) + "?part=snippet&regionCode=%1&hl=%2";
-
-	/*
-	 * All OBS locale regions aside from "US" are missing category id 29
-	 * ("Nonprofits & Activism"), but it is still available to channels
-	 * set to those regions via the YouTube Studio website.
-	 * To work around this inconsistency with the API all locales will
-	 * use the "US" region and only set the language part for localisation.
-	 * It is worth noting that none of the regions available on YouTube
-	 * feature any category not also available to the "US" region.
-	 */
-	QString url = url_template.arg("US", QLocale().name());
-
-	Json json_out;
-	if (!InsertCommand(QT_TO_UTF8(url), "application/json", "", nullptr, json_out)) {
-		if (lastErrorReason != "unsupportedLanguageCode" && lastErrorReason != "invalidLanguage") {
-			return false;
-		}
-		// Try again with en-US if YouTube error indicates an unsupported locale
-		url = url_template.arg("US", "en_US");
-		if (!InsertCommand(QT_TO_UTF8(url), "application/json", "", nullptr, json_out)) {
-			return false;
-		}
-	}
-	category_list_out = {};
-	for (auto &j : json_out["items"].array_items()) {
-		// Assignable only.
-		if (j["snippet"]["assignable"].bool_value()) {
-			category_list_out.push_back(
-				{j["id"].string_value().c_str(), j["snippet"]["title"].string_value().c_str()});
-		}
-	}
-	return category_list_out.isEmpty() ? false : true;
+	return apiClient.GetVideoCategoriesList(category_list_out);
 }
 
 bool YoutubeApiWrappers::SetVideoCategory(const QString &video_id, const QString &video_title,
 					  const QString &video_description, const QString &categorie_id)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	const std::string url = std::string(youtubeLiveVideosUrl) + "?part=snippet";
-	const Json data = Json::object{
-		{"id", QT_TO_UTF8(video_id)},
-		{"snippet",
-		 Json::object{
-			 {"title", QT_TO_UTF8(video_title)},
-			 {"description", QT_TO_UTF8(video_description)},
-			 {"categoryId", QT_TO_UTF8(categorie_id)},
-		 }},
-	};
-	Json json_out;
-	return InsertCommand(url.c_str(), "application/json", "PUT", data.dump().c_str(), json_out);
+	return apiClient.SetVideoCategory(video_id, video_title, video_description, categorie_id);
 }
 
 bool YoutubeApiWrappers::SetVideoThumbnail(const QString &video_id, const QString &thumbnail_file)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-
-	// Make sure the file hasn't been deleted since originally selecting it
-	if (!QFile::exists(thumbnail_file)) {
-		lastErrorMessage = QTStr("YouTube.Actions.Error.FileMissing");
-		return false;
-	}
-
-	QFile thumbFile(thumbnail_file);
-	if (!thumbFile.open(QFile::ReadOnly)) {
-		lastErrorMessage = QTStr("YouTube.Actions.Error.FileOpeningFailed");
-		return false;
-	}
-
-	const QByteArray fileContents = thumbFile.readAll();
-	const QString mime = QMimeDatabase().mimeTypeForData(fileContents).name();
-
-	const std::string url = std::string(youtubeLiveThumbnailUrl) + "?videoId=" + video_id.toStdString();
-	Json json_out;
-	return InsertCommand(url.c_str(), QT_TO_UTF8(mime), "POST", fileContents.constData(), json_out,
-			     fileContents.size());
+	return apiClient.SetVideoThumbnail(video_id, thumbnail_file);
 }
 
 bool YoutubeApiWrappers::StartBroadcast(const QString &broadcast_id)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-
-	Json json_out;
-	if (!FindBroadcast(broadcast_id, json_out)) {
-		return false;
-	}
-
-	auto lifeCycleStatus = json_out["items"][0]["status"]["lifeCycleStatus"].string_value();
-
-	if (lifeCycleStatus == "live" || lifeCycleStatus == "liveStarting") {
-		// Broadcast is already (going to be) live
-		return true;
-	} else if (lifeCycleStatus == "testStarting") {
-		// User will need to wait a few seconds before attempting to start broadcast
-		lastErrorMessage = QTStr("YouTube.Actions.Error.BroadcastTestStarting");
-		lastErrorReason.clear();
-		return false;
-	}
-
-	// Only reset if broadcast has monitoring enabled and is not already in "testing" mode
-	auto monitorStreamEnabled =
-		json_out["items"][0]["contentDetails"]["monitorStream"]["enableMonitorStream"].bool_value();
-	if (lifeCycleStatus != "testing" && monitorStreamEnabled && !ResetBroadcast(broadcast_id, json_out)) {
-		return false;
-	}
-
-	// TODO: Use std::format with C++20
-	const QString url_template =
-		QString(youtubeLiveBroadcastTransitionUrl.data()) + "?id=%1&broadcastStatus=%2&part=status";
-	const QString live = url_template.arg(broadcast_id, "live");
-	bool success = InsertCommand(QT_TO_UTF8(live), "application/json", "POST", "{}", json_out);
-	// Return a success if the command failed, but was redundant (broadcast already live)
-	return success || lastErrorReason == "redundantTransition";
+	return apiClient.StartBroadcast(broadcast_id);
 }
 
 bool YoutubeApiWrappers::StartLatestBroadcast()
 {
-	return StartBroadcast(this->broadcast_id);
+	return apiClient.StartLatestBroadcast();
 }
 
 bool YoutubeApiWrappers::StopBroadcast(const QString &broadcast_id)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-
-	const QString url_template =
-		QString(youtubeLiveBroadcastTransitionUrl.data()) + "?id=%1&broadcastStatus=complete&part=status";
-	const QString url = url_template.arg(broadcast_id);
-	Json json_out;
-	bool success = InsertCommand(QT_TO_UTF8(url), "application/json", "POST", "{}", json_out);
-	// Return a success if the command failed, but was redundant (broadcast already stopped)
-	return success || lastErrorReason == "redundantTransition";
+	return apiClient.StopBroadcast(broadcast_id);
 }
 
 bool YoutubeApiWrappers::StopLatestBroadcast()
 {
-	return StopBroadcast(this->broadcast_id);
+	return apiClient.StopLatestBroadcast();
 }
 
-void YoutubeApiWrappers::SetBroadcastId(QString &broadcast_id)
+void YoutubeApiWrappers::SetBroadcastId(const QString &broadcast_id)
 {
-	this->broadcast_id = broadcast_id;
+	apiClient.SetBroadcastId(broadcast_id);
 }
 
 QString YoutubeApiWrappers::GetBroadcastId()
 {
-	return this->broadcast_id;
+	return apiClient.GetBroadcastId();
 }
 
 bool YoutubeApiWrappers::ResetBroadcast(const QString &broadcast_id, json11::Json &json_out)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-
-	auto snippet = json_out["items"][0]["snippet"];
-	auto status = json_out["items"][0]["status"];
-	auto contentDetails = json_out["items"][0]["contentDetails"];
-	auto monitorStream = contentDetails["monitorStream"];
-
-	const Json data = Json::object{
-		{"id", QT_TO_UTF8(broadcast_id)},
-		{"snippet",
-		 Json::object{
-			 {"title", snippet["title"]},
-			 {"description", snippet["description"]},
-			 {"scheduledStartTime", snippet["scheduledStartTime"]},
-			 {"scheduledEndTime", snippet["scheduledEndTime"]},
-		 }},
-		{"status",
-		 Json::object{
-			 {"privacyStatus", status["privacyStatus"]},
-			 {"madeForKids", status["madeForKids"]},
-			 {"selfDeclaredMadeForKids", status["selfDeclaredMadeForKids"]},
-		 }},
-		{"contentDetails",
-		 Json::object{
-			 {
-				 "monitorStream",
-				 Json::object{
-					 {"enableMonitorStream", false},
-					 {"broadcastStreamDelayMs", monitorStream["broadcastStreamDelayMs"]},
-				 },
-			 },
-			 {"enableAutoStart", contentDetails["enableAutoStart"]},
-			 {"enableAutoStop", contentDetails["enableAutoStop"]},
-			 {"enableClosedCaptions", contentDetails["enableClosedCaptions"]},
-			 {"enableDvr", contentDetails["enableDvr"]},
-			 {"enableContentEncryption", contentDetails["enableContentEncryption"]},
-			 {"enableEmbed", contentDetails["enableEmbed"]},
-			 {"recordFromStart", contentDetails["recordFromStart"]},
-			 {"startWithSlate", contentDetails["startWithSlate"]},
-		 }},
-	};
-
-	const std::string put = std::string(youtubeLiveBroadcastUrl) + "?part=id,snippet,contentDetails,status";
-	return InsertCommand(put.c_str(), "application/json", "PUT", data.dump().c_str(), json_out);
+	return apiClient.ResetBroadcast(broadcast_id, json_out);
 }
 
 bool YoutubeApiWrappers::FindBroadcast(const QString &id, json11::Json &json_out)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	std::string url = std::string(youtubeLiveBroadcastUrl) +
-			  "?part=id,snippet,contentDetails,status&broadcastType=all&maxResults=1";
-	url += "&id=" + id.toStdString();
-
-	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
-		return false;
-	}
-
-	auto items = json_out["items"].array_items();
-	if (items.size() != 1) {
-		lastErrorMessage = QTStr("YouTube.Actions.Error.BroadcastNotFound");
-		return false;
-	}
-
-	return true;
+	return apiClient.FindBroadcast(id, json_out);
 }
 
 bool YoutubeApiWrappers::FindStream(const QString &id, json11::Json &json_out)
 {
-	lastErrorMessage.clear();
-	lastErrorReason.clear();
-	std::string url = std::string(youtubeLiveStreamUrl) + "?part=id,snippet,cdn,status&maxResults=1";
-	url += "&id=" + id.toStdString();
-
-	if (!InsertCommand(url.c_str(), "application/json", "", nullptr, json_out)) {
-		return false;
-	}
-
-	auto items = json_out["items"].array_items();
-	if (items.size() != 1) {
-		lastErrorMessage = "No active broadcast found.";
-		return false;
-	}
-
-	return true;
+	return apiClient.FindStream(id, json_out);
 }

--- a/frontend/utility/YoutubeApiWrappers.hpp
+++ b/frontend/utility/YoutubeApiWrappers.hpp
@@ -1,54 +1,18 @@
 #pragma once
 
 #include <oauth/YoutubeAuth.hpp>
+#include "YoutubeApiClient.hpp"
+#include "YoutubeApiTypes.hpp"
 
 #include <json11.hpp>
 
 #include <QString>
-
-struct ChannelDescription {
-	QString id;
-	QString title;
-};
-
-struct StreamDescription {
-	QString id;
-	QString name;
-	QString title;
-};
-
-struct CategoryDescription {
-	QString id;
-	QString title;
-};
-
-struct BroadcastDescription {
-	QString id;
-	QString title;
-	QString description;
-	QString privacy;
-	CategoryDescription category;
-	QString latency;
-	bool made_for_kids;
-	bool auto_start;
-	bool auto_stop;
-	bool dvr;
-	bool schedul_for_later;
-	QString schedul_date_time;
-	QString projection;
-};
 
 bool IsYouTubeService(const std::string &service);
 bool IsUserSignedIntoYT();
 
 class YoutubeApiWrappers : public YoutubeAuth {
 	Q_OBJECT
-
-	bool TryInsertCommand(const char *url, const char *content_type, std::string request_type, const char *data,
-			      json11::Json &ret, long *error_code = nullptr, int data_size = 0);
-	bool UpdateAccessToken();
-	bool InsertCommand(const char *url, const char *content_type, std::string request_type, const char *data,
-			   json11::Json &ret, int data_size = 0);
 
 public:
 	YoutubeApiWrappers(const Def &d);
@@ -68,19 +32,15 @@ public:
 	bool StartLatestBroadcast();
 	bool StopLatestBroadcast();
 
-	void SetBroadcastId(QString &broadcast_id);
+	void SetBroadcastId(const QString &broadcast_id);
 	QString GetBroadcastId();
 
 	bool FindBroadcast(const QString &id, json11::Json &json_out);
 	bool FindStream(const QString &id, json11::Json &json_out);
 
-	QString GetLastError() { return lastErrorMessage; };
+	QString GetLastError() const;
 	bool GetTranslatedError(QString &error_message);
 
 private:
-	QString broadcast_id;
-
-	int lastError;
-	QString lastErrorMessage;
-	QString lastErrorReason;
+	YoutubeApiClient apiClient;
 };

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -60,6 +60,7 @@ class OBSProjector;
 class VolumeControl;
 #ifdef YOUTUBE_ENABLED
 class YouTubeAppDock;
+class YoutubeApiWrappers;
 #endif
 class QMessageBox;
 class QWidgetAction;
@@ -1670,7 +1671,7 @@ private:
 	QPointer<YouTubeAppDock> youtubeAppDock;
 	uint64_t lastYouTubeAppDockCreationTime = 0;
 
-	void YoutubeStreamCheck(const std::string &key);
+	void YoutubeStreamCheck(YoutubeApiWrappers *apiYouTube, const std::string &key);
 	void ShowYouTubeAutoStartWarning();
 	void YouTubeActionDialogOk(const std::string &broadcastId, const std::string &streamId, const std::string &key,
 				   bool autostart, bool autostop, bool startNow);

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -60,6 +60,7 @@ class OBSProjector;
 class VolumeControl;
 #ifdef YOUTUBE_ENABLED
 class YouTubeAppDock;
+class YoutubeApiWrappers;
 #endif
 class QMessageBox;
 class QWidgetAction;
@@ -1671,7 +1672,7 @@ private:
 	QPointer<YouTubeAppDock> youtubeAppDock;
 	uint64_t lastYouTubeAppDockCreationTime = 0;
 
-	void YoutubeStreamCheck(const std::string &key);
+	void YoutubeStreamCheck(YoutubeApiWrappers *apiYouTube, const std::string &key);
 	void ShowYouTubeAutoStartWarning();
 	void YouTubeActionDialogOk(const std::string &broadcastId, const std::string &streamId, const std::string &key,
 				   bool autostart, bool autostop, bool startNow);

--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -256,8 +256,10 @@ void OBSBasic::StreamingStart()
 		obs_service_t *service_obj = GetService();
 		OBSDataAutoRelease settings = obs_service_get_settings(service_obj);
 		std::string key = obs_data_get_string(settings, "stream_id");
-		if (!key.empty() && !youtubeStreamCheckThread) {
-			youtubeStreamCheckThread = CreateQThread([this, key] { YoutubeStreamCheck(key); });
+		YoutubeApiWrappers *apiYouTube = dynamic_cast<YoutubeApiWrappers *>(GetAuth());
+		if (apiYouTube && !key.empty() && !youtubeStreamCheckThread) {
+			youtubeStreamCheckThread =
+				CreateQThread([this, apiYouTube, key] { YoutubeStreamCheck(apiYouTube, key); });
 			youtubeStreamCheckThread->setObjectName("YouTubeStreamCheckThread");
 			youtubeStreamCheckThread->start();
 		}

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -54,9 +54,8 @@ void OBSBasic::YouTubeActionDialogOk(const std::string &broadcastId, const std::
 	}
 }
 
-void OBSBasic::YoutubeStreamCheck(const std::string &key)
+void OBSBasic::YoutubeStreamCheck(YoutubeApiWrappers *apiYouTube, const std::string &key)
 {
-	YoutubeApiWrappers *apiYouTube(dynamic_cast<YoutubeApiWrappers *>(GetAuth()));
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
 		QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
@@ -202,8 +201,9 @@ void OBSBasic::SetupBroadcast()
 {
 #ifdef YOUTUBE_ENABLED
 	Auth *const auth = GetAuth();
-	if (IsYouTubeService(auth->service())) {
-		OBSYoutubeActions dialog(this, auth, broadcastReady);
+	YoutubeApiWrappers *apiYouTube = dynamic_cast<YoutubeApiWrappers *>(auth);
+	if (apiYouTube) {
+		OBSYoutubeActions dialog(this, *apiYouTube, broadcastReady);
 		connect(&dialog, &OBSYoutubeActions::ok, this, &OBSBasic::YouTubeActionDialogOk);
 		dialog.exec();
 	}

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -54,9 +54,8 @@ void OBSBasic::YouTubeActionDialogOk(const std::string &broadcastId, const std::
 	}
 }
 
-void OBSBasic::YoutubeStreamCheck(const std::string &key)
+void OBSBasic::YoutubeStreamCheck(YoutubeApiWrappers *apiYouTube, const std::string &key)
 {
-	YoutubeApiWrappers *apiYouTube(dynamic_cast<YoutubeApiWrappers *>(GetAuth()));
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
 		QMetaObject::invokeMethod(this, &OBSBasic::ForceStopStreaming, Qt::QueuedConnection);
@@ -202,8 +201,9 @@ void OBSBasic::SetupBroadcast()
 {
 #ifdef YOUTUBE_ENABLED
 	Auth *const auth = GetAuth();
-	if (IsYouTubeService(auth->service())) {
-		OBSYoutubeActions dialog(this, auth, broadcastReady);
+	YoutubeApiWrappers *apiYouTube = dynamic_cast<YoutubeApiWrappers *>(auth);
+	if (apiYouTube) {
+		OBSYoutubeActions dialog(this, *apiYouTube, broadcastReady);
 		connect(&dialog, &OBSYoutubeActions::ok, this, &OBSBasic::YouTubeActionDialogOk);
 		dialog.exec();
 	}

--- a/frontend/wizards/AutoConfigStreamPage.cpp
+++ b/frontend/wizards/AutoConfigStreamPage.cpp
@@ -265,7 +265,7 @@ void AutoConfigStreamPage::on_show_clicked()
 
 void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 {
-	OAuthStreamKey *a = reinterpret_cast<OAuthStreamKey *>(auth.get());
+	OAuthStreamKey *a = dynamic_cast<OAuthStreamKey *>(auth.get());
 
 	if (a) {
 		bool validKey = !a->key().empty();
@@ -292,16 +292,17 @@ void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 
 			ui->connectedAccountText->setText(QTStr("Auth.LoadingChannel.Title"));
 
-			YoutubeApiWrappers *ytAuth = reinterpret_cast<YoutubeApiWrappers *>(a);
-			ChannelDescription cd;
-			if (ytAuth->GetChannelDescription(cd)) {
-				ui->connectedAccountText->setText(cd.title);
+			if (YoutubeApiWrappers *ytAuth = dynamic_cast<YoutubeApiWrappers *>(a)) {
+				ChannelDescription cd;
+				if (ytAuth->GetChannelDescription(cd)) {
+					ui->connectedAccountText->setText(cd.title);
 
-				/* Create throwaway stream key for bandwidth test */
-				if (ui->doBandwidthTest->isChecked()) {
-					StreamDescription stream = {"", "", "OBS Studio Test Stream"};
-					if (ytAuth->InsertStream(stream)) {
-						ui->key->setText(stream.name);
+					/* Create throwaway stream key for bandwidth test */
+					if (ui->doBandwidthTest->isChecked()) {
+						StreamDescription stream = {"", "", "OBS Studio Test Stream"};
+						if (ytAuth->InsertStream(stream)) {
+							ui->key->setText(stream.name);
+						}
 					}
 				}
 			}
@@ -406,7 +407,7 @@ void AutoConfigStreamPage::reset_service_ui_fields(std::string &service)
 {
 #ifdef YOUTUBE_ENABLED
 	// when account is already connected:
-	OAuthStreamKey *a = reinterpret_cast<OAuthStreamKey *>(auth.get());
+	OAuthStreamKey *a = dynamic_cast<OAuthStreamKey *>(auth.get());
 	if (a && service == a->service() && IsYouTubeService(a->service())) {
 		ui->connectedAccountLabel->setVisible(true);
 		ui->connectedAccountText->setVisible(true);

--- a/frontend/wizards/AutoConfigStreamPage.cpp
+++ b/frontend/wizards/AutoConfigStreamPage.cpp
@@ -297,7 +297,7 @@ void AutoConfigStreamPage::OnOAuthStreamKeyConnected()
 				if (ytAuth->GetChannelDescription(cd)) {
 					ui->connectedAccountText->setText(cd.title);
 
-					/* Create throwaway stream key for bandwidth test */
+					// Create throwaway stream key for bandwidth test
 					if (ui->doBandwidthTest->isChecked()) {
 						StreamDescription stream = {"", "", "OBS Studio Test Stream"};
 						if (ytAuth->InsertStream(stream)) {


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Part of #13443

Updates YouTube-specific frontend code to pass `YoutubeApiWrappers` directly where the caller already requires YouTube auth object, instead of passing generic `Auth`.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
`OBSYoutubeActions` and related YouTube-specific paths only work with the YouTube API version of Auth object. Passing generic `Auth` into these call sites pushes constructors to perform `dynamic_cast` internally when it should be the callers responsibility.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
```
xcodebuild -configuration RelWithDebInfo -scheme obs-studio -parallelizeTargets -destination "generic/platform=macOS,name=Any Mac"
```

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
