### PR TITLE
frontend: Don't reload scene collection after rename

### DIFF
--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1105,7 +1105,7 @@ private:
 	void RefreshSceneCollectionCache();
 
 	void RefreshSceneCollections(bool refreshCache = false);
-	void ActivateSceneCollection(SceneCollection &collection);
+	void ActivateSceneCollection(SceneCollection &collection, bool loadCollection = true);
 
 public slots:
 	void DeferSaveBegin();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1106,6 +1106,7 @@ private:
 
 	void RefreshSceneCollections(bool refreshCache = false);
 	void ActivateSceneCollection(SceneCollection &collection);
+	void refreshApplicationState();
 
 public slots:
 	void DeferSaveBegin();

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -229,7 +229,7 @@ void OBSBasic::SetupRenameSceneCollection(const std::string &collectionName)
 	obs_data_save_json_safe(collection, newCollection.getFileName().c_str(), "tmp", nullptr);
 
 	cleanBackupCollision(newCollection);
-	ActivateSceneCollection(newCollection);
+	ActivateSceneCollection(newCollection, false);
 	RemoveSceneCollection(currentCollection);
 
 	blog(LOG_INFO, "Renamed scene collection '%s' to '%s' (%s)", currentCollection.getName().c_str(),
@@ -767,7 +767,7 @@ void OBSBasic::on_actionRemigrateSceneCollection_triggered()
 
 // MARK: - Scene Collection Management Helper Functions
 
-void OBSBasic::ActivateSceneCollection(SceneCollection &collection)
+void OBSBasic::ActivateSceneCollection(SceneCollection &collection, bool loadCollection)
 {
 	const std::string currentCollectionName{config_get_string(App()->GetUserConfig(), "Basic", "SceneCollection")};
 
@@ -780,7 +780,9 @@ void OBSBasic::ActivateSceneCollection(SceneCollection &collection)
 	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollection", collection.getName().c_str());
 	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollectionFile", collection.getFileName().c_str());
 
-	Load(collection);
+	if (loadCollection) {
+		Load(collection);
+	}
 
 	RefreshSceneCollections();
 

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -168,6 +168,7 @@ void OBSBasic::SetupDuplicateSceneCollection(const std::string &collectionName)
 	try {
 		std::filesystem::copy(currentCollection.getFilePath(), newCollection.getFilePath(), copyOptions);
 	} catch (const std::filesystem::filesystem_error &error) {
+		collections.erase(newCollection.getName());
 		blog(LOG_DEBUG, "%s", error.what());
 		throw std::logic_error("Failed to copy file for cloned scene collection: " + newCollection.getName());
 	}
@@ -195,7 +196,15 @@ void OBSBasic::SetupDuplicateSceneCollection(const std::string &collectionName)
 		obs_data_set_array(collection, "sources", sources);
 	}
 
-	obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr);
+	if (!obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr)) {
+		collections.erase(newCollection.getName());
+
+		// If removal fails the copy may appear again after restart using the original name and thus hide the original collection.
+		// Any changes made to the original collection may appear to be lost after restart, but are still present in the original file.
+		RemoveSceneCollection(newCollection);
+
+		throw std::logic_error("Failed to save duplicated scene collection: " + newCollection.getName());
+	}
 
 	cleanBackupCollision(newCollection);
 	ActivateSceneCollection(newCollection);
@@ -217,16 +226,24 @@ void OBSBasic::SetupRenameSceneCollection(const std::string &collectionName)
 	try {
 		std::filesystem::copy(currentCollection.getFilePath(), newCollection.getFilePath(), copyOptions);
 	} catch (const std::filesystem::filesystem_error &error) {
+		collections.erase(newCollection.getName());
 		blog(LOG_DEBUG, "%s", error.what());
 		throw std::logic_error("Failed to copy file for scene collection: " + currentCollection.getName());
 	}
 
-	collections.erase(currentCollection.getName());
-
 	OBSDataAutoRelease collection = obs_data_create_from_json_file(newCollection.getFilePathString().c_str());
 	obs_data_set_string(collection, "name", newCollection.getName().c_str());
 
