### PR TITLE
obs-qsv11: Fix CQP values in encoder log

### DIFF
--- a/plugins/obs-qsv11/obs-qsv11.c
+++ b/plugins/obs-qsv11/obs-qsv11.c
@@ -654,12 +654,19 @@ static void update_params(struct obs_qsv *obsqsv, obs_data_t *settings)
 	if (obsqsv->params.nLADEPTH)
 		blog(LOG_INFO, "\tLookahead Depth:%d", (int)obsqsv->params.nLADEPTH);
 
-	if (obsqsv->params.nRateControl == MFX_RATECONTROL_CQP)
-		blog(LOG_INFO,
-		     "\tqpi:            %d\n"
-		     "\tqpb:            %d\n"
-		     "\tqpp:            %d",
-		     qpi, qpb, qpp);
+	if (obsqsv->params.nRateControl == MFX_RATECONTROL_CQP) {
+		if (ver == 1) {
+			blog(LOG_INFO,
+			     "\tqpi:            %d\n"
+			     "\tqpb:            %d\n"
+			     "\tqpp:            %d",
+			     qpi, qpb, qpp);
+		} else {
+			blog(LOG_INFO,
+			     "\tcqp:            %d",
+			     cqp);
+		}
+	}
 
 	blog(LOG_INFO,
 	     "\ttarget_usage:   %s\n"


### PR DESCRIPTION
Log the separate QPI, QPB, and QPP settings for encoder version 1 and the shared CQP setting for version 2.

### Description
QSV encoder version 2 uses a single CQP setting, but the encoder log
currently prints the unused legacy QPI, QPB, and QPP settings. These
retain their default value of 23 regardless of the configured CQP
value.

### Motivation and Context
The current log output suggests that the configured CQP value is not
being applied, even though recordings made with different CQP values
show that the encoder does use the selected setting.

For example, recordings configured with CQP 12 and CQP 30 both report
QPI, QPB, and QPP as 23 in the log despite producing substantially
different file sizes.

### How Has This Been Tested?
The existing incorrect log behavior was reproduced with QuickSync
H.264 CQP recordings on Windows.

This change has been reviewed against the version-specific settings
paths but has not yet been runtime-tested in a locally built OBS
version.

  ### Types of changes
  - Bug fix (non-breaking change which fixes an issue)
  
  ### Checklist:
   - [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
  - [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
  - [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
  - [x] My code is not on the master branch.
  - [ ] My code has been tested.
  - [x] All commit messages are properly formatted and commits squashed where appropriate.
  - [x] I have included updates to all appropriate documentation.
