### PR TITLE
frontend: Fix volume control resizing and menu warning

### DIFF
--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -67,7 +67,7 @@ VolumeControl::VolumeControl(obs_source_t *source, QWidget *parent, bool vertica
 	utils->addClass(categoryLabel, "text-tiny");
 
 	nameButton = new VolumeName(source, this);
-	nameButton->setMaximumWidth(140);
+	nameButton->setMaximumWidth(280);
 	utils->addClass(nameButton, "text-small");
 	utils->addClass(nameButton, "mixer-name");
 
@@ -333,7 +333,7 @@ void VolumeControl::setLayoutVertical(bool vertical)
 		slider->setLayoutDirection(Qt::LeftToRight);
 		slider->setDisplayTicks(true);
 
-		nameButton->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Preferred);
+		nameButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 		categoryLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 		volumeLabel->setAlignment(Qt::AlignRight);
 

--- a/frontend/components/VolumeControl.cpp
+++ b/frontend/components/VolumeControl.cpp
@@ -393,7 +393,7 @@ void VolumeControl::showVolumeControlMenu(QPoint pos)
 		return;
 	}
 
-	QMenu *popup = new QMenu(this);
+	QMenu *popup = new QMenu(window());
 
 	// Create menu QActions
 	QAction *lockAction = new QAction(QTStr("LockVolume"), popup);

--- a/frontend/components/VolumeName.cpp
+++ b/frontend/components/VolumeName.cpp
@@ -54,6 +54,7 @@ VolumeName::VolumeName(obs_source_t *source, QWidget *parent)
 
 	label = new QLabel(this);
 	label->setIndent(0);
+	label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
 	layout->addWidget(label);
 
 	layout->setContentsMargins(0, 0, indicatorWidth, 0);
@@ -82,7 +83,9 @@ QSize VolumeName::minimumSizeHint() const
 	QFontMetrics metrics(label->font());
 	QSize textSize = metrics.size(Qt::TextSingleLine, plainText);
 
-	int width = textSize.width();
+	// A minimum sizeHint of 0 tells Qt it can try to reduce its size when an appropriate sizePolicy has been set.
+	// The text ellide behavior will ensure it fits within the actual bounds the widget is allocated.
+	int width = 0;
 	int height = textSize.height();
 
 	if (!opt.icon.isNull()) {
@@ -182,29 +185,24 @@ void VolumeName::setText(const QString &text)
 void VolumeName::updateLabelText(const QString &name)
 {
 	QString plainText = getPlainText(name);
+	fullText = name;
 
 	QFontMetrics metrics(label->font());
 
 	int availableWidth = label->contentsRect().width();
 	if (availableWidth <= 0) {
 		label->clear();
-		fullText = name;
 		return;
 	}
 
 	int textWidth = metrics.horizontalAdvance(plainText);
 
-	bool isRichText = (plainText != name);
-	bool needsElide = textWidth > availableWidth;
-
-	if (needsElide && !isRichText) {
-		QString elided = metrics.elidedText(plainText, Qt::ElideMiddle, availableWidth);
-		label->setText(elided);
-	} else {
-		label->setText(name);
+	if (availableWidth > textWidth) {
+		return;
 	}
 
-	fullText = name;
+	QString elided = metrics.elidedText(plainText, Qt::ElideMiddle, availableWidth);
+	label->setText(elided);
 }
 
 void VolumeName::onRemoved()


### PR DESCRIPTION
### Description
First commit changes the sizeHint and resize behaviour so that the VolumeName widget properly tries to ellide text when it can't fit AND a sizePolicy has been set that allows it to shrink. It also increases the maximum width of the widget in the horizontal mixer layout.

Second commit fixes a warning when showing the audio mixer menu popup.

### Motivation and Context
Better use of space for horizontal mixer and better behaviour of the VolumeName widget.

| Before | After |
|--------|--------|
|  <video width="702" height="632" alt="image" src="https://github.com/user-attachments/assets/a2baf2d3-9df5-42ff-912c-45b89dbba075" /> | <video width="702" height="632" alt="image" src="https://github.com/user-attachments/assets/922333a2-b22f-4003-ad1e-f5fe54282448" /> | 

Also warnings are bad.

### How Has This Been Tested?
👁

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality) 
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
