### PR TITLE
text-freetype2: Strip embedded nulls from text files

### DIFF
--- a/plugins/text-freetype2/text-functionality.c
+++ b/plugins/text-freetype2/text-functionality.c
@@ -409,14 +409,21 @@ void load_text_from_file(struct ft2_source *srcdata, const char *filename)
 	bytes_read = fread(tmp_read, filesize, 1, tmp_file);
 	fclose(tmp_file);
 
+	size_t clean_len = 0;
+	for (size_t i = 0; i < filesize; i++) {
+		if (tmp_read[i] != '\0' && tmp_read[i] != '\r') {
+			tmp_read[clean_len++] = tmp_read[i];
+		}
+	}
+	tmp_read[clean_len] = '\0';
+
 	if (srcdata->text != NULL) {
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
+	srcdata->text = bzalloc((clean_len + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(tmp_read, clean_len, srcdata->text, clean_len + 1);
 
-	remove_cr(srcdata->text);
 	bfree(tmp_read);
 }
 
@@ -487,18 +494,27 @@ void read_from_end(struct ft2_source *srcdata, const char *filename)
 		return;
 	}
 
-	tmp_read = bzalloc((filesize - cur_pos) + 1);
-	bytes_read = fread(tmp_read, filesize - cur_pos, 1, tmp_file);
+	size_t read_size = filesize - cur_pos;
+	tmp_read = bzalloc(read_size + 1);
+	bytes_read = fread(tmp_read, read_size, 1, tmp_file);
 	fclose(tmp_file);
+
+	// FILTER: Strip embedded null bytes (\0) and Windows carriage returns (\r)
+	size_t clean_len = 0;
+	for (size_t i = 0; i < read_size; i++) {
+		if (tmp_read[i] != '\0' && tmp_read[i] != '\r') {
+			tmp_read[clean_len++] = tmp_read[i];
+		}
+	}
+	tmp_read[clean_len] = '\0';
 
 	if (srcdata->text != NULL) {
 		bfree(srcdata->text);
 		srcdata->text = NULL;
 	}
-	srcdata->text = bzalloc((strlen(tmp_read) + 1) * sizeof(wchar_t));
-	os_utf8_to_wcs(tmp_read, strlen(tmp_read), srcdata->text, (strlen(tmp_read) + 1));
+	srcdata->text = bzalloc((clean_len + 1) * sizeof(wchar_t));
+	os_utf8_to_wcs(tmp_read, clean_len, srcdata->text, clean_len + 1);
 
-	remove_cr(srcdata->text);
 	bfree(tmp_read);
 }
 


### PR DESCRIPTION
### Description
This PR fixes an issue in the `text-freetype2` plugin where reading text files containing embedded null bytes (`\0`) caused premature string truncation.

When reading a text file in `load_text_from_file` and `read_from_end`, `tmp_read` is now filtered to strip embedded null bytes (`\0`) and carriage returns (`\r`) before converting the string with `os_utf8_to_wcs()`. This prevents downstream conversion and rendering functions (like `wcslen()`) from treating embedded null bytes as the end of the string.

### Motivation and Context
Fixes #7595

When reading hardware logs or binary-padded text files (such as those generated by certain capture card drivers), embedded null bytes caused OBS to stop rendering text past the first null byte, appearing as if only the first line of the file was read.

### How Has This Been Tested?
- **Environment:** CachyOS (Arch Linux), Hyprland (Wayland).
- Tested with standard multi-line text files to ensure normal text files render as expected.
- Tested with text files containing embedded null characters (e.g. `printf "Line 1\0Line 2\nLine 3"`).
- Verified that all lines render completely in OBS Studio without truncation or crashes.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.