### PR TITLE
frontend: Fix crash when stream check thread finishes

### DIFF
--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -259,6 +259,8 @@ void OBSBasic::StreamingStart()
 		if (!key.empty() && !youtubeStreamCheckThread) {
 			youtubeStreamCheckThread = CreateQThread([this, key] { YoutubeStreamCheck(key); });
 			youtubeStreamCheckThread->setObjectName("YouTubeStreamCheckThread");
+			connect(youtubeStreamCheckThread, &QThread::finished, youtubeStreamCheckThread,
+				&QObject::deleteLater);
 			youtubeStreamCheckThread->start();
 		}
 	}

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -60,7 +60,6 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
 		QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
-		youtubeStreamCheckThread->deleteLater();
 		blog(LOG_ERROR, "==========================================");
 		blog(LOG_ERROR, "%s: Uh, hey, we got here", __FUNCTION__);
 		blog(LOG_ERROR, "==========================================");
@@ -93,8 +92,6 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 			timeout++;
 		}
 	}
-
-	youtubeStreamCheckThread->deleteLater();
 }
 
 void OBSBasic::ShowYouTubeAutoStartWarning()


### PR DESCRIPTION
## Description

`YoutubeStreamCheck()` runs inside `YouTubeStreamCheckThread`'s own `run()` and was calling `deleteLater()` on that same `QThread` object before `run()` had actually returned. `QThreadPrivate` only marks a thread as finished after `run()` returns, so the main thread's event loop could process the deferred delete while Qt's internal state still showed the thread as running, tripping the fatal `QThread: Destroyed while thread ... is still running` check and aborting the process (observed as a `Qt6Core.dll` fault, exception code `0xc0000409`, with no OBS crash report generated).

This only affects the "Select Existing Broadcast" path, since that's the only case where `autoStartBroadcast` is `false` and the stream check thread gets started at all.

## Motivation and Context

Fixes #13746. Users hit a silent crash roughly 2-4 seconds after starting a stream via "Select Existing Broadcast" on the YouTube service, with RTMPS having already connected and the encoder already initialized.

## How Has This Been Tested?

Verified by reading through the thread's full lifecycle (creation, `run()`, and all destruction paths) and confirming the fix matches the safe idiom already used elsewhere in the codebase (`frontend/dialogs/OBSRemux.cpp`, `connect(&thread, &QThread::finished, worker, &QObject::deleteLater)`), which resolves the race by only deleting once `QThreadPrivate` has already marked the thread as finished.

I was not able to build and run this locally, so this has not been runtime-verified against the reporter's original repro steps.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] My code is not on the `master` branch