### PR TITLE
frontend: Clean up and adjustments to SceneTree

### DIFF
--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -7,7 +7,6 @@
 
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
-	installEventFilter(this);
 	setDragDropMode(InternalMove);
 	setMovement(QListView::Snap);
 }
@@ -54,11 +53,6 @@ int SceneTree::GetGridItemWidth()
 int SceneTree::GetGridItemHeight()
 {
 	return itemHeight;
-}
-
-bool SceneTree::eventFilter(QObject *obj, QEvent *event)
-{
-	return QObject::eventFilter(obj, event);
 }
 
 void SceneTree::resizeEvent(QResizeEvent *event)

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -10,7 +10,7 @@ SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 	setMovement(QListView::Snap);
 }
 
-void SceneTree::SetGridMode(bool grid)
+void SceneTree::setGridMode(bool grid)
 {
 	parent()->setProperty("class", grid ? "list-grid" : "");
 	gridMode = grid;
@@ -29,27 +29,27 @@ void SceneTree::SetGridMode(bool grid)
 	recalculateGridSize();
 }
 
-bool SceneTree::GetGridMode()
+bool SceneTree::getGridMode()
 {
 	return gridMode;
 }
 
-void SceneTree::SetGridItemWidth(int width)
+void SceneTree::setGridItemWidth(int width)
 {
-	maxWidth = width;
+	maxWidth = std::max(1, width);
 }
 
-void SceneTree::SetGridItemHeight(int height)
+void SceneTree::setGridItemHeight(int height)
 {
-	itemHeight = height;
+	itemHeight = std::max(1, height);
 }
 
-int SceneTree::GetGridItemWidth()
+int SceneTree::getGridItemWidth()
 {
 	return maxWidth;
 }
 
-int SceneTree::GetGridItemHeight()
+int SceneTree::getGridItemHeight()
 {
 	return itemHeight;
 }
@@ -125,7 +125,7 @@ void SceneTree::recalculateGridSize()
 	}
 }
 
-void SceneTree::RepositionGrid(QDragMoveEvent *event)
+void SceneTree::repositionGrid(QDragMoveEvent *event)
 {
 	int scrollWid = verticalScrollBar()->sizeHint().width();
 	const QRect firstItem = visualItemRect(item(0));
@@ -194,7 +194,7 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 void SceneTree::dragMoveEvent(QDragMoveEvent *event)
 {
 	if (gridMode) {
-		RepositionGrid(event);
+		repositionGrid(event);
 	}
 
 	QListWidget::dragMoveEvent(event);
@@ -203,7 +203,7 @@ void SceneTree::dragMoveEvent(QDragMoveEvent *event)
 void SceneTree::dragLeaveEvent(QDragLeaveEvent *event)
 {
 	if (gridMode) {
-		RepositionGrid();
+		repositionGrid();
 	}
 
 	QListWidget::dragLeaveEvent(event);

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -230,12 +230,9 @@ void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 	QListWidget::rowsInserted(parent, start, end);
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
-// Workaround for QTBUG-105870. Remove once that is solved upstream.
 void SceneTree::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
 {
 	if (selected.count() == 0 && deselected.count() > 0 && !property("clearing").toBool()) {
 		setCurrentRow(deselected.indexes().front().row());
 	}
 }
-#endif

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -19,12 +19,12 @@ void SceneTree::SetGridMode(bool grid)
 		setResizeMode(QListView::Adjust);
 		setViewMode(QListView::IconMode);
 		setUniformItemSizes(true);
-		setStyleSheet("*{padding: 0; margin: 0;}");
 	} else {
 		setViewMode(QListView::ListMode);
 		setResizeMode(QListView::Fixed);
-		setStyleSheet("");
 	}
+
+	style()->polish(this);
 
 	recalculateGridSize();
 }

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -74,6 +74,8 @@ void SceneTree::dropEvent(QDropEvent *event)
 	}
 
 	if (gridMode) {
+		QSignalBlocker block(this);
+
 		int scrollWid = verticalScrollBar()->sizeHint().width();
 		const QRect firstItem = visualItemRect(item(0));
 		const QRect lastItem = visualItemRect(item(count() - 1));

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -28,8 +28,7 @@ void SceneTree::SetGridMode(bool grid)
 		setStyleSheet("");
 	}
 
