### PR TITLE
libobs & frontend: fallback transitions when plugin is absent

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -178,6 +178,10 @@ Source Definition Structure (obs_source_info)
 
    - **OBS_SOURCE_REQUIRES_CANVAS** - Source type requires a canvas.
 
+   - **OBS_SOURCE_FALLBACK** - Source is a fallback, meaning the
+     original source is invalid, and has been replaced by another one.
+     Used for invalid transitions
+
 .. member:: const char *(*obs_source_info.get_name)(void *type_data)
 
    Get the translated name of the source type.
@@ -898,6 +902,27 @@ General Source Functions
    :c:func:`obs_save_sources()` should not exist in the back-end.
 
    :param   id:             The source type string identifier
+   :param   name:           The desired name of the source.  For private
+                            sources, this does not have to be unique,
+                            and can additionally be *NULL* if desired
+   :param   settings:       The settings for the source, or *NULL* if
+                            none
+   :return:                 A reference to the newly created source, or
+                            *NULL* if failed
+
+---------------------
+
+.. function:: obs_source_t *obs_source_create_private_with_fallback(const char *id, const char *fallback_id, const char *name, obs_data_t *settings)
+
+   Same as :c:func:`obs_source_create_private()` but with a fallback id to use if the requested id is missing or invalid.
+
+   Author's Note: The existence of this function is a result of design
+   flaw: the front-end should control saving/loading of sources, and
+   functions like :c:func:`obs_enum_sources()` and
+   :c:func:`obs_save_sources()` should not exist in the back-end.
+
+   :param   id:             The source type string identifier
+   :param   fallback_id:    The fallback source type string identifier
    :param   name:           The desired name of the source.  For private
                             sources, this does not have to be unique,
                             and can additionally be *NULL* if desired

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -321,7 +321,13 @@ OBSBasic::OBSBasic(QWidget *parent) : OBSMainWindow(parent), undo_s(ui), ui(new 
 	/* Set up transitions combobox connections */
 	connect(this, &OBSBasic::TransitionAdded, this, [this](const QString &name, const QString &uuid) {
 		QSignalBlocker sb(ui->transitions);
-		ui->transitions->addItem(name, uuid);
+		OBSSourceAutoRelease transition = obs_get_source_by_uuid(QT_TO_UTF8(uuid));
+		if ((obs_source_get_output_flags(transition) & OBS_SOURCE_FALLBACK) != 0) {
+			QString file = !App()->IsThemeDark() ? ":res/images/no_sources.svg" : "theme:Dark/no_sources.svg";
+			ui->transitions->addItem(QIcon(file), name, uuid);
+		} else {
+			ui->transitions->addItem(name, uuid);
+		}
 	});
 	connect(this, &OBSBasic::TransitionRenamed, this, [this](const QString &uuid, const QString &newName) {
 		QSignalBlocker sb(ui->transitions);

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -1456,7 +1456,13 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitionsData, obs_load_sourc
 		const char *id = obs_data_get_string(item, "id");
 		OBSDataAutoRelease settings = obs_data_get_obj(item, "settings");
 
-		OBSSourceAutoRelease source = obs_source_create_private(id, name, settings);
+		OBSSourceAutoRelease source;
+		if (safe_mode || disable_3p_plugins) {
+			source = obs_source_create_private(id, name, settings);
+		} else {
+			source = obs_source_create_private_with_fallback(id, "cut_transition", name, settings);
+		}
+
 		if (!obs_obj_invalid(source)) {
 			std::string uuid = obs_source_get_uuid(source);
 			InitTransition(source);

--- a/frontend/widgets/OBSBasic_Transitions.cpp
+++ b/frontend/widgets/OBSBasic_Transitions.cpp
@@ -1463,7 +1463,13 @@ void OBSBasic::LoadTransitions(obs_data_array_t *transitionsData, obs_load_sourc
 		const char *id = obs_data_get_string(item, "id");
 		OBSDataAutoRelease settings = obs_data_get_obj(item, "settings");
 
-		OBSSourceAutoRelease source = obs_source_create_private(id, name, settings);
+		OBSSourceAutoRelease source;
+		if (safe_mode || disable_3p_plugins) {
+			source = obs_source_create_private(id, name, settings);
+		} else {
+			source = obs_source_create_private_with_fallback(id, "cut_transition", name, settings);
+		}
+
 		if (!obs_obj_invalid(source)) {
 			std::string uuid = obs_source_get_uuid(source);
 			InitTransition(source);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -527,6 +527,25 @@ obs_source_t *obs_source_create_private(const char *id, const char *name, obs_da
 	return obs_source_create_internal(id, name, NULL, settings, NULL, true, LIBOBS_API_VER, NULL);
 }
 
+static obs_properties_t *fallback_properties(void *data)
+{
+	UNUSED_PARAMETER(data);
+	obs_properties_t *props = obs_properties_create();
+	return props;
+}
+obs_source_t *obs_source_create_private_with_fallback(const char *id, const char *fallback_id, const char *name, obs_data_t *settings)
+{
+	obs_source_t *source = obs_source_create_private(id, name, settings);
+	if (obs_obj_invalid(source)) {
+		obs_source_release(source);
+		source = obs_source_create_private(fallback_id, name, settings);
+		source->info.id = bstrdup(id);
+		source->info.get_properties = fallback_properties;
+		source->info.output_flags |= OBS_SOURCE_FALLBACK;
+	}
+	return source;
+}
+
 obs_source_t *obs_source_create_canvas(obs_canvas_t *canvas, const char *id, const char *name, obs_data_t *settings,
 				       obs_data_t *hotkey_data)
 {

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -563,6 +563,25 @@ obs_source_t *obs_source_create_private(const char *id, const char *name, obs_da
 	return obs_source_create_internal(id, name, NULL, settings, NULL, true, LIBOBS_API_VER, NULL);
 }
 
+static obs_properties_t *fallback_properties(void *data)
+{
+	UNUSED_PARAMETER(data);
+	obs_properties_t *props = obs_properties_create();
+	return props;
+}
+obs_source_t *obs_source_create_private_with_fallback(const char *id, const char *fallback_id, const char *name, obs_data_t *settings)
+{
+	obs_source_t *source = obs_source_create_private(id, name, settings);
+	if (obs_obj_invalid(source)) {
+		obs_source_release(source);
+		source = obs_source_create_private(fallback_id, name, settings);
+		source->info.id = bstrdup(id);
+		source->info.get_properties = fallback_properties;
+		source->info.output_flags |= OBS_SOURCE_FALLBACK;
+	}
+	return source;
+}
+
 obs_source_t *obs_source_create_canvas(obs_canvas_t *canvas, const char *id, const char *name, obs_data_t *settings,
 				       obs_data_t *hotkey_data)
 {

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -208,6 +208,12 @@ enum obs_media_state {
  */
 #define OBS_SOURCE_REQUIRES_CANVAS (1 << 17)
 
+/**
+ * Source is a fallback, meaning the original source is invalid,
+ * and has been replaced by another one. Used for invalid transitions
+ */
+#define OBS_SOURCE_FALLBACK (1 << 18)
+
 /** @} */
 
 typedef void (*obs_source_enum_proc_t)(obs_source_t *parent, obs_source_t *child, void *param);

--- a/libobs/obs.h
+++ b/libobs/obs.h
@@ -1047,6 +1047,13 @@ EXPORT obs_source_t *obs_source_create(const char *id, const char *name, obs_dat
 
 EXPORT obs_source_t *obs_source_create_private(const char *id, const char *name, obs_data_t *settings);
 
+/**
+ * Same as 'obs_source_create_private()' but with a fallback type to use if the requested type is missing or invalid.
+ * This hould not be used outside of OBS
+ */
+EXPORT obs_source_t *obs_source_create_private_with_fallback(const char *id, const char *fallback_id, const char *name,
+							     obs_data_t *settings);
+
 /* if source has OBS_SOURCE_DO_NOT_DUPLICATE output flag set, only returns a
  * reference */
 EXPORT obs_source_t *obs_source_duplicate(obs_source_t *source, const char *desired_name, bool create_private);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

This is a follow-up of PR #9964 which allowed to keep the disabled transition in Safe Mode.  

This PR adds a new source flag `OBS_SOURCE_FALLBACK` and a new function `obs_source_create_private_with_fallback()` in `libobs`.
The `OBS_SOURCE_FALLBACK` flag indicates that the original source type was invalid and replaced by another one.

It allows the frontend to load, save and render an invalid transition using "cut" as fallback.
This approach made the changes very limited and less prone to bugs.

The invalid/fallback'ed transitions shows the `no_sources` icon next to its name in the UI.
(I tried to change the font color to red, but apparently it does not work everywhere, I guess because of how Qt handles theming)
<img width="467" height="178" alt="Screenshot_20260711_032647" src="https://github.com/user-attachments/assets/ef3df616-6596-4ec0-b1e3-32136bba7406" />

The properties UI shows an empty configuration panel when shown:
<img width="484" height="492" alt="Screenshot_20260711_032707" src="https://github.com/user-attachments/assets/51acbba9-1514-46aa-bdaf-eb6ee0903c6d" />

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
With the new Plugin Manager, it is now easier for the user to "mess up" with their configuration and remove transitions by mistake.

Besides, it makes the experience more unified, as the invalid filters and sources are not deleted when the related plugin is not present.

Also, as a plugin developer, any change that breaks the in-dev plugin causes all its transitions to disappear, which is annoying.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
I fully tested the changes on Linux (Ubuntu 26.04) with different scenarii:
- Start with one/multiple invalid transitions ☑️
- Remove an invalid transition ☑️
- Edit transition and press OK → settings are kept ☑️
- Add the plugin back → transitions are restored ☑️

⚠️ There is one thing I don't know how to test: before these changes, a transition would *always* have a registered source type. The fallback approach creates a source that is considered valid but with an id that is *not* registered.  
However, I don't think it's a big issue, since Filters and Sources can already be in a similar situation.  
I do believe that a second pair of eyes would be useful on this.

I explored different solutions to make as few changes as possible and ensure no bug are introduced.
This was the simplest solution I found, although I'm not fond of the `obs_source_create_private_with_fallback()`, to be fair. Maybe someone could use this as a base and find a better solution?


### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
- Documentation (a change to documentation pages)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