-	obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr);
+	if (!obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr)) {
+		collections.erase(newCollection.getName());
+
+		// If removal fails the copy may appear again after restart using the original name and thus hide the original collection.
+		// Any changes made to the original collection may appear to be lost after restart, but are still present in the original file.
+		RemoveSceneCollection(currentCollection);
+		throw std::logic_error("Failed to save renamed scene collection: " + newCollection.getName());
+	}
+
+	collections.erase(currentCollection.getName());
 
 	cleanBackupCollision(newCollection);
 	ActivateSceneCollection(newCollection);

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -172,7 +172,7 @@ void OBSBasic::SetupDuplicateSceneCollection(const std::string &collectionName)
 		throw std::logic_error("Failed to copy file for cloned scene collection: " + newCollection.getName());
 	}
 
-	OBSDataAutoRelease collection = obs_data_create_from_json_file(newCollection.getFileName().c_str());
+	OBSDataAutoRelease collection = obs_data_create_from_json_file(newCollection.getFilePathString().c_str());
 
 	obs_data_set_string(collection, "name", newCollection.getName().c_str());
 
@@ -195,7 +195,7 @@ void OBSBasic::SetupDuplicateSceneCollection(const std::string &collectionName)
 		obs_data_set_array(collection, "sources", sources);
 	}
 
-	obs_data_save_json_safe(collection, newCollection.getFileName().c_str(), "tmp", nullptr);
+	obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr);
 
 	cleanBackupCollision(newCollection);
 	ActivateSceneCollection(newCollection);
@@ -223,10 +223,10 @@ void OBSBasic::SetupRenameSceneCollection(const std::string &collectionName)
 
 	collections.erase(currentCollection.getName());
 
-	OBSDataAutoRelease collection = obs_data_create_from_json_file(newCollection.getFileName().c_str());
+	OBSDataAutoRelease collection = obs_data_create_from_json_file(newCollection.getFilePathString().c_str());
 	obs_data_set_string(collection, "name", newCollection.getName().c_str());
 
-	obs_data_save_json_safe(collection, newCollection.getFileName().c_str(), "tmp", nullptr);
+	obs_data_save_json_safe(collection, newCollection.getFilePathString().c_str(), "tmp", nullptr);
 
 	cleanBackupCollision(newCollection);
 	ActivateSceneCollection(newCollection);

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -246,13 +246,18 @@ void OBSBasic::SetupRenameSceneCollection(const std::string &collectionName)
 	collections.erase(currentCollection.getName());
 
 	cleanBackupCollision(newCollection);
-	ActivateSceneCollection(newCollection);
 	RemoveSceneCollection(currentCollection);
+
+	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollection", newCollection.getName().c_str());
+	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollectionFile", newCollection.getFileName().c_str());
+
+	refreshApplicationState();
 
 	blog(LOG_INFO, "Renamed scene collection '%s' to '%s' (%s)", currentCollection.getName().c_str(),
 	     newCollection.getName().c_str(), newCollection.getFileName().c_str());
 	blog(LOG_INFO, "------------------------------------------------");
 
+	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
 	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_RENAMED);
 }
 
@@ -798,13 +803,16 @@ void OBSBasic::ActivateSceneCollection(SceneCollection &collection)
 	config_set_string(App()->GetUserConfig(), "Basic", "SceneCollectionFile", collection.getFileName().c_str());
 
 	Load(collection);
-
-	RefreshSceneCollections();
-
-	UpdateTitleBar();
+	refreshApplicationState();
 
 	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_LIST_CHANGED);
 	OnEvent(OBS_FRONTEND_EVENT_SCENE_COLLECTION_CHANGED);
+}
+
+void OBSBasic::refreshApplicationState()
+{
+	RefreshSceneCollections();
+	UpdateTitleBar();
 }
 
 // MARK: - OBSBasic Scene Collection Functions


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Skip unnecessary scene collection reload during rename for better ux.

Update: Fix issue with saving during collection rename and duplication in general, see https://github.com/obsproject/obs-studio/pull/13617#issuecomment-5227084346 for details.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

The goal is better user experience. For example the reload after renaming caused active audio/video files to reset to beginning.

As a side effect this also works around a hang issue described in #13495, since the reload is skipped. The underlying issue should still be addressed, but is outside of this pr scope.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

After renaming I monitored the scene collection is handled as should while switching scenes, collections, interacting with sources and restarting app.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
