### PR TITLE
frontend: Avoid using Monitor Only in the UI

### DIFF
--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -155,10 +155,9 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(
 	int idx;
 	if (obs_audio_monitoring_available()) {
 		monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.None"), (int)OBS_MONITORING_TYPE_NONE);
-		monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.MonitorOnly"),
-					(int)OBS_MONITORING_TYPE_MONITOR_ONLY);
 		monitoringType->addItem(QTStr("Basic.AdvAudio.Monitoring.Both"),
 					(int)OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
+		monitoringType->setPlaceholderText(QTStr("Basic.AdvAudio.Monitoring.MonitorOnly"));
 		int mt = (int)obs_source_get_monitoring_type(source);
 		idx = monitoringType->findData(mt);
 		monitoringType->setCurrentIndex(idx);

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -818,27 +818,17 @@ void VolumeControl::handleMuteButton(bool mute)
 {
 	setMuted(mute);
 
-	if (obsMonitoringType != OBS_MONITORING_TYPE_NONE) {
-		if (mute) {
-			setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
-		} else {
-			setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
-		}
+	if (!mute && obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY) {
+		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
 	}
 }
 
 void VolumeControl::handleMonitorButton(bool enableMonitoring)
 {
-	if (!enableMonitoring) {
-		setMonitoring(OBS_MONITORING_TYPE_NONE);
-		return;
-	}
+	obs_monitoring_type newType = (enableMonitoring) ? OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT
+							 : OBS_MONITORING_TYPE_NONE;
 
-	if (obsMuted) {
-		setMonitoring(OBS_MONITORING_TYPE_MONITOR_ONLY);
-	} else {
-		setMonitoring(OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT);
-	}
+	setMonitoring(newType);
 }
 
 void VolumeControl::sliderChanged(int vol)

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -164,7 +164,7 @@ VolumeControl::~VolumeControl()
 	}
 }
 
-const QIcon &VolumeControl::getUnassignedIcon()
+const QIcon &VolumeControl::getWarningIcon()
 {
 	static const QIcon &icon = *new QIcon(":/res/images/unassigned.svg");
 	return icon;
@@ -773,6 +773,7 @@ void VolumeControl::processMixerState()
 	bool showAsMuted = obsMuted || obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY;
 	bool showAsMonitored = obsMonitoringType != OBS_MONITORING_TYPE_NONE;
 	bool showAsUnassigned = !obsMuted && unassigned;
+	bool showWarningIcon = showAsUnassigned || obsMonitoringType == OBS_MONITORING_TYPE_MONITOR_ONLY;
 
 	volumeMeter->setMuted((showAsMuted || showAsUnassigned) && !showAsMonitored);
 	setUseDisabledColors(showAsMuted || !isActive);
@@ -787,8 +788,8 @@ void VolumeControl::processMixerState()
 						 : QTStr("Basic.AudioMixer.Monitoring.Enable");
 	monitorButton->setToolTip(monitorTooltip);
 
-	if (showAsUnassigned) {
-		muteButton->setIcon(getUnassignedIcon());
+	if (showWarningIcon) {
+		muteButton->setIcon(getWarningIcon());
 	} else if (showAsMuted) {
 		muteButton->setIcon(getMutedIcon());
 	} else {
@@ -806,7 +807,7 @@ void VolumeControl::processMixerState()
 	utils->toggleClass(muteButton, "checked", showAsMuted);
 	utils->toggleClass(monitorButton, "checked", showAsMonitored);
 
-	utils->toggleClass(muteButton, "mute-unassigned", showAsUnassigned);
+	utils->toggleClass(muteButton, "mute-warning", showWarningIcon);
 
 	style()->polish(muteButton);
 	style()->polish(monitorButton);

--- a/frontend/components/VolumeControl.hpp
+++ b/frontend/components/VolumeControl.hpp
@@ -92,7 +92,7 @@ private:
 
 	QMenu *contextMenu;
 
-	static const QIcon &getUnassignedIcon();
+	static const QIcon &getWarningIcon();
 	static const QIcon &getMutedIcon();
 	static const QIcon &getUnmutedIcon();
 	static const QIcon &getMonitorOnIcon();

--- a/frontend/data/locale/en-US.ini
+++ b/frontend/data/locale/en-US.ini
@@ -1387,7 +1387,7 @@ Basic.AdvAudio.SyncOffsetSource="Sync Offset for '%1'"
 Basic.AdvAudio.Monitoring="Audio Monitoring"
 Basic.AdvAudio.Monitoring.None="Monitor Off"
 Basic.AdvAudio.Monitoring.MonitorOnly="Monitor Only (mute output)"
-Basic.AdvAudio.Monitoring.Both="Monitor and Output"
+Basic.AdvAudio.Monitoring.Both="Monitoring Enabled"
 Basic.AdvAudio.MonitoringSource="Audio Monitoring for '%1'"
 Basic.AdvAudio.AudioTracks="Tracks"
 

--- a/frontend/data/themes/Yami.obt
+++ b/frontend/data/themes/Yami.obt
@@ -1674,14 +1674,14 @@ QSlider::handle:disabled {
     border-color: var(--red1);
 }
 
-.btn-mute.mute-unassigned {
+.btn-mute.mute-warning {
     color: var(--yellow1);
     background: var(--yellow6);
     qproperty-icon: url(theme:Dark/unassigned.svg);
 }
 
-.btn-mute.mute-unassigned.hover,
-.btn-mute.mute-unassigned:focus {
+.btn-mute.mute-warning.hover,
+.btn-mute.mute-warning:focus {
     border-color: var(--yellow1);
 }
 


### PR DESCRIPTION
### Description
Removes Monitor Only from the list of monitoring options in the Advanced Audio Properties window and avoids setting it when changing mute/monitor settings via the UI.

<img width="240" height="234" alt="image" src="https://github.com/user-attachments/assets/13d8d6a8-05c6-431b-b12a-e0fc72bdf2d7" />

Shows a warning icon when a source is unmuted but set to Monitor Only.

<img width="124" height="266" alt="image" src="https://github.com/user-attachments/assets/7b8781b2-9e69-4322-b3a3-75f96df3fe33" />


> [!NOTE]
> This PR intentionally does not remove Monitor Only internally or change handling of it. This will be done in a later breaking release.

### Motivation and Context
The Audio Mixer refactor in #12735 added a toggle button for controlling audio monitoring. This behaved as a pseudo tri state, setting monitoring to either `OBS_MONITORING_TYPE_MONITOR_ONLY` or `OBS_MONITORING_TYPE_MONITOR_AND_OUTPUT` depending on the muted state of the source.

This led to some state desync issues when controlling mute state via plugins or websocket, as the UI was the only thing aware of this handling. #13378 adjusted the behaviour to be handled within libobs itself so that audio monitoring was entirely dependent on the state of the sources monitoring setting itself.

However this NOW leads to the UI exposing a previously confusing state:
A source set to monitor only will never output to stream/recordings, regardless of the muted state of that source. In past versions, the UI would reflect the muted/unmuted state. We have essentially "fixed" this so the mute icon reflects whether the source is going to output but it is now confusing to use a hotkey or websockets to toggle mute state, and have nothing happen in the mixer.

With the changes to the UI and monitoring behaviour itself, the monitoring enum no longer makes sense. It will be deprecated/removed in a future version and replaced with a monitoring on/off boolean.

In the interim, this PR avoids setting Monitor Only via the UI as it is now an obsolete setting and will use the existing warning icon when an unmuted source is set to monitor only.

Any interaction via the UI will resolve this.

### How Has This Been Tested?
Toggled the mute state of sources via websockets. Ensured that untouched sources did not have their state changed and that anything set to Monitor Only remained as such in older versions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
