### PR TITLE
obs-ffmpeg: Fix SRT output data loss on transient backpressure and teardown UAF

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mpegts.c
@@ -549,6 +549,18 @@ static void close_mpegts_url(struct ffmpeg_output *stream, bool is_rist)
 	if (!h)
 		return; /* can happen when opening the url fails */
 
+	/* Detach the write callback's opaque before closing: buffered mux
+	 * output has already been delivered by av_write_trailer()'s
+	 * internal flush (ffmpeg_mpegts_data_free runs it before calling
+	 * here, while the URLContext is still alive), or was never
+	 * deliverable (header-only teardown). The avio_flush() this
+	 * function used to do after the close/free below invoked the write
+	 * callback on a freed URLContext — a use-after-free that could not
+	 * deliver data anyway, since the socket was already closed. */
+	AVIOContext *s = stream->s;
+	if (s)
+		s->opaque = NULL;
+
 	/* close rist or srt URLs ; free URLContext */
 	if (is_rist) {
 		err = librist_close(h);
@@ -560,15 +572,11 @@ static void close_mpegts_url(struct ffmpeg_output *stream, bool is_rist)
 	h = NULL;
 
 	/* close custom avio_context for srt or rist */
-	AVIOContext *s = stream->s;
-	if (!s)
-		return;
-
-	avio_flush(s);
-	s->opaque = NULL;
-	av_freep(&s->buffer);
-	avio_context_free(&s);
-	s = NULL;
+	if (s) {
+		av_freep(&s->buffer);
+		avio_context_free(&s);
+		s = NULL;
+	}
 
 	if (err)
 		info("[ffmpeg mpegts muxer]: Error closing URL %s", stream->ff_data.config.url);
@@ -785,8 +793,14 @@ static int mpegts_process_packet(struct ffmpeg_output *stream)
 					av_err2str(ret));
 
 		/* Treat "Invalid data found when processing input" and
-		 * "Invalid argument" as non-fatal */
-		if (ret == AVERROR_INVALIDDATA || ret == -EINVAL) {
+		 * "Invalid argument" as non-fatal, but only for per-packet
+		 * muxer rejections. If the error is latched on the IO
+		 * context (pb->error, which avio never clears), every
+		 * subsequent flush is silently discarded and the output
+		 * would keep "streaming" nothing forever — that must remain
+		 * fatal so the reconnect logic can recover. */
+		AVIOContext *pb = stream->ff_data.output ? stream->ff_data.output->pb : NULL;
+		if ((ret == AVERROR_INVALIDDATA || ret == -EINVAL) && (!pb || pb->error >= 0)) {
 			ret = 0;
 		}
 	}

--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -849,33 +849,50 @@ static int libsrt_write(URLContext *h, const uint8_t *buf, int size)
 	int ret;
 	SRT_TRACEBSTATS perf;
 
