### PR TITLE
virtualcam-module: Make placeholder initialization thread-safe

### DIFF
--- a/plugins/win-dshow/virtualcam-module/placeholder.cpp
+++ b/plugins/win-dshow/virtualcam-module/placeholder.cpp
@@ -8,13 +8,18 @@ using namespace Gdiplus;
 
 extern HINSTANCE dll_inst;
 
-static std::vector<uint8_t> placeholder;
-static bool initialized = false;
-int cx, cy;
+namespace {
+
+struct Placeholder {
+	std::vector<uint8_t> data;
+	int cx = 0;
+	int cy = 0;
+	bool valid = false;
+};
 
 /* XXX: optimize this later.  or don't, it's only called once. */
 
-static void convert_placeholder(const uint8_t *rgb_in, int width, int height)
+std::vector<uint8_t> convert_placeholder(const uint8_t *rgb_in, int width, int height)
 {
 	size_t size = width * height * 3;
 	size_t linesize = width * 3;
@@ -36,12 +41,13 @@ static void convert_placeholder(const uint8_t *rgb_in, int width, int height)
 		*(out++) = (uint8_t)(((112 * r - 94 * g - 18 * b + 128) >> 8) + 128);
 	}
 
-	placeholder.resize(width * height * 3 / 2);
+	std::vector<uint8_t> nv12_out;
+	nv12_out.resize(width * height * 3 / 2);
 
 	in = &yuv_out[0];
 	end = in + size;
 
-	out = &placeholder[0];
+	out = &nv12_out[0];
 	uint8_t *chroma = out + width * height;
 
 	while (in < end) {
@@ -76,20 +82,23 @@ static void convert_placeholder(const uint8_t *rgb_in, int width, int height)
 		in = in2;
 		out = out2;
 	}
+
+	return nv12_out;
 }
 
-static bool load_placeholder_internal()
+Placeholder load_placeholder_internal()
 {
+	Placeholder result;
 	Status s;
 
 	wchar_t file[MAX_PATH];
 	if (!GetModuleFileNameW(dll_inst, file, MAX_PATH)) {
-		return false;
+		return result;
 	}
 
 	wchar_t *slash = wcsrchr(file, '\\');
 	if (!slash) {
-		return false;
+		return result;
 	}
 
 	slash[1] = 0;
@@ -98,46 +107,68 @@ static bool load_placeholder_internal()
 
 	Bitmap bmp(file);
 	if (bmp.GetLastStatus() != Status::Ok) {
-		return false;
+		return result;
 	}
 
-	cx = bmp.GetWidth();
-	cy = bmp.GetHeight();
+	const int cx = bmp.GetWidth();
+	const int cy = bmp.GetHeight();
 
 	BitmapData bmd = {};
 	Rect r(0, 0, cx, cy);
 
 	s = bmp.LockBits(&r, ImageLockModeRead, PixelFormat24bppRGB, &bmd);
 	if (s != Status::Ok) {
-		return false;
+		return result;
 	}
 
-	convert_placeholder((const uint8_t *)bmd.Scan0, cx, cy);
+	result.data = convert_placeholder((const uint8_t *)bmd.Scan0, cx, cy);
+	result.cx = cx;
+	result.cy = cy;
+	result.valid = true;
 
 	bmp.UnlockBits(&bmd);
-	return true;
+	return result;
 }
+
+Placeholder load_placeholder()
+{
+	GdiplusStartupInput si;
+	ULONG_PTR token;
+
+	if (GdiplusStartup(&token, &si, nullptr) != Status::Ok) {
+		return Placeholder();
+	}
+
+	Placeholder result = load_placeholder_internal();
+
+	GdiplusShutdown(token);
+	return result;
+}
+
+// A single application can create any number of VCamFilter instances, each of
+// which loads the placeholder from its own thread. As this is shared global
+// state, ensure only a single copy is initialized with C++11 function-local
+// static initialization to prevent multiple initializations stomping on
+// each other.
+const Placeholder &get_placeholder()
+{
+	static const Placeholder placeholder = load_placeholder();
+	return placeholder;
+}
+
+} // namespace
 
 bool initialize_placeholder()
 {
-	if (initialized) {
-		return true;
-	}
-
-	GdiplusStartupInput si;
-	ULONG_PTR token;
-	GdiplusStartup(&token, &si, nullptr);
-
-	initialized = load_placeholder_internal();
-
-	GdiplusShutdown(token);
-	return initialized;
+	return get_placeholder().valid;
 }
 
 const uint8_t *get_placeholder_ptr()
 {
-	if (initialized) {
-		return placeholder.data();
+	const Placeholder &placeholder = get_placeholder();
+
+	if (placeholder.valid) {
+		return placeholder.data.data();
 	}
 
 	return nullptr;
@@ -145,9 +176,11 @@ const uint8_t *get_placeholder_ptr()
 
 const bool get_placeholder_size(int *out_cx, int *out_cy)
 {
-	if (initialized) {
-		*out_cx = cx;
-		*out_cy = cy;
+	const Placeholder &placeholder = get_placeholder();
+
+	if (placeholder.valid) {
+		*out_cx = placeholder.cx;
+		*out_cy = placeholder.cy;
 		return true;
 	}
 


### PR DESCRIPTION
### Description
A single application can create any number of `VCamFilter` instances, all of which create a thread that tries to initialize the placeholder image. This can result in a race where the placeholder vector gets resized by multiple threads, causing dangling pointers and a crash.

This PR makes placeholder initialization thread-safe by using C++11 function-local static initialization, ensuring only one thread runs the initialization and the rest wait for it. State was moved to a struct to ensure it can be updated and passed around atomically. A missing return check from `GdiplusStartup` was also added.

Note: this goes against a CODESTYLE.md section that says:

> Use thread-safe functions to initialize a function-local static variable

Initialization of function-local static variables is inherently thread-safe in C++11 and later, so adding additional synchronization seemed unnecessary.

### Motivation and Context
As the virtual camera gets injected into any application enumerating Directshow devices, we should be a good citizen and not crash the host application.

### How Has This Been Tested?
Loaded the new filter and tested that the placeholder appeared. The actual crash I wasn't able to reproduce given it's a race.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested (kind of).
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
