### PR TITLE
frontend: Fix audio mixer preview for groups and subscenes

### DIFF
--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -410,11 +410,13 @@ void AudioMixer::updatePreviewSources()
 			return;
 		}
 
-		if (!previewScene) {
-			return;
-		}
+		auto previewEnum = [](obs_scene_t *scene, obs_sceneitem_t *item, void *data) -> bool {
+			return (*static_cast<std::function<bool(obs_scene_t *, obs_sceneitem_t *)> *>(data))(scene, item);
+		};
 
-		auto getPreviewSources = [this](obs_scene_t *, obs_sceneitem_t *item) {
+		std::function<bool(obs_scene_t *, obs_sceneitem_t *)> getPreviewSources = 
+    			[&](obs_scene_t * /* scene */, obs_sceneitem_t *item) -> bool {
+
 			if (!obs_sceneitem_visible(item)) {
 				return true;
 			}
@@ -422,6 +424,22 @@ void AudioMixer::updatePreviewSources()
 			obs_source_t *source = obs_sceneitem_get_source(item);
 			if (!source) {
 				return true;
+			}
+
+			obs_scene_t *subScene = nullptr;
+
+			if(obs_source_is_group(source)) {
+				subScene = obs_group_from_source(source);
+			}
+			else {
+				subScene = obs_scene_from_source(source);
+			}
+
+			if(subScene) {
+				{
+					OBSSource safeSource = source; // Automatically adds a reference safely
+					obs_scene_enum_items(subScene, previewEnum, &getPreviewSources);
+				}
 			}
 
 			uint32_t flags = obs_source_get_output_flags(source);
@@ -439,12 +457,6 @@ void AudioMixer::updatePreviewSources()
 			}
 
 			return true;
-		};
-
-		using getPreviewSources_t = decltype(getPreviewSources);
-
-		auto previewEnum = [](obs_scene_t *scene, obs_sceneitem_t *item, void *data) -> bool {
-			return (*static_cast<getPreviewSources_t *>(data))(scene, item);
 		};
 
 		obs_scene_enum_items(previewScene, previewEnum, &getPreviewSources);


### PR DESCRIPTION

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes #13297 
The original logic inside AudioMixer::updatePreviewSources() only iterated through a scene's flat, top-level items. The fix introduces a deep recursive traversal using obs_scene_enum_items to drill down into underlying sub-scene and group structures dynamically, ensuring their internal audio tracks are properly identified and populated in the UI.

### Motivation and Context
Without this fix, users working in Studio Mode cannot view/monitor/play media or audio sources of grouped elements or nested scenes before transitioning them live to the Program output. 
Additionally, a redundant, back-to-back duplicate sanity check on previewScene was removed.
<img width="387" height="140" alt="image" src="https://github.com/user-attachments/assets/3bd416e0-0c9d-4bbe-bbb0-8b514da3a222" />



#### BEFORE:

MUSIC SCENE - 
<img width="1273" height="851" alt="image" src="https://github.com/user-attachments/assets/4ce27e97-e56a-4f47-9de0-30f3eb9d0182" />

GROUP SCENE - 
<img width="1269" height="851" alt="image" src="https://github.com/user-attachments/assets/53dc2a23-c0b8-4a85-afdf-8cf262901824" />

NESTED SCENE - 
<img width="1272" height="852" alt="image" src="https://github.com/user-attachments/assets/eb600eed-bcae-463f-83d5-83374b268c47" />

#### AFTER:

MUSIC SCENE - 
<img width="1276" height="851" alt="image" src="https://github.com/user-attachments/assets/f911e18b-7203-4001-bce5-76107da00a05" />

GROUP SCENE - 
<img width="1275" height="851" alt="image" src="https://github.com/user-attachments/assets/0381c8ea-13e4-4a5f-8d71-5b68bc95977b" />

NESTED SCENE - 
<img width="1273" height="850" alt="image" src="https://github.com/user-attachments/assets/9db41345-dda8-4455-bc83-0ad084735248" />


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
OS Version: macOS.

Scenarios Executed:
1. Created an empty QUIET scene.
2. Created a MUSIC scene and added a media source file to it(music.mp3 audio). Ticked the loop property.
3. Created a GROUP scene and added the existing music.mp3 audio source file to it
4. Created a NESTED scene and added MUSIC scene as a source to it.
Put the QUIET scene in PROGRAM. Verified all the other scenes in Preview mode and audio sources getting populated.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->
[x] Bug fix (non-breaking change which fixes an issue)

[x] Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
