### PR TITLE
frontend: Fix default thumbnail positioning

### DIFF
--- a/frontend/utility/ThumbnailItem.cpp
+++ b/frontend/utility/ThumbnailItem.cpp
@@ -36,7 +36,7 @@ QPixmap getDefaultThumbnail(obs_source_t *source)
 	OBSBasic *main = OBSBasic::Get();
 	if (main && id) {
 		QIcon icon = OBSBasic::Get()->GetSourceIcon(id);
-		QPixmap iconPixmap = icon.pixmap(90, 90);
+		QPixmap iconPixmap = icon.pixmap(QSize(90, 90), 1.0);
 
 		QPixmap defaultPixmap(kDefaultWidth, kDefaultHeight);
 		defaultPixmap.fill(Qt::transparent);


### PR DESCRIPTION
### Description

Fixes the default thumbnail icon being positioned wrong at display scaling other than 100%. This affects macOS by default due to it's higher DPI, and Windows at anything other than 100%.

**Before**
<img width="267" height="202" alt="image" src="https://github.com/user-attachments/assets/57997743-8241-4aa3-8cad-38419760d6de" />

**After**
<img width="270" height="207" alt="image" src="https://github.com/user-attachments/assets/805e5356-4a55-49d9-a2e0-30bd93dbf44d" />

### Motivation and Context
Want icons positioned properly.

### How Has This Been Tested?
👁️👁️

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
