### PR TITLE
libobs: Only emit core signal handlers for public canvases

### DIFF
--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -50,7 +50,7 @@ static inline void canvas_dosignal(obs_canvas_t *canvas, const char *signal_obs,
 
 	calldata_init_fixed(&data, stack, sizeof(stack));
 	calldata_set_ptr(&data, "canvas", canvas);
-	if (signal_obs)
+	if (signal_obs && !canvas->context.private)
 		signal_handler_signal(obs->signals, signal_obs, &data);
 	if (signal_canvas)
 		signal_handler_signal(canvas->context.signals, signal_canvas, &data);

--- a/libobs/obs-canvas.c
+++ b/libobs/obs-canvas.c
@@ -43,7 +43,7 @@ static const char *canvas_signals[] = {
 	NULL,
 };
 
-static inline void canvas_dosignal(obs_canvas_t *canvas, const char *signal_obs, const char *signal_source)
+static inline void canvas_dosignal(obs_canvas_t *canvas, const char *signal_obs, const char *signal_canvas)
 {
 	struct calldata data;
 	uint8_t stack[128];
@@ -52,8 +52,8 @@ static inline void canvas_dosignal(obs_canvas_t *canvas, const char *signal_obs,
 	calldata_set_ptr(&data, "canvas", canvas);
 	if (signal_obs)
 		signal_handler_signal(obs->signals, signal_obs, &data);
-	if (signal_source)
-		signal_handler_signal(canvas->context.signals, signal_source, &data);
+	if (signal_canvas)
+		signal_handler_signal(canvas->context.signals, signal_canvas, &data);
 }
 
 static inline void canvas_dosignal_source(const char *signal, obs_canvas_t *canvas, obs_source_t *source)


### PR DESCRIPTION
### Description
Amends behavior to match other notable object types like sources. Private canvases should never have their events emitted to the core signal handler.

### Motivation and Context
This implicitly fixes an obs-websocket crash that can occur when a private canvas with a NULL name is destroyed. For example, in #12442 

### How Has This Been Tested?
Compiles

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
