### PR TITLE
libobs: Prevent loading Mouse1/Mouse2 as hotkeys

### DIFF
--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -458,9 +458,7 @@ static inline void load_modifier(uint32_t *modifiers, obs_data_t *data, const ch
 static inline void create_binding(obs_hotkey_t *hotkey, obs_key_combination_t combo)
 {
 	if (combo.key == OBS_KEY_MOUSE1 || combo.key == OBS_KEY_MOUSE2) {
-		blog(LOG_WARNING,
-		     "obs-hotkey: Refusing to bind Mouse1/Mouse2 as hotkey \"%s\"",
-		     hotkey->name);
+		blog(LOG_WARNING, "obs-hotkey: Refusing to bind Mouse1/Mouse2 as hotkey \"%s\"", hotkey->name);
 		return;
 	}
 

--- a/libobs/obs-hotkey.c
+++ b/libobs/obs-hotkey.c
@@ -457,6 +457,13 @@ static inline void load_modifier(uint32_t *modifiers, obs_data_t *data, const ch
 
 static inline void create_binding(obs_hotkey_t *hotkey, obs_key_combination_t combo)
 {
+	if (combo.key == OBS_KEY_MOUSE1 || combo.key == OBS_KEY_MOUSE2) {
+		blog(LOG_WARNING,
+		     "obs-hotkey: Refusing to bind Mouse1/Mouse2 as hotkey \"%s\"",
+		     hotkey->name);
+		return;
+	}
+
 	obs_hotkey_binding_t *binding = da_push_back_new(obs->hotkeys.bindings);
 	if (!binding)
 		return;


### PR DESCRIPTION
### Description

Prevents Mouse1 and Mouse2 from being loaded as hotkey bindings. The UI already blocks these from being set, but if someone manually edits their scene collection JSON to add these as hotkeys, OBS would previously still load them and cause unexpected behavior.

The fix adds a validation guard in create_binding() - the single choke point through which ALL hotkey bindings are created. This covers both JSON loading (load_binding ? create_binding) and programmatic binding (obs_hotkey_load_bindings ? create_binding) paths.

### Motivation and Context

Fixes #13403

### How Has This Been Tested?

Code review and verification of the guard logic. The change is small and targeted - any attempt to bind Mouse1 or Mouse2 is now rejected with a LOG_WARNING diagnostic message.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] All commit messages are properly formatted and commits squashed where appropriate.