### PR TITLE
Add windows arm64 support for win-dshow and win-capture

### DIFF
--- a/plugins/win-capture/game-capture-file-init.c
+++ b/plugins/win-capture/game-capture-file-init.c
@@ -8,6 +8,7 @@
 #include <util/platform.h>
 #include <util/c99defs.h>
 #include <util/base.h>
+#include "process-arch.h"
 
 /* ------------------------------------------------------------------------- */
 /* helper funcs                                                              */
@@ -147,9 +148,16 @@ static LSTATUS get_reg(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name, bool b64)
 static bool programdata64_hook_exists = false;
 static bool programdata32_hook_exists = false;
 
-char *get_hook_path(bool b64)
+char *get_hook_path(enum process_arch arch)
 {
 	wchar_t path[MAX_PATH];
+	const bool b64 = arch != PROCESS_ARCH_X86;
+
+	/* Native ARM64 targets need the ARM64 hook, which is never staged into
+	 * ProgramData (only the 32-bit and 64-bit hooks are, for Vulkan layer
+	 * registration), so always load it from the plugin directory. */
+	if (arch == PROCESS_ARCH_ARM64)
+		return obs_module_file("graphics-hook-arm64.dll");
 
 	get_programdata_path(path, L"obs-studio-hook\\");
 	make_filename(path, L"graphics-hook", L".dll");

--- a/plugins/win-capture/game-capture.c
+++ b/plugins/win-capture/game-capture.c
@@ -19,6 +19,7 @@
 #include "app-helpers.h"
 #include "audio-helpers.h"
 #include "nt-stuff.h"
+#include "process-arch.h"
 
 #define do_log(level, format, ...) \
 	blog(level, "[game-capture: '%s'] " format, obs_source_get_name(gc->source), ##__VA_ARGS__)
@@ -147,7 +148,7 @@ struct game_capture {
 	bool active;
 	bool capturing;
 	bool activate_hook;
-	bool process_is_64bit;
+	enum process_arch process_arch;
 	bool error_acquiring;
 	bool dwm_capture;
 	bool initial_config;
@@ -197,6 +198,7 @@ struct game_capture {
 
 struct graphics_offsets offsets32 = {0};
 struct graphics_offsets offsets64 = {0};
+struct graphics_offsets offsets_arm64 = {0};
 
 static inline bool use_anticheat(struct game_capture *gc)
 {
@@ -689,6 +691,51 @@ static inline bool is_64bit_process(HANDLE process)
 	return !x86;
 }
 
+/* GetProcessInformation is Windows 11 and newer, so it is resolved at runtime to
+ * keep working on older systems. */
+typedef BOOL(WINAPI *get_process_information_t)(HANDLE, PROCESS_INFORMATION_CLASS, LPVOID, DWORD);
+
+/* Determine the architecture of a target process.
+ *
+ * IsWow64Process only reports whether a process runs under WOW64, so on Windows
+ * on ARM it cannot tell a native ARM64 process from an emulated x64 one -- both
+ * report "not WOW64". IsWow64Process2 is no better here: for both of those it
+ * returns IMAGE_FILE_MACHINE_UNKNOWN as the process machine (measured on an
+ * ARM64 host: native ARM64, ARM64EC and x64 targets all report UNKNOWN).
+ *
+ * GetProcessInformation(ProcessMachineTypeInfo) does report the real machine
+ * (ARM64 / AMD64 / I386) for every case, so prefer it and keep the older APIs
+ * only as a fallback for systems that lack it (pre-Windows 11). */
+static inline enum process_arch get_process_arch(HANDLE process)
+{
+	static get_process_information_t get_process_information = NULL;
+	static bool resolved = false;
+
+	if (!resolved) {
+		get_process_information = (get_process_information_t)GetProcAddress(GetModuleHandleW(L"kernel32"),
+										    "GetProcessInformation");
+		resolved = true;
+	}
+
+	if (get_process_information) {
+		PROCESS_MACHINE_INFORMATION info = {0};
+		if (get_process_information(process, ProcessMachineTypeInfo, &info, sizeof(info))) {
+			switch (info.ProcessMachine) {
+			case IMAGE_FILE_MACHINE_I386:
+				return PROCESS_ARCH_X86;
+			case IMAGE_FILE_MACHINE_AMD64:
+				return PROCESS_ARCH_X64;
+			case IMAGE_FILE_MACHINE_ARM64:
+				return PROCESS_ARCH_ARM64;
+			}
+		}
+	}
+
+	/* Fall back to the WOW64 check, which can at least separate 32-bit from
+	 * 64-bit targets. */
+	return is_64bit_process(process) ? PROCESS_ARCH_X64 : PROCESS_ARCH_X86;
+}
+
 static inline bool open_target_process(struct game_capture *gc)
 {
 	gc->target_process = open_process(PROCESS_QUERY_INFORMATION | SYNCHRONIZE, false, gc->process_id);
@@ -697,7 +744,7 @@ static inline bool open_target_process(struct game_capture *gc)
 		return false;
 	}
 
-	gc->process_is_64bit = is_64bit_process(gc->target_process);
+	gc->process_arch = get_process_arch(gc->target_process);
 	gc->is_app = is_app(gc->target_process);
 	if (gc->is_app) {
 		gc->app_sid = get_app_sid(gc->target_process);
@@ -793,7 +840,27 @@ static inline bool init_hook_info(struct game_capture *gc)
 		     "(multi-adapter compatibility mode)");
 	}
 
-	gc->global_hook_info->offsets = gc->process_is_64bit ? offsets64 : offsets32;
+	const struct graphics_offsets *offsets;
+	switch (gc->process_arch) {
+	case PROCESS_ARCH_ARM64:
+		offsets = &offsets_arm64;
+		break;
+	case PROCESS_ARCH_X64:
+		offsets = &offsets64;
+		break;
+	default:
+		offsets = &offsets32;
+		break;
+	}
+
+	/* The offsets are filled in by get-graphics-offsets-<arch>.exe at load time.
+	 * If that helper failed there is nothing for the hook to hook, so bail out
+	 * with a diagnostic instead of injecting a zeroed table. */
+	if (!offsets->d3d9.present && !offsets->dxgi.present && !offsets->dxgi.present1) {
+		warn("init_hook_info: no graphics offsets for '%s' targets", process_arch_suffix(gc->process_arch));
+		return false;
+	}
+	gc->global_hook_info->offsets = *offsets;
 	gc->global_hook_info->capture_overlay = gc->config.capture_overlays;
 	gc->global_hook_info->force_shmem = gc->config.force_shmem;
 	gc->global_hook_info->UNUSED_use_scale = false;
@@ -909,7 +976,7 @@ static inline bool create_inject_process(struct game_capture *gc, const char *in
 	return success;
 }
 
-extern char *get_hook_path(bool b64);
+extern char *get_hook_path(enum process_arch arch);
 
 static inline bool inject_hook(struct game_capture *gc)
 {
@@ -917,14 +984,15 @@ static inline bool inject_hook(struct game_capture *gc)
 	bool success = false;
 	char *inject_path;
 	char *hook_path;
+	struct dstr inject_exe = {0};
 
-	if (gc->process_is_64bit) {
-		inject_path = obs_module_file("inject-helper64.exe");
-	} else {
-		inject_path = obs_module_file("inject-helper32.exe");
-	}
+	dstr_copy(&inject_exe, "inject-helper");
+	dstr_cat(&inject_exe, process_arch_suffix(gc->process_arch));
+	dstr_cat(&inject_exe, ".exe");
+	inject_path = obs_module_file(inject_exe.array);
+	dstr_free(&inject_exe);
 
-	hook_path = get_hook_path(gc->process_is_64bit);
+	hook_path = get_hook_path(gc->process_arch);
 
 	if (!check_file_integrity(gc, inject_path, "inject helper")) {
 		goto cleanup;
@@ -933,11 +1001,11 @@ static inline bool inject_hook(struct game_capture *gc)
 		goto cleanup;
 	}
 
-#ifdef _WIN64
-	matching_architecture = gc->process_is_64bit;
-#else
-	matching_architecture = !gc->process_is_64bit;
-#endif
+	/* A remote thread can only be created in a process of the same
+	 * architecture, so anything else has to go through the inject helper.
+	 * On Windows on ARM this matters for emulated x64 targets: they are
+	 * 64-bit like this ARM64 build, but not the same architecture. */
+	matching_architecture = gc->process_arch == obs_process_arch();
 
 	if (matching_architecture && !use_anticheat(gc)) {
 		info("using direct hook");

--- a/plugins/win-capture/load-graphics-offsets.c
+++ b/plugins/win-capture/load-graphics-offsets.c
@@ -7,9 +7,36 @@
 
 #include <windows.h>
 #include "graphics-hook-info.h"
+#include "process-arch.h"
 
 extern struct graphics_offsets offsets32;
 extern struct graphics_offsets offsets64;
+extern struct graphics_offsets offsets_arm64;
+
+static inline struct graphics_offsets *offsets_for_arch(enum process_arch arch)
+{
+	switch (arch) {
+	case PROCESS_ARCH_ARM64:
+		return &offsets_arm64;
+	case PROCESS_ARCH_X64:
+		return &offsets64;
+	default:
+		return &offsets32;
+	}
+}
+
+/* Config file suffix for the cached offsets of each architecture. */
+static inline const char *config_suffix(enum process_arch arch)
+{
+	switch (arch) {
+	case PROCESS_ARCH_ARM64:
+		return "-arm64.ini";
+	case PROCESS_ARCH_X64:
+		return "64.ini";
+	default:
+		return "32.ini";
+	}
+}
 
 static inline bool load_offsets_from_string(struct graphics_offsets *offsets, const char *str)
 {
@@ -139,7 +166,7 @@ failed:
 	return !ver_mismatch;
 }
 
-bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache, const char *config_path)
+bool load_graphics_offsets(enum process_arch arch, bool use_hook_address_cache, const char *config_path)
 {
 	char *offset_exe_path = NULL;
 	struct dstr config_ini = {0};
@@ -151,13 +178,14 @@ bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache, const char
 	char data[2048];
 
 #ifndef _WIN64
-	if (!is32bit && !is_64_bit_windows()) {
+	if (arch != PROCESS_ARCH_X86 && !is_64_bit_windows()) {
 		return true;
 	}
 #endif
 
 	dstr_copy(&offset_exe, "get-graphics-offsets");
-	dstr_cat(&offset_exe, is32bit ? "32.exe" : "64.exe");
+	dstr_cat(&offset_exe, process_arch_suffix(arch));
+	dstr_cat(&offset_exe, ".exe");
 	offset_exe_path = obs_module_file(offset_exe.array);
 
 	dstr_init_move_array(&cmd, offset_exe_path);
@@ -188,13 +216,13 @@ bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache, const char
 
 	if (use_hook_address_cache) {
 		dstr_copy(&config_ini, config_path);
-		dstr_cat(&config_ini, is32bit ? "32.ini" : "64.ini");
+		dstr_cat(&config_ini, config_suffix(arch));
 
 		os_quick_write_utf8_file_safe(config_ini.array, str.array, str.len, false, "tmp", NULL);
 		dstr_free(&config_ini);
 	}
 
-	success = load_offsets_from_string(is32bit ? &offsets32 : &offsets64, str.array);
+	success = load_offsets_from_string(offsets_for_arch(arch), str.array);
 	if (!success) {
 		blog(LOG_INFO, "load_graphics_offsets: Failed to load string");
 	}
@@ -208,16 +236,16 @@ error:
 	return success;
 }
 
-bool load_cached_graphics_offsets(bool is32bit, const char *config_path)
+bool load_cached_graphics_offsets(enum process_arch arch, const char *config_path)
 {
 	struct dstr config_ini = {0};
 	bool success;
 
 	dstr_copy(&config_ini, config_path);
-	dstr_cat(&config_ini, is32bit ? "32.ini" : "64.ini");
-	success = load_offsets_from_file(is32bit ? &offsets32 : &offsets64, config_ini.array);
+	dstr_cat(&config_ini, config_suffix(arch));
+	success = load_offsets_from_file(offsets_for_arch(arch), config_ini.array);
 	if (!success)
-		success = load_graphics_offsets(is32bit, true, config_path);
+		success = load_graphics_offsets(arch, true, config_path);
 
 	dstr_free(&config_ini);
 	return success;

--- a/plugins/win-capture/plugin-main.c
+++ b/plugins/win-capture/plugin-main.c
@@ -8,6 +8,7 @@
 
 #include "compat-helpers.h"
 #include "compat-format-ver.h"
+#include "process-arch.h"
 #ifdef OBS_LEGACY
 #include "compat-config.h"
 #endif
@@ -31,15 +32,21 @@ static HANDLE init_hooks_thread = NULL;
 static update_info_t *update_info = NULL;
 
 extern bool cached_versions_match(void);
-extern bool load_cached_graphics_offsets(bool is32bit, const char *config_path);
-extern bool load_graphics_offsets(bool is32bit, bool use_hook_address_cache, const char *config_path);
+extern bool load_cached_graphics_offsets(enum process_arch arch, const char *config_path);
+extern bool load_graphics_offsets(enum process_arch arch, bool use_hook_address_cache, const char *config_path);
 
-/* temporary, will eventually be erased once we figure out how to create both
- * 32bit and 64bit versions of the helpers/hook */
+/* Offsets are needed for every architecture a capture target may run as. On
+ * Windows on ARM that includes native ARM64 as well as emulated x64. */
 #ifdef _WIN64
-#define IS32BIT false
+static const enum process_arch offset_archs[] = {
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+	PROCESS_ARCH_ARM64,
+#endif
+	PROCESS_ARCH_X64,
+	PROCESS_ARCH_X86,
+};
 #else
-#define IS32BIT true
+static const enum process_arch offset_archs[] = {PROCESS_ARCH_X86, PROCESS_ARCH_X64};
 #endif
 
 static const bool use_hook_address_cache = false;
@@ -48,13 +55,20 @@ static DWORD WINAPI init_hooks(LPVOID param)
 {
 	char *config_path = param;
 
-	if (use_hook_address_cache && cached_versions_match() && load_cached_graphics_offsets(IS32BIT, config_path)) {
+	if (use_hook_address_cache && cached_versions_match() &&
+	    load_cached_graphics_offsets(offset_archs[0], config_path)) {
 
-		load_cached_graphics_offsets(!IS32BIT, config_path);
+		for (size_t i = 1; i < OBS_COUNTOF(offset_archs); i++)
+			load_cached_graphics_offsets(offset_archs[i], config_path);
 		obs_register_source(&game_capture_info);
 
-	} else if (load_graphics_offsets(IS32BIT, use_hook_address_cache, config_path)) {
-		load_graphics_offsets(!IS32BIT, use_hook_address_cache, config_path);
+	} else {
+		/* Load each architecture independently: a failure for one must not
+		 * skip the others. On Windows on ARM the emulated x64 targets are
+		 * the common case, so losing their offsets because the ARM64
+		 * helper failed would be the worse outcome. */
+		for (size_t i = 0; i < OBS_COUNTOF(offset_archs); i++)
+			load_graphics_offsets(offset_archs[i], use_hook_address_cache, config_path);
 	}
 
 	bfree(config_path);

--- a/plugins/win-capture/process-arch.h
+++ b/plugins/win-capture/process-arch.h
@@ -1,0 +1,33 @@
+#pragma once
+
+/* Architecture of a capture target process. On Windows on ARM a 64-bit process
+ * may be either native ARM64 or emulated x64, and each needs its own hook DLL,
+ * inject helper and graphics offsets, so a plain 32/64-bit distinction is not
+ * enough. */
+enum process_arch { PROCESS_ARCH_X86, PROCESS_ARCH_X64, PROCESS_ARCH_ARM64 };
+
+/* Filename suffix used by the per-architecture helper files, e.g.
+ * graphics-hook<suffix>.dll and inject-helper<suffix>.exe. */
+static inline const char *process_arch_suffix(enum process_arch arch)
+{
+	switch (arch) {
+	case PROCESS_ARCH_ARM64:
+		return "-arm64";
+	case PROCESS_ARCH_X64:
+		return "64";
+	default:
+		return "32";
+	}
+}
+
+/* The architecture this build of OBS runs as. */
+static inline enum process_arch obs_process_arch(void)
+{
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+	return PROCESS_ARCH_ARM64;
+#elif defined(_WIN64)
+	return PROCESS_ARCH_X64;
+#else
+	return PROCESS_ARCH_X86;
+#endif
+}

--- a/plugins/win-dshow/virtualcam-module/CMakeLists.txt
+++ b/plugins/win-dshow/virtualcam-module/CMakeLists.txt
@@ -123,6 +123,58 @@ if(OBS_PARENT_ARCHITECTURE STREQUAL CMAKE_VS_PLATFORM_NAME)
     )
   endif()
 
+  # On ARM64, rebuild the module as an ARM64X hybrid image, replacing the plain
+  # ARM64 DLL in place. Native-ARM64 and emulated-x64 processes share a single
+  # 64-bit COM registration view, so the one InprocServer32 slot can point at
+  # only one architecture. An ARM64X image holds both an arm64 and an arm64ec
+  # slice, letting that single registration serve both kinds of consumer.
+  # See cmake/windows/build-arm64x.cmake for the mechanism.
+  if(CMAKE_VS_PLATFORM_NAME STREQUAL ARM64)
+    # Derive the ARM64 cross tools and vcvarsall from the configured linker:
+    #   <VC>/Tools/MSVC/<ver>/bin/Hostx64/arm64/link.exe
+    cmake_path(GET CMAKE_LINKER PARENT_PATH _arm64x_bindir)
+    set(ARM64X_LINK "${CMAKE_LINKER}")
+    set(ARM64X_CL "${_arm64x_bindir}/cl.exe")
+    string(REGEX REPLACE "/VC/Tools/MSVC/.*$" "/VC/Auxiliary/Build/vcvarsall.bat" VCVARSALL "${CMAKE_LINKER}")
+
+    # configure_file() cannot expand $<CONFIG>, so the wrapper takes the real
+    # configuration as argument 1 and substitutes it for %CONFIG% at build time.
+    set(ARM64X_NATIVE_OBJ_DIR "${CMAKE_CURRENT_BINARY_DIR}/obs-virtualcam-module.dir/%CONFIG%")
+    set(ARM64X_EC_OBJ_DIR "${CMAKE_CURRENT_BINARY_DIR}/arm64ec.dir/%CONFIG%")
+    set(ARM64X_WORK_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+    set(ARM64X_SCRIPT "${CMAKE_CURRENT_SOURCE_DIR}/cmake/windows/build-arm64x.cmake")
+    # Reuse the native ARM64 exports: an ARM64X image needs the same six COM
+    # entry points in both of its views.
+    set(ARM64X_DEF "${CMAKE_CURRENT_SOURCE_DIR}/cmake/windows/virtualcam-module-arm64.def")
+    # Overwrite the module the native link just produced, PDB included: the native
+    # PDB does not describe the hybrid image, and it is packaged next to the DLL.
+    set(ARM64X_OUT_DLL "${CMAKE_CURRENT_BINARY_DIR}/%CONFIG%/obs-virtualcam-module-arm64.dll")
+    set(ARM64X_OUT_PDB "${CMAKE_CURRENT_BINARY_DIR}/%CONFIG%/obs-virtualcam-module-arm64.pdb")
+
+    # vcvarsall takes <host>_<target>; on an ARM64 host this is a native build.
+    if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+      set(ARM64X_VCVARS_ARG arm64)
+    else()
+      set(ARM64X_VCVARS_ARG amd64_arm64)
+    endif()
+    # Mirrors the native link: the libraries linked above plus the Win32 defaults.
+    set(ARM64X_SYSTEM_LIBS "gdiplus.lib strmiids.lib winmm.lib ${CMAKE_CXX_STANDARD_LIBRARIES}")
+
+    configure_file(cmake/windows/build-arm64x.bat.in build-arm64x.bat @ONLY)
+
+    # Under the VS generator the command runs inside a .rule via cmd, which
+    # resolves a bare .bat first token as a relative command and fails to find
+    # it. Go through `cmd /c call "<native abs path>"` instead.
+    cmake_path(NATIVE_PATH CMAKE_CURRENT_BINARY_DIR _arm64x_bindir_native)
+    add_custom_command(
+      TARGET obs-virtualcam-module
+      POST_BUILD
+      COMMAND cmd /c call "${_arm64x_bindir_native}\\build-arm64x.bat" $<CONFIG>
+      COMMENT "Build ARM64X obs-virtualcam-module"
+      VERBATIM
+    )
+  endif()
+
   add_dependencies(win-dshow obs-virtualcam-module)
 endif()
 

--- a/plugins/win-dshow/virtualcam-module/cmake/windows/build-arm64x.bat.in
+++ b/plugins/win-dshow/virtualcam-module/cmake/windows/build-arm64x.bat.in
@@ -1,0 +1,35 @@
+@echo off
+rem Auto-generated wrapper: set up the ARM64 cross toolchain environment, then
+rem run the ARM64X post-build driver via cmake -P.
+rem
+rem The build configuration (Debug/RelWithDebInfo/...) is passed as %1 at build
+rem time. CMake's configure_file() does NOT expand generator expressions, so the
+rem paths below use %CONFIG% and we substitute the real config at run time.
+setlocal EnableDelayedExpansion
+set "CONFIG=%~1"
+if "%CONFIG%"=="" (
+  echo ARM64X: no build configuration passed as argument 1
+  exit /b 1
+)
+
+rem The vcvarsall argument is <host>_<target>, so it depends on the machine doing
+rem the build: an x64 host cross-compiles (amd64_arm64) while an ARM64 host builds
+rem natively (arm64). Use the host architecture CMake detected at configure time.
+call "@VCVARSALL@" @ARM64X_VCVARS_ARG@ >nul 2>&1
+if errorlevel 1 (
+  echo ARM64X: failed to initialize @ARM64X_VCVARS_ARG@ environment via vcvarsall
+  exit /b 1
+)
+
+"@CMAKE_COMMAND@" ^
+  -DNATIVE_OBJ_DIR="@ARM64X_NATIVE_OBJ_DIR@" ^
+  -DWORK_DIR="@ARM64X_WORK_DIR@" ^
+  -DCL="@ARM64X_CL@" ^
+  -DLINK="@ARM64X_LINK@" ^
+  -DDEF="@ARM64X_DEF@" ^
+  -DOUT_DLL="@ARM64X_OUT_DLL@" ^
+  -DEC_OBJ_DIR="@ARM64X_EC_OBJ_DIR@" ^
+  -DSYSTEM_LIBS="@ARM64X_SYSTEM_LIBS@" ^
+  -DOUT_PDB="@ARM64X_OUT_PDB@" ^
+  -P "@ARM64X_SCRIPT@"
+exit /b %errorlevel%

--- a/plugins/win-dshow/virtualcam-module/cmake/windows/build-arm64x.cmake
+++ b/plugins/win-dshow/virtualcam-module/cmake/windows/build-arm64x.cmake
@@ -1,0 +1,169 @@
+# build-arm64x.cmake
+#
+# Post-build driver that produces an ARM64X hybrid variant of the virtual-camera
+# DirectShow filter from the already-built native ARM64 object files.
+#
+# Why ARM64X: the DirectShow filter DLL is loaded IN-PROCESS by the application
+# that consumes the camera. On Windows on ARM the native-ARM64 and emulated-x64
+# processes share ONE 64-bit COM registration view (HKCR\CLSID\{guid}\InprocServer32),
+# which has a single slot. A single-arch DLL can therefore serve only one of the two.
+# An ARM64X image contains BOTH an arm64 slice (for native ARM64 consumers) and an
+# arm64ec slice (for emulated x64 consumers), so one registered DLL serves both.
+#
+# Approach: recompile the same translation units with /arm64EC, then merge the
+# native arm64 objects and the arm64ec objects with `link /MACHINE:ARM64X`.
+#
+# Invoked via cmake -P with these -D arguments:
+#   NATIVE_OBJ_DIR  - directory holding native ARM64 .obj/.res AND the *.tlog dir
+#   WORK_DIR        - working dir the native compile ran in (module build dir)
+#   CL              - full path to the ARM64-targeting cl.exe (Hostx64/arm64)
+#   LINK            - full path to link.exe (Hostx64/arm64)
+#   DEF             - path to the arm64x .def (exports)
+#   OUT_DLL         - final output DLL path
+#   EC_OBJ_DIR      - scratch dir for arm64ec .obj output
+#   SYSTEM_LIBS     - space-separated list of system import libs to link
+#   OUT_PDB         - PDB path for the hybrid image
+
+cmake_minimum_required(VERSION 3.28)
+
+# Locate the native CL command tlogs. The parent dir name carries an MSBuild hash
+# (obs-virt.XXXXXXXX.tlog), so glob rather than hard-code it. MSBuild may shard
+# the commands across CL.command.1.tlog, CL.command.2.tlog, ... so process all of
+# them, not just the first.
+file(GLOB TLOGS "${NATIVE_OBJ_DIR}/*.tlog/CL.command.*.tlog")
+if(NOT TLOGS)
+  message(FATAL_ERROR "ARM64X: no CL.command tlog under ${NATIVE_OBJ_DIR}/*.tlog/")
+endif()
+list(LENGTH TLOGS _tlog_count)
+message(STATUS "ARM64X: using ${_tlog_count} compile tlog(s): ${TLOGS}")
+
+file(MAKE_DIRECTORY "${EC_OBJ_DIR}")
+
+# --- Parse the UTF-16 MSBuild CL tlogs into (source, args) command pairs -------
+# Each command is two logical lines:
+#   ^<absolute source path>
+#   <cl argument string ending in the source path, contains /c /I /D ...>
+set(_ec_objs "")
+set(_compile_failed FALSE)
+set(_obj_index 0)
+
+foreach(_tlog IN LISTS TLOGS)
+  file(STRINGS "${_tlog}" _tlog_lines ENCODING UTF-16LE)
+  set(_pending_src "")
+
+  foreach(_line IN LISTS _tlog_lines)
+    # Strip a leading BOM if present on the first entry
+    string(REGEX REPLACE "^﻿" "" _line "${_line}")
+    if(_line MATCHES "^\\^(.+)$")
+      set(_pending_src "${CMAKE_MATCH_1}")
+    elseif(NOT _pending_src STREQUAL "")
+      # _line is the argument string for _pending_src. The sources come from
+      # several directories, so prefix an index to keep object names unique even
+      # when two trees contain the same file name.
+      get_filename_component(_base "${_pending_src}" NAME_WE)
+      set(_obj "${EC_OBJ_DIR}/${_obj_index}-${_base}.obj")
+      math(EXPR _obj_index "${_obj_index}+1")
+
+      # MSBuild records the object directory as /Fo"...\RelWithDebInfo\\", whose
+      # escaped trailing backslash makes separate_arguments() swallow the
+      # following separator and glue /Fo and /Fd into a single argument. Both are
+      # replaced below anyway, so drop them before parsing.
+      string(REGEX REPLACE "/F[od]\"[^\"]*\"" "" _line "${_line}")
+
+      # Recompile as ARM64EC. We keep the recorded args verbatim (they carry the
+      # exact /I include dirs, /D defines incl. the quoted CMAKE_INTDIR, /std,
+      # /EH, /MT, /WX and the source path) and only append overrides:
+      #   /arm64EC  -> emit ARM64EC code
+      #   /Fo<obj>  -> object output into our scratch dir
+      #   /Fd<pdb>  -> compiler PDB in our scratch dir, so the EC compile cannot
+      #                touch the native compile's vcNNN.pdb
+      # The args must run with WORKING_DIRECTORY = NATIVE_OBJ_DIR's parent (the
+      # module build dir) so relative /I and generated headers resolve as in the
+      # real build; the caller sets that via the wrapper's cd.
+      separate_arguments(_args NATIVE_COMMAND "${_line}")
+      execute_process(
+        COMMAND "${CL}" /arm64EC ${_args} "/Fo${_obj}" "/Fd${EC_OBJ_DIR}/arm64ec-cl.pdb"
+        WORKING_DIRECTORY "${WORK_DIR}"
+        RESULT_VARIABLE _rc
+        OUTPUT_VARIABLE _out
+        ERROR_VARIABLE _err
+      )
+      if(NOT _rc EQUAL 0)
+        message(WARNING "ARM64X: EC compile failed for ${_base}:\n${_out}\n${_err}")
+        set(_compile_failed TRUE)
+      else()
+        list(APPEND _ec_objs "${_obj}")
+      endif()
+      set(_pending_src "")
+    endif()
+  endforeach()
+endforeach()
+
+if(_compile_failed)
+  message(FATAL_ERROR "ARM64X: one or more ARM64EC compilations failed")
+endif()
+
+list(LENGTH _ec_objs _ec_count)
+if(_ec_count EQUAL 0)
+  message(FATAL_ERROR "ARM64X: no ARM64EC objects were produced (tlog parse failed?)")
+endif()
+message(STATUS "ARM64X: compiled ${_ec_count} ARM64EC object(s)")
+
+# --- Collect native objects (+ resource) --------------------------------------
+file(GLOB _native_objs "${NATIVE_OBJ_DIR}/*.obj")
+file(GLOB _native_res "${NATIVE_OBJ_DIR}/*.res")
+list(LENGTH _native_objs _nat_count)
+if(_nat_count EQUAL 0)
+  message(FATAL_ERROR "ARM64X: no native ARM64 objects in ${NATIVE_OBJ_DIR}")
+endif()
+message(STATUS "ARM64X: linking ${_nat_count} native + ${_ec_count} EC objects")
+
+# --- Merge-link into an ARM64X DLL --------------------------------------------
+# A single link invocation with /MACHINE:ARM64X and both object sets lets the
+# linker partition native vs EC code. CRT is pulled automatically (sources use
+# /MT) from the vcvars-provided lib paths for both slices.
+#
+# CRITICAL: an ARM64X image carries TWO export tables — one per view. /DEF only
+# populates the ARM64EC (emulated-x64) view; without /defArm64Native the NATIVE
+# ARM64 view exports nothing, so `dumpbin -exports` shows 0 functions and
+# regsvr32 cannot find DllRegisterServer/DllGetClassObject. The same .def (the
+# six Dll* COM entry points) applies to both views, so pass it to both switches.
+#
+# /DEBUG + /PDB and /Brepro mirror what MSBuild passes to the native link. Without
+# them the hybrid has no CodeView debug directory entry at all, so it cannot be
+# symbolized, and the stale PDB left behind by the native link would be packaged
+# alongside a DLL it does not describe.
+separate_arguments(_libs NATIVE_COMMAND "${SYSTEM_LIBS}")
+
+# The native link already wrote a PDB at this path. Left in place, link reuses it
+# and bumps its age on every rebuild, which changes the image and therefore the
+# /Brepro hash — an unchanged source tree would keep producing different bytes.
+file(REMOVE "${OUT_PDB}")
+
+execute_process(
+  COMMAND "${LINK}"
+    /nologo /DLL /MACHINE:ARM64X
+    /DEBUG /Brepro
+    "/PDB:${OUT_PDB}"
+    "/DEF:${DEF}"
+    "/defArm64Native:${DEF}"
+    "/OUT:${OUT_DLL}"
+    ${_native_objs}
+    ${_ec_objs}
+    ${_native_res}
+    ${_libs}
+  RESULT_VARIABLE _link_rc
+  OUTPUT_VARIABLE _link_out
+  ERROR_VARIABLE _link_err
+)
+if(NOT _link_rc EQUAL 0)
+  message(FATAL_ERROR "ARM64X: link failed:\n${_link_out}\n${_link_err}")
+endif()
+
+if(NOT EXISTS "${OUT_DLL}")
+  message(FATAL_ERROR "ARM64X: link reported success but ${OUT_DLL} is missing")
+endif()
+if(NOT EXISTS "${OUT_PDB}")
+  message(FATAL_ERROR "ARM64X: link reported success but ${OUT_PDB} is missing")
+endif()
+message(STATUS "ARM64X: produced ${OUT_DLL}")


### PR DESCRIPTION

### Description

Two Windows-on-ARM fixes, both about resolving the right architecture at load
time.

**1. `win-dshow` — build the virtual camera module as an ARM64X hybrid.**

The DirectShow filter is loaded *in-process* by the consuming application, and
native ARM64 and emulated x64 processes share a single 64-bit COM registration
key (`HKLM\SOFTWARE\Classes\CLSID\{guid}\InprocServer32`) with one slot for a DLL
path. A single-architecture module can therefore only ever serve one of the two,
whatever the installer does.

This recompiles the module's translation units with `/arm64EC` and merge-links
them with the native ARM64 objects via `link /MACHINE:ARM64X`, producing an image
with both an arm64 and an arm64ec slice. It **replaces**
`obs-virtualcam-module-arm64.dll` in place, so packaging, the `.def` and the
registration scripts are unchanged.

**2. `win-capture` — select the game capture hook by the target's architecture.**

`IsWow64Process()` cannot tell a native ARM64 target from an emulated x64 one —
both are 64-bit and both are "not WOW64" — so game capture injected
`graphics-hook64.dll` / `inject-helper64.exe` into native ARM64 games, even though
the `-arm64` hook, helper and offsets tool are already built and shipped. The code
just never selected them, which is why there are no build-system changes in this
half.

* Three-state `enum process_arch { X86, X64, ARM64 }` replaces the
  `process_is_64bit` / `is32bit` flags.
* Detection via `GetProcessInformation(ProcessMachineTypeInfo)`, resolved with
  `GetProcAddress` since it needs Windows 11; the WOW64 check remains as a
  fallback that at least separates 32-bit from 64-bit.

### Motivation and Context

**Virtual camera.** Emulated x64 applications are still most of the ecosystem on
Windows on ARM, and with a single-architecture module whichever architecture the
installer registers, the other gets no virtual camera at all. ARM64X is the only
fix because the constraint is the single COM registration slot, not the build.

This is the win dshow fix program in  #12768 .

**Game capture.** Native ARM64 games could not be captured at all — wrong-arch
hook, plus a direct-hook attempt across an architecture boundary where it cannot
work.

### How Has This Been Tested?

Snapdragon X Elite, Windows 11, VS 2022 

**Virtual camera.** Each module was registered with `regsvr32` for real, then
consumed via `CoCreateInstance(CLSID_OBSVirtualCam, CLSCTX_INPROC_SERVER,
IID_IBaseFilter)` from a native ARM64, an ARM64EC and an emulated x64 process.
Three arms, three rounds each, identical every round:

| Consumer | A: pure ARM64 (= #12768 alone) | B: **ARM64X (this PR)** | C: pure x64 (= master today) |
| --- | --- | --- | --- |
| native ARM64 | **OK** | **OK** | `0x800700C1` |
| ARM64EC | `0x800700C1` | **OK** | **OK** |
| emulated x64 | `0x800700C1` | **OK** | **OK** |



**Game capture.** Detection was checked against four purpose-built targets whose
real architecture was established independently with `dumpbin -headers`; all four
were classified correctly and got the matching hook and helper. ARM64EC images
report machine type `x64`, so classifying them as X64 is correct rather than a
fallback — the matrix above confirms it, since an ARM64EC process is served by an
x64 in-process DLL and rejected by a pure ARM64 one.


### Types of changes

Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

