### PR TITLE
libobs: Fix deadlock on executing tasks

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -493,18 +493,15 @@ static inline void release_audio_sources(struct obs_core_audio *audio)
 static inline void execute_audio_tasks(void)
 {
 	struct obs_core_audio *audio = &obs->audio;
-	bool tasks_remaining = true;
-
-	while (tasks_remaining) {
-		pthread_mutex_lock(&audio->task_mutex);
-		if (audio->tasks.size) {
-			struct obs_task_info info;
-			deque_pop_front(&audio->tasks, &info, sizeof(info));
-			info.task(info.param);
-		}
-		tasks_remaining = !!audio->tasks.size;
+	pthread_mutex_lock(&audio->task_mutex);
+	while (audio->tasks.size) {
+		struct obs_task_info info;
+		deque_pop_front(&audio->tasks, &info, sizeof(info));
 		pthread_mutex_unlock(&audio->task_mutex);
+		info.task(info.param);
+		pthread_mutex_lock(&audio->task_mutex);
 	}
+	pthread_mutex_unlock(&audio->task_mutex);
 }
 
 /* In case monitoring and an 'Audio Output Capture' source have the same device, one silences all the monitored

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -957,18 +957,15 @@ extern THREAD_LOCAL bool is_graphics_thread;
 static void execute_graphics_tasks(void)
 {
 	struct obs_core_video *video = &obs->video;
-	bool tasks_remaining = true;
-
-	while (tasks_remaining) {
-		pthread_mutex_lock(&video->task_mutex);
-		if (video->tasks.size) {
-			struct obs_task_info info;
-			deque_pop_front(&video->tasks, &info, sizeof(info));
-			info.task(info.param);
-		}
-		tasks_remaining = !!video->tasks.size;
+	pthread_mutex_lock(&video->task_mutex);
+	while (video->tasks.size) {
+		struct obs_task_info info;
+		deque_pop_front(&video->tasks, &info, sizeof(info));
 		pthread_mutex_unlock(&video->task_mutex);
+		info.task(info.param);
+		pthread_mutex_lock(&video->task_mutex);
 	}
+	pthread_mutex_unlock(&video->task_mutex);
 }
 
 #ifdef _WIN32


### PR DESCRIPTION
### Description
Fix deadlock on executing tasks

### Motivation and Context
Do not keep the task mutex locked while executing a task.
There are multiple tasks in OBS itself and in plugins that use other mutexes and queue tasks.

### How Has This Been Tested?
On windows 11 by trying to get deadlocks using an OBS plugin.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
