### PR TITLE
frontend: Fix empty volume name label

### DIFF
--- a/frontend/components/VolumeName.cpp
+++ b/frontend/components/VolumeName.cpp
@@ -198,6 +198,7 @@ void VolumeName::updateLabelText(const QString &name)
 	int textWidth = metrics.horizontalAdvance(plainText);
 
 	if (availableWidth > textWidth) {
+		label->setText(name);
 		return;
 	}
 


### PR DESCRIPTION
### Description
Fixes an issue reported on Discord where volume name labels were sometimes empty. This bug is somewhat conditional on the length of source names and the geometry of the window at startup.

<img width="397" height="289" alt="image" src="https://github.com/user-attachments/assets/30dd2db4-3c46-4d27-9abb-db9f8cfc29d6" />

### Motivation and Context
Fix bug.

### How Has This Been Tested?
Reproduced the issue locally with Appearance settings set to font size 9 and Compact density and then tested this change to verify it was fixed.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
