### PR TITLE
obs-nvenc: Handle invalid GPU indices

### DIFF
--- a/plugins/obs-nvenc/data/locale/en-US.ini
+++ b/plugins/obs-nvenc/data/locale/en-US.ini
@@ -58,7 +58,7 @@ Opts.Invalid="Invalid Custom Encoder options, check the log for details.<br><br>
 
 Error="Failed to open NVENC codec: %1"
 GenericError="Try installing the latest <a href=\"https://obsproject.com/go/nvidia-drivers\">NVIDIA driver</a> and closing other recording software that might be using NVENC such as NVIDIA ShadowPlay or Windows Game DVR."
-BadGPUIndex="You have selected GPU %1 in your output encoder settings. Set this back to 0 and try again."
+BadGPUIndex="Invalid GPU index %1 selected!<br>There are %2 NVIDIA devices, valid indices are 0-%3."
 OutdatedDriver="The installed NVIDIA driver does not support this NVENC version, try <a href=\"https://obsproject.com/go/nvidia-drivers\">updating the driver</a>."
 UnsupportedDevice="NVENC Error: Unsupported device. Check that your video card <a href=\"https://obsproject.com/go/nvenc-matrix\">supports NVENC</a> and try <a href=\"https://obsproject.com/go/nvidia-drivers\">updating the driver</a>."
 TooManySessions="NVENC Error: Too many concurrent sessions. Try closing other recording software that might be using NVENC such as NVIDIA ShadowPlay or Windows Game DVR."

--- a/plugins/obs-nvenc/nvenc-cuda.c
+++ b/plugins/obs-nvenc/nvenc-cuda.c
@@ -19,6 +19,10 @@ bool cuda_ctx_init(struct nvenc_data *enc, obs_data_t *settings, const bool text
 	CUdevice device;
 
 	int gpu = (int)obs_data_get_int(settings, "device");
+	/* Ignore invalid GPU incides */
+	if (gpu >= num_encoder_devices()) {
+		gpu = 0;
+	}
 #ifndef _WIN32
 	/* CUDA can do fairly efficient cross-GPU OpenGL mappings, allow it as
 	 * a hidden option for experimentation. */

--- a/plugins/obs-nvenc/nvenc.c
+++ b/plugins/obs-nvenc/nvenc.c
@@ -4,6 +4,8 @@
 #include <util/darray.h>
 #include <util/dstr.h>
 
+#include <stdio.h>
+
 /* ========================================================================= */
 
 #define EXTRA_BUFFERS 5
@@ -935,15 +937,42 @@ static void *nvenc_create_base(enum codec_type codec, obs_data_t *settings, obs_
 	 */
 	const int gpu = (int)obs_data_get_int(settings, "device");
 	const bool gpu_set = obs_data_has_user_value(settings, "device");
+	const int devices = num_encoder_devices();
 #ifndef _WIN32
 	const bool force_tex = obs_data_get_bool(settings, "force_cuda_tex");
 #else
 	const bool force_tex = false;
 #endif
 
-	if (gpu_set && gpu != -1 && texture && !force_tex) {
-		blog(LOG_INFO, "[obs-nvenc] different GPU selected by user, falling back "
-			       "to non-texture encoder");
+	if (gpu_set && gpu >= devices) {
+		if (devices == 1) {
+			blog(LOG_WARNING, "[obs-nvenc] Nonzero GPU index when only one device is available, ignoring.");
+		} else {
+			struct dstr error_message;
+			char gpu_str[16];
+
+			dstr_init_copy(&error_message, obs_module_text("BadGPUIndex"));
+			/* Selected index */
+			snprintf(gpu_str, sizeof(gpu_str) - 1, "%d", gpu);
+			gpu_str[sizeof(gpu_str) - 1] = 0;
+			dstr_replace(&error_message, "%1", gpu_str);
+			/* Number of devices */
+			snprintf(gpu_str, sizeof(gpu_str) - 1, "%d", devices);
+			gpu_str[sizeof(gpu_str) - 1] = 0;
+			dstr_replace(&error_message, "%2", gpu_str);
+			/* Maximum valid index */
+			snprintf(gpu_str, sizeof(gpu_str) - 1, "%d", devices - 1);
+			gpu_str[sizeof(gpu_str) - 1] = 0;
+			dstr_replace(&error_message, "%3", gpu_str);
+
+			obs_encoder_set_last_error(encoder, error_message.array);
+			dstr_free(&error_message);
+
+			blog(LOG_ERROR, "[obs-nvenc] User has set invalid GPU index (%d >= %d)", gpu, devices);
+			return NULL;
+		}
+	} else if (gpu_set && gpu != -1 && texture && !force_tex) {
+		blog(LOG_INFO, "[obs-nvenc] different GPU selected by user, falling back to non-texture encoder");
 		goto reroute;
 	}
 


### PR DESCRIPTION
### Description

Adds some extra handling of invalid GPU indices:
- If there's only one NVIDIA GPU: Ignore it since the property control will be hidden and the user can't fix it
- If there's more than one: Set an encoder error and fail initialising earlier

### Motivation and Context

Various reports of people removing an NVIDIA GPU and running into this problem.

### How Has This Been Tested?

Manually edited the config to see what happens.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
