### PR TITLE
frontend: Fix invokeMethod call in VolumeMeter

### DIFF
--- a/frontend/components/VolumeMeter.hpp
+++ b/frontend/components/VolumeMeter.hpp
@@ -203,5 +203,5 @@ protected:
 	void paintEvent(QPaintEvent *event) override;
 
 private slots:
-	void handleSourceDestroyed() { deleteLater(); }
+	void onSourceDestroyed() { deleteLater(); }
 };


### PR DESCRIPTION
### Description
The call to this function was meant to be renamed in #13378 but was only changed in the invokeMethod call and not the function itself.

### Motivation and Context
Fix a warning.

### How Has This Been Tested?
Compiled and deleted audio sources.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
