### PR TITLE
libobs-winrt: Fix compile error with MSVC 2026

### DIFF
--- a/libobs-winrt/CMakeLists.txt
+++ b/libobs-winrt/CMakeLists.txt
@@ -28,4 +28,7 @@ target_precompile_headers(
 
 target_link_libraries(libobs-winrt PRIVATE OBS::libobs OBS::COMutils Dwmapi windowsapp)
 
+# FIXME: WinRT library headers trigger deprecation warning until OBS Studio uses C++20 or newer
+target_compile_definitions(libobs-winrt PRIVATE _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS)
+
 set_target_properties_obs(libobs-winrt PROPERTIES FOLDER core)


### PR DESCRIPTION
### Description
Sets preprocessor define to silence deprecation warning about removal of experimental coroutine headers used by WinRT's `base.h` header.

### Motivation and Context
MSVC Build Tools 14.50 shipping in Visual Studio 2026 18.0 have officially deprecated any experimental implementation of coroutines.

The WinRT base header does conditionally include the experimental header if no "native" implementation can be found (which will be true for any C++ language version before C++20).

Even though libobs-winrt does not make use of any coroutines, it has to include the base header and will thus trigger this error.

Per the official deprecation notice, this warning can be silenced and will be automatically resolved once the project upgrades to C++20 support.

### How Has This Been Tested?
Tested on Windows 11 with Visual Studio 2026 18.6.2.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
