### PR TITLE
libobs-metal: Wrap blitSwapChains in autoreleasepool to fix mach port leak

### DIFF
--- a/libobs-metal/MetalDevice.swift
+++ b/libobs-metal/MetalDevice.swift
@@ -149,38 +149,43 @@ class MetalDevice {
     func blitSwapChains() {
         guard swapChains.count > 0 else { return }
 
-        guard let commandBuffer = commandQueue.makeCommandBuffer(),
-            let encoder = commandBuffer.makeBlitCommandEncoder()
-        else {
-            return
-        }
-
         self.swapChainQueue.sync {
             swapChains = swapChains.filter { $0.discard == false }
         }
 
-        for swapChain in swapChains {
-            guard let renderTarget = swapChain.renderTarget, let drawable = swapChain.layer.nextDrawable() else {
-                continue
-            }
-
-            guard renderTarget.texture.width == drawable.texture.width,
-                renderTarget.texture.height == drawable.texture.height,
-                renderTarget.texture.pixelFormat == drawable.texture.pixelFormat
+        autoreleasepool {
+            guard let commandBuffer = commandQueue.makeCommandBuffer(),
+                let encoder = commandBuffer.makeBlitCommandEncoder()
             else {
-                continue
+                return
             }
 
-            autoreleasepool {
+            var drawablesToPresent: [CAMetalDrawable] = []
+            for swapChain in swapChains {
+                guard let renderTarget = swapChain.renderTarget, let drawable = swapChain.layer.nextDrawable() else {
+                    continue
+                }
+
+                guard renderTarget.texture.width == drawable.texture.width,
+                    renderTarget.texture.height == drawable.texture.height,
+                    renderTarget.texture.pixelFormat == drawable.texture.pixelFormat
+                else {
+                    continue
+                }
+
                 encoder.waitForFence(swapChain.fence)
                 encoder.copy(from: renderTarget.texture, to: drawable.texture)
+                drawablesToPresent.append(drawable)
+            }
 
+            encoder.endEncoding()
+
+            for drawable in drawablesToPresent {
                 commandBuffer.present(drawable)
             }
-        }
 
-        encoder.endEncoding()
-        commandBuffer.commit()
+            commandBuffer.commit()
+        }
     }
 
     /// Simulates an explicit "clear" command commonly used in OpenGL or Direct3D11 implementations.


### PR DESCRIPTION
### Description
Wraps the full frame cycle within `blitSwapChains()` in an `autoreleasepool` block, covering `nextDrawable()` → blit → `commandBuffer.present(drawable)` → `commandBuffer.commit()`.

The `blitSwapChains()` method is driven by a CVDisplayLink callback thread, which has no implicit autorelease pool. `CAMetalLayer.nextDrawable()` returns autoreleased `CAMetalDrawable` objects, each backed by an IOSurface with an associated `IOSurfaceSharedEventReference` mach port. Without a pool, these autoreleased objects are never drained, leaking one IOSurface (and port) per frame.

Additionally, the drawable presentation order is corrected: drawables are now collected and presented via `commandBuffer.present(drawable)` after `encoder.endEncoding()` and before `commandBuffer.commit()`, matching the standard Metal ordering where presentation calls must occur after all encoding is complete but before the command buffer is committed.

### Motivation and Context
This primarily manifests when using cross-process rendering via CAContext/CALayerHost (e.g., a source preview rendered in a separate process and composited into the main process). In that scenario `swapChain.renderTarget` is non-nil, so `nextDrawable()` is called per frame and the autoreleased drawables accumulate indefinitely, resulting in unbounded mach port growth.

The in-process projector path (OBS app's own preview) is masked because the on-screen compositor drives drawable recycling even without explicit draining — but the leak exists there too and can accumulate under sustained usage.

### How Has This Been Tested?
- **Environment**: macOS, Apple Silicon, cross-process source preview via CAContext/CALayerHost.
- **Method**: Monitored mach ports via `lsmp` differential snapshots. Before the fix, `IOSurfaceSharedEventReference` ports grew linearly per frame with the preview window open. After the fix, port count stabilizes at a small upper bound (≈ pool size × swapchain count) and remains flat.
- **Regression check**: In-process preview continues to render correctly with no artifacts, no black frames, and no tearing.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the contributing document.
- [x] My code has been run through clang-format / swift-format.
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation (N/A)
