### PR TITLE
nv-filters: Load Cuda from system directory

### DIFF
--- a/plugins/nv-filters/nvafx-load.h
+++ b/plugins/nv-filters/nvafx-load.h
@@ -310,7 +310,6 @@ static inline bool load_lib()
 {
 	char sdkPath[MAX_PATH];
 	char effectsPath[MAX_PATH];
-	char cudaPath[MAX_PATH];
 
 	if (!nvafx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return false;
@@ -320,14 +319,10 @@ static inline bool load_lib()
 		return false;
 	}
 
-	if (_snprintf_s(cudaPath, _countof(cudaPath), _TRUNCATE, "%s\\nvcuda.dll", sdkPath) == -1) {
-		return false;
-	}
-
 	nv_audiofx =
 		LoadLibraryExA(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
-	nv_cuda = LoadLibraryExA(cudaPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	nv_cuda = LoadLibraryExA("nvcuda.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 
 	return !!nv_audiofx && !!nv_cuda;
 }


### PR DESCRIPTION
### Description
Cuda is installed system-wide, it isn't part of the NVAFX SDK.

### Motivation and Context
Fix https://github.com/obsproject/obs-studio/issues/13607

### How Has This Been Tested?
Ran OBS, saw it loaded OK.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
