### PR TITLE
CI: Use jq to transform SARIF files in macOS job

### DIFF
--- a/.github/workflows/analyze-project.yaml
+++ b/.github/workflows/analyze-project.yaml
@@ -131,8 +131,42 @@ jobs:
 
           pushd ${analytics_root}
 
-          npx @microsoft/sarif-multitool merge --merge-runs *.sarif
+          # The jq expression below merges the results of all separate compilation (and
+          # analysis) runs into a single result of all tools, thus meeting the
+          # requirements of the codeql-action's upload job.
+          # The merged sarif file contains a single "runs" array with a single
+          # corresponding "tool" object.
+          #
+          # Each sarif file will have its own "rules" array (depending on which rules the
+          # file violated), so all violated rules across all compilations need to be
+          # collected into this array.
+          #
+          # Next, all "artifacts" array elements and "rules" array elements from all
+          # sarif files have to be added to the same "global" corresponding arrays in the
+          # new single "runs" object.
+          #
+          # Finally, because LLVM produces codeflow regions with invalid "endLine" and
+          # "endColumn" entries (with value 0), those entries are removed from the
+          # regions in the results' codeFlows arrays.
 
+          jq -s '{
+            "$schema": first(.[]."$schema"),
+            "version": first(.[].version),
+            "runs": [{
+              "tool": {
+                "driver": (first(.[].runs[].tool.driver) | del(.rules)) + {
+                  "rules": reduce(.[].runs[].tool.driver.rules) as $obj ([]; . + $obj) | unique
+                }
+              },
+              "artifacts": reduce(.[].runs[].artifacts) as $obj ([]; . + $obj) | unique,
+              "results": (reduce(.[].runs[].results) as $obj ([]; . + $obj))
+              | del(
+                .[].codeFlows[].threadFlows[].locations[].location.physicalLocation.region.endLine,
+                .[].codeFlows[].threadFlows[].locations[].location.physicalLocation.region.endColumn
+                | select(. == 0)
+              )
+            }]
+          }' *.sarif > merged.sarif
           popd
 
       - name: Upload SARIF report files 📦


### PR DESCRIPTION
### Description
Replaces use of `sarif-multitool` with a `jq`-based transformation for macOS static code analysis job.

### Motivation and Context
Microsoft's sarif-multitool requires platform-specific binaries to run (even though it's installed via npm) and does not ship an Apple Silicon binary. With Rosetta 2 being deprecated in macOS 27, the tool would stop working once the project had updated to macOS 27 runners.

Using "jq" provides a cleaner alternative, as the required transformation is transparent in code and does not require any additional tools or binaries.

This is also necessary because in a recent release Microsoft removed the `--merge-runs` argument that the job currently relies on.

### How Has This Been Tested?
Scheduled analysis job was run manually on separate fork with all existing security analyses deleted. Confirmed after a successful run that the static code analysis reports were correctly posted to GitHub's "Security and quality" tab.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
