### PR TITLE
build-aux: add LD_LIBRARY_PATH env to flatpak

### DIFF
--- a/build-aux/com.obsproject.Studio.json
+++ b/build-aux/com.obsproject.Studio.json
@@ -17,7 +17,8 @@
         "--talk-name=org.freedesktop.Flatpak",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.a11y.Bus",
-        "--env=VST_PATH=/app/extensions/Plugins/vst"
+        "--env=VST_PATH=/app/extensions/Plugins/vst",
+        "--env=LD_LIBRARY_PATH=/app/lib"
     ],
     "add-extensions": {
         "com.obsproject.Studio.Plugin": {


### PR DESCRIPTION
### Description
This PR adds the `LD_LIBRARY_PATH` environment variable in the flatpak runtime to `/app/lib`


### Motivation and Context
Shared objects in the flatpak are located under /app/lib however, linux by default only looks under /lib and /usr/lib if LD_LIBRARY_PATH is not set, so plugins that need shared obs objects (such as `libobs-frontend-api.so`) will not be able to find them. Adding this environment variable to the exported flatpak context solves this problem.


This came up when I was trying to make a flatpak for this closed caption plugin https://github.com/ratwithacompiler/OBS-captions-plugin. This produces a `.so` object that needs `libos-frontend-api.so` but under this build structure it cannot find it and therefore fails to load. this has lead a couple of issues in that repository. In one of the issues it was discovered that running the OBS flatpak with `--env=LD_LIBRARY_PATH=/app/lib/ ` solves the problem. Since `app` is the default mount point in flatpak, I think this is a sensible config to have (a similar one has already been added for VSTs), and it could help some other plugins as well run under flatpak. 

I am not an expert in flatpak or the OBS build config, but this seems like a normal variable to set which shouldn't break anything as it just includes the so files that were shipped with the flatpak. If they are not found there the other locations will still be searched. (I'm happy to be corrected)


### How Has This Been Tested?

The test for this perticular was done by installing the OBS flatpak from flathub, and buildling a flatpak installation around the plugin. The flatpak manifest that was used for this test can be found here: https://github.com/aslowwriter/OBS-captions-plugin/blob/feat/flatpak-manifest/com.obsproject.Studio.Plugin.ClosedCaption.yaml (currently that's my own fork of the plugin, but I hope to make a PR for the flatpak manifest files there shortly) 

When launched OBS says that the closed caption plugin failed to load. 
As mentioned in https://github.com/ratwithacompiler/OBS-captions-plugin/issues/155 this issue can be resolved by running the flatpak with `flatpak run --env=LD_LIBRARY_PATH=/app/lib/ com.obsproject.Studio`, but if the flatpak is run without the `--env` flag the plugin fails to load again. 

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
