### PR TITLE
libobs: Resolve bin_path and data_path to absolute paths for modules

### DIFF
--- a/libobs/obs-module.c
+++ b/libobs/obs-module.c
@@ -672,6 +672,26 @@ static bool parse_binary_from_directory(struct dstr *parsed_bin_path, const char
 	return found;
 }
 
+#ifdef _WIN32
+/* libobs used to give modules their paths as relative, non-resolved unix-style paths which caused issues if
+ * the current directory changed. We now resolve relative paths to absolute paths to fix this, but lots of existing
+ * code still assumes that / is the only valid path separator, so we convert back to / for compatibility. */
+static const char *fixup_path(char *path_in)
+{
+	char *p = path_in;
+
+	while ((p = strchr(p, '\\')))
+		*p++ = '/';
+
+	return path_in;
+}
+#else
+static const char *fixup_path(char *path_in)
+{
+	return path_in;
+}
+#endif
+
 static void process_found_module(struct obs_module_path *omp, const char *path, bool directory,
 				 obs_find_module_callback2_t callback, void *param)
 {
@@ -702,10 +722,14 @@ static void process_found_module(struct obs_module_path *omp, const char *path, 
 	parsed_data_dir = make_data_directory(name.array, omp->data);
 
 	if (parsed_data_dir && bin_found) {
-		info.bin_path = parsed_bin_path.array;
-		info.data_path = parsed_data_dir;
+		/* Ensure modules receive absolute paths so they can find their resources correctly */
+		info.bin_path = fixup_path(os_get_abs_path_ptr(parsed_bin_path.array));
+		info.data_path = fixup_path(os_get_abs_path_ptr(parsed_data_dir));
+
 		info.name = name.array;
 		callback(param, &info);
+		bfree((void *)info.bin_path);
+		bfree((void *)info.data_path);
 	}
 
 	bfree(parsed_data_dir);


### PR DESCRIPTION
### Description
Many modules create paths based on `obs_module_config_path` and similar functions, which return a relative path based on the current directory.

This causes a problem on Windows in combination with #11569. The path to the game capture hook DLL is sometimes passed as a relative path when the global hook can't be updated after an OBS update if it's in use. After calling `SetDefaultDLLDirectories`, the current directory is no longer searched, so the relative path to the hook DLL can't load and we get an inject -4 error.

After this change, inject-helper is launched with both an absolute binary path and absolute argument, so nothing relies on the current directory any more. This commit extends beyond just win-capture though, as any module that was relying on the current directory will now be given absolute paths, which is more reliable in case any random DLL decides to change the CWD.

An unfortunate `fixup_path` call is needed on Windows, as we have historically only ever used module paths with / as a path separator, and libobs itself also assumes this, so for compatibility we convert Windows \\ directory separators back to /.

### Motivation and Context
Fix reported inject -4 errors.

### How Has This Been Tested?
Forced OBS to inject with local hook DLL and verified full path to inject helper and its arguments were used.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
- Breaking change (fix or feature that would cause existing functionality to change)
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
