### PR TITLE
frontend: Fix deprecated header order in Add Source dialog

### DIFF
--- a/frontend/dialogs/OBSBasicSourceSelect.cpp
+++ b/frontend/dialogs/OBSBasicSourceSelect.cpp
@@ -546,10 +546,10 @@ void OBSBasicSourceSelect::rebuildSourceTypeList()
 
 	// Shift Deprecated sources to the bottom
 	QList<QListWidgetItem *> deprecatedItems;
-	for (int i = 0; i < ui->sourceTypeList->count(); ++i) {
+	for (int i = ui->sourceTypeList->count() - 1; i >= 0; --i) {
 		QListWidgetItem *item = ui->sourceTypeList->item(i);
 		if (!item) {
-			break;
+			continue;
 		}
 
 		bool isDeprecated = item->data(kDeprecatedRole).toBool();
@@ -562,6 +562,7 @@ void OBSBasicSourceSelect::rebuildSourceTypeList()
 		}
 	}
 
+	std::reverse(deprecatedItems.begin(), deprecatedItems.end());
 	for (const auto &item : deprecatedItems) {
 		ui->sourceTypeList->addItem(item);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Fixes the placement of the "deprecated" header in the Add Source dialog such that all deprecated sources actually lie beneath it.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Some deprecated sources would lie above the "deprecated" header because the iterator that moved the sources removed items from the list while iterating through it (skipping some items).

This PR just makes the iterator operate in reverse order to avoid skipping any items as they're removed.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested on macOS to verify that deprecated sources all now sit beneath the header. Verified that a deprecated source at the first or last position in the list is scooped up by the iterator.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
