### PR TITLE
frontend: Use same base theme on Win 10/11

### DIFF
--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -1050,6 +1050,8 @@ bool OBSApp::InitTheme()
 	defaultPalette = palette();
 #if !defined(_WIN32) && !defined(__APPLE__)
 	setStyle(new OBSProxyStyle("Fusion"));
+#elif defined(_WIN32)
+	setStyle(new OBSProxyStyle("windowsvista"));
 #else
 	setStyle(new OBSProxyStyle());
 #endif


### PR DESCRIPTION
### Description
Forces Windows 11 to use the `windowsvista` base theme.

Fixes some weird padding issues on Windows 11 on the current Qt version.
<img width="321" height="191" alt="image" src="https://github.com/user-attachments/assets/7af57cdd-8797-4608-ac8d-2d1bbf4521c9" />

Fixes #13598

### Motivation and Context
We override pretty much every aspect of the style via our stylesheet so this just ensures Win 10 and Win 11 both start from the same base appearance, instead of the system default Qt style (`windowsvista` on Win10, `windows11` on Win11)

### How Has This Been Tested?
Compiled and ran on my Windows 11 laptop. Confirmed that the extra padding in list views is gone.

Also compiled and ran on my Windows 10 machine with the style set to `windows11` instead, which caused the excessive padding on my Windows 10 machine.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
