### PR TITLE
libobs: Fix color space query through non-video filters

### DIFF
--- a/libobs/obs-source.c
+++ b/libobs/obs-source.c
@@ -3010,6 +3010,12 @@ enum gs_color_space obs_source_get_color_space(obs_source_t *source, size_t coun
 			return obs_source_get_color_space(source->filter_parent, count, preferred_spaces);
 	}
 
+	/* a filter that produces no video must not answer for the chain below it */
+	if (source->info.type == OBS_SOURCE_TYPE_FILTER && (source->info.output_flags & OBS_SOURCE_VIDEO) == 0) {
+		if (source->filter_target)
+			return obs_source_get_color_space(source->filter_target, count, preferred_spaces);
+	}
+
 	if (!source->context.data || !source->enabled) {
 		if (source->filter_target)
 			return obs_source_get_color_space(source->filter_target, count, preferred_spaces);


### PR DESCRIPTION
### Description
This change fixes HDR color space identification when multiple filters are added to a source in different orders. Previously, if an audio filter was added before the HDR tonemapping override filter, the color space could be identified incorrectly and the HDR tonemapping filter would be skipped.

### Motivation and Context
I ran into this while streaming and investigating why HDR tonemapping was not being applied consistently. After reproducing the issue from a clean build, I found that the filter order affected HDR source detection: adding an audio filter first and then the HDR tonemapping override filter could cause the wrong color space to be returned, which prevented the HDR filter from applying.

### How Has This Been Tested?
I tested the behavior before and after the change using the HDR tonemapping filter. It now applies correctly regardless of whether audio or video filters were added first.

Tested on Windows 11 x64.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.