### PR TITLE
virtualcam-module: Improve lock tracking for DLL unloading

### DIFF
--- a/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-filter.cpp
@@ -16,6 +16,9 @@ extern volatile long locks;
 
 VCamFilter::VCamFilter() : OutputFilter()
 {
+	os_atomic_inc_long(&locks);
+	AddRef();
+
 	thread_start = CreateEvent(nullptr, true, false, nullptr);
 	thread_stop = CreateEvent(nullptr, true, false, nullptr);
 
@@ -94,9 +97,6 @@ VCamFilter::VCamFilter() : OutputFilter()
 	/* ---------------------------------------- */
 
 	th = std::thread([this] { Thread(); });
-
-	AddRef();
-	os_atomic_inc_long(&locks);
 }
 
 VCamFilter::~VCamFilter()

--- a/plugins/win-dshow/virtualcam-module/virtualcam-module.cpp
+++ b/plugins/win-dshow/virtualcam-module/virtualcam-module.cpp
@@ -17,7 +17,8 @@ class VCamFactory : public IClassFactory {
 	CLSID cls;
 
 public:
-	inline VCamFactory(CLSID cls_) : cls(cls_) {}
+	inline VCamFactory(CLSID cls_) : cls(cls_) { os_atomic_inc_long(&locks); }
+	inline ~VCamFactory() { os_atomic_dec_long(&locks); }
 
 	// IUnknown
 	STDMETHODIMP QueryInterface(REFIID riid, void **p_ptr);


### PR DESCRIPTION
### Description
The locks variable is used to determine if the DLL can safely be unloaded. If we're in the middle of constructing a `VCamFilter`, we don't want something to unload us half-way through so incrementing locks and reference count should be the first thing we do.

Clients can also get a reference to `VCamFactory` which had no lock tracking at all, so the DLL could potentially be unloaded while still having outstanding `VCamFactory` references, causing a crash the next time the `VCamFactory` was used.

### Motivation and Context
Looking into possible causes of https://github.com/obsproject/obs-studio/issues/10566. An active `VCamFactory` with an unloaded DLL is my best guess currently.

### How Has This Been Tested?
Used virtual camera, observed no regressions.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
