### PR TITLE
Fix a few vertex buffer related issues

### DIFF
--- a/frontend/utility/display-helpers.hpp
+++ b/frontend/utility/display-helpers.hpp
@@ -130,6 +130,7 @@ static inline void RenderSafeAreas(gs_vertbuffer_t *vb, int cx, int cy)
 	transform.y.y = cy;
 
 	gs_load_vertexbuffer(vb);
+	gs_load_indexbuffer(nullptr);
 
 	gs_matrix_push();
 	gs_matrix_mul(&transform);

--- a/frontend/widgets/OBSBasicPreview.cpp
+++ b/frontend/widgets/OBSBasicPreview.cpp
@@ -1784,6 +1784,7 @@ static void DrawRotationHandle(gs_vertbuffer_t *circle, float rot, float pixelRa
 	gs_matrix_translate3f(0.0f, -HANDLE_RADIUS * 2 / 3, 0.0f);
 
 	gs_load_vertexbuffer(circle);
+	gs_load_indexbuffer(nullptr);
 	gs_draw(GS_TRISTRIP, 0, 0);
 
 	gs_matrix_pop();
@@ -2099,6 +2100,7 @@ bool OBSBasicPreview::DrawSelectedItem(obs_scene_t *, obs_sceneitem_t *item, voi
 	gs_technique_begin_pass(tech, 0);
 
 	gs_load_vertexbuffer(main->box);
+	gs_load_indexbuffer(nullptr);
 	gs_effect_set_vec4(colParam, &red);
 
 	if (selected) {
@@ -2170,6 +2172,7 @@ bool OBSBasicPreview::DrawSelectionBox(float x1, float y1, float x2, float y2, g
 
 	gs_effect_set_vec4(colParam, &fillColor);
 	gs_load_vertexbuffer(rectFill);
+	gs_load_indexbuffer(nullptr);
 	gs_draw(GS_TRISTRIP, 0, 0);
 
 	gs_effect_set_vec4(colParam, &borderColor);

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -118,6 +118,7 @@ void OBSBasic::DrawBackdrop(float cx, float cy)
 	gs_matrix_scale3f(float(cx), float(cy), 1.0f);
 
 	gs_load_vertexbuffer(box);
+	gs_load_indexbuffer(nullptr);
 	gs_draw(GS_TRISTRIP, 0, 0);
 
 	gs_matrix_pop();

--- a/libobs-d3d11/d3d11-rebuild.cpp
+++ b/libobs-d3d11/d3d11-rebuild.cpp
@@ -575,6 +575,8 @@ try {
 	curVertexShader = nullptr;
 	curPixelShader = nullptr;
 	curSwapChain = nullptr;
+	lastVertexBuffer = nullptr;
+	lastVertexShader = nullptr;
 	zstencilStateChanged = true;
 	rasterStateChanged = true;
 	blendStateChanged = true;

--- a/libobs-d3d11/d3d11-shader.cpp
+++ b/libobs-d3d11/d3d11-shader.cpp
@@ -32,7 +32,9 @@ void gs_vertex_shader::GetBuffersExpected(const std::vector<D3D11_INPUT_ELEMENT_
 {
 	for (size_t i = 0; i < inputs.size(); i++) {
 		const D3D11_INPUT_ELEMENT_DESC &input = inputs[i];
-		if (strcmp(input.SemanticName, "NORMAL") == 0) {
+		if (strcmp(input.SemanticName, "SV_Position") == 0) {
+			hasPositions = true;
+		} else if (strcmp(input.SemanticName, "NORMAL") == 0) {
 			hasNormals = true;
 		} else if (strcmp(input.SemanticName, "TANGENT") == 0) {
 			hasTangents = true;
@@ -46,6 +48,7 @@ void gs_vertex_shader::GetBuffersExpected(const std::vector<D3D11_INPUT_ELEMENT_
 
 gs_vertex_shader::gs_vertex_shader(gs_device_t *device, const char *file, const char *shaderString)
 	: gs_shader(device, gs_type::gs_vertex_shader, GS_SHADER_VERTEX),
+	  hasPositions(false),
 	  hasNormals(false),
 	  hasColors(false),
 	  hasTangents(false),
@@ -386,9 +389,16 @@ void gs_shader::UploadParams()
 
 void gs_shader_destroy(gs_shader_t *shader)
 {
-	if (shader && shader->device->lastVertexShader == shader) {
-		shader->device->lastVertexShader = nullptr;
+	if (shader) {
+		gs_device_t *device = shader->device;
+		if (device->curVertexShader == shader) {
+			device->curVertexShader = nullptr;
+		}
+		if (device->lastVertexShader == shader) {
+			device->lastVertexShader = nullptr;
+		}
 	}
+
 	delete shader;
 }
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -2901,9 +2901,16 @@ void gs_samplerstate_destroy(gs_samplerstate_t *samplerstate)
 
 void gs_vertexbuffer_destroy(gs_vertbuffer_t *vertbuffer)
 {
-	if (vertbuffer && vertbuffer->device->lastVertexBuffer == vertbuffer) {
-		vertbuffer->device->lastVertexBuffer = nullptr;
+	if (vertbuffer) {
+		gs_device_t *device = vertbuffer->device;
+		if (device->curVertexBuffer == vertbuffer) {
+			device->curVertexBuffer = nullptr;
+		}
+		if (device->lastVertexBuffer == vertbuffer) {
+			device->lastVertexBuffer = nullptr;
+		}
 	}
+
 	delete vertbuffer;
 }
 
@@ -2956,6 +2963,10 @@ struct gs_vb_data *gs_vertexbuffer_get_data(const gs_vertbuffer_t *vertbuffer)
 
 void gs_indexbuffer_destroy(gs_indexbuffer_t *indexbuffer)
 {
+	if (indexbuffer && indexbuffer->device->curIndexBuffer == indexbuffer) {
+		indexbuffer->device->curIndexBuffer = nullptr;
+	}
+
 	delete indexbuffer;
 }
 

--- a/libobs-d3d11/d3d11-subsystem.hpp
+++ b/libobs-d3d11/d3d11-subsystem.hpp
@@ -723,6 +723,7 @@ struct gs_vertex_shader : gs_shader {
 
 	std::vector<D3D11_INPUT_ELEMENT_DESC> layoutData;
 
+	bool hasPositions;
 	bool hasNormals;
 	bool hasColors;
 	bool hasTangents;
@@ -739,7 +740,10 @@ struct gs_vertex_shader : gs_shader {
 
 	inline uint32_t NumBuffersExpected() const
 	{
-		uint32_t count = nTexUnits + 1;
+		uint32_t count = nTexUnits;
+		if (hasPositions) {
+			count++;
+		}
 		if (hasNormals) {
 			count++;
 		}

--- a/libobs-d3d11/d3d11-vertexbuffer.cpp
+++ b/libobs-d3d11/d3d11-vertexbuffer.cpp
@@ -48,8 +48,10 @@ void gs_vertex_buffer::FlushBuffer(ID3D11Buffer *buffer, void *array, size_t ele
 UINT gs_vertex_buffer::MakeBufferList(gs_vertex_shader *shader, ID3D11Buffer **buffers, uint32_t *strides)
 {
 	UINT numBuffers = 0;
-	PushBuffer(&numBuffers, buffers, strides, vertexBuffer, sizeof(vec3), "point");
 
+	if (shader->hasPositions) {
+		PushBuffer(&numBuffers, buffers, strides, vertexBuffer, sizeof(vec3), "point");
+	}
 	if (shader->hasNormals) {
 		PushBuffer(&numBuffers, buffers, strides, normalBuffer, sizeof(vec3), "normal");
 	}

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2421,6 +2421,8 @@ static bool update_async_texrender(struct obs_source *source, const struct obs_s
 			gs_effect_set_val(max_param, frame->color_range_max, sizeof(float) * 3);
 		}
 
+		gs_load_vertexbuffer(NULL);
+		gs_load_indexbuffer(NULL);
 		gs_draw(GS_TRIS, 0, 3);
 
 		gs_technique_end_pass(tech);

--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -2458,6 +2458,8 @@ static bool update_async_texrender(struct obs_source *source, const struct obs_s
 			gs_effect_set_val(max_param, frame->color_range_max, sizeof(float) * 3);
 		}
 
+		gs_load_vertexbuffer(NULL);
+		gs_load_indexbuffer(NULL);
 		gs_draw(GS_TRIS, 0, 3);
 
 		gs_technique_end_pass(tech);

--- a/libobs/obs-video.c
+++ b/libobs/obs-video.c
@@ -331,6 +331,9 @@ static void render_convert_plane(gs_effect_t *effect, gs_texture_t *target, cons
 	gs_set_render_target(target, NULL);
 	set_render_size(width, height);
 
+	gs_load_vertexbuffer(NULL);
+	gs_load_indexbuffer(NULL);
+
 	size_t passes = gs_technique_begin(tech);
 	for (size_t i = 0; i < passes; i++) {
 		gs_technique_begin_pass(tech, i);

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -944,6 +944,9 @@ static void nvvfx_filter_render(void *data, gs_effect_t *effect, bool has_blur)
 			gs_effect_set_texture_srgb(filter->image_param, gs_texrender_get_texture(render));
 			gs_effect_set_float(filter->multiplier_param, multiplier);
 
+			gs_load_vertexbuffer(NULL);
+			gs_load_indexbuffer(NULL);
+
 			while (gs_effect_loop(filter->effect, tech_name)) {
 				gs_draw(GS_TRIS, 0, 3);
 			}

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -942,6 +942,9 @@ static void nvvfx_filter_render(void *data, gs_effect_t *effect, bool has_blur)
 			gs_effect_set_texture_srgb(filter->image_param, gs_texrender_get_texture(render));
 			gs_effect_set_float(filter->multiplier_param, multiplier);
 
+			gs_load_vertexbuffer(NULL);
+			gs_load_indexbuffer(NULL);
+
 			while (gs_effect_loop(filter->effect, tech_name)) {
 				gs_draw(GS_TRIS, 0, 3);
 			}


### PR DESCRIPTION
### Description
Crash reports indicated something was crashing in `LoadVertexBufferData`. While I was unable to reproduce a crash, I did notice some dangling pointers if vertex buffers, index buffers or vertex shaders were freed while rendering was still active. Worse, the code assumed that every draw call would have vertex positions, which is not true for the triangles used when rendering textures for GPU conversion and async sources. Those would end up using whatever vertex buffer was last loaded into buffer list, which if since-freed could also trigger a use-after-free crash.

I also noticed that we were inconsistent in our use of `gs_load_indexbuffer` - many places neglected to call it before drawing, causing it to use whatever the last draw caller set. Currently there's no direct code in OBS that ever calls this with a non-NULL value, but as this is exported to the API we should always assume it can be changed between draw calls.

### Motivation and Context
Code correctness and hopefully crash fixes.

### How Has This Been Tested?
Basic run of OBS with async texture sources, no obvious regression spotted. Unable to reproduce the crashing.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