-	QResizeEvent event(size(), size());
-	resizeEvent(&event);
+	recalculateGridSize();
 }
 
 bool SceneTree::GetGridMode()
@@ -64,33 +63,7 @@ bool SceneTree::eventFilter(QObject *obj, QEvent *event)
 
 void SceneTree::resizeEvent(QResizeEvent *event)
 {
-	if (gridMode) {
-		int scrollWid = verticalScrollBar()->sizeHint().width();
-		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
-
-		if (h < height()) {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
-		} else {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-		}
-
-		int wid = contentsRect().width() - scrollWid - 1;
-		int items = (int)std::ceil((float)wid / maxWidth);
-		int itemWidth = wid / items;
-
-		setGridSize(QSize(itemWidth, itemHeight));
-
-		for (int i = 0; i < count(); i++) {
-			item(i)->setSizeHint(QSize(itemWidth, itemHeight));
-		}
-	} else {
-		setGridSize(QSize());
-		for (int i = 0; i < count(); i++) {
-			item(i)->setData(Qt::SizeHintRole, QVariant());
-		}
-	}
+	recalculateGridSize();
 
 	QListWidget::resizeEvent(event);
 }
@@ -133,17 +106,44 @@ void SceneTree::dropEvent(QDropEvent *event)
 		QListWidgetItem *item = takeItem(selectedIndexes()[0].row());
 		insertItem(r, item);
 		setCurrentItem(item);
-		resize(size());
 	}
 
 	QListWidget::dropEvent(event);
 
-	// We must call resizeEvent to correctly place all grid items.
-	// We also do this in rowsInserted.
-	QResizeEvent resEvent(size(), size());
-	SceneTree::resizeEvent(&resEvent);
+	recalculateGridSize();
 
 	QTimer::singleShot(100, [this]() { emit scenesReordered(); });
+}
+
+void SceneTree::recalculateGridSize()
+{
+	if (gridMode) {
+		int scrollWid = verticalScrollBar()->sizeHint().width();
+		const QRect lastItem = visualItemRect(item(count() - 1));
+		const int h = lastItem.y() + lastItem.height();
+
+		if (h < height()) {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+			scrollWid = 0;
+		} else {
+			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		}
+
+		int wid = contentsRect().width() - scrollWid - 1;
+		int items = (int)std::ceil((float)wid / maxWidth);
+		int itemWidth = wid / items;
+
+		setGridSize(QSize(itemWidth, itemHeight));
+
+		for (int i = 0; i < count(); i++) {
+			item(i)->setSizeHint(QSize(itemWidth, itemHeight));
+		}
+	} else {
+		setGridSize(QSize());
+		for (int i = 0; i < count(); i++) {
+			item(i)->setData(Qt::SizeHintRole, QVariant());
+		}
+	}
 }
 
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
@@ -230,8 +230,7 @@ void SceneTree::dragLeaveEvent(QDragLeaveEvent *event)
 
 void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 {
-	QResizeEvent event(size(), size());
-	SceneTree::resizeEvent(&event);
+	recalculateGridSize();
 
 	QListWidget::rowsInserted(parent, start, end);
 }

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -1,7 +1,6 @@
 #include "SceneTree.hpp"
 
 #include <QScrollBar>
-#include <QTimer>
 
 #include "moc_SceneTree.cpp"
 
@@ -106,7 +105,7 @@ void SceneTree::dropEvent(QDropEvent *event)
 
 	recalculateGridSize();
 
