### PR TITLE
nv-filters: Remove direct calls to CUDA in Audio FX

### DIFF
--- a/plugins/nv-filters/nvafx-load.h
+++ b/plugins/nv-filters/nvafx-load.h
@@ -12,7 +12,6 @@
 
 #ifdef LIBNVAFX_ENABLED
 static HMODULE nv_audiofx = NULL;
-static HMODULE nv_cuda = NULL;
 
 /** Effects @ref NvAFX_EffectSelector  */
 #define NVAFX_EFFECT_DENOISER "denoiser"
@@ -166,60 +165,6 @@ typedef NvAFX_Status NVAFX_API (*NvAFX_Reset_t)(NvAFX_Handle effect);
 typedef NvAFX_Status NVAFX_API (*NvAFX_InitializeLogger_t)(LoggingSeverity level, LoggingTarget target,
 							   const char *filename, logging_cb_t cb, void *userdata);
 typedef NvAFX_Status NVAFX_API (*NvAFX_UninitializeLogger_t)();
-/* cuda */
-typedef enum cudaError_enum {
-	CUDA_SUCCESS = 0,
-	CUDA_ERROR_INVALID_VALUE = 1,
-	CUDA_ERROR_OUT_OF_MEMORY = 2,
-	CUDA_ERROR_NOT_INITIALIZED = 3,
-	CUDA_ERROR_DEINITIALIZED = 4,
-	CUDA_ERROR_PROFILER_DISABLED = 5,
-	CUDA_ERROR_PROFILER_NOT_INITIALIZED = 6,
-	CUDA_ERROR_PROFILER_ALREADY_STARTED = 7,
-	CUDA_ERROR_PROFILER_ALREADY_STOPPED = 8,
-	CUDA_ERROR_NO_DEVICE = 100,
-	CUDA_ERROR_INVALID_DEVICE = 101,
-	CUDA_ERROR_INVALID_IMAGE = 200,
-	CUDA_ERROR_INVALID_CONTEXT = 201,
-	CUDA_ERROR_CONTEXT_ALREADY_CURRENT = 202,
-	CUDA_ERROR_MAP_FAILED = 205,
-	CUDA_ERROR_UNMAP_FAILED = 206,
-	CUDA_ERROR_ARRAY_IS_MAPPED = 207,
-	CUDA_ERROR_ALREADY_MAPPED = 208,
-	CUDA_ERROR_NO_BINARY_FOR_GPU = 209,
-	CUDA_ERROR_ALREADY_ACQUIRED = 210,
-	CUDA_ERROR_NOT_MAPPED = 211,
-	CUDA_ERROR_NOT_MAPPED_AS_ARRAY = 212,
-	CUDA_ERROR_NOT_MAPPED_AS_POINTER = 213,
-	CUDA_ERROR_ECC_UNCORRECTABLE = 214,
-	CUDA_ERROR_UNSUPPORTED_LIMIT = 215,
-	CUDA_ERROR_CONTEXT_ALREADY_IN_USE = 216,
-	CUDA_ERROR_INVALID_SOURCE = 300,
-	CUDA_ERROR_FILE_NOT_FOUND = 301,
-	CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND = 302,
-	CUDA_ERROR_SHARED_OBJECT_INIT_FAILED = 303,
-	CUDA_ERROR_OPERATING_SYSTEM = 304,
-	CUDA_ERROR_INVALID_HANDLE = 400,
-	CUDA_ERROR_NOT_FOUND = 500,
-	CUDA_ERROR_NOT_READY = 600,
-	CUDA_ERROR_LAUNCH_FAILED = 700,
-	CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701,
-	CUDA_ERROR_LAUNCH_TIMEOUT = 702,
-	CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING = 703,
-	CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704,
-	CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705,
-	CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708,
-	CUDA_ERROR_CONTEXT_IS_DESTROYED = 709,
-	CUDA_ERROR_ASSERT = 710,
-	CUDA_ERROR_TOO_MANY_PEERS = 711,
-	CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712,
-	CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713,
-	CUDA_ERROR_UNKNOWN = 999
-} CUresult;
-typedef struct CUctx_st *CUcontext;
-typedef CUresult(__stdcall *cuCtxGetCurrent_t)(CUcontext *pctx);
-typedef CUresult(__stdcall *cuCtxPopCurrent_t)(CUcontext *pctx);
-typedef CUresult(__stdcall *cuInit_t)(unsigned int Flags);
 
 static NvAFX_GetEffectList_t NvAFX_GetEffectList = NULL;
 static NvAFX_CreateEffect_t NvAFX_CreateEffect = NULL;
@@ -243,10 +188,6 @@ static NvAFX_Reset_t NvAFX_Reset = NULL;
 /* SDK >= 1.6.0 */
 static NvAFX_InitializeLogger_t NvAFX_InitializeLogger = NULL;
 static NvAFX_UninitializeLogger_t NvAFX_UninitializeLogger = NULL;
-/* cuda */
-static cuCtxGetCurrent_t cuCtxGetCurrent = NULL;
-static cuCtxPopCurrent_t cuCtxPopCurrent = NULL;
-static cuInit_t cuInit = NULL;
 
 void release_lib(void)
 {
@@ -276,13 +217,6 @@ void release_lib(void)
 		FreeLibrary(nv_audiofx);
 		nv_audiofx = NULL;
 	}
-	cuCtxGetCurrent = NULL;
-	cuCtxPopCurrent = NULL;
-	cuInit = NULL;
-	if (nv_cuda) {
-		FreeLibrary(nv_cuda);
-		nv_cuda = NULL;
-	}
 }
 
 static inline bool nvafx_get_sdk_path(char *buffer, const size_t len)
