### PR TITLE
libobs: Fix Wayland segfault on shutdown

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -252,6 +252,8 @@ static bool obs_nix_wayland_hotkeys_platform_init(struct obs_core_hotkeys *hotke
 static void obs_nix_wayland_hotkeys_platform_free(struct obs_core_hotkeys *hotkeys)
 {
 	obs_hotkeys_platform_t *plat = hotkeys->platform_context;
+	if (plat->keyboard)
+		wl_keyboard_release(plat->keyboard);
 	xkb_context_unref(plat->xkb_context);
 	xkb_keymap_unref(plat->xkb_keymap);
 	xkb_state_unref(plat->xkb_state);


### PR DESCRIPTION
### Description
The keyboard_listener events can still be triggered after obs_nix_wayland_hotkeys_platform_free has been called, resulting in a segfault inside rebuild_keymap_data. Add a call to wl_keyboard_release to prevent new events from being triggered.

### Motivation and Context
I was running OBS 32.1.2 on Ubuntu26.04 and when I closed it the app crashed.
An Ubuntu Apport dialog appeared and after investigating the core dump I found the issue.

```
#0  xkb_keymap_key_get_syms_by_level()       libxkbcommon      <-- SIGSEGV
#1  load_keymap_data()                       libobs           (obs-nix-wayland.c:48-67)
#2  xkb_keymap_key_for_each()                libxkbcommon     (iterates keymap, calls #1)
#3  libffi
#4  libffi
#5  ffi_call()                               libffi           (Wayland invokes the listener)
#6  libwayland-client
#7  libwayland-client
#8  wl_display_dispatch_queue_pending()      libwayland-client
#9  QtWaylandClient::QWaylandDisplay::flushRequests()
#10 QEventDispatcherGlib::processEvents()    libQt6Core
#11 QEventLoop::exec()                       libQt6Core
#12 QCoreApplication::exec()                 libQt6Core
#13 obs main
```

### How Has This Been Tested?
Since this is a race condition its very hard to reproduce.
I let Claude make a reproduction with a copy of the relevant code from obs-nix-wayland.c and verified with AddressSanitizer.

After the fix I also compiled OBS and ran it couple of times to see if no new shutdown errors appeared.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
