### PR TITLE
CI: Update used clang-format version to 22.1.3

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -35,7 +35,7 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
-        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@19/bin" >> $GITHUB_PATH
+        echo "/home/linuxbrew/.linuxbrew/opt/clang-format@22/bin" >> $GITHUB_PATH
         brew install --quiet zsh
         echo ::endgroup::
 
@@ -50,11 +50,11 @@ runs:
         : Run clang-format 🐉
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
         
-        print ::group::Install clang-format-19
-        brew install --quiet obsproject/tools/clang-format@19
+        print ::group::Install clang-format-22
+        brew install --quiet obsproject/tools/clang-format@22
         print ::endgroup::
 
-        print ::group::Run clang-format-19
+        print ::group::Run clang-format-22
         local -a changes=(${(s:,:)CHANGED_FILES//[\[\]\'\"]/})
         ./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
         print ::endgroup::

--- a/build-aux/.run-format.zsh
+++ b/build-aux/.run-format.zsh
@@ -33,25 +33,24 @@ invoke_formatter() {
 
   case ${formatter} {
     clang)
-      if (( ${+commands[clang-format-19]} )) {
-        local formatter=clang-format-19
+      if (( ${+commands[clang-format-22]} )) {
+        local formatter=clang-format-22
       } elif (( ${+commands[clang-format]} )) {
         local formatter=clang-format
       } else {
-        log_error "No viable clang-format version found (required 19.1.1)"
+        log_error "No viable clang-format version found (required 22.1.3)"
         exit 2
       }
 
       local -a formatter_version=($(${formatter} --version))
 
-      if ! is-at-least 19.1.1 ${formatter_version[-1]}; then
-        log_error "clang-format is not version 19.1.1 or above (found ${formatter_version[-1]}."
+      if ! is-at-least 22.1.3 ${formatter_version[-1]}; then
+        log_error "clang-format is not version 22.1.3 or above (found ${formatter_version[-1]}."
         exit 2
       fi
 
-      if ! is-at-least ${formatter_version[-1]} 19.1.1; then
-        log_error "clang-format is more recent than version 19.1.1 (found ${formatter_version[-1]})."
-        exit 2
+      if ! is-at-least ${formatter_version[-1]} 22.1.3; then
+        log_warning "clang-format is more recent than version 22.1.3 (found ${formatter_version[-1]})."
       fi
 
       if (( ! #source_files )) source_files=((libobs|libobs-*|frontend|plugins|deps|shared|test)/**/*.(c|cpp|h|hpp|m|mm)(.N))


### PR DESCRIPTION
### Description
Updates the clang-format version used by the `run-clang-format` action and associated script to 22.1.3.

### Motivation and Context
To enable formatting rules that explicitly differentiate between C and C++, a clang-format version of at least 20 is needed.

Visual Studio 18.7 ships with clang 22 and its associated clang-format version, which usually becomes the baseline for the project (as its easier to install specific clang-format versions on macOS and Linux than on Windows).

### How Has This Been Tested?
Formatting script used with clang-format 22.1.7 locally. Warning about more recent version was correctly triggered, formatting changes were correct detected.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
