### PR TITLE
frontend: Explicitly set plugin manager linkage to nlohmann_json

### DIFF
--- a/frontend/cmake/feature-plugin-manager.cmake
+++ b/frontend/cmake/feature-plugin-manager.cmake
@@ -1,3 +1,5 @@
+find_package(nlohmann_json 3.11 REQUIRED)
+
 target_sources(
   obs-studio
   PRIVATE
@@ -6,3 +8,5 @@ target_sources(
     plugin-manager/PluginManagerWindow.cpp
     plugin-manager/PluginManagerWindow.hpp
 )
+
+target_link_libraries(obs-studio PRIVATE nlohmann_json::nlohmann_json)


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

nlohmann_json is not always linked to the obs-studio target and the plugin manager requires it to build.

In some scenario, nothing at configure time would caught nlohmann_json being missing.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

I met a compiling issue asking for a nlohmann_json header in a minimal build-test, where CMake should have caught it missing way earlier in the config stage.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Now CMake errors out at config stage

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
