### PR TITLE
UI: Clamp YouTube broadcast dialog to screen size

### DIFF
--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -8,6 +8,7 @@
 #include <QDesktopServices>
 #include <QFileInfo>
 #include <QImageReader>
+#include <QScreen>
 #include <QStandardPaths>
 #include <QToolTip>
 
@@ -251,6 +252,16 @@ OBSYoutubeActions::OBSYoutubeActions(QWidget *parent, Auth *auth, bool broadcast
 	// MacOS theming issues
 	this->resize(this->width() + 200, this->height() + 120);
 #endif
+
+	// Clamp dialog to available screen geometry
+	if (QScreen *screen = this->screen(); screen) {
+		const QRect available = screen->availableGeometry();
+		const int maxH = static_cast<int>(available.height() * 0.85);
+		const int maxW = static_cast<int>(available.width() * 0.85);
+		if (height() > maxH || width() > maxW)
+			resize(std::min(width(), maxW), std::min(height(), maxH));
+	}
+
 	valid = true;
 }
 

--- a/frontend/forms/OBSYoutubeActions.ui
+++ b/frontend/forms/OBSYoutubeActions.ui
@@ -27,7 +27,7 @@
     <number>6</number>
    </property>
    <property name="sizeConstraint">
-    <enum>QLayout::SetMinimumSize</enum>
+    <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <item>
     <widget class="QTabWidget" name="tabWidget">


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
The YouTube Manage Broadcast dialog (`OBSYoutubeActions`) defaults to a height of 738 pixels (858 pixels on macOS) with `QLayout::SetMinimumSize` on its main layout, preventing it from shrinking below its content size hint. There is no code to clamp the dialog size to the available screen geometry.

On smaller screens or external monitors with different DPI scaling, the dialog height exceeds the visible screen area, pushing the bottom action buttons — "Select broadcast", "Select broadcast and start streaming", "Create broadcast", etc. — below the bottom edge where they are not initially visible. The user must manually drag or resize the dialog to access them.

#### Changes

- Added screen-size clamping in the constructor using `QScreen::availableGeometry()` to constrain
  the dialog to 85% of available screen space
- Relaxed the layout `sizeConstraint` from `QLayout::SetMinimumSize` to
  `QLayout::SetDefaultConstraint` so the dialog can be manually resized smaller when needed
  (the `QScrollArea` widgets inside both tabs already handle content overflow correctly)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Fixes #13556 - a UI accessibility issue where the YouTube broadcast setup dialog renders taller
than the available screen area on multi-monitor setups with mismatched DPI scaling, cutting off
the bottom action buttons. Users are forced to manually reposition or resize the dialog every
time they open it just to reach essential controls.

I encountered this firsthand while using OBS to stream church sermons — our team had been
working around it every session by dragging and resizing the window without realizing it was
a bug. Assuming it had already been reported, I dug into it and found it hadn't been - and
that it was fixable with a minimal code change.

The fix is intentionally small: 5 lines of clamping logic and a 1-line constraint change,
using Qt's built-in `QScreen::availableGeometry()` which correctly accounts for taskbar
height, DPI scaling, and multi-monitor configurations - no custom geometry math needed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Windows 11 with an external monitor at different DPI scaling — dialog now fits within the visible screen area without manual resizing
Built with Visual Studio using cmake --build build_x64 --config Debug
Verified both tabs ("Create New Broadcast" and "Select Existing Broadcast") remain functional
Verified that QScrollArea widgets inside each tab still scroll correctly when the dialog is manually resized smaller
Verified the macOS width workaround (`#ifdef __APPLE__` resize) is preserved and still applies before clamping

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