-	QTimer::singleShot(100, [this]() { emit scenesReordered(); });
+	emit scenesReordered();
 }
 
 void SceneTree::recalculateGridSize()

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -76,31 +76,15 @@ void SceneTree::dropEvent(QDropEvent *event)
 	if (gridMode) {
 		QSignalBlocker block(this);
 
-		int scrollWid = verticalScrollBar()->sizeHint().width();
-		const QRect firstItem = visualItemRect(item(0));
-		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
-		const int firstItemY = abs(firstItem.y());
-
-		if (h < height()) {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
-		} else {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+		QListWidgetItem *draggedItem = takeItem(selectedIndexes().first().row());
+		if (!draggedItem) {
+			return;
 		}
 
-		float wid = contentsRect().width() - scrollWid - 1;
+		insertItem(lastTargetRow, draggedItem);
+		setCurrentItem(draggedItem);
 
-		QPoint point = event->position().toPoint();
-
-		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
-		int y = (point.y() + firstItemY) / itemHeight;
-
-		int r = x + y * std::ceil(wid / maxWidth);
-
-		QListWidgetItem *item = takeItem(selectedIndexes()[0].row());
-		insertItem(r, item);
-		setCurrentItem(item);
+		lastTargetRow = -1;
 	}
 
 	QListWidget::dropEvent(event);
@@ -166,6 +150,8 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 
 		int r = x + y * std::ceil(wid / maxWidth);
 		int orig = selectedIndexes()[0].row();
+
+		lastTargetRow = r;
 
 		for (int i = 0; i < count(); i++) {
 			auto *wItem = item(i);

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -216,12 +216,9 @@ void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 	QListWidget::rowsInserted(parent, start, end);
 }
 
-#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
-// Workaround for QTBUG-105870. Remove once that is solved upstream.
 void SceneTree::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
 {
 	if (selected.count() == 0 && deselected.count() > 0 && !property("clearing").toBool()) {
 		setCurrentRow(deselected.indexes().front().row());
 	}
 }
-#endif

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -1,7 +1,6 @@
 #include "SceneTree.hpp"
 
 #include <QScrollBar>
-#include <QTimer>
 
 #include "moc_SceneTree.cpp"
 
@@ -28,8 +27,7 @@ void SceneTree::SetGridMode(bool grid)
 		setStyleSheet("");
 	}
 
-	QResizeEvent event(size(), size());
-	resizeEvent(&event);
+	recalculateGridSize();
 }
 
 bool SceneTree::GetGridMode()
@@ -64,6 +62,46 @@ bool SceneTree::eventFilter(QObject *obj, QEvent *event)
 
 void SceneTree::resizeEvent(QResizeEvent *event)
 {
+	recalculateGridSize();
+
+	QListWidget::resizeEvent(event);
+}
+
+void SceneTree::startDrag(Qt::DropActions supportedActions)
+{
+	QListWidget::startDrag(supportedActions);
+}
+
+void SceneTree::dropEvent(QDropEvent *event)
+{
+	if (event->source() != this) {
+		QListWidget::dropEvent(event);
+		return;
+	}
+
+	if (gridMode) {
+		QSignalBlocker block(this);
+
+		QListWidgetItem *draggedItem = takeItem(selectedIndexes().first().row());
+		if (!draggedItem) {
+			return;
+		}
+
+		insertItem(lastTargetRow, draggedItem);
+		setCurrentItem(draggedItem);
+
+		lastTargetRow = -1;
+	}
+
+	QListWidget::dropEvent(event);
+
+	recalculateGridSize();
+
+	emit scenesReordered();
+}
+
+void SceneTree::recalculateGridSize()
+{
 	if (gridMode) {
 		int scrollWid = verticalScrollBar()->sizeHint().width();
 		const QRect lastItem = visualItemRect(item(count() - 1));
@@ -91,59 +129,6 @@ void SceneTree::resizeEvent(QResizeEvent *event)
 			item(i)->setData(Qt::SizeHintRole, QVariant());
 		}
 	}
-
-	QListWidget::resizeEvent(event);
-}
-
-void SceneTree::startDrag(Qt::DropActions supportedActions)
-{
-	QListWidget::startDrag(supportedActions);
-}
-
-void SceneTree::dropEvent(QDropEvent *event)
-{
-	if (event->source() != this) {
-		QListWidget::dropEvent(event);
-		return;
-	}
-
-	if (gridMode) {
-		int scrollWid = verticalScrollBar()->sizeHint().width();
-		const QRect firstItem = visualItemRect(item(0));
-		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
-		const int firstItemY = abs(firstItem.y());
-
-		if (h < height()) {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
-		} else {
-			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
-		}
-
-		float wid = contentsRect().width() - scrollWid - 1;
-
-		QPoint point = event->position().toPoint();
-
-		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
-		int y = (point.y() + firstItemY) / itemHeight;
-
-		int r = x + y * std::ceil(wid / maxWidth);
-
-		QListWidgetItem *item = takeItem(selectedIndexes()[0].row());
-		insertItem(r, item);
-		setCurrentItem(item);
-		resize(size());
-	}
-
-	QListWidget::dropEvent(event);
-
-	// We must call resizeEvent to correctly place all grid items.
-	// We also do this in rowsInserted.
-	QResizeEvent resEvent(size(), size());
-	SceneTree::resizeEvent(&resEvent);
-
-	QTimer::singleShot(100, [this]() { emit scenesReordered(); });
 }
 
 void SceneTree::RepositionGrid(QDragMoveEvent *event)
