### PR TITLE
frontend: Fix build with Qt 6.12

### DIFF
--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -29,6 +29,7 @@
 
 #include <QAbstractNativeEventFilter>
 #include <QApplication>
+#include <QHash>
 #include <QPalette>
 #include <QPointer>
 #include <QUuid>

--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -31,6 +31,7 @@
 #include <QFileSystemWatcher>
 #include <QMetaEnum>
 #include <QRandomGenerator>
+#include <QSet>
 #include <QTimer>
 
 using namespace std;


### PR DESCRIPTION
### Description

This fixes compiling OBS Studio against Qt 6.12 (unreleased at the time of writing) .

### Motivation and Context

After Qt upstream commit 556028d16a0 [1], 'QHash' and 'QSet' need to be explicitly included when using 'QT_ENABLE_STRICT_MODE_UP_TO'.

Without these changes, compiling fails like so:

```
frontend/OBSApp.hpp:117:34: error: field ‘themes’ has incomplete type ‘QHash<QString, OBSTheme>’
  117 |         QHash<QString, OBSTheme> themes;
      |                                  ^~~~~~
```

```
frontend/OBSApp_Themes.cpp:440:23: error: aggregate ‘QSet<QString> invalid’ has incomplete type and cannot be defined
  440 |         QSet<QString> invalid;
      |                       ^~~~~~~
```

1. https://code.qt.io/cgit/qt/qtbase.git/commit/?id=556028d16a059006cc5a03676260aff5428b767e

### How Has This Been Tested?

Tested by compiling and running on Gentoo Linux, on amd64 (OBS Studio `git master` / Qt `6.12 git master`) and arm64 (OBS Studio `32.1.0` / Qt `6.10.3`) architectures.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
