### PR TITLE
frontend: Auto release OBS data objects

### DIFF
--- a/frontend/components/SourceTree.cpp
+++ b/frontend/components/SourceTree.cpp
@@ -169,9 +169,8 @@ void SourceTree::dropEvent(QDropEvent *event)
 
 	bool dropOnCollapsed = false;
 	if (dropGroup) {
-		obs_data_t *data = obs_sceneitem_get_private_settings(dropGroup);
+		OBSDataAutoRelease data = obs_sceneitem_get_private_settings(dropGroup);
 		dropOnCollapsed = obs_data_get_bool(data, "collapsed");
-		obs_data_release(data);
 	}
 
 	if (indicator == QAbstractItemView::BelowItem || indicator == QAbstractItemView::OnItem ||

--- a/frontend/dialogs/OBSBasicProperties.cpp
+++ b/frontend/dialogs/OBSBasicProperties.cpp
@@ -63,9 +63,6 @@ OBSBasicProperties::OBSBasicProperties(QWidget *parent, OBSSource source_)
 		resize(cx, cy);
 	}
 
-	/* The OBSData constructor increments the reference once */
-	obs_data_release(oldSettings);
-
 	OBSDataAutoRelease nd_settings = obs_source_get_settings(source);
 	obs_data_apply(oldSettings, nd_settings);
 

--- a/frontend/dialogs/OBSBasicProperties.hpp
+++ b/frontend/dialogs/OBSBasicProperties.hpp
@@ -37,7 +37,7 @@ private:
 	OBSSignal removedSignal;
 	OBSSignal renamedSignal;
 	OBSSignal updatePropertiesSignal;
-	OBSData oldSettings;
+	OBSDataAutoRelease oldSettings;
 	OBSPropertiesView *view;
 	QSplitter *windowSplitter;
 

--- a/frontend/settings/OBSBasicSettings.cpp
+++ b/frontend/settings/OBSBasicSettings.cpp
@@ -1945,9 +1945,9 @@ OBSPropertiesView *OBSBasicSettings::CreateEncoderPropertyView(const char *encod
 		const std::filesystem::path jsonFilePath = currentProfile.path / std::filesystem::u8path(path);
 
 		if (!jsonFilePath.empty()) {
-			obs_data_t *data = obs_data_create_from_json_file_safe(jsonFilePath.u8string().c_str(), "bak");
+			OBSDataAutoRelease data =
+				obs_data_create_from_json_file_safe(jsonFilePath.u8string().c_str(), "bak");
 			obs_data_apply(settings, data);
-			obs_data_release(data);
 		}
 	}
 

