### PR TITLE
frontend: API call obs_frontend_add_transition()

### DIFF
--- a/docs/sphinx/reference-frontend-api.rst
+++ b/docs/sphinx/reference-frontend-api.rst
@@ -318,6 +318,20 @@ Functions
 
 ---------------------------------------
 
+.. function:: obs_source_t * obs_frontend_add_transition(const char *transition_id, const char *transition_name, obs_data_t *settings = NULL)
+
+   Adds a global transition in the collection.
+   The transition must have a unique name, otherwise it won't be added.
+
+   :param transition_id: Identifier of the transition
+   :param transition_name: Name of the transition
+   :param settings: An :c:type:`obs_data_t` pointer with the settings of the transition
+
+   :return: A new reference to the new transition, or *NULL* if the transition has not been added.
+            Release with :c:func:`obs_source_release()`.
+
+---------------------------------------
+
 .. function:: obs_source_t *obs_frontend_get_current_transition(void)
 
    :return: A new reference to the currently active transition.

--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -85,6 +85,17 @@ void OBSStudioAPI::obs_frontend_get_transitions(struct obs_frontend_source_list 
 	}
 }
 
+obs_source_t *OBSStudioAPI::obs_frontend_add_transition(const char *transition_id, const char *transition_name,
+							obs_data_t *settings)
+{
+	main->AddTransition(transition_id, transition_name, false);
+	OBSSource tr = main->FindTransition(transition_name);
+	if (settings != nullptr) {
+		obs_source_reset_settings(tr, settings);
+	}
+	return obs_source_get_ref(tr);
+}
+
 obs_source_t *OBSStudioAPI::obs_frontend_get_current_transition()
 {
 	OBSSource tr = main->GetCurrentTransition();

--- a/frontend/OBSStudioAPI.cpp
+++ b/frontend/OBSStudioAPI.cpp
@@ -84,6 +84,17 @@ void OBSStudioAPI::obs_frontend_get_transitions(struct obs_frontend_source_list 
 	}
 }
 
+obs_source_t *OBSStudioAPI::obs_frontend_add_transition(const char *transition_id, const char *transition_name,
+							obs_data_t *settings)
+{
+	main->AddTransition(transition_id, transition_name, false);
+	OBSSource tr = main->FindTransition(transition_name);
+	if (settings != nullptr) {
+		obs_source_reset_settings(tr, settings);
+	}
+	return obs_source_get_ref(tr);
+}
+
 obs_source_t *OBSStudioAPI::obs_frontend_get_current_transition()
 {
 	OBSSource tr = main->GetCurrentTransition();

--- a/frontend/OBSStudioAPI.hpp
+++ b/frontend/OBSStudioAPI.hpp
@@ -49,6 +49,8 @@ struct OBSStudioAPI : obs_frontend_callbacks {
 	void obs_frontend_set_current_scene(obs_source_t *scene) override;
 
 	void obs_frontend_get_transitions(struct obs_frontend_source_list *sources) override;
+	obs_source_t *obs_frontend_add_transition(const char *transition_name, const char *transition_id,
+						  obs_data_t *settings) override;
 
 	obs_source_t *obs_frontend_get_current_transition(void) override;
 

--- a/frontend/api/obs-frontend-api.cpp
+++ b/frontend/api/obs-frontend-api.cpp
@@ -119,6 +119,14 @@ void obs_frontend_get_transitions(struct obs_frontend_source_list *sources)
 	}
 }
 
