### PR TITLE
text-freetype2: Read full file even when source has embedded NULs (#7595)

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -413,8 +413,13 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
+	/* Use the explicit byte count rather than strlen(tmp_read): a source
+	 * file may contain embedded NULs (e.g. fields from `usb-devices`-style
+	 * reports), which previously caused only the first line to render.
+	 * os_utf8_to_wcs() expects an explicit length when one is available
+	 * and treats embedded NULs as regular symbols (see libobs/util/utf8.c). */
+	srcdata->text = bzalloc((filesize + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(tmp_read, filesize, srcdata->text, (filesize + 1));
 
 	remove_cr(srcdata->text);
 	bfree(tmp_read);
@@ -495,8 +500,11 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
+	/* Use the explicit byte count rather than strlen(tmp_read) so that
+	 * embedded NULs in the source file (issue #7595) do not cause the
+	 * tail of a "scroll-from-end" log feed to be discarded. */
+	srcdata->text = bzalloc((filesize - cur_pos + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(tmp_read, filesize - cur_pos, srcdata->text, (filesize - cur_pos + 1));
 
 	remove_cr(srcdata->text);
 	bfree(tmp_read);


### PR DESCRIPTION
Fixes #7595

## Summary

When the "Text (FreeType 2)" source is set to "Read from file", OBS
only rendered the first line of files that contained embedded NUL
bytes. Both `load_text_from_file()` and `read_from_end()`
(`plugins/text-freetype2/text-functionality.c`) measured how much of
the just-read file buffer to feed into `os_utf8_to_wcs()` with
`strlen(tmp_read)`, which stops at the first NUL. Everything past
that byte — including all subsequent lines — was discarded.

Pass the actual byte count (the file size returned by `ftell()`, or
the log-tail slice) instead of `strlen()` into `os_utf8_to_wcs()`,
and size the wide-char buffer off the same value. The underlying
`libobs/util/utf8.c::utf8_to_wchar()` already accepts an explicit
length and treats embedded NULs as regular symbols, so no other
call site needs to change.

## Test plan

- Build the source on Linux/macOS with `cmake --build build`; the
  change is isolated to `plugins/text-freetype2/text-functionality.c`
  and touches no public API or struct layout.
- Open OBS, add a "Text (FreeType 2)" source, tick "Read from file",
  and point it at a multi-line UTF-8 text file where each line is
  NUL-padded to a fixed width (the `test.txt` attached to #7595 is
  exactly this shape — produced by `lsusb -v`-style utilities).
- Before the patch: only "Manufacturer: EVGA" renders.
- After the patch: every line — Product, Serial number and the
  bus-id footer — renders, and a manual edit to the file is picked
  up within a second by the existing mtime poll.
- Repeat the experiment with the source set to "Read from file" in
  log mode (scroll from end); the same multi-line file should keep
  its tail visible.

## AI assistance

None.
