### PR TITLE
libobs-d3d11: Avoid exceptions in shader cache file handling

### DIFF
--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -27,6 +27,7 @@
 #include <filesystem>
 #include <fstream>
 #include <d3dcompiler.h>
+#include <system_error>
 
 void gs_vertex_shader::GetBuffersExpected(const std::vector<D3D11_INPUT_ELEMENT_DESC> &inputs)
 {
@@ -218,6 +219,16 @@ static uint64_t fnv1a_hash(const char *str, size_t len)
 	return hash;
 }
 
+static void remove_cache_file(const std::filesystem::path &cachePath, const char *reason) noexcept
+{
+	blog(LOG_WARNING, "Discarding shader cache file %s: %s",
+	     reinterpret_cast<const char *>(cachePath.u8string().c_str()), reason);
+
+	// Intentionally ignored - we don't care about failure here, we just don't want exceptions
+	std::error_code ec;
+	std::filesystem::remove(cachePath, ec);
+}
+
 void gs_shader::Compile(const char *shaderString, const char *file, const char *target, ID3D10Blob **shader)
 {
 	ComPtr<ID3D10Blob> errorsBlob;
@@ -239,41 +250,47 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 	// Increment if on-disk format changes
 	cachePath += ".v2";
 
-	std::fstream cacheFile;
-	cacheFile.exceptions(std::fstream::badbit | std::fstream::eofbit);
-
-	if (std::filesystem::exists(cachePath) && !std::filesystem::is_empty(cachePath)) {
-		cacheFile.open(cachePath, std::ios::in | std::ios::binary | std::ios::ate);
-	}
-
+	std::ifstream cacheFile(cachePath, std::ios::binary | std::ios::ate);
 	if (cacheFile.is_open()) {
-		uint64_t checksum;
+		uint64_t checksum = 0;
 
-		try {
-			std::streampos len = cacheFile.tellg();
-			// Not enough data for checksum + shader
-			if (len <= sizeof(checksum)) {
-				throw std::length_error("File truncated");
-			}
+		std::streamoff len = cacheFile.tellg();
 
-			cacheFile.seekg(0, std::ios::beg);
-
-			len -= sizeof(checksum);
-			D3DCreateBlob(len, shader);
-			cacheFile.read((char *)(*shader)->GetBufferPointer(), len);
-			uint64_t calculated_checksum = fnv1a_hash((char *)(*shader)->GetBufferPointer(), len);
-
-			cacheFile.read((char *)&checksum, sizeof(checksum));
-			if (calculated_checksum != checksum) {
-				throw std::exception("Checksum mismatch");
-			}
-
-			is_cached = true;
-		} catch (const std::exception &e) {
-			// Something went wrong reading the cache file, delete it
-			blog(LOG_WARNING, "Loading shader cache file failed with \"%s\": %s", e.what(), file);
+		// Not enough data for checksum + shader
+		if (len < 0 || len <= static_cast<std::streamoff>(sizeof(checksum))) {
 			cacheFile.close();
-			std::filesystem::remove(cachePath);
+			remove_cache_file(cachePath, "truncated or unreadable");
+		} else {
+			len -= sizeof(checksum);
+
+			hr = D3DCreateBlob(len, shader);
+			if (FAILED(hr)) {
+				cacheFile.close();
+				remove_cache_file(cachePath, "cache blob allocation failed");
+			} else {
+				cacheFile.seekg(0, std::ios::beg);
+				cacheFile.read(static_cast<char *>((*shader)->GetBufferPointer()), len);
+				cacheFile.read(reinterpret_cast<char *>(&checksum), sizeof(checksum));
+
+				const bool success = static_cast<bool>(cacheFile);
+
+				if (success) {
+					uint64_t calculated_checksum =
+						fnv1a_hash(static_cast<char *>((*shader)->GetBufferPointer()), len);
+
+					if (calculated_checksum == checksum) {
+						is_cached = true;
+					}
+				}
+
+				if (!is_cached) {
+					(*shader)->Release();
+					*shader = nullptr;
+
+					cacheFile.close();
+					remove_cache_file(cachePath, !success ? "read error" : "checksum mismatch");
+				}
+			}
 		}
 	}
 
@@ -288,18 +305,17 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			}
 		}
 
