### PR TITLE
obs-ffmpeg: Fix B-frame offset calculation in AMF

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1720,8 +1720,8 @@ static void amf_avc_create_internal(amf_base *enc, obs_data_t *settings)
 		amf_int64 b_max = 0;
 
 		if (get_avc_property(enc, B_PIC_PATTERN, &b_frames) &&
-		    get_avc_property(enc, MAX_CONSECUTIVE_BPICTURES, &b_max)) {
-			enc->dts_offset = b_frames + 1;
+		    get_avc_property(enc, MAX_CONSECUTIVE_BPICTURES, &b_max) && b_frames > 0) {
+			enc->dts_offset = std::min(b_frames, b_max) + 1;
 		} else {
 			enc->dts_offset = 0;
 		}
@@ -2542,18 +2542,6 @@ static void amf_av1_create_internal(amf_base *enc, obs_data_t *settings)
 	res = enc->amf_encoder->GetProperty(AMF_VIDEO_ENCODER_AV1_EXTRA_DATA, &p);
 	if (res == AMF_OK && p.type == AMF_VARIANT_INTERFACE) {
 		enc->header = AMFBufferPtr(p.pInterface);
-	}
-
-	if (enc->bframes_supported) {
-		amf_int64 b_frames = 0;
-		amf_int64 b_max = 0;
-
-		if (get_av1_property(enc, B_PIC_PATTERN, &b_frames) &&
-		    get_av1_property(enc, MAX_CONSECUTIVE_BPICTURES, &b_max)) {
-			enc->dts_offset = b_frames + 1;
-		} else {
-			enc->dts_offset = 0;
-		}
 	}
 }
 


### PR DESCRIPTION
AMF AVC and AV1 encoders support B-frames in more recent GPUs, however the `enc->dts_offset` was being incremented even when b-frames were set to 0. 

For AVC, this caused IVS Stages to reject the stream because the offset is used to infer the presence of B-frames, which are not supported by IVS Stages (and WebRTC). 

For AV1, the code is not needed and was removed. See below for details.

### Description

For AVC, only increment the `enc->dts_offset` if the AMF encoder supports B-frames *and* b-frames are greater than 0. 

For AV1, remove the `dts_offset` calculation from `amf_av1_create_internal`. This code was dead — `convert_to_encoder_packet` already excludes AV1 from the DTS subtraction (added in [`b2d83efcf`](https://github.com/obsproject/obs-studio/pull/10996), PR #10996), since AV1 handles frame reordering transparently and doesn't require decode-order delay compensation at the mux layer.

The AV1 `dts_offset` block was introduced in [`1a2f8c284`](https://github.com/obsproject/obs-studio/commit/1a2f8c284450738db085dd39f1aea4597f05b434) (AMD AV1 B-frame support) as a mechanical copy of the AVC pattern without accounting for this exclusion. This aligns with the NVENC implementation (`plugins/obs-nvenc/nvenc.c`), which similarly guards its DTS adjustment with `if (enc->codec != CODEC_AV1)` and has no offset calculation in its AV1 path.

### Motivation and Context
The original bug report at https://github.com/obsproject/obs-studio/issues/13723 provides the details.

### How Has This Been Tested?
I created an IVS Stage and reproduced the problem initially, then implemented the fix and tested on the same stage. There were no disconnects after the fix was in place.

### Types of changes
- Bug fix (non-breaking change which fixes an issue) 

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
