### PR TITLE
frontend: Add 'Do not show again' to multitrack warning dialog

### DIFF
--- a/frontend/utility/GoLiveAPI_Network.cpp
+++ b/frontend/utility/GoLiveAPI_Network.cpp
@@ -4,9 +4,11 @@
 #include <OBSApp.hpp>
 #include <utility/MultitrackVideoError.hpp>
 #include <utility/RemoteTextThread.hpp>
+#include <widgets/OBSBasic.hpp>
 
 #include <obs.hpp>
 
+#include <QCheckBox>
 #include <QMessageBox>
 #include <QThreadPool>
 #include <nlohmann/json.hpp>
@@ -32,6 +34,12 @@ void HandleGoLiveApiErrors(QWidget *parent, const json &raw_json, const GoLiveAp
 	}
 
 	auto warn_continue = [&](QString message) {
+		if (config_get_bool(OBSBasic::Get()->Config(), "Stream1", "MultitrackVideoSkipWarningDialog")) {
+			blog(LOG_WARNING, "Go live config status warning (dialog suppressed): %s",
+			     message.toUtf8().constData());
+			return;
+		}
+
 		bool ret = false;
 		QMetaObject::invokeMethod(
 			parent,
@@ -43,7 +51,17 @@ void HandleGoLiveApiErrors(QWidget *parent, const json &raw_json, const GoLiveAp
 				mb.setText(message + QTStr("FailedToStartStream.WarningRetry"));
 				mb.setStandardButtons(QMessageBox::StandardButton::Yes |
 						      QMessageBox::StandardButton::No);
-				return mb.exec() == QMessageBox::StandardButton::No;
+
+				QCheckBox *dontShowAgain = new QCheckBox(QTStr("DoNotShowAgain"), &mb);
+				mb.setCheckBox(dontShowAgain);
+
+				bool cancel = mb.exec() == QMessageBox::StandardButton::No;
+				if (!cancel && dontShowAgain->isChecked()) {
+					config_t *config = OBSBasic::Get()->Config();
+					config_set_bool(config, "Stream1", "MultitrackVideoSkipWarningDialog", true);
+					config_save_safe(config, "tmp", nullptr);
+				}
+				return cancel;
 			},
 			BlockingConnectionTypeFor(parent), &ret);
 		if (ret) {


### PR DESCRIPTION
### Description

Always skip the Twitch Enhanced Broadcasting dialog that pops up when clicking "Start Streaming"

### Motivation and Context
Hello 👋 

I'm echohack and I've been streaming to twitch for 16 years on MacOS. (Proof: https://www.twitch.tv/echohack) I currently use a Mac Pro M2 and it has plenty of power to support Twitch's Enhanced Broadcasting (In fact, I stream multi-platform with LOTS of other things enabled, with plenty plenty of overhead). However, at stream connection time, twitch sends a warning string to the client which pops up an annoying modal to the user as so:

<img width="414" height="262" alt="Screenshot 2026-07-16 at 10 41 38" src="https://github.com/user-attachments/assets/1268fadb-6b46-4d13-a5af-17c31d0ea35c" />

This adds an unnecessary button press for anyone who wants to just go live. It's a nag modal, and it kind of holds the user hostage until they click yes. In other words, twitch is able to annoy any user with a warning message, with no way for the user to suppress the warning.

In this scenario, I will *always* click yes.

Thus, I wanted to add a checkbox that allows the user to remember to always skip it.

I've been dealing with this for months and months by hand and I'm kind of sick of it. Please consider my pull request. Thank you!!!!


### How Has This Been Tested?

Tested locally on my Mac Pro M2. This is a UI only change, plus an ini setting.

### Types of changes
- Tweak (non-breaking change to improve existing functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
