### PR TITLE
Fix inserted SEI NAL order in AVC outputs

### DIFF
--- a/libobs/obs-avc.c
+++ b/libobs/obs-avc.c
@@ -52,6 +52,35 @@ const uint8_t *obs_avc_find_startcode(const uint8_t *p, const uint8_t *end)
 	return obs_nal_find_startcode(p, end);
 }
 
+const uint8_t *obs_avc_find_first_vcl_nal(const uint8_t *p, size_t size)
+{
+	const uint8_t *const end = p + size;
+	const uint8_t *nal_start = obs_nal_find_startcode(p, end);
+	const uint8_t *vcl_start = NULL;
+
+	while (true) {
+		const uint8_t *original_start = nal_start;
+		/* Skip start code */
+		while (nal_start < end && !*(nal_start++))
+			;
+
+		if (nal_start == end)
+			break;
+
+		/* Type 1-5 are VCL NALs */
+		const int type = nal_start[0] & 0x1F;
+		if (type == OBS_NAL_SLICE || type == OBS_NAL_SLICE_DPA || type == OBS_NAL_SLICE_DPB ||
+		    type == OBS_NAL_SLICE_DPC || type == OBS_NAL_SLICE_IDR) {
+			vcl_start = original_start;
+			break;
+		}
+
+		nal_start = obs_nal_find_startcode(nal_start, end);
+	}
+
+	return vcl_start;
+}
+
 static int compute_avc_keyframe_priority(const uint8_t *nal_start, bool *is_keyframe, int priority)
 {
 	const int type = nal_start[0] & 0x1F;

--- a/libobs/obs-avc.h
+++ b/libobs/obs-avc.h
@@ -43,6 +43,7 @@ enum {
 
 EXPORT bool obs_avc_keyframe(const uint8_t *data, size_t size);
 EXPORT const uint8_t *obs_avc_find_startcode(const uint8_t *p, const uint8_t *end);
+EXPORT const uint8_t *obs_avc_find_first_vcl_nal(const uint8_t *p, size_t size);
 EXPORT void obs_parse_avc_packet(struct encoder_packet *avc_packet, const struct encoder_packet *src);
 EXPORT int obs_parse_avc_packet_priority(const struct encoder_packet *packet);
 EXPORT size_t obs_parse_avc_header(uint8_t **header, const uint8_t *data, size_t size);

--- a/libobs/obs-output.c
+++ b/libobs/obs-output.c
@@ -23,6 +23,7 @@
 #include "obs.h"
 #include "obs-internal.h"
 #include "obs-av1.h"
+#include "obs-avc.h"
 
 #include <caption/caption.h>
 #include <caption/mpeg.h>
@@ -1627,10 +1628,18 @@ static bool add_caption(struct obs_output *output, struct encoder_packet *out)
 		 * mechanisms. A slightly modified SEI for HEVC and a metadata
 		 * OBU for AV1. */
 		if (avc) {
-			/* TODO: SEI should come after AUD/SPS/PPS,
-			 * but before any VCL */
-			da_push_back_array(out_data, nal_start, 4);
-			da_push_back_array(out_data, data, size);
+			/* Find the first VCL NAL to insert SEIs at the correct location. */
+			const uint8_t *first_vcl_nal = obs_avc_find_first_vcl_nal(out_data.array, out_data.num);
+
+			if (first_vcl_nal != NULL) {
+				size_t idx = first_vcl_nal - out_data.array;
+				da_insert_array(out_data, idx, nal_start, 4);
+				da_insert_array(out_data, idx + 4, data, size);
+			} else {
+				/* Fallback: Just insert at end */
+				da_push_back_array(out_data, nal_start, 4);
+				da_push_back_array(out_data, data, size);
+			}
 #ifdef ENABLE_HEVC
 		} else if (hevc) {
 			/* Only first NAL (VPS/PPS/SPS) should use the 4 byte

--- a/shared/bpm/bpm.c
+++ b/shared/bpm/bpm.c
@@ -1,4 +1,5 @@
 #include "obs.h"
+#include "obs-avc.h"
 #include "bpm-internal.h"
 
 static void render_metrics_time(struct metrics_time *m_time)
@@ -415,10 +416,19 @@ static bool process_metrics(obs_output_t *output, struct encoder_packet *out, st
 				 * A slightly modified SEI for HEVC and a metadata OBU for AV1.
 				 */
 				if (avc) {
-					/* TODO: SEI should come after AUD/SPS/PPS,
-					 * but before any VCL */
-					da_push_back_array(out_data, nal_start, 4);
-					da_push_back_array(out_data, data, size);
+					/* Find the first VCL NAL to insert SEIs at the correct location. */
+					const uint8_t *first_vcl_nal =
+						obs_avc_find_first_vcl_nal(out_data.array, out_data.num);
+
+					if (first_vcl_nal != NULL) {
+						size_t idx = first_vcl_nal - out_data.array;
+						da_insert_array(out_data, idx, nal_start, 4);
+						da_insert_array(out_data, idx + 4, data, size);
+					} else {
+						/* Fallback: Just insert at end */
+						da_push_back_array(out_data, nal_start, 4);
+						da_push_back_array(out_data, data, size);
+					}
 #ifdef ENABLE_HEVC
 				} else if (hevc) {
 					/* Only first NAL (VPS/PPS/SPS) should use the 4 byte


### PR DESCRIPTION
### Description

Fixes the position where SEI NALs are inserted into AVC bitstreams.

### Motivation and Context

H.264 specification section 7.4.1.2.3 "Order of NAL units and coded pictures and association to access units" clarifies that SEI NALs shall come before any VCL NALs:
> - When any SEI NAL units are present, they shall precede the primary coded picture

Apparently the current method (just appending the SEIs) can cause issues with Android playback in some cases. 

This is analogous to #12658 which addressed a similar issue for HEVC. AVC does not have a "suffix" SEI type, so we actually need to insert them at the correct position.

### How Has This Been Tested?

Recorded some videos locally (Hybrid MP4 supports the `bpm=1` option to manually enable BPM insertion for testing) and verified with a bitstream analyzer (StreamEye) that SEIs are now inserted at the correct position in the output bitstream.

My coworker who was working on diagnosing the issue on her Android phone has also confirmed that with this PR applied the issue is fixed.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
