### PR TITLE
frontend: Mark nested audio sources as previewed

### DIFF
--- a/frontend/widgets/AudioMixer.cpp
+++ b/frontend/widgets/AudioMixer.cpp
@@ -409,44 +409,7 @@ void AudioMixer::updatePreviewSources()
 			return;
 		}
 
-		if (!previewScene) {
-			return;
-		}
-
-		auto getPreviewSources = [this](obs_scene_t *, obs_sceneitem_t *item) {
-			if (!obs_sceneitem_visible(item)) {
-				return true;
-			}
-
-			obs_source_t *source = obs_sceneitem_get_source(item);
-			if (!source) {
-				return true;
-			}
-
-			uint32_t flags = obs_source_get_output_flags(source);
-			if ((flags & OBS_SOURCE_AUDIO) == 0) {
-				return true;
-			}
-
-			if (!obs_source_audio_active(source)) {
-				return true;
-			}
-
-			auto uuidPointer = obs_source_get_uuid(source);
-			if (uuidPointer && *uuidPointer) {
-				previewSources.insert(QString::fromUtf8(uuidPointer));
-			}
-
-			return true;
-		};
-
-		using getPreviewSources_t = decltype(getPreviewSources);
-
-		auto previewEnum = [](obs_scene_t *scene, obs_sceneitem_t *item, void *data) -> bool {
-			return (*static_cast<getPreviewSources_t *>(data))(scene, item);
-		};
-
-		obs_scene_enum_items(previewScene, previewEnum, &getPreviewSources);
+		findAudioSourcesInScene(previewScene);
 	}
 }
 
@@ -750,6 +713,52 @@ void AudioMixer::updateVolumeLayouts()
 	stackedMixerArea->setMinimumSize(minimumSize.width() + scrollBarSize, minimumSize.height() + scrollBarSize);
 
 	setUpdatesEnabled(true);
+}
+
+bool AudioMixer::enumPreviewSources(obs_scene_t *, obs_sceneitem_t *item)
+{
+	if (!obs_sceneitem_visible(item)) {
+		return true;
+	}
+
+	obs_source_t *source = obs_sceneitem_get_source(item);
+	if (!source) {
+		return true;
+	}
+
+	if (obs_source_is_scene(source)) {
+		findAudioSourcesInScene(obs_scene_from_source(source));
+		return true;
+	} else if (obs_source_is_group(source)) {
+		findAudioSourcesInScene(obs_group_from_source(source));
+		return true;
+	}
+
+	uint32_t flags = obs_source_get_output_flags(source);
+	if ((flags & OBS_SOURCE_AUDIO) == 0) {
+		return true;
+	}
+
+	if (!obs_source_audio_active(source)) {
+		return true;
+	}
+
+	auto uuidPointer = obs_source_get_uuid(source);
+	if (uuidPointer && *uuidPointer) {
+		previewSources.insert(QString::fromUtf8(uuidPointer));
+	}
+
+	return true;
+}
+
+void AudioMixer::findAudioSourcesInScene(obs_scene_t *scene)
+{
+	auto getPreviewSources = [](obs_scene_t *scene, obs_sceneitem_t *item, void *data) -> bool {
+		auto mixer = static_cast<AudioMixer *>(data);
+		return mixer->enumPreviewSources(scene, item);
+	};
+
+	obs_scene_enum_items(scene, getPreviewSources, this);
 }
 
 void AudioMixer::mixerContextMenuRequested()

--- a/frontend/widgets/AudioMixer.hpp
+++ b/frontend/widgets/AudioMixer.hpp
@@ -116,6 +116,9 @@ private:
 	QTimer updateTimer;
 	void updateVolumeLayouts();
 
+	bool enumPreviewSources(obs_scene_t *scene, obs_sceneitem_t *item);
+	void findAudioSourcesInScene(obs_scene_t *scene);
+
 	// OBS Callbacks
 	static void obsSourceActivated(void *data, calldata_t *params);
 	static void obsSourceDeactivated(void *data, calldata_t *params);


### PR DESCRIPTION
### Description
Makes the check for previewed audio sources to be recursive for nested scenes or groups.

Fixes #13297

### Motivation and Context
Ensure all audio sources in the previewed scene are properly marked as Preview.

### How Has This Been Tested?
Tested with a scene that had grouped audio sources, and a scene with a subscene containing audio sources.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
