### PR TITLE
CI: Fix broken CAS path for macOS analyze builds

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -71,6 +71,12 @@ jobs:
           if (( #remove_formulas )) brew uninstall --ignore-dependencies ${remove_formulas}
           print '::endgroup::'
 
+          local xcode_cas_path="${HOME}/Library/Developer/Xcode/DerivedData/CompilationCache.noindex"
+
+          if ! [[ -d ${xcode_cas_path} ]] mkdir -p ${xcode_cas_path}
+
+          print "xcodeCasPath=${xcode_cas_path}" >> $GITHUB_OUTPUT
+
       - name: Set Up Code Signing 🔑
         uses: ./.github/actions/setup-macos-codesigning
         id: codesign
@@ -96,6 +102,7 @@ jobs:
           CODESIGN_IDENT: ${{ steps.codesign.outputs.codesignIdent }}
           CODESIGN_TEAM: ${{ steps.codesign.outputs.codesignTeam }}
           PROVISIONING_PROFILE: ${{ steps.codesign.outputs.provisioningProfileUUID }}
+          XCODE_CAS_PATH: ${{ steps.setup.outputs.xcodeCasPath }}
         run: |
           : Run macOS Build
 


### PR DESCRIPTION
### Description
Set explicit CAS path for macOS analyse builds to fix broken scheduled workflow runs.

### Motivation and Context
With the switch to Xcode 26.5 the analyze command started to use the built-in compilation cache (per the CMake preset) which breaks those builds specifically as no writable CAS path is set for this workflow.

This change adds the same code used for the normal build workflow to set a specific CAS path. Because the contents of that path are not retained by a caching action, no actual caching for analyze builds takes place.

### How Has This Been Tested?
Tested on fork by pushing change to master and manually dispatching the scheduled workflow. Confirmed that compilation starts and the CAS-path related error is not logged.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
