### PR TITLE
frontend: Fix rescale dropdown enable desync

### DIFF
--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -5944,8 +5944,8 @@ void OBSBasicSettings::UpdateMultitrackVideo()
 		ui->advOutEncoder->setDisabled(disable_video);
 
 		ui->advOutUseRescale->setDisabled(disable_video);
-		ui->advOutRescale->setDisabled(disable_video);
 		ui->advOutRescaleFilter->setDisabled(disable_video);
+		ui->advOutRescale->setDisabled(disable_video || ui->advOutRescaleFilter->currentIndex() == 0);
 
 		if (streamEncoderProps) {
 			streamEncoderProps->SetDisabled(disable_video);


### PR DESCRIPTION
### Description
Fixes Multitrack Video inadvertently re-enabling the rescale output resolution dropdown.

This is a bandaid solution but settings is a known mess


### Motivation and Context
Fixes #11908

### How Has This Been Tested?
Toggled Multitrack video on and off. Toggled `Use stream encoder` for Recording on/off.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
