### PR TITLE
frontend: Fix crash when stream check thread finishes

### DIFF
--- a/frontend/widgets/OBSBasic_Streaming.cpp
+++ b/frontend/widgets/OBSBasic_Streaming.cpp
@@ -259,6 +259,8 @@ void OBSBasic::StreamingStart()
 		if (!key.empty() && !youtubeStreamCheckThread) {
 			youtubeStreamCheckThread = CreateQThread([this, key] { YoutubeStreamCheck(key); });
 			youtubeStreamCheckThread->setObjectName("YouTubeStreamCheckThread");
+			connect(youtubeStreamCheckThread, &QThread::finished, youtubeStreamCheckThread,
+				&QObject::deleteLater);
 			youtubeStreamCheckThread->start();
 		}
 	}

--- a/frontend/widgets/OBSBasic_YouTube.cpp
+++ b/frontend/widgets/OBSBasic_YouTube.cpp
@@ -60,7 +60,6 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 	if (!apiYouTube) {
 		/* technically we should never get here -Lain */
 		QMetaObject::invokeMethod(this, "ForceStopStreaming", Qt::QueuedConnection);
-		youtubeStreamCheckThread->deleteLater();
 		blog(LOG_ERROR, "==========================================");
 		blog(LOG_ERROR, "%s: Uh, hey, we got here", __FUNCTION__);
 		blog(LOG_ERROR, "==========================================");
@@ -93,8 +92,6 @@ void OBSBasic::YoutubeStreamCheck(const std::string &key)
 			timeout++;
 		}
 	}
-
-	youtubeStreamCheckThread->deleteLater();
 }
 
 void OBSBasic::ShowYouTubeAutoStartWarning()


### PR DESCRIPTION
YoutubeStreamCheck() runs on youtubeStreamCheckThread, and it used to delete that same thread object from inside its own run() via deleteLater(). QThread only marks itself as finished after run() returns, so there's a small window where the main thread's event loop can process that deferred delete before Qt's internal state has actually caught up. That trips the "Destroyed while thread is still running" check and aborts the process.

That matches the crash in #13746 closely: a Qt6Core.dll fault, exception code 0xc0000409, right after "QThread: Destroyed while thread 'YouTubeStreamCheckThread' is still running" shows up as the last log line. It only happens on the "Select Existing Broadcast" path, since that's the only case where autoStartBroadcast ends up false, which is what spins up youtubeStreamCheckThread in the first place.

The fix here is to connect finished() to deleteLater() instead of calling deleteLater() manually from inside run(). finished() only fires once QThreadPrivate has actually settled its running/finished state, so the race goes away. There's already a similar pattern for this in OBSRemux.cpp, so this keeps things consistent with how the rest of the codebase handles it.

I wasn't able to build and run this locally, so if someone who can reproduce #13746 wants to confirm this actually clears up the crash, that'd be great.

Closes #13746