### PR TITLE
CI: Trust obsproject tools tap for format actions

### DIFF
--- a/.github/actions/run-clang-format/action.yaml
+++ b/.github/actions/run-clang-format/action.yaml
@@ -51,6 +51,7 @@ runs:
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
         
         print ::group::Install clang-format-22
+        brew trust obsproject/tools
         brew install --quiet obsproject/tools/clang-format@22
         print ::endgroup::
 

--- a/.github/actions/run-gersemi/action.yaml
+++ b/.github/actions/run-gersemi/action.yaml
@@ -50,6 +50,7 @@ runs:
         if (( ${+RUNNER_DEBUG} )) setopt XTRACE
 
         print ::group::Install gersemi
+        brew trust obsproject/tools
         brew install --quiet obsproject/tools/gersemi@0.25
         print ::endgroup::
 


### PR DESCRIPTION
### Description
Add code to explicitly trust `obsproject/tools` tap for installation of third-party formulas.

### Motivation and Context
Recent Homebrew versions require 3rd party taps to be explicitly trusted before they can be used to install formulas.

The "obsproject/tools" tap is used to provide pinned formulas of some code formatters used by CI and thus needs to be trusted to enable installation of these formulas.

### How Has This Been Tested?
Will be tested via temporary commit in PR triggering both the `clang-format` and `gersemi` check actions.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
