### PR TITLE
frontend: Fix exit from tray context menu

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1708,6 +1708,23 @@ void OBSBasic::close()
 		return;
 	}
 
+	// qt glitch workaround, wayland-specific:
+	//
+	// if a window has been created but never shown, QWindow has no instantiated QPlatformWindow
+	// this causes QWindow::close() to report success without actually closing
+	// this means the handleClose fallback in QWidgetPrivate::close() gets skipped and nothing gets closed
+	//
+	// so we do it manually instead
+	//
+	// we don't want to do this *by default* because then we'd skip UI cleanup in the normal close path
+	// which doesn't matter if there's no UI to clean up, though!
+	QWindow *window = windowHandle();
+	if (window && !window->handle()) {
+		QCloseEvent closeEvent;
+		QApplication::sendEvent(this, &closeEvent);
+		return;
+	}
+
 	OBSMainWindow::close();
 }
 


### PR DESCRIPTION
### Description
Due to unintuitive Qt behavior in Wayland, right-clicking tray context menu and choosing "exit" works only if the main window has already been displayed.

Work around by sending the close event manually when necessary.

Fixes #13494.

### Motivation and Context
--minimize-to-tray allows starting in tray-minimized form. On Wayland, this prevents you from using the right-click menu to close it.

### How Has This Been Tested?
Opened with --minimize-to-tray, verified I could close it. Opened without that, verified I could still close it. Opened with it and opened the window manually, verified I could still close it.

Tested on Manjaro Linux, Wayland, KDE desktop.

### Types of changes
Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [X] My code is not on the master branch.
- [X] My code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
