### PR TITLE
obs-outputs: Surface RTMP publish error to user

### DIFF
--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -315,6 +315,7 @@ void OBSBasic::StreamingStop(int code, QString last_error)
 		break;
 
 	case OBS_OUTPUT_INVALID_STREAM:
+		use_last_error = true;
 		errorDescription = Str("Output.ConnectFail.InvalidStream");
 		break;
 

--- a/plugins/obs-outputs/librtmp/rtmp.c
+++ b/plugins/obs-outputs/librtmp/rtmp.c
@@ -3101,6 +3101,7 @@ static const AVal av_NetStream_Publish_Start = AVC("NetStream.Publish.Start");
 static const AVal av_NetStream_Publish_Rejected = AVC("NetStream.Publish.Rejected");
 static const AVal av_NetStream_Publish_Denied = AVC("NetStream.Publish.Denied");
 static const AVal av_NetStream_Publish_BadName = AVC("NetStream.Publish.BadName");
+static const AVal av_NetStream_Publish_Failed = AVC("NetStream.Publish.Failed");
 
 
 /* Returns 0 for OK/Failed/error, 1 for 'Stop or Complete' */
@@ -3353,13 +3354,18 @@ HandleInvoke(RTMP *r, const char *body, unsigned int nBodySize)
                 || AVMATCH(&code, &av_NetConnection_Connect_InvalidApp)
                 || AVMATCH(&code, &av_NetStream_Publish_Rejected)
                 || AVMATCH(&code, &av_NetStream_Publish_Denied)
-                || AVMATCH(&code, &av_NetStream_Publish_BadName))
+                || AVMATCH(&code, &av_NetStream_Publish_BadName)
+                || AVMATCH(&code, &av_NetStream_Publish_Failed))
         {
             r->m_stream_id = -1;
             RTMP_Close(r);
 
             if (description.av_len)
+            {
+                snprintf(r->last_error_description, sizeof(r->last_error_description),
+                         "%.*s", description.av_len, description.av_val);
                 RTMP_Log(RTMP_LOGERROR, "%s:\n%s (%s)", r->Link.tcUrl.av_val, code.av_val, description.av_val);
+            }
             else
                 RTMP_Log(RTMP_LOGERROR, "%s:\n%s", r->Link.tcUrl.av_val, code.av_val);
         }

--- a/plugins/obs-outputs/librtmp/rtmp.h
+++ b/plugins/obs-outputs/librtmp/rtmp.h
@@ -454,6 +454,7 @@ extern "C"
         RTMP_LNK Link;
         int connect_time_ms;
         int last_error_code;
+        char last_error_description[256];
 
 #ifdef CRYPTO
         TLS_CTX RTMP_TLS_ctx;

--- a/plugins/obs-outputs/rtmp-stream.c
+++ b/plugins/obs-outputs/rtmp-stream.c
@@ -581,6 +581,9 @@ static void set_output_error(struct rtmp_stream *stream)
 		}
 	}
 
+	if (stream->rtmp.last_error_description[0])
+		msg = stream->rtmp.last_error_description;
+
 	if (msg)
 		obs_output_set_last_error(stream->output, msg);
 }
@@ -1219,8 +1222,10 @@ static int try_connect(struct rtmp_stream *stream)
 		return OBS_OUTPUT_CONNECT_FAILED;
 	}
 
-	if (!RTMP_ConnectStream(&stream->rtmp, 0))
+	if (!RTMP_ConnectStream(&stream->rtmp, 0)) {
+		set_output_error(stream);
 		return OBS_OUTPUT_INVALID_STREAM;
+	}
 
 	char ip_address[INET6_ADDRSTRLEN] = {0};
 	netif_addr_to_str(&stream->rtmp.m_sb.sb_addr, ip_address, INET6_ADDRSTRLEN);


### PR DESCRIPTION
## Description

When an RTMP server denies a publish, OBS showed a generic error even when the server provided a human-readable reason in the `onStatus` `description`. Three things were in the way: `NetStream.Publish.Failed` was not among the recognized failure codes (it fell through to the "Unhandled" branch), the `description` was only logged and never stored for the output, and the `OBS_OUTPUT_INVALID_STREAM` failure message did not include the output's last error.

This captures the server's `onStatus` `description` on a failed publish (adding `NetStream.Publish.Failed`), reports it via `obs_output_set_last_error` on the publish-denied path, and lets the invalid-stream failure message include it. The reason is then shown to the user instead of only a generic message.

## Motivation and Context

Servers frequently reject a publish for actionable reasons (quota/credit limits, expired or disabled keys, etc.). OBS currently discards that message, leaving the user with no explanation. Surfacing it addresses https://obsproject.com/forum/threads/feature-request-alert-with-netstream-publish-failed-commands-description.66266/

## How Has This Been Tested?

Built OBS locally and streamed to an RTMP server that rejects the publish with an `onStatus` `description` (an ingest that denies the stream with a reason).

- Before: only the generic *"Could not access the specified channel or stream key…"*.
- After: that message followed by the server's reason (e.g. *"You have surpassed your monthly streaming minutes."*).

Verified on the `32.1.2` tag; `master` currently requires a newer macOS SDK than the test machine has, and the changed code is identical on both.

## Types of changes

- Tweak (non-breaking change to improve existing functionality)

## Checklist:

- [x] I have read the contributing document.
- [x] My code has been run through clang-format.
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
