### PR TITLE
libobs: Prevent loading Mouse1/Mouse2 as hotkeys

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -457,6 +457,19 @@ static inline void load_modifier(uint32_t *modifiers, obs_data_t *data, const ch
 
 static inline void create_binding(obs_hotkey_t *hotkey, obs_key_combination_t combo)
 {
+	/*
+	 * Prevent loading Mouse1 and Mouse2 as hotkeys. The frontend
+	 * already prevents users from setting these keys via the UI,
+	 * but they could still be loaded from a manually modified scene
+	 * collection JSON file, causing unexpected behavior.
+	 *
+	 * Placed in create_binding() rather than load_binding() so
+	 * this also covers third-party plugins using the public API
+	 * obs_hotkey_load_bindings().
+	 */
+	if (combo.key == OBS_KEY_MOUSE1 || combo.key == OBS_KEY_MOUSE2)
+		return;
+
 	obs_hotkey_binding_t *binding = da_push_back_new(obs->hotkeys.bindings);
 	if (!binding)
 		return;


### PR DESCRIPTION
The frontend already prevents users from setting Mouse1 or Mouse2 as hotkeys via the UI, but if someone manually edits their scene collection JSON file to add these keys, OBS would still load them, causing unexpected behavior.

Add a guard in create_binding() to filter out OBS_KEY_MOUSE1 and OBS_KEY_MOUSE2. This placement ensures the protection also covers third-party plugins that call the public API function obs_hotkey_load_bindings().

Closes #13403

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [ ] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [ ] My code is not on the master branch.
- [ ] My code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