--- a/frontend/utility/AdvancedOutput.cpp
+++ b/frontend/utility/AdvancedOutput.cpp
@@ -35,8 +35,7 @@ static OBSData GetDataFromJsonFile(const char *jsonFile)
 
 static void ApplyEncoderDefaults(OBSData &settings, const obs_encoder_t *encoder)
 {
-	OBSData dataRet = obs_encoder_get_defaults(encoder);
-	obs_data_release(dataRet);
+	OBSDataAutoRelease dataRet = obs_encoder_get_defaults(encoder);
 
 	if (!!settings) {
 		obs_data_apply(dataRet, settings);

--- a/frontend/utility/GoLiveAPI_CensoredJson.cpp
+++ b/frontend/utility/GoLiveAPI_CensoredJson.cpp
@@ -21,9 +21,8 @@ void censorRecurse(obs_data_t *data)
 		enum obs_data_type typ = obs_data_item_gettype(item);
 
 		if (typ == OBS_DATA_OBJECT) {
-			obs_data_t *child_data = obs_data_item_get_obj(item);
+			OBSDataAutoRelease child_data = obs_data_item_get_obj(item);
 			censorRecurse(child_data);
-			obs_data_release(child_data);
 		} else if (typ == OBS_DATA_ARRAY) {
 			OBSDataArrayAutoRelease child_array = obs_data_item_get_array(item);
 			censorRecurseArray(child_array);
@@ -35,9 +34,8 @@ void censorRecurseArray(obs_data_array_t *array)
 {
 	const size_t sz = obs_data_array_count(array);
 	for (size_t i = 0; i < sz; i++) {
-		obs_data_t *item = obs_data_array_item(array, i);
+		OBSDataAutoRelease item = obs_data_array_item(array, i);
 		censorRecurse(item);
-		obs_data_release(item);
 	}
 }
 
@@ -49,16 +47,13 @@ QString censoredJson(obs_data_t *data, bool pretty)
 
 	// Ugly clone via JSON write/read
 	const char *j = obs_data_get_json(data);
-	obs_data_t *clone = obs_data_create_from_json(j);
+	OBSDataAutoRelease clone = obs_data_create_from_json(j);
 
 	// Censor our copy
 	censorRecurse(clone);
 
 	// Turn our copy into JSON
 	QString s = pretty ? obs_data_get_json_pretty(clone) : obs_data_get_json(clone);
-
-	// Eliminate our copy
-	obs_data_release(clone);
 
 	return s;
 }

--- a/frontend/utility/audio-encoders.cpp
+++ b/frontend/utility/audio-encoders.cpp
@@ -54,10 +54,7 @@ static void HandleListProperty(obs_property_t *prop, const char *id, std::vector
 
 static void HandleSampleRate(obs_property_t *prop, const char *id)
 {
-	auto ReleaseData = [](obs_data_t *data) {
-		obs_data_release(data);
-	};
-	std::unique_ptr<obs_data_t, decltype(ReleaseData)> data{obs_encoder_defaults(id), ReleaseData};
+	OBSDataAutoRelease data = obs_encoder_defaults(id);
 
 	if (!data) {
 		blog(LOG_ERROR,
@@ -76,9 +73,9 @@ static void HandleSampleRate(obs_property_t *prop, const char *id)
 
 	uint32_t sampleRate = config_get_uint(main->Config(), "Audio", "SampleRate");
 
-	obs_data_set_int(data.get(), "samplerate", sampleRate);
+	obs_data_set_int(data, "samplerate", sampleRate);
 
-	obs_property_modified(prop, data.get());
+	obs_property_modified(prop, data);
 }
 
 static void HandleEncoderProperties(const char *id, std::vector<int> &bitrates)

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -1083,7 +1083,7 @@ private:
 	void DisableRelativeCoordinates(bool disable);
 	void CreateDefaultScene(bool firstStart);
 	void Save(SceneCollection &collection);
-	void LoadData(obs_data_t *data, SceneCollection &collection);
+	void LoadData(OBSData data, SceneCollection &collection);
 	void Load(SceneCollection &collection);
 
 	void ClearSceneData();

--- a/frontend/widgets/OBSBasic_SceneCollections.cpp
+++ b/frontend/widgets/OBSBasic_SceneCollections.cpp
@@ -1136,7 +1136,7 @@ void OBSBasic::Load(SceneCollection &collection)
 	lastOutputResolution.reset();
 	collection.setMigrationResolution(0, 0);
 
-	obs_data_t *data = obs_data_create_from_json_file_safe(collection.getFilePathString().c_str(), "bak");
+	OBSDataAutoRelease data = obs_data_create_from_json_file_safe(collection.getFilePathString().c_str(), "bak");
 
 	if (!data) {
 		disableSaving--;
@@ -1167,7 +1167,7 @@ void OBSBasic::Load(SceneCollection &collection)
 		return;
 	}
 
-	LoadData(data, collection);
+	LoadData(data.Get(), collection);
 }
 
 namespace {
@@ -1192,7 +1192,7 @@ void addMissingFiles(void *data, obs_source_t *source)
 }
 } // namespace
 
-void OBSBasic::LoadData(obs_data_t *data, SceneCollection &collection)
+void OBSBasic::LoadData(OBSData data, SceneCollection &collection)
 {
 	ClearSceneData();
 	ClearContextBar();
@@ -1474,8 +1474,6 @@ retryScene:
 	if (api) {
 		api->on_load(modulesObj);
 	}
-
-	obs_data_release(data);
 
 	if (!opt_starting_scene.empty()) {
 		opt_starting_scene.clear();

--- a/frontend/widgets/OBSBasic_SceneItems.cpp
+++ b/frontend/widgets/OBSBasic_SceneItems.cpp
@@ -534,8 +534,7 @@ QMenu *OBSBasic::AddBackgroundColorMenu(QMenu *menu, QWidgetAction *widgetAction
 				    "*[bgColor=\"7\"]{background-color:rgba(68,68,68,33%);}"
 				    "*[bgColor=\"8\"]{background-color:rgba(255,255,255,33%);}"));
 
-	obs_data_t *privData = obs_sceneitem_get_private_settings(item);
-	obs_data_release(privData);
+	OBSDataAutoRelease privData = obs_sceneitem_get_private_settings(item);
 
 	obs_data_set_default_int(privData, "color-preset", 0);
 	int preset = obs_data_get_int(privData, "color-preset");

--- a/frontend/widgets/OBSBasic_Scenes.cpp
+++ b/frontend/widgets/OBSBasic_Scenes.cpp
@@ -790,9 +790,8 @@ OBSData OBSBasic::BackupScene(obs_scene_t *scene, std::vector<obs_source_t *> *s
 		obs_scene_enum_items(scene, save_undo_source_enum, undo_array);
 	} else {
 		for (obs_source_t *source : *sources) {
-			obs_data_t *source_data = obs_save_source(source);
+			OBSDataAutoRelease source_data = obs_save_source(source);
 			obs_data_array_push_back(undo_array, source_data);
-			obs_data_release(source_data);
 		}
 	}
 


### PR DESCRIPTION
### Description
These obs_data_t objects were still being manually released.

### Motivation and Context
Cleaner code

### How Has This Been Tested?
Ran OBS and made sure everything still worked.

### Types of changes
- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
