### PR TITLE
frontend: Avoid sender() in path editors

### DIFF
--- a/frontend/importer/ImporterEntryPathItemDelegate.cpp
+++ b/frontend/importer/ImporterEntryPathItemDelegate.cpp
@@ -61,7 +61,10 @@ QWidget *ImporterEntryPathItemDelegate::createEditor(QWidget *parent, const QSty
 					QSizePolicy::ControlType::LineEdit));
 	layout->addWidget(text);
 
-	QObject::connect(text, &QLineEdit::editingFinished, this, &ImporterEntryPathItemDelegate::updateText);
+	auto commitCallback = [this, container]() {
+		emit const_cast<ImporterEntryPathItemDelegate *>(this)->commitData(container);
+	};
+	QObject::connect(text, &QLineEdit::editingFinished, this, commitCallback);
 
 	QToolButton *browseButton = new QToolButton();
 	browseButton->setText("...");
@@ -151,11 +154,4 @@ void ImporterEntryPathItemDelegate::handleClear(QWidget *container)
 	container->setProperty(PATH_LIST_PROP, QStringList());
 
 	emit commitData(container);
-}
-
-void ImporterEntryPathItemDelegate::updateText()
-{
-	QLineEdit *lineEdit = dynamic_cast<QLineEdit *>(sender());
-	QWidget *editor = lineEdit->parentWidget();
-	emit commitData(editor);
 }

--- a/frontend/importer/ImporterEntryPathItemDelegate.hpp
+++ b/frontend/importer/ImporterEntryPathItemDelegate.hpp
@@ -38,7 +38,4 @@ private:
 
 	void handleBrowse(QWidget *container);
 	void handleClear(QWidget *container);
-
-private slots:
-	void updateText();
 };

--- a/frontend/utility/RemuxEntryPathItemDelegate.cpp
+++ b/frontend/utility/RemuxEntryPathItemDelegate.cpp
@@ -78,7 +78,10 @@ QWidget *RemuxEntryPathItemDelegate::createEditor(QWidget *parent, const QStyleO
 						QSizePolicy::ControlType::LineEdit));
 		layout->addWidget(text);
 
-		QObject::connect(text, &QLineEdit::editingFinished, this, &RemuxEntryPathItemDelegate::updateText);
+		auto commitCallback = [this, container]() {
+			emit const_cast<RemuxEntryPathItemDelegate *>(this)->commitData(container);
+		};
+		QObject::connect(text, &QLineEdit::editingFinished, this, commitCallback);
 
 		QToolButton *browseButton = new QToolButton();
 		browseButton->setText("...");
@@ -205,11 +208,4 @@ void RemuxEntryPathItemDelegate::handleClear(QWidget *container)
 	container->setProperty(PATH_LIST_PROP, QStringList());
 
 	emit commitData(container);
-}
-
-void RemuxEntryPathItemDelegate::updateText()
-{
-	QLineEdit *lineEdit = dynamic_cast<QLineEdit *>(sender());
-	QWidget *editor = lineEdit->parentWidget();
-	emit commitData(editor);
 }

--- a/frontend/utility/RemuxEntryPathItemDelegate.hpp
+++ b/frontend/utility/RemuxEntryPathItemDelegate.hpp
@@ -40,7 +40,4 @@ private:
 
 	void handleBrowse(QWidget *container);
 	void handleClear(QWidget *container);
-
-private slots:
-	void updateText();
 };


### PR DESCRIPTION
### Description

Replace `sender()` in the scene collection importer and remux path item delegates.

Those editors recovered the line edit from `editingFinished` via `sender()`. The browse and clear buttons in the same `createEditor()` already capture the editor widget in a lambda, so `editingFinished` now does the same and the `updateText` slots are removed.

This is a partial fix. Other `sender()` call sites are left for follow-up PRs, as suggested in the issue.

### Motivation and Context

Fixes part of #13444

`QObject::sender()` is a legacy pattern that breaks type safety. The issue explicitly points at `ImporterEntryPathItemDelegate` and notes this does not need to be one PR.

### How Has This Been Tested?

- clang-format 19 on the changed files
- Not runtime-tested in the importer or remux dialogs

### Types of changes

- Code cleanup (non-breaking change which makes code smaller or more readable)

### Checklist:

- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format)
- [x] I have read the [**CONTRIBUTING** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md)
- [x] My code is not on the master branch
- [x] The code has been tested
- [x] All commit messages are properly formatted and commits squashed where appropriate
- [x] I have included updates to all appropriate documentation