### PR TITLE
frontend: Adjust What's New dialog window

### DIFF
--- a/frontend/dialogs/OBSWhatsNew.cpp
+++ b/frontend/dialogs/OBSWhatsNew.cpp
@@ -37,17 +37,8 @@ OBSWhatsNew::OBSWhatsNew(QWidget *parent, const std::string &url) : QDialog(pare
 
 	connect(cefWidget, &QCefWidget::titleChanged, this, &OBSWhatsNew::setWindowTitle);
 
-	QPushButton *close = new QPushButton(QTStr("Close"));
-	connect(close, &QAbstractButton::clicked, this, &QDialog::accept);
-
-	QHBoxLayout *bottomLayout = new QHBoxLayout();
-	bottomLayout->addStretch();
-	bottomLayout->addWidget(close);
-	bottomLayout->addStretch();
-
 	QVBoxLayout *topLayout = new QVBoxLayout(this);
 	topLayout->addWidget(cefWidget);
-	topLayout->addLayout(bottomLayout);
 
 	show();
 #else

--- a/frontend/dialogs/OBSWhatsNew.cpp
+++ b/frontend/dialogs/OBSWhatsNew.cpp
@@ -38,6 +38,7 @@ OBSWhatsNew::OBSWhatsNew(QWidget *parent, const std::string &url) : QDialog(pare
 	connect(cefWidget, &QCefWidget::titleChanged, this, &OBSWhatsNew::setWindowTitle);
 
 	QVBoxLayout *topLayout = new QVBoxLayout(this);
+	topLayout->setContentsMargins(0, 0, 0, 0);
 	topLayout->addWidget(cefWidget);
 
 	show();


### PR DESCRIPTION
### Description
Removes the content margins and Close button from the What's New dialog

| Before | After |
|--------|--------|
| <img width="702" height="632" alt="image" src="https://github.com/user-attachments/assets/bf90e8b1-8d6f-47e1-b227-b9f3458d2434" /> | <img width="702" height="632" alt="image" src="https://github.com/user-attachments/assets/87e6def6-124a-4fa8-a980-fbeec02e3ffe" /> | 


### Motivation and Context
Cleaning up visual appearance stuff. The close button adds a bunch of unnecessary space to the bottom of the window for a singular redundant action. It's also centered which doesn't match most other dialog we have.

### How Has This Been Tested?
Tested on 32.2 with the current What's New page.

### Types of changes
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