+obs_source_t *obs_frontend_add_transition(const char *transition_id, const char *transition_name, obs_data_t *settings)
+{
+	if (callbacks_valid()) {
+		return c->obs_frontend_add_transition(transition_id, transition_name, settings);
+	}
+	return nullptr;
+}
+
 obs_source_t *obs_frontend_get_current_transition(void)
 {
 	return !!callbacks_valid() ? c->obs_frontend_get_current_transition() : nullptr;

--- a/frontend/api/obs-frontend-api.h
+++ b/frontend/api/obs-frontend-api.h
@@ -125,6 +125,8 @@ EXPORT obs_source_t *obs_frontend_get_current_scene(void);
 EXPORT void obs_frontend_set_current_scene(obs_source_t *scene);
 
 EXPORT void obs_frontend_get_transitions(struct obs_frontend_source_list *sources);
+EXPORT obs_source_t *obs_frontend_add_transition(const char *transition_id, const char *transition_name,
+						 obs_data_t *settings = NULL);
 EXPORT obs_source_t *obs_frontend_get_current_transition(void);
 EXPORT void obs_frontend_set_current_transition(obs_source_t *transition);
 EXPORT int obs_frontend_get_transition_duration(void);

--- a/frontend/api/obs-frontend-internal.hpp
+++ b/frontend/api/obs-frontend-internal.hpp
@@ -16,6 +16,8 @@ struct obs_frontend_callbacks {
 	virtual void obs_frontend_set_current_scene(obs_source_t *scene) = 0;
 
 	virtual void obs_frontend_get_transitions(struct obs_frontend_source_list *sources) = 0;
+	virtual obs_source_t *obs_frontend_add_transition(const char *transition_id, const char *transition_name,
+							  obs_data_t *settings) = 0;
 	virtual obs_source_t *obs_frontend_get_current_transition(void) = 0;
 	virtual void obs_frontend_set_current_transition(obs_source_t *transition) = 0;
 	virtual int obs_frontend_get_transition_duration(void) = 0;

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1568,7 +1568,7 @@ public slots:
 	void SetTransitionDuration(int duration);
 
 private slots:
-	void AddTransition(const char *id);
+	void AddTransition(const char *id, const char *transitionName, bool showProperties);
 	void RenameTransition(OBSSource transition);
 
 	void TransitionClicked();

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1569,7 +1569,7 @@ public slots:
 	void SetTransitionDuration(int duration);
 
 private slots:
-	void AddTransition(const char *id);
+	void AddTransition(const char *id, const char *transitionName, bool showProperties);
 	void RenameTransition(OBSSource transition);
 
 	void TransitionClicked();

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -452,7 +452,7 @@ OBSSource OBSBasic::GetCurrentTransition()
 	return transition->second;
 }
 
-void OBSBasic::AddTransition(const char *id)
+void OBSBasic::AddTransition(const char *id, const char *transitionName = nullptr, bool showProperties = true)
 {
 	std::string name;
 	QString placeHolderText = QT_UTF8(obs_source_get_display_name(id));
@@ -464,23 +464,32 @@ void OBSBasic::AddTransition(const char *id)
 		placeHolderText = format.arg(++i);
 	}
 
-	bool accepted = NameDialog::AskForName(this, QTStr("TransitionNameDlg.Title"), QTStr("TransitionNameDlg.Text"),
-					       name, placeHolderText);
+	bool accepted;
+	if (transitionName != nullptr) {
+		accepted = true;
+		name = std::string(transitionName);
+	} else {
+		accepted = NameDialog::AskForName(this, QTStr("TransitionNameDlg.Title"),
+						  QTStr("TransitionNameDlg.Text"), name, placeHolderText);
+	}
 
 	if (accepted) {
 		std::string uuid;
 
 		if (name.empty()) {
-			OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
-			AddTransition(id);
+			if (transitionName == nullptr) {
+				OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
+				AddTransition(id, nullptr, showProperties);
+			}
 			return;
 		}
 
 		source = FindTransition(name.c_str());
 		if (source) {
-			OBSMessageBox::warning(this, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
-
-			AddTransition(id);
+			if (transitionName == nullptr) {
+				OBSMessageBox::warning(this, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
+				AddTransition(id, nullptr, showProperties);
+			}
 			return;
 		}
 
@@ -494,9 +503,10 @@ void OBSBasic::AddTransition(const char *id)
 
 		emit TransitionAdded(QString::fromStdString(name), QString::fromStdString(uuid));
 
-		UpdateCurrentTransition(uuid, true);
-
-		CreatePropertiesWindow(source);
+		if (showProperties) {
+			UpdateCurrentTransition(uuid, true);
+			CreatePropertiesWindow(source);
+		}
 		obs_source_release(source);
 
 		OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -460,7 +460,7 @@ OBSSource OBSBasic::GetCurrentTransition()
 	return transition->second;
 }
 
-void OBSBasic::AddTransition(const char *id)
+void OBSBasic::AddTransition(const char *id, const char *transitionName = nullptr, bool showProperties = true)
 {
 	std::string name;
 	QString placeHolderText = QT_UTF8(obs_source_get_display_name(id));
@@ -472,23 +472,32 @@ void OBSBasic::AddTransition(const char *id)
 		placeHolderText = format.arg(++i);
 	}
 
-	bool accepted = NameDialog::AskForName(this, QTStr("TransitionNameDlg.Title"), QTStr("TransitionNameDlg.Text"),
-					       name, placeHolderText);
+	bool accepted;
+	if (transitionName != nullptr) {
+		accepted = true;
+		name = std::string(transitionName);
+	} else {
+		accepted = NameDialog::AskForName(this, QTStr("TransitionNameDlg.Title"),
+						  QTStr("TransitionNameDlg.Text"), name, placeHolderText);
+	}
 
 	if (accepted) {
 		std::string uuid;
 
 		if (name.empty()) {
-			OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
-			AddTransition(id);
+			if (transitionName == nullptr) {
+				OBSMessageBox::warning(this, QTStr("NoNameEntered.Title"), QTStr("NoNameEntered.Text"));
+				AddTransition(id, nullptr, showProperties);
+			}
 			return;
 		}
 
 		source = FindTransition(name.c_str());
 		if (source) {
-			OBSMessageBox::warning(this, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
-
-			AddTransition(id);
+			if (transitionName == nullptr) {
+				OBSMessageBox::warning(this, QTStr("NameExists.Title"), QTStr("NameExists.Text"));
+				AddTransition(id, nullptr, showProperties);
+			}
 			return;
 		}
 
@@ -502,9 +511,10 @@ void OBSBasic::AddTransition(const char *id)
 
 		emit TransitionAdded(QString::fromStdString(name), QString::fromStdString(uuid));
 
-		UpdateCurrentTransition(uuid, true);
-
-		CreatePropertiesWindow(source);
+		if (showProperties) {
+			UpdateCurrentTransition(uuid, true);
+			CreatePropertiesWindow(source);
+		}
 		obs_source_release(source);
 
 		OnEvent(OBS_FRONTEND_EVENT_TRANSITION_LIST_CHANGED);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

This is my first PR on the OBS project, I hope I'll do it as expected :-)

### Description
This PR adds the `obs_frontend_add_transition()` frontend API call.
This function allows to add global transitions in the collection without showing the popups.

This change required two modifications :
- Extend `OBSBasic::AddTransition()` with two new arguments : `const char *transitionName = nullptr, bool showProperties = true`. The default values ensures retro-compatibility.
- Add `obs_source_t *obs_frontend_add_transition()` to the frontend API, with the related documentation

<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

### Motivation and Context
I needed this to make a backup system for transitions in my plugin.
I didn't find any reason why it wasn't there, so I assumed it was forgotten.
However, there might be a reason why it wasn't implemented in the first place.

### How Has This Been Tested?
I have tested this on Linux with success, not on Windows or MacOS.

Given the changes made, I don't believe much more testing is required.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
