### PR TITLE
rtmp-services: Rename Vaughn Live and update Vaughn Live/Breakers.TV ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -5,7 +5,7 @@
     "files": [
         {
             "name": "services.json",
-            "version": 285
+            "version": 286
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -385,55 +385,15 @@
             ]
         },
         {
-            "name": "Vaughn Live / iNSTAGIB",
+            "name": "Vaughn Live",
+            "stream_key_link": "https://vaughn.live/settings/channel",
+            "alt_names": [
+                "Vaughn Live / iNSTAGIB"
+            ],
             "servers": [
                 {
-                    "name": "US: Vint Hill, VA",
-                    "url": "rtmp://live-iad.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Vint Hill, VA #2",
-                    "url": "rtmp://live-iad2.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Dallas, TX",
-                    "url": "rtmp://live-dfw.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Denver, CO",
-                    "url": "rtmp://live-den.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: New York, NY",
-                    "url": "rtmp://live-nyc.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Miami, FL",
-                    "url": "rtmp://live-mia.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Seattle, WA",
-                    "url": "rtmp://live-sea.vaughnsoft.net/live"
-                },
-                {
-                    "name": "CA: Toronto",
-                    "url": "rtmp://live-tor.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: Amsterdam, NL",
-                    "url": "rtmp://live-ams.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: London, UK",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: Paris, FR",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
-                },
-                {
-                    "name": "Tokyo, JP",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
+                    "name": "Default",
+                    "url": "rtmp://live.vaughnsoft.net/live"
                 }
             ],
             "recommended": {
@@ -449,52 +409,8 @@
             "name": "Breakers.TV",
             "servers": [
                 {
-                    "name": "US: Vint Hill, VA",
-                    "url": "rtmp://live-iad.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Vint Hill, VA #2",
-                    "url": "rtmp://live-iad2.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Dallas, TX",
-                    "url": "rtmp://live-dfw.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Denver, CO",
-                    "url": "rtmp://live-den.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: New York, NY",
-                    "url": "rtmp://live-nyc.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Miami, FL",
-                    "url": "rtmp://live-mia.vaughnsoft.net/live"
-                },
-                {
-                    "name": "US: Seattle, WA",
-                    "url": "rtmp://live-sea.vaughnsoft.net/live"
-                },
-                {
-                    "name": "CA: Toronto",
-                    "url": "rtmp://live-tor.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: Amsterdam, NL",
-                    "url": "rtmp://live-ams.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: London, UK",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
-                },
-                {
-                    "name": "EU: Paris, FR",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
-                },
-                {
-                    "name": "Tokyo, JP",
-                    "url": "rtmp://live-lhr.vaughnsoft.net/live"
+                    "name": "Default",
+                    "url": "rtmp://live.vaughnsoft.net/live"
                 }
             ],
             "recommended": {


### PR DESCRIPTION
### Description
Renames the "Vaughn Live / iNSTAGIB" entry to "Vaughn Live" and adds the old
name to `alt_names` so existing users are migrated automatically (no lost
service selection). Adds a `stream_key_link` for Vaughn Live
(`https://vaughn.live/settings/channel`). Also updates the Vaughn Live and
Breakers.TV ingest lists to our current geo-DNS balanced endpoint
`rtmp://live.vaughnsoft.net/live` — the per-location ingest servers are retired,
so the old regional entries are removed and replaced with a single `Default`
server. `package.json` version bumped 285 → 286.
 
### Motivation and Context
The regional ingest hostnames are no longer in service; all traffic now routes
through the geo-balanced address. The entry name is being simplified to
"Vaughn Live"; `alt_names` preserves migration for existing users.
 
### How Has This Been Tested?
Replaced `services.json` / `package.json` in
`%APPDATA%\obs-studio\plugin_config\rtmp-services` and confirmed the renamed
"Vaughn Live" entry appears with the single Default server, the stream-key link
opens the channel settings page, streaming works, and an existing profile set to
"Vaughn Live / iNSTAGIB" migrates over.
 
### Types of changes
- Tweak (non-breaking change to improve existing functionality)
### Checklist:
- [ ] My code has been run through clang-format.
- [x] I have read the contributing document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.
 