### PR TITLE
frontend: Add --ignore-unclean-shutdown option

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -69,6 +69,7 @@ string lastCrashLogFile;
 extern bool portable_mode;
 extern bool safe_mode;
 extern bool multi;
+extern bool opt_ignore_unclean_shutdown;
 extern bool disable_3p_plugins;
 extern bool opt_disable_updater;
 extern bool opt_disable_missing_files_check;
@@ -944,7 +945,7 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 #endif
 	connect(qApp, &QGuiApplication::commitDataRequest, this, &OBSApp::commitData, Qt::DirectConnection);
 
-	if (multi) {
+	if (multi || opt_ignore_unclean_shutdown) {
 		crashHandler_ = std::make_unique<OBS::CrashHandler>();
 	} else {
 		crashHandler_ = std::make_unique<OBS::CrashHandler>(appLaunchUUID_);

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -62,6 +62,7 @@ bool safe_mode = false;
 bool disable_3p_plugins = false;
 static bool unclean_shutdown = false;
 bool multi = false;
+bool opt_ignore_unclean_shutdown = false;
 static bool log_verbose = false;
 static bool unfiltered_log = false;
 bool opt_start_streaming = false;
@@ -964,6 +965,9 @@ int main(int argc, char *argv[])
 		if (arg_is(argv[i], "--multi", "-m")) {
 			multi = true;
 
+		} else if (arg_is(argv[i], "--ignore-unclean-shutdown", nullptr)) {
+			opt_ignore_unclean_shutdown = true;
+
 #if ALLOW_PORTABLE_MODE
 		} else if (arg_is(argv[i], "--portable", "-p")) {
 			portable_mode = true;
@@ -1046,6 +1050,7 @@ int main(int argc, char *argv[])
 				"--portable, -p: Use portable mode.\n"
 #endif
 				"--multi, -m: Don't warn when launching multiple instances.\n\n"
+				"--ignore-unclean-shutdown: Disable unsafe shutdown check dialog.\n"
 				"--safe-mode: Run in Safe Mode (disables third-party plugins, scripting, and WebSockets).\n"
 				"--only-bundled-plugins: Only load included (first-party) plugins\n"
 				"--verbose: Make log more verbose.\n"


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
This commit / pr adds command line option ```--ignore-unclean-shutdown``` to the OBS binary file.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
When using ```taskschd.msc``` to initiate a recording for OBS and limit the recording length through ```Settings -> Stop the task if it runs longer than```, sometimes it might cause an unclean shutdown for OBS. This option add a skip logic same as ```--multi``` did.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Manually place a ```run_``` file in ```%AppData%\obs-studio\.sentinel```, before this modification, the recording's being blocked by an unclean shutdown check dialog. After this modification, when you apply ```--ignore-unclean-shutdown```, the recording won't being blocked by an unclean shutdown check dialog while the multi instance checking is maintained.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
