### PR TITLE
plugins/obs-ffmpeg: remove restart guard for RIST

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-source.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-source.c
@@ -386,8 +386,6 @@ static void ffmpeg_source_tick(void *data, float seconds)
 	}
 }
 
-#define RIST_PROTO "rist"
-
 static void ffmpeg_source_update(void *data, obs_data_t *settings)
 {
 	struct ffmpeg_source *s = data;
@@ -457,9 +455,7 @@ static void ffmpeg_source_update(void *data, obs_data_t *settings)
 	s->is_hw_decoding = is_hw_decoding;
 	s->full_decode = obs_data_get_bool(settings, "full_decode");
 	s->is_clear_on_media_end = obs_data_get_bool(settings, "clear_on_media_end");
-	s->restart_on_activate = !astrcmpi_n(input, RIST_PROTO, sizeof(RIST_PROTO) - 1)
-					 ? false
-					 : obs_data_get_bool(settings, "restart_on_activate");
+	s->restart_on_activate = obs_data_get_bool(settings, "restart_on_activate");
 	s->range = range;
 	is_linear_alpha = obs_data_get_bool(settings, "linear_alpha");
 	s->is_linear_alpha = is_linear_alpha;


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Remove restart guard. Media Source running RIST can shutdown successfully when it becomes inactive.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Media Source with RIST protocol consuming 1 CPU core at 100% when not active. Updated to the latest library version solved the CPU issue but it is still running in the background which is not ideal. I think the original intention is to prevent crash. After years of development, `librist` is much stable now. The guard can be removed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
- Windows 10
- MSVC build
(`librist` in `obs-deps` need to be updated accordingly)

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
 - Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