@@ -310,7 +244,6 @@ static inline bool load_lib()
 {
 	char sdkPath[MAX_PATH];
 	char effectsPath[MAX_PATH];
-	char cudaPath[MAX_PATH];
 
 	if (!nvafx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return false;
@@ -320,16 +253,10 @@ static inline bool load_lib()
 		return false;
 	}
 
-	if (_snprintf_s(cudaPath, _countof(cudaPath), _TRUNCATE, "%s\\nvcuda.dll", sdkPath) == -1) {
-		return false;
-	}
-
 	nv_audiofx =
 		LoadLibraryExA(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
-	nv_cuda = LoadLibraryExA(cudaPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
-
-	return !!nv_audiofx && !!nv_cuda;
+	return !!nv_audiofx;
 }
 
 static unsigned int get_lib_version(void)

--- a/plugins/nv-filters/nvidia-audiofx-filter.c
+++ b/plugins/nv-filters/nvidia-audiofx-filter.c
@@ -205,13 +205,6 @@ void release_afxlib(void)
 		FreeLibrary(nv_audiofx);
 		nv_audiofx = NULL;
 	}
-	cuCtxGetCurrent = NULL;
-	cuCtxPopCurrent = NULL;
-	cuInit = NULL;
-	if (nv_cuda) {
-		FreeLibrary(nv_cuda);
-		nv_cuda = NULL;
-	}
 }
 
 bool load_nvidia_afx(void)
@@ -276,11 +269,6 @@ bool load_nvidia_afx(void)
 	LOAD_SYM(NvAFX_Run);
 	LOAD_SYM(NvAFX_Reset);
 #undef LOAD_SYM
-#define LOAD_SYM(sym) LOAD_SYM_FROM_LIB(sym, nv_cuda, "nvcuda.dll")
-	LOAD_SYM(cuCtxGetCurrent);
-	LOAD_SYM(cuCtxPopCurrent);
-	LOAD_SYM(cuInit);
-#undef LOAD_SYM
 #define LOAD_SYM(sym) LOAD_SYM_FROM_LIB2(sym, nv_audiofx, "NVAudioEffects.dll")
 	LOAD_SYM(NvAFX_InitializeLogger);
 	bool new_sdk = nvafx_new_sdk;
@@ -291,33 +279,10 @@ bool load_nvidia_afx(void)
 	}
 #undef LOAD_SYM
 	NvAFX_Status err;
-	CUresult cudaerr;
 
 	NvAFX_Handle h = NULL;
 
-	cudaerr = cuInit(0);
-	if (cudaerr != CUDA_SUCCESS) {
-		goto cuda_errors;
-	}
-	CUcontext old = {0};
-	CUcontext curr = {0};
-	cudaerr = cuCtxGetCurrent(&old);
-	if (cudaerr != CUDA_SUCCESS) {
-		goto cuda_errors;
-	}
-
 	err = NvAFX_CreateEffect(NVAFX_EFFECT_DENOISER, &h);
-	cudaerr = cuCtxGetCurrent(&curr);
-	if (cudaerr != CUDA_SUCCESS) {
-		goto cuda_errors;
-	}
-
-	if (curr != old) {
-		cudaerr = cuCtxPopCurrent(NULL);
-		if (cudaerr != CUDA_SUCCESS)
-			goto cuda_errors;
-	}
-
 	if (err != NVAFX_STATUS_SUCCESS) {
 		if (err == NVAFX_STATUS_GPU_UNSUPPORTED) {
 			blog(LOG_INFO, "[NVIDIA Audio Effects:] disabled: unsupported GPU");
@@ -337,8 +302,6 @@ bool load_nvidia_afx(void)
 	blog(LOG_INFO, "[NVIDIA Audio Effects:] enabled");
 	return true;
 
-cuda_errors:
-	blog(LOG_ERROR, "[NVIDIA Audio Effects:] disabled, CUDA error %i", cudaerr);
 unload_everything:
 	release_afxlib();
 
@@ -367,21 +330,10 @@ static bool nvidia_audio_initialize_internal(void *data)
 		ng->sample_rate = NVAFX_SAMPLE_RATE;
 		for (size_t i = 0; i < ng->channels; i++) {
 			// Create FX
-			CUcontext old = {0};
-			CUcontext curr = {0};
-			if (cuCtxGetCurrent(&old) != CUDA_SUCCESS) {
-				goto failure;
-			}
 			err = NvAFX_CreateEffect(ng->fx, &ng->handle[i]);
 			if (err != NVAFX_STATUS_SUCCESS) {
 				do_log(LOG_ERROR, "%s FX creation failed, error %i", ng->fx, err);
 				goto failure;
-			}
-			if (cuCtxGetCurrent(&curr) != CUDA_SUCCESS) {
-				goto failure;
-			}
-			if (curr != old) {
-				cuCtxPopCurrent(NULL);
 			}
 			// Set sample rate of FX
 			err = NvAFX_SetU32(ng->handle[i], NVAFX_PARAM_INPUT_SAMPLE_RATE, ng->sample_rate);


### PR DESCRIPTION
### Description
The CUDA calls in AUDIO FX were added initially to big a bug on the SDK side where the SDK functions where not checking the CUDA context. This led to interference with the VIDEO FX, potentially breaking it. These bugs have been fixed by the SDK so we don't need anymore these CUDA calls.

### Motivation and Context
Cleanup and this also fixes https://github.com/obsproject/obs-studio/issues/13607


### How Has This Been Tested?
NVIDIA Audio FX works (noise removal, dereverb).
NVIDIA Video FX works (greeenscreen).

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 
 - Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
