### PR TITLE
win-capture: Skip disconnected display devices

### DIFF
--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -182,6 +182,17 @@ static void GetMonitorName(HMONITOR handle, char *name, size_t count)
 	}
 }
 
+static bool get_active_display_device(LPCSTR device_name, DISPLAY_DEVICEA *device)
+{
+	for (DWORD i = 0;; i++) {
+		device->cb = sizeof(*device);
+		if (!EnumDisplayDevicesA(device_name, i, device, EDD_GET_DEVICE_INTERFACE_NAME))
+			return false;
+		if (device->StateFlags & DISPLAY_DEVICE_ATTACHED_TO_DESKTOP)
+			return true;
+	}
+}
+
 static BOOL CALLBACK enum_monitor(HMONITOR handle, HDC hdc, LPRECT rect, LPARAM param)
 {
 	UNUSED_PARAMETER(hdc);
@@ -194,8 +205,7 @@ static BOOL CALLBACK enum_monitor(HMONITOR handle, HDC hdc, LPRECT rect, LPARAM 
 	mi.cbSize = sizeof(mi);
 	if (GetMonitorInfoA(handle, (LPMONITORINFO)&mi)) {
 		DISPLAY_DEVICEA device;
-		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+		if (get_active_display_device(mi.szDevice, &device)) {
 			match = strcmp(monitor->device_id, device.DeviceID) == 0;
 			if (match) {
 				strcpy_s(monitor->id, _countof(monitor->id), device.DeviceID);
@@ -743,8 +753,7 @@ static BOOL CALLBACK enum_monitor_props(HMONITOR handle, HDC hdc, LPRECT rect, L
 			dstr_catf(&monitor_desc, " (%s)", TEXT_PRIMARY_MONITOR);
 
 		DISPLAY_DEVICEA device;
-		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+		if (get_active_display_device(mi.szDevice, &device)) {
 			obs_property_list_add_string(monitor_list, monitor_desc.array, device.DeviceID);
 		} else {
 			blog(LOG_WARNING,


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Use DISPLAY_DEVICE_ATTACHED_TO_DESKTOP flag to select the attached display instead of assuming index 0 is active. When researching this issue I saw this flag mentioned in the [Microsoft docs](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-enumdisplaydevicesa)

> To select all display devices in the desktop, use only the display devices that have the DISPLAY_DEVICE_ATTACHED_TO_DESKTOP flag in the [DISPLAY_DEVICE](https://learn.microsoft.com/en-us/windows/desktop/api/wingdi/ns-wingdi-display_devicea) structure.

Just as a note I wasn't sure whether to use LPCSTR or const char in the helper so I just followed the Microsoft docs, open to changing if this makes a difference as my C knowledge is on a "learn as you go" basis.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Not sure if there were other Github issues that I am not seeing, but https://github.com/obsproject/obs-studio/issues/8040 described this issue and was closed although the issue remains. 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Ran a build of OBS before these changes with one of my 3 displays disconnected, the remaining two both displayed the same display when selected in a display capture source. Performed the same test with these changes, the two displays now showed correctly. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [] I have used AI tooling in the creation of this PR -->
<!-- - [] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
