### PR TITLE
libobs: Add global hotkey support on Wayland

### DIFF
--- a/libobs/cmake/os-linux.cmake
+++ b/libobs/cmake/os-linux.cmake
@@ -84,9 +84,19 @@ endif()
 if(ENABLE_WAYLAND)
   find_package(Wayland REQUIRED Client)
   find_package(Xkbcommon REQUIRED)
+  find_package(WaylandScanner REQUIRED)
 
   target_sources(libobs PRIVATE obs-nix-wayland.c)
   target_link_libraries(libobs PRIVATE Wayland::Client xkbcommon::xkbcommon)
+
+  # Client stubs for the vendored vicinae-hotkey protocol, generated into CMAKE_CURRENT_BINARY_DIR
+  ecm_add_wayland_client_protocol(
+    libobs
+    PROTOCOL "${CMAKE_CURRENT_SOURCE_DIR}/wayland-protocols/vicinae-hotkey-v1.xml"
+    BASENAME vicinae-hotkey-v1
+  )
+  target_include_directories(libobs PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")
+
   target_enable_feature(libobs "Wayland compositor support (Linux)")
 else()
   target_disable_feature(libobs "Wayland compositor support (Linux)")

--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -22,14 +22,33 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <string.h>
+#include <poll.h>
+#include <errno.h>
+#include <pthread.h>
 
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+
+#include "wayland-vicinae-hotkey-v1-client-protocol.h"
 
 // X11 only supports 256 scancodes, most keyboards dont have 256 keys so this should be reasonable.
 #define MAX_KEYCODES 256
 // X11 keymaps only have 4 shift levels, im not sure xkbcommon supports a way to shift the state into a higher level anyway.
 #define MAX_SHIFT_LEVELS 4
+
+/* An OBS key combination: INTERACT_* modifier bits plus the trigger key. */
+struct vicinae_combo {
+	uint32_t modifiers;
+	obs_key_t key;
+};
+
+/* Heap allocated so its address stays stable as wl listener user data. */
+struct vicinae_binding {
+	obs_hotkeys_platform_t *plat;
+	struct vicinae_combo combo;
+	struct vicinae_hotkey_v1 *obj;
+	bool active;
+};
 
 struct obs_hotkeys_platform {
 	struct wl_display *display;
@@ -41,9 +60,24 @@ struct obs_hotkeys_platform {
 	xkb_keysym_t key_to_sym[MAX_SHIFT_LEVELS][MAX_KEYCODES];
 	xkb_keysym_t obs_to_key[OBS_KEY_LAST_VALUE];
 	uint32_t current_layout;
+
+	/* vicinae_hotkey_v1 state, owned by the vicinae thread, except
+	 * vicinae_held which is also read by the libobs hotkey thread and is
+	 * guarded by vicinae_mutex. */
+	struct wl_event_queue *vicinae_queue;
+	struct vicinae_hotkey_manager_v1 *vicinae_manager;
+	pthread_t vicinae_thread;
+	bool vicinae_thread_active;
+	volatile bool vicinae_running;
+	int vicinae_stop_pipe[2];
+	pthread_mutex_t vicinae_mutex;
+	DARRAY(struct vicinae_binding *) vicinae_bindings;
+	DARRAY(struct vicinae_combo) vicinae_denied;
+	DARRAY(struct vicinae_combo) vicinae_held;
 };
 
 static obs_key_t obs_nix_wayland_key_from_virtual_key(int sym);
+static int obs_nix_wayland_key_to_virtual_key(obs_key_t key);
 
 static void load_keymap_data(struct xkb_keymap *keymap, xkb_keycode_t key, void *data)
 {
@@ -225,6 +259,374 @@ const struct wl_registry_listener registry_listener = {
 	.global_remove = platform_registry_remover,
 };
 
+/* The libobs hotkey thread drives press/release detection off is_pressed().
+ * On X11 that polls the X server, but Wayland never delivers key events to
+ * unfocused clients, so out-of-focus hotkeys historically did not work. When
+ * the compositor supports vicinae_hotkey_v1 we instead bind every distinct
+ * OBS combination as a global hotkey, track which ones the compositor reports
+ * as held, and answer is_pressed() from that set. */
+
+static inline bool vicinae_combo_equal(const struct vicinae_combo *a, const struct vicinae_combo *b)
+{
+	return a->key == b->key && a->modifiers == b->modifiers;
+}
+
+static inline uint32_t obs_modifiers_to_vicinae(uint32_t modifiers)
+{
+	uint32_t bits = 0;
+	if (modifiers & INTERACT_SHIFT_KEY)
+		bits |= VICINAE_HOTKEY_MANAGER_V1_MODIFIERS_SHIFT;
+	if (modifiers & INTERACT_CONTROL_KEY)
+		bits |= VICINAE_HOTKEY_MANAGER_V1_MODIFIERS_CTRL;
+	if (modifiers & INTERACT_ALT_KEY)
+		bits |= VICINAE_HOTKEY_MANAGER_V1_MODIFIERS_ALT;
+	if (modifiers & INTERACT_COMMAND_KEY)
+		bits |= VICINAE_HOTKEY_MANAGER_V1_MODIFIERS_SUPER;
+	return bits;
+}
+
+/* The protocol expects unshifted keysyms (XKB_KEY_b, not XKB_KEY_B), so
+ * prefer the live keymap and lowercase letters from the fallback table. */
+static uint32_t vicinae_keysym_for_key(obs_hotkeys_platform_t *plat, obs_key_t key)
+{
+	if (key >= OBS_KEY_MOUSE1 && key <= OBS_KEY_MOUSE29)
+		return 0;
+
+	xkb_keycode_t keycode = plat->obs_to_key[key];
+	if (keycode) {
+		xkb_keysym_t sym = plat->key_to_sym[0][keycode];
+		if (sym)
+			return sym;
+	}
+
+	int sym = obs_nix_wayland_key_to_virtual_key(key);
+	if (sym >= XKB_KEY_A && sym <= XKB_KEY_Z)
+		sym = sym - XKB_KEY_A + XKB_KEY_a;
+	return (uint32_t)sym;
+}
+
+static void vicinae_held_set(obs_hotkeys_platform_t *plat, const struct vicinae_combo *combo, bool pressed)
+{
+	pthread_mutex_lock(&plat->vicinae_mutex);
+	size_t idx = DARRAY_INVALID;
+	for (size_t i = 0; i < plat->vicinae_held.num; i++) {
+		if (vicinae_combo_equal(&plat->vicinae_held.array[i], combo)) {
+			idx = i;
+			break;
+		}
+	}
+	if (pressed && idx == DARRAY_INVALID)
+		da_push_back(plat->vicinae_held, combo);
+	else if (!pressed && idx != DARRAY_INVALID)
+		da_erase(plat->vicinae_held, idx);
+	pthread_mutex_unlock(&plat->vicinae_mutex);
+}
+
+static void vicinae_hotkey_handle_bound(void *data, struct vicinae_hotkey_v1 *hotkey)
+{
+	UNUSED_PARAMETER(hotkey);
+	struct vicinae_binding *vb = data;
+	vb->active = true;
+	blog(LOG_DEBUG, "[wayland] global hotkey bound (key %d, mods 0x%x)", (int)vb->combo.key, vb->combo.modifiers);
+}
+
+static void vicinae_remove_binding(obs_hotkeys_platform_t *plat, struct vicinae_binding *vb, bool deny)
+{
+	struct vicinae_combo combo = vb->combo;
+	vicinae_held_set(plat, &combo, false);
+
+	for (size_t i = 0; i < plat->vicinae_bindings.num; i++) {
+		if (plat->vicinae_bindings.array[i] == vb) {
+			da_erase(plat->vicinae_bindings, i);
+			break;
+		}
+	}
+
+	if (vb->obj)
+		vicinae_hotkey_v1_destroy(vb->obj);
+	bfree(vb);
+
+	if (deny)
+		da_push_back(plat->vicinae_denied, &combo);
+}
+
+static void vicinae_hotkey_handle_denied(void *data, struct vicinae_hotkey_v1 *hotkey, uint32_t reason,
+					 const char *message)
+{
+	UNUSED_PARAMETER(hotkey);
+	struct vicinae_binding *vb = data;
+	blog(LOG_DEBUG, "[wayland] global hotkey denied (key %d, mods 0x%x, reason %u): %s", (int)vb->combo.key,
+	     vb->combo.modifiers, reason, message ? message : "");
+	/* Remember the denial so reconcile does not keep re-requesting it. */
+	vicinae_remove_binding(vb->plat, vb, true);
+}
+
+static void vicinae_hotkey_handle_revoked(void *data, struct vicinae_hotkey_v1 *hotkey, uint32_t reason,
+					  const char *message)
+{
+	UNUSED_PARAMETER(hotkey);
+	struct vicinae_binding *vb = data;
+	blog(LOG_DEBUG, "[wayland] global hotkey revoked (key %d, mods 0x%x, reason %u): %s", (int)vb->combo.key,
+	     vb->combo.modifiers, reason, message ? message : "");
+	/* Re-request later only if the combination was merely superseded;
+	 * removals and policy changes must not be silently re-bound. */
+	bool deny = reason != VICINAE_HOTKEY_V1_REVOKE_REASON_SUPERSEDED;
+	vicinae_remove_binding(vb->plat, vb, deny);
+}
+
+static void vicinae_hotkey_handle_pressed(void *data, struct vicinae_hotkey_v1 *hotkey, uint32_t serial, uint32_t time)
+{
+	UNUSED_PARAMETER(hotkey);
+	UNUSED_PARAMETER(serial);
+	UNUSED_PARAMETER(time);
+	struct vicinae_binding *vb = data;
+	vicinae_held_set(vb->plat, &vb->combo, true);
+}
+
+static void vicinae_hotkey_handle_released(void *data, struct vicinae_hotkey_v1 *hotkey, uint32_t serial, uint32_t time)
+{
+	UNUSED_PARAMETER(hotkey);
+	UNUSED_PARAMETER(serial);
+	UNUSED_PARAMETER(time);
+	struct vicinae_binding *vb = data;
+	vicinae_held_set(vb->plat, &vb->combo, false);
+}
+
+static const struct vicinae_hotkey_v1_listener vicinae_hotkey_listener = {
+	.bound = vicinae_hotkey_handle_bound,
+	.denied = vicinae_hotkey_handle_denied,
+	.revoked = vicinae_hotkey_handle_revoked,
+	.pressed = vicinae_hotkey_handle_pressed,
+	.released = vicinae_hotkey_handle_released,
+};
+
+static void vicinae_registry_global(void *data, struct wl_registry *registry, uint32_t name, const char *interface,
+				    uint32_t version)
+{
+	obs_hotkeys_platform_t *plat = data;
+	if (strcmp(interface, vicinae_hotkey_manager_v1_interface.name) == 0) {
+		uint32_t bind_version = version < 1 ? version : 1;
+		plat->vicinae_manager =
+			wl_registry_bind(registry, name, &vicinae_hotkey_manager_v1_interface, bind_version);
+	}
+}
+
+static void vicinae_registry_global_remove(void *data, struct wl_registry *registry, uint32_t name)
+{
+	UNUSED_PARAMETER(data);
+	UNUSED_PARAMETER(registry);
+	UNUSED_PARAMETER(name);
+}
+
+static const struct wl_registry_listener vicinae_registry_listener = {
+	.global = vicinae_registry_global,
+	.global_remove = vicinae_registry_global_remove,
+};
+
+static bool vicinae_has_binding(obs_hotkeys_platform_t *plat, const struct vicinae_combo *combo)
+{
+	for (size_t i = 0; i < plat->vicinae_bindings.num; i++) {
+		if (vicinae_combo_equal(&plat->vicinae_bindings.array[i]->combo, combo))
+			return true;
+	}
+	return false;
+}
+
+static bool vicinae_combo_in(const struct darray *list, const struct vicinae_combo *combo)
+{
+	const struct vicinae_combo *array = list->array;
+	for (size_t i = 0; i < list->num; i++) {
+		if (vicinae_combo_equal(&array[i], combo))
+			return true;
+	}
+	return false;
+}
+
+/* Make the set of vicinae_hotkey_v1 objects match the combinations OBS has
+ * bound. Runs on the vicinae thread. */
+static void vicinae_reconcile(obs_hotkeys_platform_t *plat)
+{
+	if (!plat->vicinae_manager)
+		return;
+
+	DARRAY(struct vicinae_combo) desired;
+	da_init(desired);
+
+	pthread_mutex_lock(&obs->hotkeys.mutex);
+	for (size_t i = 0; i < obs->hotkeys.bindings.num; i++) {
+		obs_hotkey_binding_t *binding = &obs->hotkeys.bindings.array[i];
+		struct vicinae_combo combo = {binding->key.modifiers, binding->key.key};
+		if (combo.key == OBS_KEY_NONE || combo.key >= OBS_KEY_LAST_VALUE)
+			continue;
+		if (combo.key >= OBS_KEY_MOUSE1 && combo.key <= OBS_KEY_MOUSE29)
+			continue;
+		if (!vicinae_combo_in(&desired.da, &combo))
+			da_push_back(desired, &combo);
+	}
+	pthread_mutex_unlock(&obs->hotkeys.mutex);
+
+	for (size_t i = plat->vicinae_bindings.num; i > 0; i--) {
+		struct vicinae_binding *vb = plat->vicinae_bindings.array[i - 1];
+		if (!vicinae_combo_in(&desired.da, &vb->combo))
+			vicinae_remove_binding(plat, vb, false);
+	}
+
+	/* Forget denials for combinations no longer in use so a reconfigured
+	 * shortcut gets another chance. */
+	for (size_t i = plat->vicinae_denied.num; i > 0; i--) {
+		if (!vicinae_combo_in(&desired.da, &plat->vicinae_denied.array[i - 1]))
+			da_erase(plat->vicinae_denied, i - 1);
+	}
+
+	for (size_t i = 0; i < desired.num; i++) {
+		struct vicinae_combo combo = desired.array[i];
+		if (vicinae_has_binding(plat, &combo) || vicinae_combo_in(&plat->vicinae_denied.da, &combo))
+			continue;
+
+		uint32_t keysym = vicinae_keysym_for_key(plat, combo.key);
+		if (!keysym)
+			continue;
+
+		struct vicinae_binding *vb = bzalloc(sizeof(struct vicinae_binding));
+		vb->plat = plat;
+		vb->combo = combo;
+		vb->obj = vicinae_hotkey_manager_v1_bind(plat->vicinae_manager, keysym,
+							 obs_modifiers_to_vicinae(combo.modifiers), NULL,
+							 "com.obsproject.Studio", "OBS Studio hotkey");
+		vicinae_hotkey_v1_add_listener(vb->obj, &vicinae_hotkey_listener, vb);
+		da_push_back(plat->vicinae_bindings, &vb);
+	}
+
+	da_free(desired);
+}
+
+static void *vicinae_thread(void *arg)
+{
+	obs_hotkeys_platform_t *plat = arg;
+	struct wl_display *display = plat->display;
+	struct wl_event_queue *queue = plat->vicinae_queue;
+
+	os_set_thread_name("libobs: vicinae hotkey thread");
+
+	struct pollfd fds[2];
+	fds[0].fd = wl_display_get_fd(display);
+	fds[0].events = POLLIN;
+	fds[1].fd = plat->vicinae_stop_pipe[0];
+	fds[1].events = POLLIN;
+
+	while (os_atomic_load_bool(&plat->vicinae_running)) {
+		vicinae_reconcile(plat);
+
+		while (wl_display_prepare_read_queue(display, queue) != 0)
+			wl_display_dispatch_queue_pending(display, queue);
+		wl_display_flush(display);
+
+		fds[0].revents = 0;
+		fds[1].revents = 0;
+		int ret = poll(fds, 2, 250);
+		if (ret < 0) {
+			wl_display_cancel_read(display);
+			if (errno == EINTR)
+				continue;
+			break;
+		}
+
+		if (!os_atomic_load_bool(&plat->vicinae_running) || (fds[1].revents & POLLIN)) {
+			wl_display_cancel_read(display);
+			break;
+		}
+
+		if (fds[0].revents & POLLIN) {
+			if (wl_display_read_events(display) < 0)
+				break;
+			wl_display_dispatch_queue_pending(display, queue);
+		} else {
+			wl_display_cancel_read(display);
+		}
+	}
+
+	return NULL;
+}
+
+static void vicinae_init(obs_hotkeys_platform_t *plat)
+{
+	struct wl_display *display = plat->display;
+
+	plat->vicinae_queue = wl_display_create_queue(display);
+
+	struct wl_registry *registry = wl_display_get_registry(display);
+	wl_proxy_set_queue((struct wl_proxy *)registry, plat->vicinae_queue);
+	wl_registry_add_listener(registry, &vicinae_registry_listener, plat);
+	wl_display_roundtrip_queue(display, plat->vicinae_queue);
+	wl_registry_destroy(registry);
+
+	if (!plat->vicinae_manager) {
+		blog(LOG_INFO, "[wayland] vicinae_hotkey_v1 not available; "
+			       "global hotkeys are limited to when OBS is focused");
+		wl_event_queue_destroy(plat->vicinae_queue);
+		plat->vicinae_queue = NULL;
+		return;
+	}
+
+	if (pipe(plat->vicinae_stop_pipe) != 0) {
+		blog(LOG_WARNING, "[wayland] failed to create vicinae stop pipe; global hotkeys disabled");
+		vicinae_hotkey_manager_v1_destroy(plat->vicinae_manager);
+		plat->vicinae_manager = NULL;
+		wl_event_queue_destroy(plat->vicinae_queue);
+		plat->vicinae_queue = NULL;
+		return;
+	}
+
+	os_atomic_set_bool(&plat->vicinae_running, true);
+	if (pthread_create(&plat->vicinae_thread, NULL, vicinae_thread, plat) == 0) {
+		plat->vicinae_thread_active = true;
+		blog(LOG_INFO, "[wayland] vicinae_hotkey_v1 available; global hotkeys enabled");
+	} else {
+		os_atomic_set_bool(&plat->vicinae_running, false);
+		blog(LOG_WARNING, "[wayland] failed to start vicinae hotkey thread; global hotkeys disabled");
+		close(plat->vicinae_stop_pipe[0]);
+		close(plat->vicinae_stop_pipe[1]);
+		vicinae_hotkey_manager_v1_destroy(plat->vicinae_manager);
+		plat->vicinae_manager = NULL;
+		wl_event_queue_destroy(plat->vicinae_queue);
+		plat->vicinae_queue = NULL;
+	}
+}
+
+static void vicinae_free(obs_hotkeys_platform_t *plat)
+{
+	if (plat->vicinae_thread_active) {
+		os_atomic_set_bool(&plat->vicinae_running, false);
+		const char stop = 1;
+		(void)!write(plat->vicinae_stop_pipe[1], &stop, 1);
+		pthread_join(plat->vicinae_thread, NULL);
+		plat->vicinae_thread_active = false;
+		close(plat->vicinae_stop_pipe[0]);
+		close(plat->vicinae_stop_pipe[1]);
+	}
+
+	for (size_t i = 0; i < plat->vicinae_bindings.num; i++) {
+		struct vicinae_binding *vb = plat->vicinae_bindings.array[i];
+		if (vb->obj)
+			vicinae_hotkey_v1_destroy(vb->obj);
+		bfree(vb);
+	}
+	da_free(plat->vicinae_bindings);
+	da_free(plat->vicinae_denied);
+	da_free(plat->vicinae_held);
+
+	if (plat->vicinae_manager) {
+		vicinae_hotkey_manager_v1_destroy(plat->vicinae_manager);
+		plat->vicinae_manager = NULL;
+		wl_display_flush(plat->display);
+	}
+	if (plat->vicinae_queue) {
+		wl_event_queue_destroy(plat->vicinae_queue);
+		plat->vicinae_queue = NULL;
+	}
+	pthread_mutex_destroy(&plat->vicinae_mutex);
+}
+
 void obs_nix_wayland_log_info(void)
 {
 	struct wl_display *display = obs_get_nix_platform_display();
@@ -246,12 +648,16 @@ static bool obs_nix_wayland_hotkeys_platform_init(struct obs_core_hotkeys *hotke
 	struct wl_registry *registry = wl_display_get_registry(display);
 	wl_registry_add_listener(registry, &registry_listener, hotkeys->platform_context);
 	wl_display_roundtrip(display);
+
+	pthread_mutex_init(&hotkeys->platform_context->vicinae_mutex, NULL);
+	vicinae_init(hotkeys->platform_context);
 	return true;
 }
 
 static void obs_nix_wayland_hotkeys_platform_free(struct obs_core_hotkeys *hotkeys)
 {
 	obs_hotkeys_platform_t *plat = hotkeys->platform_context;
+	vicinae_free(plat);
 	xkb_context_unref(plat->xkb_context);
 	xkb_keymap_unref(plat->xkb_keymap);
 	xkb_state_unref(plat->xkb_state);
@@ -260,12 +666,36 @@ static void obs_nix_wayland_hotkeys_platform_free(struct obs_core_hotkeys *hotke
 
 static bool obs_nix_wayland_hotkeys_platform_is_pressed(obs_hotkeys_platform_t *context, obs_key_t key)
 {
-	UNUSED_PARAMETER(context);
-	UNUSED_PARAMETER(key);
-	// This function is only used by the hotkey thread for capturing out of
-	// focus hotkey triggers. Since wayland never delivers key events when out
-	// of focus we leave this blank intentionally.
-	return false;
+	/* A modifier key is pressed if any held vicinae combination requires
+	 * it, a trigger key if a held combination uses it. Without the
+	 * protocol vicinae_held stays empty and this returns false as it
+	 * always did on Wayland. */
+	bool pressed = false;
+	pthread_mutex_lock(&context->vicinae_mutex);
+	for (size_t i = 0; i < context->vicinae_held.num; i++) {
+		const struct vicinae_combo *combo = &context->vicinae_held.array[i];
+		switch (key) {
+		case OBS_KEY_SHIFT:
+			pressed = combo->modifiers & INTERACT_SHIFT_KEY;
+			break;
+		case OBS_KEY_CONTROL:
+			pressed = combo->modifiers & INTERACT_CONTROL_KEY;
+			break;
+		case OBS_KEY_ALT:
+			pressed = combo->modifiers & INTERACT_ALT_KEY;
+			break;
+		case OBS_KEY_META:
+			pressed = combo->modifiers & INTERACT_COMMAND_KEY;
+			break;
+		default:
+			pressed = combo->key == key;
+			break;
+		}
+		if (pressed)
+			break;
+	}
+	pthread_mutex_unlock(&context->vicinae_mutex);
+	return pressed;
 }
 
 static void obs_nix_wayland_key_to_str(obs_key_t key, struct dstr *dstr)

--- a/libobs/obs.c
+++ b/libobs/obs.c
@@ -1150,11 +1150,13 @@ static inline bool obs_init_hotkeys(void)
 	hotkeys->sceneitem_show = bstrdup("Show '%1'");
 	hotkeys->sceneitem_hide = bstrdup("Hide '%1'");
 
-	if (!obs_hotkeys_platform_init(hotkeys))
+	/* The mutex must exist before the platform layer initializes, as a
+	 * platform backend may spawn a thread that uses it right away. */
+	if (pthread_mutex_init_recursive(&hotkeys->mutex) != 0)
 		return false;
 
-	if (pthread_mutex_init_recursive(&hotkeys->mutex) != 0)
-		goto fail;
+	if (!obs_hotkeys_platform_init(hotkeys))
+		return false;
 
 	if (os_event_init(&hotkeys->stop_event, OS_EVENT_TYPE_MANUAL) != 0)
 		goto fail;

--- a/libobs/wayland-protocols/vicinae-hotkey-v1.xml
+++ b/libobs/wayland-protocols/vicinae-hotkey-v1.xml
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="vicinae_hotkey_v1">
+  <copyright>
+    Copyright © 2026 Aurelien Brabant
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="client-managed global hotkeys">
+    This protocol lets a client choose, and freely reconfigure, its own
+    global hotkeys: it requests a specific key combination and the compositor
+    accepts it or rejects it with a reason. The compositor remains the eventual
+    arbiter (it may deny a request, revoke a binding at any time, or apply
+    whatever policy it likes), but within that the application manages its own
+    bindings, including changing them at runtime, with no out-of-band user
+    configuration and no persisted compositor state.
+
+    A hotkey is a key combination that fires regardless of which surface holds
+    keyboard focus. This is unrelated to keyboard-shortcuts-inhibit, which lets a
+    focused client suppress the compositor's own shortcuts.
+
+    Whether a combination is exclusive is compositor policy. A compositor MAY
+    treat combinations as exclusive and reject a clashing request with
+    "already_bound", or MAY grant the same combination to more than one binding
+    (each bound hotkey then receives the events), as some platforms do. Clients
+    must cope with either.
+
+    It is intentionally a thin mechanism. It does NOT define which combinations
+    are acceptable: that is policy and belongs to the compositor, expressed
+    through the accept/deny channel. It does NOT persist hotkeys: a binding lives
+    only as long as its vicinae_hotkey_v1 object and the client connection; there is
+    no configure or storage step, a binding never outlives the client that created
+    it, and reconfiguring is simply destroying a hotkey and binding the new
+    combination.
+
+    Warning! The protocol described in this file is currently in the testing
+    phase. Backward incompatible changes may be added together with the
+    corresponding interface version bump. Backward compatible changes are added
+    by bumping the interface version.
+
+    Security considerations:
+
+    A global hotkey lets an unfocused client observe that a specific key
+    combination was pressed. Compositors are the security boundary and SHOULD
+    apply policy when deciding whether to accept a request. In particular,
+    implementations SHOULD reject combinations that do not include at least one
+    non-latching modifier among Ctrl, Alt or Super, unless the trigger is a
+    function key, because unmodified (and Shift-only) keys carry ordinary text
+    entry and grabbing them turns this protocol into a keylogger.
+
+    The protocol's one hard guarantee is containment: a compositor MUST NOT
+    deliver events for a combination the client did not successfully bind, and
+    never forwards the raw key stream, so a client learns nothing about input it
+    did not explicitly, and successfully, bind. Beyond that, a compositor MAY
+    apply any further policy it sees fit (for example prompting the user,
+    restricting which clients may bind, or limiting how many bindings a client may
+    hold) and MAY revoke a binding at any time via the "revoked" event, including
+    under user control.
+
+    These are recommendations, not wire requirements: a combination the
+    compositor disallows is simply reported through the "denied" event with the
+    "not_permitted" reason, so applications can rely on a uniform rejection path
+    regardless of each compositor's policy.
+  </description>
+
+  <interface name="vicinae_hotkey_manager_v1" version="1">
+    <description summary="global hotkey factory">
+      This interface is the entry point of the protocol. It is used to request
+      global hotkeys.
+    </description>
+
+    <enum name="modifiers" bitfield="true">
+      <description summary="modifier keys required by a hotkey">
+        A bitmask of the modifiers that must be held for the hotkey to fire.
+
+        These are fixed, keymap-independent semantic bits naming the standard
+        modifiers, suitable for expressing a binding, unlike wl_keyboard.modifiers,
+        which carries opaque, keymap-derived masks for runtime state. A compositor
+        matches each bit against the corresponding modifier in its keyboard state
+        as the keymap defines it; for the xkb_v1 keymap format that is shift ->
+        XKB_MOD_NAME_SHIFT, ctrl -> XKB_MOD_NAME_CTRL, alt -> XKB_MOD_NAME_ALT
+        ("Mod1"), super -> XKB_MOD_NAME_LOGO ("Mod4").
+
+        Lock modifiers (Caps Lock, Num Lock) are never part of a binding and are
+        ignored when matching.
+      </description>
+      <entry name="shift" value="1" summary="the Shift modifier"/>
+      <entry name="ctrl" value="2" summary="the Control modifier"/>
+      <entry name="alt" value="4" summary="the Alt modifier"/>
+      <entry name="super" value="8" summary="the Super/Logo modifier"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        Destroy the manager object. Hotkey objects created through this manager
+        are unaffected and remain valid; their bindings persist until they are
+        themselves destroyed or the client disconnects.
+      </description>
+    </request>
+
+    <request name="bind">
+      <description summary="request a global hotkey">
+        Request that the given key combination be bound as a global hotkey.
+
+        The keysym identifies the trigger key using the keysym numbering shared
+        with the keymap delivered over wl_keyboard (for the xkb_v1 keymap format,
+        an XKB_KEY_* value), taken in its unshifted form (XKB_KEY_b not XKB_KEY_B). A compositor SHOULD match
+        it against any of the user's layout groups, so a binding keeps firing after
+        the user switches layout group. This is one deliberately specified rule,
+        not a universal one: other platforms differ (macOS matches a physical
+        keycode, X11 re-grabs per layout, Windows tracks the active layout's key),
+        and no rule serves a layout that never produces the keysym; the single
+        documented rule is chosen for predictability across compositors.
+
+        The request creates an vicinae_hotkey_v1 object immediately, but the binding
+        is not active yet. The compositor replies asynchronously with either the
+        "bound" event (the hotkey is now active) or the "denied" event (the
+        request was rejected, with a reason).
+
+        seat is the wl_seat whose keyboard should trigger the hotkey, or null to
+        request it on all of the client's seats. Most clients pass null; seat is
+        provided for completeness on multi-seat systems.
+
+        app_id identifies the requesting application, for use in the compositor's
+        policy and any user-facing audit UI. Where the application has a desktop
+        entry, app_id SHOULD be its desktop file ID as defined by the
+        freedesktop.org Desktop Entry specification, that is the .desktop file
+        name with the .desktop suffix removed (for example "org.example.Launcher"),
+        matching the convention used by xdg_toplevel.set_app_id so a compositor
+        can correlate the two. It is advisory and may be spoofed; a compositor
+        that needs a trustworthy identity SHOULD obtain it through the
+        security-context mechanism rather than relying on this string.
+
+        description is a human-readable, localized description of what the hotkey
+		  does (e.g. "Toggle the launcher"), for display in compositor UI or even in this protocol error messages.
+      </description>
+      <arg name="id" type="new_id" interface="vicinae_hotkey_v1"
+           summary="the new hotkey object"/>
+      <arg name="keysym" type="uint" summary="keysym of the trigger key (see description)"/>
+      <arg name="modifiers" type="uint" enum="modifiers"
+           summary="bitmask of required modifiers"/>
+      <arg name="seat" type="object" interface="wl_seat" allow-null="true"
+           summary="target seat, or null for all of the client's seats"/>
+      <arg name="app_id" type="string"
+           summary="advisory application identifier (SHOULD be the desktop file ID)"/>
+      <arg name="description" type="string"
+           summary="human-readable action description"/>
+    </request>
+  </interface>
+
+  <interface name="vicinae_hotkey_v1" version="1">
+    <description summary="a single global hotkey">
+      Represents one requested global hotkey. Its binding is ephemeral: it is
+      released when this object is destroyed or when the client disconnects, and
+      it is never written to any persistent store.
+
+      After bind, exactly one of "bound" or "denied" is sent. While the hotkey is
+      bound, "pressed" and "released" are sent as the combination is activated.
+      The compositor may send "revoked" at any time after "bound" to indicate the
+      binding is no longer active (for example because the user removed it, or a
+      higher-priority binding took the combination).
+    </description>
+
+    <enum name="deny_reason">
+      <description summary="why a bind request was denied">
+        Carried by the "denied" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it (or try a different combination).
+      </description>
+      <entry name="already_bound" value="0"
+             summary="already held by another hotkey the compositor treats as exclusive. The compositor is not obligated to give this level of detail and can just give not_permitted as the general 'deny' reason."/>
+      <entry name="not_permitted" value="1"
+             summary="the combination is disallowed by compositor policy"/>
+      <entry name="invalid" value="2"
+             summary="the keysym or combination is not a valid trigger"/>
+    </enum>
+
+    <enum name="revoke_reason">
+      <description summary="why a previously bound hotkey was withdrawn">
+        Carried by the "revoked" event. This is a reason code, not a fatal
+        protocol error: the object remains valid and the client should destroy
+        it.
+
+        The distinction is actionable: on "superseded" the combination may
+        become available again, so a client may reasonably re-request it later;
+        on "removed" the withdrawal is a deliberate user or compositor decision,
+        so a client MUST NOT silently re-request the same combination. A client
+        that receives a value it does not recognise (a future addition) MUST
+        treat it conservatively as "removed" and not auto-rebind.
+      </description>
+      <entry name="removed" value="0"
+             summary="withdrawn by the user or compositor; do not auto-rebind"/>
+      <entry name="superseded" value="1"
+             summary="a higher-priority binding took the combination; it may become available again"/>
+      <entry name="not_permitted" value="2"
+             summary="the combination is no longer allowed by compositor policy"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="release the hotkey">
+        Release the binding and destroy the object. The combination becomes
+        available again immediately. It is valid to destroy the object before
+        receiving "bound" or "denied", which cancels the pending request.
+      </description>
+    </request>
+
+    <event name="bound">
+      <description summary="the hotkey is now active">
+        The requested combination was accepted and is now active. "pressed" and
+        "released" events may follow.
+      </description>
+    </event>
+
+    <event name="denied">
+      <description summary="the request was rejected">
+        The requested combination was not bound. No input events will be sent.
+        The client should destroy this object; it may then create a new request
+        with a different combination.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI (for
+        example a "change shortcut" settings screen). It may be empty, and a
+        compositor is never required to provide it. Clients MUST NOT parse it or
+        rely on its contents in any way; all programmatic behavior keys off
+        reason. A client with nowhere to show it simply ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="deny_reason" summary="why it was rejected"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="revoked">
+      <description summary="a previously active hotkey was withdrawn">
+        A binding that was previously "bound" is no longer active. No further
+        input events will be sent for it. The client should destroy this object;
+        it may request the combination again later.
+
+        message is an optional, advisory, human-readable explanation in the
+        compositor's locale, intended for verbatim display in client UI. It may
+        be empty, and a compositor is never required to provide it. Clients MUST
+        NOT parse it or rely on its contents in any way; all programmatic
+        behavior keys off reason. A client with nowhere to show it simply
+        ignores it.
+      </description>
+      <arg name="reason" type="uint" enum="revoke_reason" summary="why it was withdrawn"/>
+      <arg name="message" type="string"
+           summary="optional human-readable detail for display (may be empty)"/>
+    </event>
+
+    <event name="pressed">
+      <description summary="the hotkey combination was pressed">
+        The bound combination was activated.
+
+        This event is sent once per activation. While the combination is held
+        down no further "pressed" events are sent, and a single "released"
+        follows when the trigger key is released: the compositor does not
+        auto-repeat the hotkey.
+
+        serial is a compositor-issued input serial that counts as a recent user
+        interaction, so the client can act on the hotkey even though the
+        triggering key press is not otherwise delivered to it (the compositor
+        consumes it). In particular, a client may pass this serial to
+        xdg_activation_token_v1.set_serial in order to raise or focus a surface in
+        response to the hotkey; a compositor SHOULD honor activation carried by
+        this serial, since the hotkey is itself a deliberate user action. The
+        serial is drawn from the same space as other input event serials.
+
+        time is the event timestamp, with the same millisecond clock as wl_pointer
+        and wl_keyboard input events; it is useful for ordering and for measuring
+        press-to-release duration.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+
+    <event name="released">
+      <description summary="the hotkey combination was released">
+        The trigger key of a previously pressed combination was released. This
+        enables press-and-hold uses (e.g. push-to-talk); clients that only act
+        on activation may ignore it.
+
+        serial and time have the same meaning as in the "pressed" event.
+      </description>
+      <arg name="serial" type="uint" summary="input serial for the activation (e.g. xdg-activation)"/>
+      <arg name="time" type="uint" summary="timestamp in milliseconds"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description

Implements the [vicinae hotkey](https://github.com/vicinaehq/vicinae-wayland-protocols/tree/main/staging/vicinae-hotkey) wayland protocol which allows clients such as OBS to bind global shortcuts.

A quick word about the implementation: this protocol is not a raw keyboard hook, and therefore didn't fit the existing shortcut model inside OBS. I'm not fully sure why OBS does this instead of using native APIs to register global shortcuts on other platforms, but I think my adapter is not too bad.

The protocol can return an error when a bind is refused by the compositor, in which case the global trigger will not be honored. Since there was no UI to communicate this kind of thing, I just let it be an error message in the console

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Currently, there is no good way to bind global shortcuts on wayland environments.  

The [desktop portal](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.GlobalShortcuts.html) solution is inadequate for most applications as it doesn't allow the client to control its global bindings to the fullest.  Due to these limitations it is also not widely implemented.

Some time ago I came up with the `vicinae-hotkey` protocol which simply mirrors the way global shortcuts work on other desktop platforms such as Windows and macOS. The client is free to bind, rebind, and revoke any global shortcut. The compositor only responsibility is to allow or deny the bind.

This protocol got merged into [Hyprland](https://github.com/hyprwm/Hyprland/pull/15010) and there is an open PR for the [niri](https://github.com/niri-wm/niri/pull/4145) compositor as well, two prominent wayland desktops.

The goal is to further the adoption of this protocol by getting more clients to use it. OBS is the main piece of software affected by the lack of proper global shortcuts on most wayland desktops so this would greatly help.

Technically, this would fix https://github.com/obsproject/obs-studio/issues/10538

### How Has This Been Tested?

Tested on my Gentoo Linux 2.18 machine, with my [niri fork](https://github.com/niri-wm/niri/pull/4145) as the running Wayland compositor. This can also be tested with Hyprland git but niri is easier to build.

Binding a shortcut in OBS works as it usually does, but also activates when the OBS window is not focused.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
