### PR TITLE
rtmp-services: Add Velora.tv

### DIFF
--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -385,6 +385,18 @@
             ]
         },
         {
+            "name": "Velora.tv",
+            "servers": [
+                {
+                    "name": "Velora.tv Main Server"
+                    "url": "rtmp://publish.velora.tv/live"
+                }
+            ],
+            "supported video codecs": [
+                "h264"
+            ]
+        },
+        {
             "name": "Vaughn Live / iNSTAGIB",
             "servers": [
                 {


### PR DESCRIPTION
### Description
This adds Velora.tv to the dropdown list of OBS Studio

### Motivation and Context
This allows streamers on VeloraTV to just put in their streamkey and go live from there without needing to add the RTMP URL as well.

### How Has This Been Tested?
This has been tested on a separate RTMP file in a separate Repo of mine.
- OS: Fedora 44 KDE Plasma under the Wayland session
- Tests Ran: Using a valid streamkey from my VeloraTV account and replacing the existing `services.json` on my Local OBS Studio install, I was able to successfully go live on my channel.

### Types of changes
- New feature (non-breaking change which adds functionality) 
- Tweak (non-breaking change to improve existing functionality) 

### Checklist:
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [X] My code is not on the master branch.
- [X] My code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [X] I have included updates to all appropriate documentation.
