### PR TITLE
frontend: Merge Windows process mitigation functions

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -811,38 +811,6 @@ static void load_debug_privilege(void)
 
 	CloseHandle(token);
 }
-
-static void set_process_mitigations(void)
-{
-	// SetProcessMitigationPolicy is Windows 8+
-	typedef BOOL(WINAPI * PFN_SetProcessMitigationPolicy)(PROCESS_MITIGATION_POLICY, PVOID, SIZE_T);
-	PFN_SetProcessMitigationPolicy pSetProcessMitigationPolicy;
-
-	pSetProcessMitigationPolicy = (PFN_SetProcessMitigationPolicy)GetProcAddress(GetModuleHandle(L"KERNEL32"),
-										     "SetProcessMitigationPolicy");
-
-	if (pSetProcessMitigationPolicy) {
-		PROCESS_MITIGATION_DEP_POLICY dep = {0};
-		dep.DisableAtlThunkEmulation = 1;
-		dep.Enable = 1;
-		dep.Permanent = TRUE;
-		pSetProcessMitigationPolicy(ProcessDEPPolicy, &dep, sizeof(dep));
-
-		PROCESS_MITIGATION_ASLR_POLICY aslr = {0};
-		aslr.EnableBottomUpRandomization = 1;
-		aslr.EnableHighEntropy = 1;
-		aslr.EnableForceRelocateImages = 1;
-		aslr.DisallowStrippedImages = 1;
-		pSetProcessMitigationPolicy(ProcessASLRPolicy, &aslr, sizeof(aslr));
-
-#ifdef _DEBUG
-		PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY hcheck = {0};
-		hcheck.RaiseExceptionOnInvalidHandleReference = 1;
-		hcheck.HandleExceptionsPermanentlyEnabled = 1;
-		pSetProcessMitigationPolicy(ProcessStrictHandleCheckPolicy, &hcheck, sizeof(hcheck));
-#endif
-	}
-}
 #endif
 
 static inline bool arg_is(const char *arg, const char *long_form, const char *short_form)
@@ -882,6 +850,26 @@ static void set_process_mitigation_policies()
 	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {};
 	policy.PreferSystem32Images = 1;
 	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
+
+	PROCESS_MITIGATION_DEP_POLICY dep = {0};
+	dep.DisableAtlThunkEmulation = 1;
+	dep.Enable = 1;
+	dep.Permanent = TRUE;
+	SetProcessMitigationPolicy(ProcessDEPPolicy, &dep, sizeof(dep));
+
+	PROCESS_MITIGATION_ASLR_POLICY aslr = {0};
+	aslr.EnableBottomUpRandomization = 1;
+	aslr.EnableHighEntropy = 1;
+	aslr.EnableForceRelocateImages = 1;
+	aslr.DisallowStrippedImages = 1;
+	SetProcessMitigationPolicy(ProcessASLRPolicy, &aslr, sizeof(aslr));
+
+#ifdef _DEBUG
+	PROCESS_MITIGATION_STRICT_HANDLE_CHECK_POLICY hcheck = {0};
+	hcheck.RaiseExceptionOnInvalidHandleReference = 1;
+	hcheck.HandleExceptionsPermanentlyEnabled = 1;
+	SetProcessMitigationPolicy(ProcessStrictHandleCheckPolicy, &hcheck, sizeof(hcheck));
+#endif
 }
 #endif
 
@@ -951,7 +939,6 @@ int main(int argc, char *argv[])
 	SetDllDirectoryW(L"");
 	load_debug_privilege();
 	base_set_crash_handler(main_crash_handler, nullptr);
-	set_process_mitigations();
 
 	/* Shutdown priority value is a range from 0 - 4FF with higher values getting first priority.
 	 * 000 - 0FF and 400 - 4FF are reserved system ranges.


### PR DESCRIPTION
### Description
We already started using `SetProcessMitigationPolicy` before #5164 got merged and we dropped Windows 7 support, so we can do away with the runtime detection too.

### Motivation and Context
Remove redundant function and Windows 7 support.

### How Has This Been Tested?
Ran OBS on Windows 10.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