@@ -171,6 +156,8 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 
 		int r = x + y * std::ceil(wid / maxWidth);
 		int orig = selectedIndexes()[0].row();
+
+		lastTargetRow = r;
 
 		for (int i = 0; i < count(); i++) {
 			auto *wItem = item(i);
@@ -230,8 +217,7 @@ void SceneTree::dragLeaveEvent(QDragLeaveEvent *event)
 
 void SceneTree::rowsInserted(const QModelIndex &parent, int start, int end)
 {
-	QResizeEvent event(size(), size());
-	SceneTree::resizeEvent(&event);
+	recalculateGridSize();
 
 	QListWidget::rowsInserted(parent, start, end);
 }

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -6,7 +6,6 @@
 
 SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 {
-	installEventFilter(this);
 	setDragDropMode(InternalMove);
 	setMovement(QListView::Snap);
 }
@@ -53,11 +52,6 @@ int SceneTree::GetGridItemWidth()
 int SceneTree::GetGridItemHeight()
 {
 	return itemHeight;
-}
-
-bool SceneTree::eventFilter(QObject *obj, QEvent *event)
-{
-	return QObject::eventFilter(obj, event);
 }
 
 void SceneTree::resizeEvent(QResizeEvent *event)

--- a/frontend/components/SceneTree.cpp
+++ b/frontend/components/SceneTree.cpp
@@ -10,7 +10,7 @@ SceneTree::SceneTree(QWidget *parent_) : QListWidget(parent_)
 	setMovement(QListView::Snap);
 }
 
-void SceneTree::SetGridMode(bool grid)
+void SceneTree::setGridMode(bool grid)
 {
 	parent()->setProperty("class", grid ? "list-grid" : "");
 	gridMode = grid;
@@ -29,27 +29,27 @@ void SceneTree::SetGridMode(bool grid)
 	recalculateGridSize();
 }
 
-bool SceneTree::GetGridMode()
+bool SceneTree::getGridMode()
 {
 	return gridMode;
 }
 
-void SceneTree::SetGridItemWidth(int width)
+void SceneTree::setGridItemWidth(int width)
 {
-	maxWidth = width;
+	maxWidth = std::max(1, width);
 }
 
-void SceneTree::SetGridItemHeight(int height)
+void SceneTree::setGridItemHeight(int height)
 {
-	itemHeight = height;
+	itemHeight = std::max(1, height);
 }
 
-int SceneTree::GetGridItemWidth()
+int SceneTree::getGridItemWidth()
 {
 	return maxWidth;
 }
 
-int SceneTree::GetGridItemHeight()
+int SceneTree::getGridItemHeight()
 {
 	return itemHeight;
 }