-		cacheFile.open(cachePath, std::ios::out | std::ios::binary);
-		if (cacheFile.is_open()) {
-			try {
-				uint64_t calculated_checksum =
-					fnv1a_hash((char *)(*shader)->GetBufferPointer(), (*shader)->GetBufferSize());
+		std::ofstream outFile(cachePath, std::ios::binary | std::ios::trunc);
+		if (outFile.is_open()) {
+			uint64_t calculated_checksum = fnv1a_hash(static_cast<char *>((*shader)->GetBufferPointer()),
+								  (*shader)->GetBufferSize());
 
-				cacheFile.write((char *)(*shader)->GetBufferPointer(), (*shader)->GetBufferSize());
-				cacheFile.write((char *)&calculated_checksum, sizeof(calculated_checksum));
-			} catch (const std::exception &e) {
-				blog(LOG_WARNING, "Writing shader cache file failed with \"%s\": %s", e.what(), file);
-				cacheFile.close();
-				std::filesystem::remove(cachePath);
+			outFile.write(static_cast<char *>((*shader)->GetBufferPointer()), (*shader)->GetBufferSize());
+			outFile.write(reinterpret_cast<char *>(&calculated_checksum), sizeof(calculated_checksum));
+			outFile.close();
+
+			if (outFile.fail()) {
+				remove_cache_file(cachePath, "write error");
 			}
 		}
 	}

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -27,6 +27,21 @@
 #include <filesystem>
 #include <fstream>
 #include <d3dcompiler.h>
+#include <system_error>
+
+namespace {
+
+void remove_cache_file(const std::filesystem::path &cachePath, const char *reason) noexcept
+{
+	blog(LOG_WARNING, "Discarding shader cache file %s: %s",
+	     reinterpret_cast<const char *>(cachePath.u8string().c_str()), reason);
+
+	// Intentionally ignored - we don't care about failure here, we just don't want exceptions
+	std::error_code ec;
+	std::filesystem::remove(cachePath, ec);
+}
+
+} // namespace
 
 void gs_vertex_shader::GetBuffersExpected(const std::vector<D3D11_INPUT_ELEMENT_DESC> &inputs)
 {
@@ -239,41 +254,47 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 	// Increment if on-disk format changes
 	cachePath += ".v2";
 
-	std::fstream cacheFile;
-	cacheFile.exceptions(std::fstream::badbit | std::fstream::eofbit);
-
-	if (std::filesystem::exists(cachePath) && !std::filesystem::is_empty(cachePath)) {
-		cacheFile.open(cachePath, std::ios::in | std::ios::binary | std::ios::ate);
-	}
-
+	std::ifstream cacheFile{cachePath, std::ios::binary | std::ios::ate};
 	if (cacheFile.is_open()) {
-		uint64_t checksum;
+		uint64_t checksum = 0;
 
-		try {
-			std::streampos len = cacheFile.tellg();
-			// Not enough data for checksum + shader
-			if (len <= sizeof(checksum)) {
-				throw std::length_error("File truncated");
-			}
+		std::streamoff len = cacheFile.tellg();
 
-			cacheFile.seekg(0, std::ios::beg);
-
-			len -= sizeof(checksum);
-			D3DCreateBlob(len, shader);
-			cacheFile.read((char *)(*shader)->GetBufferPointer(), len);
-			uint64_t calculated_checksum = fnv1a_hash((char *)(*shader)->GetBufferPointer(), len);
-
-			cacheFile.read((char *)&checksum, sizeof(checksum));
-			if (calculated_checksum != checksum) {
-				throw std::exception("Checksum mismatch");
-			}
-
-			is_cached = true;
-		} catch (const std::exception &e) {
-			// Something went wrong reading the cache file, delete it
-			blog(LOG_WARNING, "Loading shader cache file failed with \"%s\": %s", e.what(), file);
+		// Not enough data for checksum + shader
+		if (len < 0 || len <= static_cast<std::streamoff>(sizeof(checksum))) {
 			cacheFile.close();
-			std::filesystem::remove(cachePath);
+			remove_cache_file(cachePath, "truncated or unreadable");
+		} else {
+			len -= sizeof(checksum);
+
+			hr = D3DCreateBlob(len, shader);
+			if (FAILED(hr)) {
+				cacheFile.close();
+				remove_cache_file(cachePath, "cache blob allocation failed");
+			} else {
+				cacheFile.seekg(0, std::ios::beg);
+				cacheFile.read(static_cast<char *>((*shader)->GetBufferPointer()), len);
+				cacheFile.read(reinterpret_cast<char *>(&checksum), sizeof(checksum));
+
+				const bool success = static_cast<bool>(cacheFile);
+
+				if (success) {
+					uint64_t calculated_checksum =
+						fnv1a_hash(static_cast<char *>((*shader)->GetBufferPointer()), len);
+
+					if (calculated_checksum == checksum) {
+						is_cached = true;
+					}
+				}
+
+				if (!is_cached) {
+					(*shader)->Release();
+					*shader = nullptr;
+
+					cacheFile.close();
+					remove_cache_file(cachePath, !success ? "read error" : "checksum mismatch");
+				}
+			}
 		}
 	}
 
@@ -288,18 +309,17 @@ void gs_shader::Compile(const char *shaderString, const char *file, const char *
 			}
 		}
 
-		cacheFile.open(cachePath, std::ios::out | std::ios::binary);
-		if (cacheFile.is_open()) {
-			try {
-				uint64_t calculated_checksum =
-					fnv1a_hash((char *)(*shader)->GetBufferPointer(), (*shader)->GetBufferSize());
+		std::ofstream outFile{cachePath, std::ios::binary | std::ios::trunc};
+		if (outFile.is_open()) {
+			uint64_t calculated_checksum = fnv1a_hash(static_cast<char *>((*shader)->GetBufferPointer()),
+								  (*shader)->GetBufferSize());
 
-				cacheFile.write((char *)(*shader)->GetBufferPointer(), (*shader)->GetBufferSize());
-				cacheFile.write((char *)&calculated_checksum, sizeof(calculated_checksum));
-			} catch (const std::exception &e) {
-				blog(LOG_WARNING, "Writing shader cache file failed with \"%s\": %s", e.what(), file);
-				cacheFile.close();
-				std::filesystem::remove(cachePath);
+			outFile.write(static_cast<char *>((*shader)->GetBufferPointer()), (*shader)->GetBufferSize());
+			outFile.write(reinterpret_cast<char *>(&calculated_checksum), sizeof(calculated_checksum));
+			outFile.close();
+
+			if (outFile.fail()) {
+				remove_cache_file(cachePath, "write error");
 			}
 		}
 	}


### PR DESCRIPTION
### Description
We're still getting crash reports from this code and it seems like C++ file I/O with exceptions set is a minefield - even closing a file in an exception handler can trigger further exceptions from buffer flushes for example. Using std::filesystem to check the file exists before opening it also introduces exceptions and is a pointless TOCTOU check anyway.

This commit removes the exception bits from the streams and relies on ifstream operator bool and ofstream fail() instead, greatly reducing the number of possible exception generating paths we need to worry about.

### Motivation and Context
Fix reported crashes.

### How Has This Been Tested?
Tested with read only, deleted files, corrupt files as much as possible.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
