### PR TITLE
frontend: Add Image SAFER to DLL blocklist

### DIFF
--- a/frontend/utility/win-dll-blocklist.c
+++ b/frontend/utility/win-dll-blocklist.c
@@ -196,6 +196,11 @@ static blocked_module_t blocked_modules[] = {
 	// The app is defunct as of July 2023 and the plugin no longer has a purpose.
 	// Reference: https://github.com/obsproject/obs-studio/issues/13636
 	{L"\\soundtrack-plugin.dll", 0, 0, TS_IGNORE},
+
+	// More Korean banking anti-screenshot "security" software that injects and crashes OBS.
+	// Found via internal crash reports. Classified as malware by some vendors.
+	// Reference: https://vms.drweb.com/virus/?i=32005995
+	{L"\\imgsf50dxfilter_x64.dll", 0, 0, TS_IGNORE},
 };
 
 static bool is_module_blocked(wchar_t *dll, uint32_t timestamp)


### PR DESCRIPTION
### Description
More useless "security" software to try to prevent screenshots that installs global hooks and kernel drivers. Crash reports indicate that their hook attaches to and subsequently crashes OBS.

### Motivation and Context
Prevent crashes from shitty 3rd party software.

### How Has This Been Tested?
Not tested, prefer not to install random likely-buggy kernel drivers on my PC.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
