### PR TITLE
obs-scripting: Add obs_properties_add_button2

### DIFF
--- a/plugins/frontend-tools/data/scripts/countdown.lua
+++ b/plugins/frontend-tools/data/scripts/countdown.lua
@@ -121,7 +121,7 @@ function script_properties()
 	obs.source_list_release(sources)
 
 	obs.obs_properties_add_text(props, "stop_text", "Final Text", obs.OBS_TEXT_DEFAULT)
-	obs.obs_properties_add_button(props, "reset_button", "Reset Timer", reset_button_clicked)
+	obs.obs_properties_add_button2(props, "reset_button", "Reset Timer", reset_button_clicked)
 
 	return props
 end

--- a/plugins/frontend-tools/data/scripts/url-text.py
+++ b/plugins/frontend-tools/data/scripts/url-text.py
@@ -73,5 +73,5 @@ def script_properties():
 
 		obs.source_list_release(sources)
 
-	obs.obs_properties_add_button(props, "button", "Refresh", refresh_pressed)
+	obs.obs_properties_add_button2(props, "button", "Refresh", refresh_pressed)
 	return props

--- a/shared/obs-scripting/obs-scripting-lua.c
+++ b/shared/obs-scripting/obs-scripting-lua.c
@@ -1027,6 +1027,7 @@ static void add_hook_functions(lua_State *script)
 	add_func("obs_hotkey_unregister", hotkey_unregister);
 	add_func("obs_hotkey_register_frontend", hotkey_register_frontend);
 	add_func("obs_properties_add_button", properties_add_button);
+	add_func("obs_properties_add_button2", properties_add_button);
 	add_func("obs_property_set_modified_callback", property_set_modified_callback);
 	add_func("remove_current_callback", remove_current_callback);
 

--- a/shared/obs-scripting/obs-scripting-python.c
+++ b/shared/obs-scripting/obs-scripting-python.c
@@ -1218,6 +1218,7 @@ static void add_hook_functions(PyObject *module)
 		DEF_FUNC("obs_hotkey_unregister", hotkey_unregister),
 		DEF_FUNC("obs_hotkey_register_frontend", hotkey_register_frontend),
 		DEF_FUNC("obs_properties_add_button", properties_add_button),
+		DEF_FUNC("obs_properties_add_button2", properties_add_button),
 		DEF_FUNC("obs_property_set_modified_callback", property_set_modified_callback),
 		DEF_FUNC("remove_current_callback", remove_current_callback),
 

--- a/shared/obs-scripting/obslua/obslua.i
+++ b/shared/obs-scripting/obslua/obslua.i
@@ -67,6 +67,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore obs_enum_sources;
 %ignore obs_source_enum_filters;
 %ignore obs_properties_add_button;
+%ignore obs_properties_add_button2;
 %ignore obs_property_set_modified_callback;
 %ignore signal_handler_connect;
 %ignore signal_handler_disconnect;

--- a/shared/obs-scripting/obspython/obspython.i
+++ b/shared/obs-scripting/obspython/obspython.i
@@ -78,6 +78,7 @@ static inline void wrap_blog(int log_level, const char *message)
 %ignore obs_remove_main_render_callback;
 %ignore obs_enum_sources;
 %ignore obs_properties_add_button;
+%ignore obs_properties_add_button2;
 %ignore obs_property_set_modified_callback;
 %ignore signal_handler_connect;
 %ignore signal_handler_disconnect;


### PR DESCRIPTION

### Description
Add obs_properties_add_button2 to scripting

### Motivation and Context
obs_properties_add_button is deprecated, so the documentation indicates to use obs_properties_add_button2, but that does not exist yet in scripting

### How Has This Been Tested?
On windows 11 by running the scripts that are modified

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
