### PR TITLE
obs-ffmpeg: Fix AMD AV1 CBR filler data bug

### DIFF
--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -1399,7 +1399,8 @@ static bool amf_avc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 		set_avc_property(enc, PEAK_BITRATE, bitrate);
 		set_avc_property(enc, VBV_BUFFER_SIZE, bitrate);
 
-		if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR) {
+		if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR ||
+		    rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
 			set_avc_property(enc, FILLER_DATA_ENABLE, true);
 			pipeline_flush = false;
 		} else if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
@@ -1882,7 +1883,8 @@ static bool amf_hevc_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t
 		set_hevc_property(enc, PEAK_BITRATE, bitrate);
 		set_hevc_property(enc, VBV_BUFFER_SIZE, bitrate);
 
-		if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR) {
+		if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_CBR ||
+		    rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
 			set_hevc_property(enc, FILLER_DATA_ENABLE, true);
 			pipeline_flush = false;
 		} else if (rc == AMF_VIDEO_ENCODER_HEVC_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
@@ -2308,10 +2310,11 @@ static bool amf_av1_update_data(amf_base *enc, int rc, int64_t bitrate, int64_t 
 		set_av1_property(enc, PEAK_BITRATE, bitrate);
 		set_av1_property(enc, VBV_BUFFER_SIZE, bitrate);
 
-		if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_CBR) {
+		if (rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_CBR ||
+		    rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_CBR) {
 			set_av1_property(enc, FILLER_DATA, true);
 			pipeline_flush = false;
-		} else if (rc == AMF_VIDEO_ENCODER_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
+		} else if (rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_PEAK_CONSTRAINED_VBR ||
 			   rc == AMF_VIDEO_ENCODER_AV1_RATE_CONTROL_METHOD_HIGH_QUALITY_VBR) {
 			set_av1_property(enc, PEAK_BITRATE, bitrate * 1.5);
 			set_av1_property(enc, VBV_BUFFER_SIZE, bitrate * 1.5);


### PR DESCRIPTION
### Description
The AV1 rate control function uses H.264 enum constants instead of AV1 ones, and the enum values differ (H.264 CBR=1, AV1 CBR=3), so the CBR filler data check never matches (the value 3 is used by H.264 for LATENCY_CONSTRAINED_VBR).
Also, HQCBR doesn't enable filler data on any codec (AVC/HEVC/AV1), only plain CBR does.

This PR simply swaps the enum constants with the correct ones, and adds HQCBR to the filler data check on all three codecs.

### Motivation and Context
Without filler data, AV1 CBR can't maintain constant bitrate and the encoder is liable to overshoots, leading to frame drops on YouTube.
Fixes #12013.

### How Has This Been Tested?
Testing environment:
- Windows 10 22H2 x64 (with extended security updates)
- AMD Ryzen 5 3600X, AMD Radeon RX 9060 XT, 16GB DDR4, Kingston KC3000 SSD

Steps:
- Built obs-ffmpeg.dll from master with the change, swapped into OBS 32.2.1
- Recorded a static scene for 32 seconds with AV1 CBR 6000 Kbps, B-frames disabled
- With fix: steady ~6300 kbps in Stats, file 19.1 MB
- Counter-test with original DLL: ~5345 kbps in Stats, file 20.7 MB 
- Checked both video files with ffprobe:
  the fixed version produced 1220 sub-100-byte frames (filler data padding) vs only 116 in the original version
- Also tested HQCBR, it behaves identically to CBR with the fix

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
- [x] I have used AI tooling in the creation of this PR.
