### PR TITLE
libobs: Add non-numlock keypad mappings for Wayland

### DIFF
--- a/libobs/obs-nix-wayland.c
+++ b/libobs/obs-nix-wayland.c
@@ -305,6 +305,8 @@ static void obs_nix_wayland_key_to_str(obs_key_t key, struct dstr *dstr)
 		return translate_key(key, "Page Down");
 	case OBS_KEY_NUMLOCK:
 		return translate_key(key, "Num Lock");
+	case OBS_KEY_CLEAR:
+		return translate_key(key, "Clear");
 	case OBS_KEY_SCROLLLOCK:
 		return translate_key(key, "Scroll Lock");
 	case OBS_KEY_CAPSLOCK:
@@ -399,6 +401,28 @@ static obs_key_t obs_nix_wayland_key_from_virtual_key(int sym)
 		return OBS_KEY_8;
 	case XKB_KEY_9:
 		return OBS_KEY_9;
+	case XKB_KEY_KP_Home:
+		return OBS_KEY_HOME;
+	case XKB_KEY_KP_Left:
+		return OBS_KEY_LEFT;
+	case XKB_KEY_KP_Up:
+		return OBS_KEY_UP;
+	case XKB_KEY_KP_Right:
+		return OBS_KEY_RIGHT;
+	case XKB_KEY_KP_Down:
+		return OBS_KEY_DOWN;
+	case XKB_KEY_KP_Prior:
+		return OBS_KEY_PAGEUP;
+	case XKB_KEY_KP_Next:
+		return OBS_KEY_PAGEDOWN;
+	case XKB_KEY_KP_End:
+		return OBS_KEY_END;
+	case XKB_KEY_KP_Begin:
+		return OBS_KEY_CLEAR;
+	case XKB_KEY_KP_Insert:
+		return OBS_KEY_INSERT;
+	case XKB_KEY_KP_Delete:
+		return OBS_KEY_DELETE;
 	case XKB_KEY_A:
 		return OBS_KEY_A;
 	case XKB_KEY_a:


### PR DESCRIPTION
### Description
This PR adds key mappings for non-numlocked keypad keys on Wayland in `libobs/obs-nix-wayland.c`.

When NumLock is off, XKB generates navigation keysyms (`XKB_KEY_KP_Home`, `XKB_KEY_KP_End`, `XKB_KEY_KP_Begin`, etc.). Previously, these keysyms were unhandled in `obs_nix_wayland_key_from_virtual_key()`, causing hotkey input fields to remain blank when pressed.

This maps non-numlocked keypad keysyms to their corresponding standard keys (`OBS_KEY_HOME`, `OBS_KEY_END`, `OBS_KEY_CLEAR`, etc.) and adds translation string support for `OBS_KEY_CLEAR` in `obs_nix_wayland_key_to_str()`.

### Motivation and Context
Fixes #9244

Wayland users (e.g. on Hyprland, Sway, GNOME Wayland) with NumLock disabled could not assign numpad navigation keys as hotkeys in OBS Settings.

### How Has This Been Tested?
- **Environment:** CachyOS (Arch Linux), Hyprland (Wayland).
- Tested Numpad keys (0–9) and (.) with NumLock OFF in OBS Settings -> Hotkeys.
- Verified all non-numlocked keypad keys correctly register and display their corresponding labels (`Insert`, `End`, `Down`, `PageDown`, `Left`, `Clear`, `Right`, `Home`, `Up`, `Page Up`, `Delete`).

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.