@@ -74,7 +74,7 @@ void SceneTree::dropEvent(QDropEvent *event)
 	}
 
 	if (gridMode) {
-		QSignalBlocker block(this);
+		QSignalBlocker block{this};
 
 		QListWidgetItem *draggedItem = takeItem(selectedIndexes().first().row());
 		if (!draggedItem) {
@@ -97,58 +97,58 @@ void SceneTree::dropEvent(QDropEvent *event)
 void SceneTree::recalculateGridSize()
 {
 	if (gridMode) {
-		int scrollWid = verticalScrollBar()->sizeHint().width();
+		int scrollWidth = verticalScrollBar()->sizeHint().width();
 		const QRect lastItem = visualItemRect(item(count() - 1));
-		const int h = lastItem.y() + lastItem.height();
+		const int totalHeight = lastItem.y() + lastItem.height();
 
-		if (h < height()) {
+		if (totalHeight < height()) {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-			scrollWid = 0;
+			scrollWidth = 0;
 		} else {
 			setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 		}
 
-		int wid = contentsRect().width() - scrollWid - 1;
-		int items = (int)std::ceil((float)wid / maxWidth);
-		int itemWidth = wid / items;
+		int width = contentsRect().width() - scrollWidth - 1;
+		int items = static_cast<int>(std::ceil(static_cast<float>(width) / maxWidth));
+		int itemWidth = width / items;
 
-		setGridSize(QSize(itemWidth, itemHeight));
+		setGridSize(QSize{itemWidth, itemHeight});
 
 		for (int i = 0; i < count(); i++) {
-			item(i)->setSizeHint(QSize(itemWidth, itemHeight));
+			item(i)->setSizeHint(QSize{itemWidth, itemHeight});
 		}
 	} else {
-		setGridSize(QSize());
+		setGridSize(QSize{});
 		for (int i = 0; i < count(); i++) {
 			item(i)->setData(Qt::SizeHintRole, QVariant());
 		}
 	}
 }
 
-void SceneTree::RepositionGrid(QDragMoveEvent *event)
+void SceneTree::repositionGrid(QDragMoveEvent *event)
 {
-	int scrollWid = verticalScrollBar()->sizeHint().width();
-	const QRect firstItem = visualItemRect(item(0));
-	const QRect lastItem = visualItemRect(item(count() - 1));
-	const int h = lastItem.y() + lastItem.height();
-	const int firstItemY = abs(firstItem.y());
+	int scrollWidth = verticalScrollBar()->sizeHint().width();
+	const QRect firstItemRect = visualItemRect(item(0));
+	const QRect lastItemRect = visualItemRect(item(count() - 1));
+	const int totalHeight = lastItemRect.y() + lastItemRect.height();
+	const int firstItemY = abs(firstItemRect.y());
 
-	if (h < height()) {
+	if (totalHeight < height()) {
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-		scrollWid = 0;
+		scrollWidth = 0;
 	} else {
 		setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
 	}
 
-	float wid = contentsRect().width() - scrollWid - 1;
+	float width = contentsRect().width() - scrollWidth - 1;
 
 	if (event) {
 		QPoint point = event->position().toPoint();
 
-		int x = (float)point.x() / wid * std::ceil(wid / maxWidth);
+		int x = (float)point.x() / width * std::ceil(width / maxWidth);
 		int y = (point.y() + firstItemY) / itemHeight;
 
-		int r = x + y * std::ceil(wid / maxWidth);
+		int r = x + y * std::ceil(width / maxWidth);
 		int orig = selectedIndexes()[0].row();
 
 		lastTargetRow = r;
@@ -164,12 +164,12 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 
 			int off = (i >= r ? 1 : 0) - (i > orig && i > r ? 1 : 0) - (i > orig && i == r ? 2 : 0);
 
-			int xPos = (i + off) % (int)std::ceil(wid / maxWidth);
-			int yPos = (i + off) / (int)std::ceil(wid / maxWidth);
-			QSize g = gridSize();
+			int xPos = (i + off) % static_cast<int>(std::ceil(width / maxWidth));
+			int yPos = (i + off) / static_cast<int>(std::ceil(width / maxWidth));
+			QSize gridSize_ = gridSize();
 
-			QPoint position(xPos * g.width(), yPos * g.height());
-			setPositionForIndex(position, index);
+			QPoint newPosition{xPos * gridSize_.width(), yPos * gridSize_.height()};
+			setPositionForIndex(newPosition, index);
 		}
 	} else {
 		for (int i = 0; i < count(); i++) {
@@ -181,12 +181,12 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 
 			QModelIndex index = indexFromItem(wItem);
 
-			int xPos = i % (int)std::ceil(wid / maxWidth);
-			int yPos = i / (int)std::ceil(wid / maxWidth);
-			QSize g = gridSize();
+			int xPos = i % static_cast<int>(std::ceil(width / maxWidth));
+			int yPos = i / static_cast<int>(std::ceil(width / maxWidth));
+			QSize gridSize_ = gridSize();
 
-			QPoint position(xPos * g.width(), yPos * g.height());
-			setPositionForIndex(position, index);
+			QPoint newPosition{xPos * gridSize_.width(), yPos * gridSize_.height()};
+			setPositionForIndex(newPosition, index);
 		}
 	}
 }
@@ -194,7 +194,7 @@ void SceneTree::RepositionGrid(QDragMoveEvent *event)
 void SceneTree::dragMoveEvent(QDragMoveEvent *event)
 {
 	if (gridMode) {
-		RepositionGrid(event);
+		repositionGrid(event);
 	}
 
 	QListWidget::dragMoveEvent(event);
@@ -203,7 +203,7 @@ void SceneTree::dragMoveEvent(QDragMoveEvent *event)
 void SceneTree::dragLeaveEvent(QDragLeaveEvent *event)
 {
 	if (gridMode) {
-		RepositionGrid();
+		repositionGrid();
 	}
 
 	QListWidget::dragLeaveEvent(event);

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -36,9 +36,7 @@ protected:
 	virtual void dragMoveEvent(QDragMoveEvent *event) override;
 	virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 	virtual void rowsInserted(const QModelIndex &parent, int start, int end) override;
-#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
 	virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-#endif
 
 signals:
 	void scenesReordered();

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -13,6 +13,7 @@ class SceneTree : public QListWidget {
 	bool gridMode = false;
 	int maxWidth = 150;
 	int itemHeight = 24;
+	int lastTargetRow = -1;
 
 public:
 	void SetGridMode(bool grid);

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -30,7 +30,6 @@ private:
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
 
 protected:
-	virtual bool eventFilter(QObject *obj, QEvent *event) override;
 	virtual void resizeEvent(QResizeEvent *event) override;
 	virtual void startDrag(Qt::DropActions supportedActions) override;
 	virtual void dropEvent(QDropEvent *event) override;

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -26,6 +26,7 @@ public:
 	explicit SceneTree(QWidget *parent = nullptr);
 
 private:
+	void recalculateGridSize();
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
 
 protected:

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -7,8 +7,8 @@
 
 class SceneTree : public QListWidget {
 	Q_OBJECT
-	Q_PROPERTY(int gridItemWidth READ GetGridItemWidth WRITE SetGridItemWidth DESIGNABLE true)
-	Q_PROPERTY(int gridItemHeight READ GetGridItemHeight WRITE SetGridItemHeight DESIGNABLE true)
+	Q_PROPERTY(int gridItemWidth READ getGridItemWidth WRITE setGridItemWidth DESIGNABLE true)
+	Q_PROPERTY(int gridItemHeight READ getGridItemHeight WRITE setGridItemHeight DESIGNABLE true)
 
 	bool gridMode = false;
 	int maxWidth = 150;
@@ -16,19 +16,19 @@ class SceneTree : public QListWidget {
 	int lastTargetRow = -1;
 
 public:
-	void SetGridMode(bool grid);
-	bool GetGridMode();
+	void setGridMode(bool grid);
+	bool getGridMode();
 
-	void SetGridItemWidth(int width);
-	void SetGridItemHeight(int height);
-	int GetGridItemWidth();
-	int GetGridItemHeight();
+	void setGridItemWidth(int width);
+	void setGridItemHeight(int height);
+	int getGridItemWidth();
+	int getGridItemHeight();
 
 	explicit SceneTree(QWidget *parent = nullptr);
 
 private:
 	void recalculateGridSize();
-	void RepositionGrid(QDragMoveEvent *event = nullptr);
+	void repositionGrid(QDragMoveEvent *event = nullptr);
 
 protected:
 	virtual void resizeEvent(QResizeEvent *event) override;

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -37,9 +37,7 @@ protected:
 	virtual void dragMoveEvent(QDragMoveEvent *event) override;
 	virtual void dragLeaveEvent(QDragLeaveEvent *event) override;
 	virtual void rowsInserted(const QModelIndex &parent, int start, int end) override;
-#if QT_VERSION < QT_VERSION_CHECK(6, 4, 3)
 	virtual void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
-#endif
 
 signals:
 	void scenesReordered();

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -31,7 +31,6 @@ private:
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
 
 protected:
-	virtual bool eventFilter(QObject *obj, QEvent *event) override;
 	virtual void resizeEvent(QResizeEvent *event) override;
 	virtual void startDrag(Qt::DropActions supportedActions) override;
 	virtual void dropEvent(QDropEvent *event) override;

--- a/frontend/components/SceneTree.hpp
+++ b/frontend/components/SceneTree.hpp
@@ -13,6 +13,7 @@ class SceneTree : public QListWidget {
 	bool gridMode = false;
 	int maxWidth = 150;
 	int itemHeight = 24;
+	int lastTargetRow = -1;
 
 public:
 	void SetGridMode(bool grid);
@@ -26,6 +27,7 @@ public:
 	explicit SceneTree(QWidget *parent = nullptr);
 
 private:
+	void recalculateGridSize();
 	void RepositionGrid(QDragMoveEvent *event = nullptr);
 
 protected:

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -389,7 +389,7 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	ui->sources->setAttribute(Qt::WA_MacShowFocusRect, false);
 
 	bool sceneGrid = config_get_bool(App()->GetUserConfig(), "BasicWindow", "gridMode");
-	ui->scenes->SetGridMode(sceneGrid);
+	ui->scenes->setGridMode(sceneGrid);
 
 	if (sceneGrid) {
 		ui->actionSceneGridMode->setChecked(true);

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -534,7 +534,7 @@ void OBSBasic::on_resetUI_triggered()
 	ui->toggleContextBar->setChecked(true);
 	ui->toggleSourceIcons->setChecked(true);
 	ui->toggleStatusBar->setChecked(true);
-	ui->scenes->SetGridMode(false);
+	ui->scenes->setGridMode(false);
 	ui->actionSceneListMode->setChecked(true);
 
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode", false);

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -626,7 +626,7 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 	popup.addSeparator();
 
-	bool grid = ui->scenes->GetGridMode();
+	bool grid = ui->scenes->getGridMode();
 
 	QAction *gridAction = new QAction(grid ? QTStr("Basic.Main.ListMode") : QTStr("Basic.Main.GridMode"), this);
 	connect(gridAction, &QAction::triggered, this, &OBSBasic::GridActionClicked);
@@ -637,20 +637,20 @@ void OBSBasic::on_scenes_customContextMenuRequested(const QPoint &pos)
 
 void OBSBasic::on_actionSceneListMode_triggered()
 {
-	ui->scenes->SetGridMode(false);
+	ui->scenes->setGridMode(false);
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode", false);
 }
 
 void OBSBasic::on_actionSceneGridMode_triggered()
 {
-	ui->scenes->SetGridMode(true);
+	ui->scenes->setGridMode(true);
 	config_set_bool(App()->GetUserConfig(), "BasicWindow", "gridMode", true);
 }
 
 void OBSBasic::GridActionClicked()
 {
-	bool gridMode = !ui->scenes->GetGridMode();
-	ui->scenes->SetGridMode(gridMode);
+	bool gridMode = !ui->scenes->getGridMode();
+	ui->scenes->setGridMode(gridMode);
 
 	if (gridMode) {
 		ui->actionSceneGridMode->setChecked(true);


### PR DESCRIPTION
### Description
A medley of clean up to the SceneTree widget. 

Pile o' commits:

- Split out scene tree grid calculation
  - Moved this logic into it's own function rather than the hacky approach of forcing a resizeEvent which might have other side effects
- Remove empty eventFilter
  - Function is empty and always has been since it was added? Perhaps a misunderstanding of Qt from years ago.
- Remove deferred scenesReordered signal
  - This was added in #3398 to hack around an issue where the order was incorrect in the multiview, which I believe was due to...
- Block signals while updating the grid list
  - This also fixes a bug where reordering the grid list caused OBS to swap to the scene at the target index and then immediately swap back to the scene being dragged. Visually this bug was invisible until #13088 fixed interrupted transitions.
 - Restore old safety guard on selectionChanged
   - An old QTBUG allowed the scene to be deselected by clicking in the empty area of the QList. This was (allegedly) fixed at some point, however it is still possible to deselect the scene by clicking and dragging in the empty area now sooo we need this guard again.
- Simplify grid reordering logic
  - There's **a lot** going on here and I will type it up later.
- Adjust style refresh logic
  - Polish the widget instead of setting/clearing a stylesheet.
- Codestyle cleanup
 
### Motivation and Context
Originally I was trying to chase down a UI deadlock a friend ran into when changing scenes. In the DMP I received from them, the main thread was stuck inside the SceneTree's drag event. I have yet to determine if the SceneTree was _actually_ responsible in any way for that lock up, but looking around at what could have potentially caused it led me to the resizeEvent stuff.

### How Has This Been Tested?
Tested all the functionality I changed. Reordered scenes in grid mode, adjusted the scene tree styling locally. Resized the dock before and after reordering items. Ensured Multiview behaved correctly in list and grid mode when making changes.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
