### PR TITLE
frontend, plugins: Remove PreferSystem32Images mitigation

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -846,11 +846,6 @@ static bool vc_runtime_outdated()
 
 static void set_process_mitigation_policies()
 {
-	// DLL planting protection - prefer system32 images
-	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {};
-	policy.PreferSystem32Images = 1;
-	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
-
 	PROCESS_MITIGATION_DEP_POLICY dep = {0};
 	dep.DisableAtlThunkEmulation = 1;
 	dep.Enable = 1;

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -1156,10 +1156,6 @@ int main(int argc, char *argv[])
 	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 	SetDllDirectoryW(L"");
 
-	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
-	policy.PreferSystem32Images = 1;
-	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
-
 	argv = malloc(argc * sizeof(char *));
 	for (int i = 0; i < argc; i++) {
 		size_t len = wcslen(argv_w[i]);

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
@@ -21,10 +21,6 @@ int main(int argc, char *argv[])
 	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 	SetDllDirectoryW(L"");
 
-	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
-	policy.PreferSystem32Images = 1;
-	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
-
 	if (!RegisterClassA(&wc)) {
 		printf("failed to register '%s'\n", DUMMY_WNDCLASS);
 		return -1;

--- a/plugins/win-capture/inject-helper/inject-helper.c
+++ b/plugins/win-capture/inject-helper/inject-helper.c
@@ -101,10 +101,6 @@ int main(void)
 	SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 	SetDllDirectoryW(L"");
 
-	PROCESS_MITIGATION_IMAGE_LOAD_POLICY policy = {0};
-	policy.PreferSystem32Images = 1;
-	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
-
 	load_debug_privilege();
 
 	pCommandLineW = GetCommandLineW();


### PR DESCRIPTION
### Description
This process mitigation flag is inherited by child processes and applies to load-time DLL resolution, pushing the application's own directory below the system directories. If there are system-installed copies of dependent DLLs such as FFmpeg, those get loaded when OBS is updated as the updater and subsequent relaunch of OBS inherit the mitigation.

As we use `SetDefaultDllDirectories`, this mitigation is less important, the proper fix would be to use `/DEPENDENTLOADFLAG` to protect load-time import resolution.

### Motivation and Context
Fix incorrect import resolution if OBS is relaunched by the updater.

### How Has This Been Tested?
Replaced obs64.exe with a version from this change, updated and observed no more failure to load plugins.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
