### PR TITLE
CI: Skip automatic artifact creation for PR runs

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -146,6 +146,7 @@ jobs:
 
       - name: Package OBS Studio 📀
         uses: ./.github/actions/package-obs
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           target: ${{ matrix.target }}
           config: ${{ needs.check-event.outputs.config }}
@@ -158,6 +159,7 @@ jobs:
 
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           name: obs-studio-macos-${{ matrix.target }}-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/build_macos/obs-studio-*-macos-${{ steps.setup.outputs.cpuName }}.*
@@ -216,6 +218,7 @@ jobs:
 
       - name: Package OBS Studio 📀
         uses: ./.github/actions/package-obs
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           target: x86_64
           config: ${{ needs.check-event.outputs.config }}
@@ -223,12 +226,14 @@ jobs:
 
       - name: Upload Source Tarball 🗜️
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           name: obs-studio-${{ matrix.os }}-sources-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/build_ubuntu/obs-studio-*-sources.*
 
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           name: obs-studio-${{ matrix.os }}-x86_64-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/build_ubuntu/obs-studio-*-x86_64-ubuntu-gnu.*
@@ -408,6 +413,7 @@ jobs:
 
       - name: Package OBS Studio 📀
         uses: ./.github/actions/package-obs
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           target: ${{ matrix.architecture }}
           config: ${{ needs.check-event.outputs.config }}
@@ -415,6 +421,7 @@ jobs:
 
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ fromJSON(needs.check-event.outputs.package) }}
         with:
           name: obs-studio-windows-${{ matrix.architecture }}-${{ needs.check-event.outputs.commitHash }}
           path: ${{ github.workspace }}/build_${{ matrix.architecture }}/obs-studio-*-windows-${{ matrix.architecture }}.zip


### PR DESCRIPTION
### Description
Changes the "PR Push" workflow to only generate artifacts when the "Seeking Testers" label has been added to a PR prior to a run.

### Motivation and Context
Only when the pull request has been given the appropriate label on GitHub should the workflow generate actual artifacts available for download. This puts the project in control if and when OBS Studio builds based on changes in a PR are made available for download automatically.

### How Has This Been Tested?
Test will be performed by opening this PR and checking CI runs without the associated label added to the PR.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
