### PR TITLE
frontend: Add defunct Twitch Soundtrack plugin to DLL blocklist

### DIFF
--- a/frontend/utility/win-dll-blocklist.c
+++ b/frontend/utility/win-dll-blocklist.c
@@ -191,6 +191,11 @@ static blocked_module_t blocked_modules[] = {
 	// Different versions seem to be installed in different places, so we have to match on DLL only.
 	// Reference: https://www.hanselman.com/blog/webcam-randomly-pausing-in-obs-discord-and-websites-lsvcam-and-tiktok-studio
 	{L"\\lsvcam.dll", 0, 0, TS_IGNORE},
+
+	// Twitch Soundtrack plugin, causes issues with VOD track.
+	// The app is defunct as of July 2023 and the plugin no longer has a purpose.
+	// Reference: https://github.com/obsproject/obs-studio/issues/13636
+	{L"\\soundtrack-plugin.dll", 0, 0, TS_IGNORE},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
### Description

Blacklists the defunct Twitch Soundtrack app's plugin from loading.

### Motivation and Context

Breaks VOD track, see #13636

### How Has This Been Tested?

Hasn't, the app is long gone and I didn't want to find a random download just to test this. Since we know the DLL name from above issue's log this should probably be good enough though.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
