### PR TITLE
win-capture: Fix crash on GL context loss in fullscreen switch

### DIFF
--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -90,17 +90,19 @@ static inline bool gl_error(const char *func, const char *str)
 	return false;
 }
 
-static void gl_free(void)
+static void gl_free(bool gl_valid)
 {
 	capture_free();
 
 	if (data.using_shtex) {
-		if (data.gl_dxobj)
-			obsglDXUnregisterObjectNV(data.gl_device, data.gl_dxobj);
-		if (data.gl_device)
-			obsglDXCloseDeviceNV(data.gl_device);
-		if (data.texture)
-			glDeleteTextures(1, &data.texture);
+		if (gl_valid) {
+			if (data.gl_dxobj)
+				obsglDXUnregisterObjectNV(data.gl_device, data.gl_dxobj);
+			if (data.gl_device)
+				obsglDXCloseDeviceNV(data.gl_device);
+			if (data.texture)
+				glDeleteTextures(1, &data.texture);
+		}
 		if (data.d3d11_tex)
 			ID3D11Resource_Release(data.d3d11_tex);
 		if (data.d3d11_context)
@@ -111,7 +113,7 @@ static void gl_free(void)
 			IDXGISwapChain_Release(data.dxgi_swap);
 		if (data.hwnd)
 			DestroyWindow(data.hwnd);
-	} else {
+	} else if (gl_valid) {
 		for (size_t i = 0; i < NUM_BUFFERS; i++) {
 			if (data.pbos[i]) {
 				if (data.texture_mapped[i]) {
@@ -128,10 +130,12 @@ static void gl_free(void)
 		}
 	}
 
-	if (data.fbo)
-		glDeleteFramebuffers(1, &data.fbo);
+	if (gl_valid) {
+		if (data.fbo)
+			glDeleteFramebuffers(1, &data.fbo);
 
-	gl_error("gl_free", "GL error occurred on free");
+		gl_error("gl_free", "GL error occurred on free");
+	}
 
 	memset(&data, 0, sizeof(data));
 
@@ -536,7 +540,7 @@ static int gl_init(HDC hdc)
 	}
 
 	if (!success)
-		gl_free();
+		gl_free(true);
 	else
 		ret = INIT_SUCCESS;
 
@@ -706,7 +710,7 @@ static void gl_capture(HDC hdc)
 	glGetError();
 
 	if (capture_should_stop()) {
-		gl_free();
+		gl_free(true);
 	}
 	if (capture_should_init()) {
 		if (gl_init(hdc) == INIT_SHTEX_FAILED) {
@@ -722,7 +726,7 @@ static void gl_capture(HDC hdc)
 		get_window_size(hdc, &new_cx, &new_cy);
 		if (new_cx != data.cx || new_cy != data.cy) {
 			if (new_cx != 0 && new_cy != 0)
-				gl_free();
+				gl_free(true);
 			return;
 		}
 
@@ -787,12 +791,7 @@ static BOOL WINAPI hook_wgl_swap_layer_buffers(HDC hdc, UINT planes)
 static BOOL WINAPI hook_wgl_delete_context(HGLRC hrc)
 {
 	if (capture_active() && functions_initialized) {
-		HDC last_hdc = obsglGetCurrentDC();
-		HGLRC last_hrc = obsglGetCurrentContext();
-
-		obsglMakeCurrent(data.hdc, hrc);
-		gl_free();
-		obsglMakeCurrent(last_hdc, last_hrc);
+		gl_free(false);
 	}
 
 	return RealWglDeleteContext(hrc);


### PR DESCRIPTION
## Description

The OpenGL graphics hook crashed the host game when the game destroyed
and recreated its GL context — for example LWJGL/GLFW based games such
as Minecraft toggling fullscreen, which changes the screen resolution.

The `wglDeleteContext` hook made the capture DC (`data.hdc`, captured at
init time and already invalid after the mode change) current with the
context being deleted, then ran the full `gl_free()` teardown. Issuing
GL and NV_DX_interop calls against a context that is being torn down
crashes inside the driver.

`gl_free()` now takes a `gl_valid` flag. In the delete-context path it is
called with `false`: only the API-independent resources (D3D11 device,
swap chain, dummy window, shared memory) are released, and the GL objects
and interop registrations are left for the driver to free together with
the context. The capture re-initializes on the next swap. All other
callers, where the game's context is current, pass `true`, so existing
behavior is unchanged.

## Motivation and Context

Game Capture of OpenGL games (notably Minecraft) crashes the game on
every enter/exit of fullscreen while recording, because fullscreen
toggles recreate the GL context and change resolution.

## How Has This Been Tested?

Built the graphics hook and full OBS (Windows x64, VS 2026), captured
Minecraft via Game Capture, and toggled fullscreen repeatedly. The
capture now releases and re-initializes cleanly without crashing the
game.
