### PR TITLE
win-capture: Add Hearthstone Deck Tracker to compatibility list

### DIFF
--- a/plugins/win-capture/data/compatibility.json
+++ b/plugins/win-capture/data/compatibility.json
@@ -659,6 +659,34 @@
             "window_capture_wgc": false,
             "message": "Wuthering Waves may require OBS to be run as admin to use Game Capture.",
             "url": "https://obsproject.com/kb/game-capture-troubleshooting"
+        },
+        {
+            "name": "Hearthstone Deck Tracker",
+            "translation_key": "Compatibility.WindowCapture.BitBlt",
+            "severity": 1,
+            "executable": "HearthstoneDeckTracker.exe",
+            "window_class": "",
+            "window_title": "HearthstoneOverlay",
+            "match_flags": 3,
+            "game_capture": false,
+            "window_capture": true,
+            "window_capture_wgc": false,
+            "message": "Hearthstone Deck Tracker can not be captured by using the selected Capture Method (BitBlt).",
+            "url": ""
+        },
+        {
+            "name": "Hearthstone Deck Tracker",
+            "translation_key": "Compatibility.GameCapture.Blocked",
+            "severity": 1,
+            "executable": "HearthstoneDeckTracker.exe",
+            "window_class": "",
+            "window_title": "HearthstoneOverlay",
+            "match_flags": 3,
+            "game_capture": true,
+            "window_capture": false,
+            "window_capture_wgc": false,
+            "message": "Hearthstone Deck Tracker cannot be captured using Game Capture. Use Window Capture or Display Capture instead.",
+            "url": ""
         }
     ]
 }

--- a/plugins/win-capture/data/package.json
+++ b/plugins/win-capture/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/win-capture/v1",
-    "version": 9,
+    "version": 10,
     "files": [
         {
             "name": "compatibility.json",
-            "version": 9
+            "version": 10
         }
     ]
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This PR updates the compatibility file to show a warning when the game overlay window of Hearthstone Deck Tracker is captured via a non-functional capture method (BitBlt or Game Capture):

|Correct Capture Method|BitBlt Warning (auto-selected)|Game Capture Warning|
|-|-|-|
|<img width="722" height="606" alt="image" src="https://github.com/user-attachments/assets/4d29cc67-13c7-4514-8aaf-49f38183ab70" />|<img width="722" height="606" alt="image" src="https://github.com/user-attachments/assets/97bda95c-6793-4553-aff8-138ea0676ec0" />|<img width="722" height="606" alt="image" src="https://github.com/user-attachments/assets/b54ac8f2-ab83-407c-b0c1-743cdcecabcb" />|

I've kept with the style of the other applications in this file. One thing to call out maybe is that this targets the executable *and* the window name (which we're willing to keep stable). This is because some streamers might still be capturing the chroma window, which works fine with the old capture method. We'll deprecate that in Hearthstone Deck Tracker in future.

I also bumped the version in `win-capture/data/package.json` akin to past PRs such as #12218 and #12327.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

My team develops "Hearthstone Deck Tracker", a companion app for Blizzard's Hearthstone that's used by Hearthstone players all around the world. It works by overlaying an invisible window with alpha on top of the game to add some helpful information for the player. Streamers use it to give themselves and their viewers extra context.

In the past, we've asked streamers to use either screen capture or a chroma-keyed window we built. However, we've recently made a change to our app to make the overlay visible to other apps and discovered we can just use the Windows 10 capture method in OBS to make the overlay capturable itself, obsoleting our Chroma key setup (and Screen capture is disliked by somne streamers).

However, to make setting this up easy, we need to ensure the modern capture method is selected so the alpha channel works. In this PR I've updated the compatibility file to show warnings, akin to many other apps. I understand that technically we could also make the "auto" method smarter, however it looks like that mostly works on the framework level right now rather than on a per-app level. As we use a WPF app here, we also only really control the window title, not the window class.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

I've tested this on my local device, screenshots above.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). **(noop)**
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. **(noop)**
