### PR TITLE
media-playback: Own FFmpeg options

### DIFF
--- a/shared/media-playback/media-playback/cache.c
+++ b/shared/media-playback/media-playback/cache.c
@@ -561,7 +561,7 @@ bool mp_cache_init(mp_cache_t *c, const struct mp_media_info *info)
 	c->v_cb = info->v_cb;
 	c->a_cb = info->a_cb;
 	c->stop_cb = info->stop_cb;
-	c->ffmpeg_options = info->ffmpeg_options;
+	c->ffmpeg_options = info->ffmpeg_options ? bstrdup(info->ffmpeg_options) : NULL;
 	c->v_seek_cb = info->v_seek_cb;
 	c->v_preload_cb = info->v_preload_cb;
 	c->request_preload = info->request_preload;
@@ -618,6 +618,7 @@ void mp_cache_free(mp_cache_t *c)
 
 	bfree(c->path);
 	bfree(c->format_name);
+	bfree(c->ffmpeg_options);
 	pthread_mutex_destroy(&c->mutex);
 	os_sem_destroy(c->sem);
 	memset(c, 0, sizeof(*c));

--- a/shared/media-playback/media-playback/media-playback.h
+++ b/shared/media-playback/media-playback/media-playback.h
@@ -36,7 +36,7 @@ struct mp_media_info {
 
 	const char *path;
 	const char *format;
-	char *ffmpeg_options;
+	const char *ffmpeg_options;
 	int buffering;
 	int speed;
 	enum video_range_type force_range;

--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -859,6 +859,7 @@ static inline bool mp_media_init_internal(mp_media_t *m, const struct mp_media_i
 	m->path = info->path ? bstrdup(info->path) : NULL;
 	m->format_name = info->format ? bstrdup(info->format) : NULL;
 	m->hw = info->hardware_decoding;
+	m->ffmpeg_options = info->ffmpeg_options ? bstrdup(info->ffmpeg_options) : NULL;
 
 	if (info->full_decode)
 		return true;
@@ -880,7 +881,6 @@ bool mp_media_init(mp_media_t *media, const struct mp_media_info *info)
 	media->v_cb = info->v_cb;
 	media->a_cb = info->a_cb;
 	media->stop_cb = info->stop_cb;
-	media->ffmpeg_options = info->ffmpeg_options;
 	media->v_seek_cb = info->v_seek_cb;
 	media->v_preload_cb = info->v_preload_cb;
 	media->force_range = info->force_range;
@@ -943,6 +943,7 @@ void mp_media_free(mp_media_t *media)
 	av_freep(&media->scale_pic[0]);
 	bfree(media->path);
 	bfree(media->format_name);
+	bfree(media->ffmpeg_options);
 	memset(media, 0, sizeof(*media));
 	pthread_mutex_init_value(&media->mutex);
 }


### PR DESCRIPTION
### Description

This changes media playback so `ffmpeg_options` is copied into each
playback instance instead of reusing the pointer from the source settings.

`mp_media` and `mp_cache` now handle this value the same way they already
handle `path` and `format_name`.

### Motivation and Context

The media source can be updated while an existing playback object is still
running or being destroyed. In that case, keeping `ffmpeg_options` as a
borrowed pointer makes its lifetime depend on the source settings object.

Copying the string into the playback object makes the ownership clear and
keeps active playback state independent from later source setting updates.

### How Has This Been Tested?

Tested on macOS 15.7.4 with a local OBS 32.1.2 Debug build.

Built and launched successfully with:

```bash
cmake --build build_macos --target obs-ffmpeg --config Debug
cmake --build build_macos --target obs-studio --config Debug