### PR TITLE
frontend: Fix duplicate layout name

### DIFF
--- a/frontend/forms/OBSBasicSettings.ui
+++ b/frontend/forms/OBSBasicSettings.ui
@@ -2087,7 +2087,7 @@
                 <property name="title">
                  <string>Basic.Settings.Stream.WHIPSimulcastLabel</string>
                 </property>
-                <layout class="QVBoxLayout" name="verticalLayout_35">
+                <layout class="QVBoxLayout" name="verticalLayout_36">
                  <property name="leftMargin">
                   <number>9</number>
                  </property>
@@ -2143,19 +2143,19 @@
                    </property>
                    <item row="1" column="0">
                     <widget class="QLabel" name="whipSimulcastTotalLayersLabel">
-                     <property name="text">
-                      <string>Basic.Settings.Stream.WHIPSimulcastTotalLayers</string>
-                     </property>
                      <property name="minimumSize">
                       <size>
                        <width>170</width>
                        <height>0</height>
                       </size>
                      </property>
+                     <property name="text">
+                      <string>Basic.Settings.Stream.WHIPSimulcastTotalLayers</string>
+                     </property>
                     </widget>
                    </item>
                    <item row="1" column="1">
-                    <layout class="QHBoxLayout" name="horizontalLayout_35" stretch="0,0">
+                    <layout class="QHBoxLayout" name="horizontalLayout_35" stretch="0">
                      <item>
                       <widget class="QSpinBox" name="whipSimulcastTotalLayers">
                        <property name="minimum">


### PR DESCRIPTION
### Description
There are two different layouts named verticalLayout_35 in OBSBasicSettings.ui. Qt will automatically resolve this when generating the form code but it spits out a warning.

Some other formatting fixes are also included from properly saving the file with Designer.

### Motivation and Context
Fix warnings.

### How Has This Been Tested?
Compiled.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
