### PR TITLE
media-playback: Fix RIST input crash

### DIFF
--- a/shared/media-playback/media-playback/media.c
+++ b/shared/media-playback/media-playback/media.c
@@ -682,6 +682,9 @@ static bool init_avformat(mp_media_t *m)
 			blog(LOG_WARNING, "Failed to parse FFmpeg options: %s\n%s", av_err2str(ret), m->ffmpeg_options);
 	}
 
+	if (is_rist)
+		av_dict_set(&opts, "log_level", "-1", 0);
+
 	m->fmt = avformat_alloc_context();
 	if (m->buffering == 0) {
 		m->fmt->flags |= AVFMT_FLAG_NOBUFFER;


### PR DESCRIPTION
### Description

This disables librist logging for RIST media inputs by forcing the
`log_level` option to `-1` before opening the input.

The crash happens while FFmpeg is opening the RIST receiver. During
`rist_receiver_create`, librist emits log messages through the callback
registered by FFmpeg's RIST protocol wrapper. That callback forwards the
message to `av_log` using the context provided by the wrapper. On macOS, OBS
can crash in that `librist -> av_log` path while the media source is being
reopened after an input URL change.

The change only applies to inputs using the `rist` protocol and avoids that
callback path for OBS media sources.

### Motivation and Context

Changing a RIST media source URL could crash OBS on macOS while opening the
receiver. The crash occurred on `mp_media_thread` during
`rist_receiver_create`, through the `librist -> av_log` logging path.

Local debugging showed that librist was able to open the receiver and emit log
messages successfully when the FFmpeg log callback ignored the logging
context and forwarded messages with a null context instead. This suggests the
underlying issue is likely in FFmpeg's RIST protocol wrapper, or in how that
wrapper passes its logging context to `av_log`, rather than in the media
source settings themselves.

This change is a local OBS workaround until the underlying issue can be fixed
in librist or in FFmpeg's librist protocol wrapper.

The crash can be reproduced with a local RIST sender on macOS.

Terminal 1, generate an MPEG-TS test stream over UDP:

```bash
ffmpeg -re \
  -f lavfi -i 'testsrc=size=1280x720:rate=25' \
  -f lavfi -i 'sine=frequency=1000' \
  -c:v libx264 -b:v 4M \
  -c:a aac \
  -f mpegts 'udp://127.0.0.1:6000'
```

Terminal 2, send that UDP stream over RIST:

``` bash
ristsender \
  -i 'udp://127.0.0.1:6000' \
  -o 'rist://127.0.0.1:5000'
```

In OBS, create a Media Source with:

Input: rist://@:5000
Input Format: mpegts
Then open the Media Source properties and change the RIST input URL.

Before this change, OBS would crash while reopening the RIST receiver. The crash occurred on the mp_media_thread in the librist -> av_log path during rist_receiver_create.

This is intended as a local workaround for OBS until the underlying issue can be fixed in librist or in FFmpeg's librist protocol wrapper.

### How Has This Been Tested?

Tested on macOS 15.7.4 with a local OBS 32.1.2 Debug build.

Built successfully with:

```bash
cmake --build build_macos --target obs-ffmpeg --config Debug
cmake --build build_macos --target obs-studio --config Debug