-	ret = libsrt_network_wait_fd_timeout(h, s->eid, 1, h->rw_timeout, &h->interrupt_callback);
-	if (ret)
-		return ret;
+	for (;;) {
+		ret = libsrt_network_wait_fd_timeout(h, s->eid, 1, h->rw_timeout, &h->interrupt_callback);
+		if (ret)
+			return ret;
 
-	ret = srt_send(s->fd, (char *)buf, size);
-	if (ret < 0) {
-		ret = libsrt_neterrno(h);
-	} else {
-		/* log every 60 seconds the rtt and link bandwidth
-		 * rtt: round-trip time
-		 * link bandwidth: bandwidth from ingest to egress
-		*/
-#ifdef _WIN32
-		struct timeb timebuffer;
-		ftime(&timebuffer);
-		double time = (double)timebuffer.time + 0.001 * (double)timebuffer.millitm;
-#else
-		struct timespec timesp;
-		clock_gettime(CLOCK_REALTIME, &timesp);
-		double time = (double)timesp.tv_sec + 0.000000001 * (double)timesp.tv_nsec;
-#endif
-		if (time > (s->time + 60.0)) {
-			srt_bistats(s->fd, &perf, 0, 1);
-			blog(LOG_DEBUG, "[obs-ffmpeg mpegts muxer / libsrt]: RTT [%.2f ms], Link Bandwidth [%.1f Mbps]",
-			     perf.msRTT, perf.mbpsBandwidth);
-			s->time = time;
+		ret = srt_send(s->fd, (char *)buf, size);
+		if (ret >= 0)
+			break;
+
+		if (srt_getlasterror(NULL) == SRT_EASYNCSND) {
+			/* Transient send backpressure: re-poll writability and
+			 * retry, quietly. This callback sits directly on a
+			 * custom AVIOContext, so unlike ffmpeg's own protocols
+			 * there is no retry_transfer_wrapper above it;
+			 * returning EAGAIN here latches a sticky error on the
+			 * AVIOContext, losing this flush (~7 TS packets) and
+			 * tearing the output down on the next write — or, if
+			 * the muxer keeps rejecting packets, wedging it into a
+			 * silent-discard state. */
+			srt_clearlasterror();
+			continue;
 		}
+
+		return libsrt_neterrno(h);
+	}
+
+	/* log every 60 seconds the rtt and link bandwidth
+	 * rtt: round-trip time
+	 * link bandwidth: bandwidth from ingest to egress
+	*/
+#ifdef _WIN32
+	struct timeb timebuffer;
+	ftime(&timebuffer);
+	double time = (double)timebuffer.time + 0.001 * (double)timebuffer.millitm;
+#else
+	struct timespec timesp;
+	clock_gettime(CLOCK_REALTIME, &timesp);
+	double time = (double)timesp.tv_sec + 0.000000001 * (double)timesp.tv_nsec;
+#endif
+	if (time > (s->time + 60.0)) {
+		srt_bistats(s->fd, &perf, 0, 1);
+		blog(LOG_DEBUG, "[obs-ffmpeg mpegts muxer / libsrt]: RTT [%.2f ms], Link Bandwidth [%.1f Mbps]",
+		     perf.msRTT, perf.mbpsBandwidth);
+		s->time = time;
 	}
 
 	return ret;


### PR DESCRIPTION
## Description

Three related robustness fixes in the mpegts-over-SRT output path, found while doing a wire-level forensic investigation of SRT output corruption (context and full evidence in #13469, comment forthcoming):

1. **`libsrt_write`: retry on transient backpressure.** The write callback sits directly on a custom `AVIOContext`, so there is no `retry_transfer_wrapper` above it like ffmpeg's own protocols have. Returning `AVERROR(EAGAIN)` on `SRT_EASYNCSND` latches a sticky `pb->error`: the in-flight flush (~7 TS packets) is discarded, and the latched error tears the output down on the next write — or, in the corner where the muxer keeps rejecting packets, wedges the output into silent discard. Now re-polls writability and retries quietly.
2. **`close_mpegts_url`: remove use-after-free flush.** `avio_flush()` ran *after* `libsrt_close()`/`av_freep(&h->priv_data)`/`av_freep(&h)`, invoking the write callback on a freed `URLContext` aimed at an already-closed socket. Buffered output is already delivered by `av_write_trailer()`'s internal flush, which runs before this function while the context is alive; the removed flush could never deliver data.
3. **`mpegts_process_packet`: don't mask latched IO errors.** `AVERROR_INVALIDDATA`/`-EINVAL` remain non-fatal for per-packet muxer rejections, but are now fatal when `pb->error` is latched — once latched, avio silently discards every subsequent flush while advancing its position, so continuing converts a dead output into a permanent silent blackout instead of letting reconnect logic recover.

Known pre-existing behavior deliberately left unchanged (candidate follow-up): with the default `rw_timeout == 0` and no `interrupt_callback` wired, `libsrt_network_wait_fd_timeout` can block indefinitely on a full send window over a live connection; this patch neither introduces nor worsens that (the old code entered the same wait before its single send attempt).

## Motivation and Context

Live production streams over SRT showed periodic TS continuity errors and, separately, "streaming but nothing arrives" wedges. Packet captures at the receiver proved complete SRT sequence delivery while the payload carried mux-level gaps — see #13469 for the matching report (OBS sender corrupt / ffmpeg CLI sender clean under identical conditions). Items 1 and 3 close the silent-data-loss mechanisms in this path; item 2 is a straight UAF fix verified by call-site audit (`av_write_trailer` precedes the close on all paths).

## How Has This Been Tested?

- Line-level audit against FFmpeg 7.1 `aviobuf.c`/`mux.c` semantics (`writeout()` error latching, `flush_buffer` fill accounting, `av_write_trailer` flush ordering) and upstream libsrt send semantics (`SRT_EASYNCSND` consumes nothing, so retrying the same buffer is correct).
- Receiver-side validation environment: GStreamer `srtserversrc` ingest with TR 101-290 analysis and full-payload packet capture, which reproduces the original data-loss symptoms on demand at 6 Mbps.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code has been run through clang-format.
- [x] I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/.github/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.