### PR TITLE
frontend: Fix pasting scene item on not the current scene

### DIFF
--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -148,15 +148,17 @@ void setupSceneItem(void *_data, obs_scene_t *scene)
 }
 
 std::optional<OBSSceneItem> setupExistingSource(std::string_view uuid, bool visible, bool duplicate,
-						SourceCopyInfo *info = nullptr)
+						SourceCopyInfo *info = nullptr, OBSScene scene = nullptr)
 {
 	OBSSourceAutoRelease temp = obs_get_source_by_uuid(uuid.data());
 	if (!temp) {
 		return std::nullopt;
 	}
 
-	OBSBasic *main = OBSBasic::Get();
-	OBSScene scene = main->GetCurrentScene();
+	if (!scene) {
+		OBSBasic *main = OBSBasic::Get();
+		scene = main->GetCurrentScene();
+	}
 	if (!scene) {
 		return std::nullopt;
 	}
@@ -310,7 +312,7 @@ void OBSBasicSourceSelect::obsSourceRemoved(void *data, calldata_t *params)
 				  Qt::QueuedConnection, Q_ARG(QString, QString::fromUtf8(uuidPointer)));
 }
 
-void OBSBasicSourceSelect::sourcePaste(SourceCopyInfo &info, bool duplicate)
+void OBSBasicSourceSelect::sourcePaste(SourceCopyInfo &info, bool duplicate, OBSScene scene)
 {
 	OBSSource source = OBSGetStrongRef(info.weak_source);
 	if (!source) {
@@ -319,7 +321,7 @@ void OBSBasicSourceSelect::sourcePaste(SourceCopyInfo &info, bool duplicate)
 
 	std::string uuid = obs_source_get_uuid(source);
 
-	setupExistingSource(uuid, info.visible, duplicate, &info);
+	setupExistingSource(uuid, info.visible, duplicate, &info, scene);
 }
 
 void OBSBasicSourceSelect::showEvent(QShowEvent *)

--- a/frontend/dialogs/OBSBasicSourceSelect.hpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.hpp
@@ -38,7 +38,7 @@ public:
 
 	OBSSource newSource;
 
-	static void sourcePaste(SourceCopyInfo &info, bool duplicate);
+	static void sourcePaste(SourceCopyInfo &info, bool duplicate, OBSScene scene = nullptr);
 
 protected:
 	void showEvent(QShowEvent *event) override;

--- a/frontend/widgets/OBSBasic_Clipboard.cpp
+++ b/frontend/widgets/OBSBasic_Clipboard.cpp
@@ -149,7 +149,7 @@ void OBSBasic::pasteSceneItem(OBSScene scene, bool duplicate)
 			continue;
 		}
 
-		OBSBasicSourceSelect::sourcePaste(copyInfo, duplicate);
+		OBSBasicSourceSelect::sourcePaste(copyInfo, duplicate, scene);
 		RefreshSources(scene);
 	}
 


### PR DESCRIPTION
### Description
Fix pasting scene item on not the current scene

### Motivation and Context
The option to paste to an other scene was added in #8286, but while rebasing that PR the other scene functionality was broken.

### How Has This Been Tested?
Adding the feature to copy and paste to Aitum Stream Suite.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
