### PR TITLE
cmake: Use 'CMAKE_OBJDUMP' instead of 'objdump' directly

### DIFF
--- a/cmake/finders/FindFFmpeg.cmake
+++ b/cmake/finders/FindFFmpeg.cmake
@@ -252,7 +252,7 @@ macro(FFmpeg_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${FFmpeg_${component}_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${FFmpeg_${component}_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLibrist.cmake
+++ b/cmake/finders/FindLibrist.cmake
@@ -57,7 +57,7 @@ macro(Librist_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Librist_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Librist_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLibrnnoise.cmake
+++ b/cmake/finders/FindLibrnnoise.cmake
@@ -57,7 +57,7 @@ macro(librnnoise_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Librnnoise_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Librnnoise_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLibspeexdsp.cmake
+++ b/cmake/finders/FindLibspeexdsp.cmake
@@ -57,7 +57,7 @@ macro(libspeexdsp_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Libspeexdsp_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Libspeexdsp_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLibsrt.cmake
+++ b/cmake/finders/FindLibsrt.cmake
@@ -57,7 +57,7 @@ macro(libsrt_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Libsrt_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Libsrt_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLibx264.cmake
+++ b/cmake/finders/FindLibx264.cmake
@@ -57,7 +57,7 @@ macro(Libx264_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Libx264_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Libx264_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindLuajit.cmake
+++ b/cmake/finders/FindLuajit.cmake
@@ -57,7 +57,7 @@ macro(Luajit_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Luajit_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Luajit_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/FindMbedTLS.cmake
+++ b/cmake/finders/FindMbedTLS.cmake
@@ -82,7 +82,7 @@ macro(MbedTLS_set_soname component)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${Mbed${component}_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${Mbed${component}_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )

--- a/cmake/finders/Findjansson.cmake
+++ b/cmake/finders/Findjansson.cmake
@@ -57,7 +57,7 @@ macro(jansson_set_soname)
     endif()
   elseif(CMAKE_HOST_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     execute_process(
-      COMMAND sh -c "objdump -p '${jansson_LIBRARY}' | grep SONAME"
+      COMMAND sh -c "${CMAKE_OBJDUMP} -p '${jansson_LIBRARY}' | grep SONAME"
       OUTPUT_VARIABLE _output
       RESULT_VARIABLE _result
     )


### PR DESCRIPTION
### Description

Make use of 'CMAKE_OBJDUMP' instead of calling the 'objdump' executable directly.

### Motivation and Context

This makes the calls to 'objdump' more environment-friendly, and the finders more consistent-like, although before this, only 'Findqrcodegencpp.cmake' used the variable form.

Downstream-bug: https://bugs.gentoo.org/946059

### How Has This Been Tested?

Compiled with the change on Gentoo Linux at 'git master' on 'amd64', and '32.2.0' on 'arm64' machines.

### Types of changes

- Bug fix (non-breaking change which fixes an issue)

### Checklist:


- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
