### PR TITLE
libobs: Fix premultiplied sRGB source rendering

### DIFF
--- a/docs/sphinx/reference-sources.rst
+++ b/docs/sphinx/reference-sources.rst
@@ -178,6 +178,9 @@ Source Definition Structure (obs_source_info)
 
    - **OBS_SOURCE_REQUIRES_CANVAS** - Source type requires a canvas.
 
+   - **OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF** - Source type prefers
+     newly created scene items to use the nonlinear (SRGB_OFF) blending method.
+
 .. member:: const char *(*obs_source_info.get_name)(void *type_data)
 
    Get the translated name of the source type.

--- a/libobs/data/default.effect
+++ b/libobs/data/default.effect
@@ -85,6 +85,15 @@ float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
+float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	rgba.rgb *= rgba.a;
+	return rgba;
+}
+
 float4 PSDrawSrgbDecompressMultiply(VertInOut vert_in) : TARGET
 {
 	float4 rgba = image.Sample(def_sampler, vert_in.uv);
@@ -204,6 +213,15 @@ technique DrawSrgbDecompress
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawSrgbDecompress(vert_in);
+	}
+}
+
+technique DrawSrgbDecompressPremultiplied
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }
 

--- a/libobs/data/default_rect.effect
+++ b/libobs/data/default_rect.effect
@@ -47,6 +47,15 @@ float4 PSDrawSrgbDecompress(VertInOut vert_in) : TARGET
 	return rgba;
 }
 
+float4 PSDrawSrgbDecompressPremultiplied(VertInOut vert_in) : TARGET
+{
+	float4 rgba = image.Sample(def_sampler, vert_in.uv);
+	rgba.rgb *= (rgba.a > 0.) ? (1. / rgba.a) : 0.;
+	rgba.rgb = srgb_nonlinear_to_linear(rgba.rgb);
+	rgba.rgb *= rgba.a;
+	return rgba;
+}
+
 technique Draw
 {
 	pass
@@ -80,5 +89,14 @@ technique DrawSrgbDecompress
 	{
 		vertex_shader = VSDefault(vert_in);
 		pixel_shader  = PSDrawSrgbDecompress(vert_in);
+	}
+}
+
+technique DrawSrgbDecompressPremultiplied
+{
+	pass
+	{
+		vertex_shader = VSDefault(vert_in);
+		pixel_shader  = PSDrawSrgbDecompressPremultiplied(vert_in);
 	}
 }

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -24,6 +24,9 @@
 
 const struct obs_source_info group_info;
 
+/* TODO: Set to the OBS version that first ships this migration. */
+#define SRGB_OFF_INITIAL_BLEND_MIGRATION_VERSION MAKE_SEMANTIC_VERSION(32, 2, 2)
+
 static void resize_group(obs_sceneitem_t *group, bool scene_resize);
 static void resize_scene(obs_scene_t *scene);
 static void signal_parent(obs_scene_t *parent, const char *name, calldata_t *params);
@@ -34,6 +37,14 @@ static inline bool item_texture_enabled(const struct obs_scene_item *item);
 static void init_hotkeys(obs_scene_t *scene, obs_sceneitem_t *item, const char *name);
 
 typedef DARRAY(struct obs_scene_item *) obs_scene_item_ptr_array_t;
+
+static inline enum obs_blending_method source_initial_blend_method(obs_source_t *source)
+{
+	if ((source->info.output_flags & OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF) != 0)
+		return OBS_BLEND_METHOD_SRGB_OFF;
+
+	return OBS_BLEND_METHOD_DEFAULT;
+}
 
 /* NOTE: For proper mutex lock order (preventing mutual cross-locks), never
  * lock the graphics mutex inside either of the scene mutexes.
@@ -1239,6 +1250,12 @@ static void scene_load_item(struct obs_scene *scene, obs_data_t *item_data)
 			item->blend_method = OBS_BLEND_METHOD_SRGB_OFF;
 	}
 
+	if (obs_source_get_last_obs_version(source) < SRGB_OFF_INITIAL_BLEND_MIGRATION_VERSION) {
+		const enum obs_blending_method initial_blend_method = source_initial_blend_method(source);
+		if (initial_blend_method != OBS_BLEND_METHOD_DEFAULT && item->blend_method == OBS_BLEND_METHOD_DEFAULT)
+			item->blend_method = initial_blend_method;
+	}
+
 	blend_str = obs_data_get_string(item_data, "blend_type");
 	item->blend_type = OBS_BLEND_NORMAL;
 
@@ -2300,6 +2317,7 @@ static obs_sceneitem_t *obs_scene_add_internal(obs_scene_t *scene, obs_source_t 
 	item->is_group = strcmp(source->info.id, group_info.id) == 0;
 	item->is_scene = strcmp(source->info.id, scene_info.id) == 0;
 	item->private_settings = obs_data_create();
+	item->blend_method = source_initial_blend_method(source);
 	item->toggle_visibility = OBS_INVALID_HOTKEY_PAIR_ID;
 	item->absolute_coordinates = scene->absolute_coordinates;
 	os_atomic_set_long(&item->active_refs, 1);

--- a/libobs/obs-scene.c
+++ b/libobs/obs-scene.c
@@ -914,6 +914,9 @@ static inline void render_item(struct obs_scene_item *item)
 		item->item_render = gs_texrender_create(format, GS_ZS_NONE);
 	}
 
+	const bool linear_srgb = !item->item_render || (item->blend_method != OBS_BLEND_METHOD_SRGB_OFF);
+	const bool previous = gs_get_linear_srgb();
+
 	if (item->item_render) {
 		uint32_t width = obs_source_get_width(item->source);
 		uint32_t height = obs_source_get_height(item->source);
@@ -937,6 +940,7 @@ static inline void render_item(struct obs_scene_item *item)
 			gs_matrix_scale3f(cx_scale, cy_scale, 1.0f);
 			gs_matrix_translate3f(-(float)(item->crop.left + item->bounds_crop.left),
 					      -(float)(item->crop.top + item->bounds_crop.top), 0.0f);
+			gs_set_linear_srgb(linear_srgb);
 
 			if (item->user_visible && transition_active(item->show_transition)) {
 				const int cx = obs_source_get_width(item->source);
@@ -954,12 +958,12 @@ static inline void render_item(struct obs_scene_item *item)
 				obs_source_set_texcoords_centered(item->source, false);
 			}
 
+			gs_set_linear_srgb(previous);
 			gs_texrender_end(item->item_render);
 		}
 	}
 
-	const bool linear_srgb = !item->item_render || (item->blend_method != OBS_BLEND_METHOD_SRGB_OFF);
-	const bool previous = gs_set_linear_srgb(linear_srgb);
+	gs_set_linear_srgb(linear_srgb);
 	gs_matrix_push();
 	gs_matrix_mul(&item->draw_transform);
 	if (item->item_render) {

--- a/libobs/obs-source.h
+++ b/libobs/obs-source.h
@@ -208,6 +208,11 @@ enum obs_media_state {
  */
 #define OBS_SOURCE_REQUIRES_CANVAS (1 << 17)
 
+/**
+ * Source should initially use OBS_BLEND_METHOD_SRGB_OFF when added to a scene
+ */
+#define OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF (1 << 18)
+
 /** @} */
 
 typedef void (*obs_source_enum_proc_t)(obs_source_t *parent, obs_source_t *child, void *param);


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Fixes rendering of sources that provide premultiplied sRGB textures and allows a source to request nonlinear blending as the initial blending method for its scene items.

This PR:

- Adds `DrawSrgbDecompressPremultiplied` techniques to the default 2D and rectangle effects. The shader unpremultiplies the sampled RGB value, converts it from nonlinear sRGB to linear light, and premultiplies it again before linear compositing.
- Propagates the scene item's linear-sRGB state while rendering a source into an intermediate texture, allowing custom-draw sources to select the correct rendering path for the active blending method.
- Adds `OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF`, which allows a source type to initialize newly created scene items with `OBS_BLEND_METHOD_SRGB_OFF`.
- Migrates older scene items belonging to opted-in source types from `OBS_BLEND_METHOD_DEFAULT` to `OBS_BLEND_METHOD_SRGB_OFF`. Other source types and items already using another method are left unchanged.

This PR should be merged after #13790, which renames the user-facing blending methods from `Default` and `SRGB Off` to `Linear` and `Nonlinear`.

Companion obs-browser PR: https://github.com/obsproject/obs-browser/pull/533

The obs-browser companion PR depends on this API and must ship in the same OBS release.

> [!IMPORTANT]
> Before this PR is merged, `SRGB_OFF_INITIAL_BLEND_MIGRATION_VERSION` must be set to the OBS version that first ships this migration:
>
> ```c
> /* TODO: Set to the OBS version that first ships this migration. */
> #define SRGB_OFF_INITIAL_BLEND_MIGRATION_VERSION MAKE_SEMANTIC_VERSION(32, 2, 2)
> ```
>
> The current value is temporary and must be updated or explicitly confirmed once the target release is known.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

Chromium composites page content in nonlinear sRGB and provides OBS with premultiplied sRGB textures. Correctly supporting both OBS blending methods therefore requires two distinct rendering paths:

- `Linear` must unpremultiply the encoded RGB values, convert them to linear light, and premultiply them again before compositing.
- `Nonlinear` must preserve the Chromium-composited values and blend them without linear-sRGB processing.

OBS previously attempted to implement the correct premultiplied conversion in [obs-studio#4935](https://github.com/obsproject/obs-studio/pull/4935) ([commit `05b507d`](https://github.com/obsproject/obs-studio/commit/05b507d9008edc84fa82edb657fbb15880b79210)) together with [obs-browser#300](https://github.com/obsproject/obs-browser/pull/300) ([commit `aa3d36c`](https://github.com/obsproject/obs-browser/commit/aa3d36c398256f3c675b973f4e810754cd3db9a4)).

That implementation was later replaced by [obs-browser#318](https://github.com/obsproject/obs-browser/pull/318) ([commit `94cbfba`](https://github.com/obsproject/obs-browser/commit/94cbfbae012c079d81e678d6f46a21a1ed7f86ab)). The PR explicitly described the replacement as an attempt to preserve Chromium's RGB values that would work on a black background, while blending against other backgrounds would still happen in linear space and might not look correct.

The unused premultiplied conversion technique was subsequently removed in [obs-studio#5360](https://github.com/obsproject/obs-studio/pull/5360) ([commit `4e6765a`](https://github.com/obsproject/obs-studio/commit/4e6765a01b1b566c64cb9906a0b82483d13dcf17)). Browser rendering was later switched to the sRGB texture sampling path by [commit `344626c`](https://github.com/obsproject/obs-browser/commit/344626c31df1c90b4605733f8706f033bc8a648b), but it continued to apply the sRGB transfer function to premultiplied RGB values.

Nonlinear blending was added afterward in [obs-studio#6257](https://github.com/obsproject/obs-studio/pull/6257) ([commit `e638cc9`](https://github.com/obsproject/obs-studio/commit/e638cc9f82)) primarily to reproduce browser compositing behavior. Browser sources were not automatically opted into it, however, and the earlier black-background workaround remained in place.

As a result, the current browser renderer does not provide a mathematically correct linear path. It approximates the Chromium/nonlinear appearance on a black background, but semi-transparent content can produce incorrect results when composited over other backgrounds. It also prevents users who deliberately select linear blending—for example, for visual effects or color-correct compositing—from receiving correct linear-light results.

This PR restores the correct premultiplied sRGB conversion needed by the linear method. The companion obs-browser change will use that path for linear blending and use the unconverted path for nonlinear blending.

#### Why migrate existing scene items?

Existing browser scene items are normally serialized with `OBS_BLEND_METHOD_DEFAULT`, but users have observed the appearance produced by the historical workaround. On black backgrounds that appearance approximates Chromium's nonlinear compositing.

After correcting the renderer, leaving those existing items on the now-correct linear method would visibly change their appearance. From the user's perspective, upgrading OBS would look like a rendering regression or downgrade, even though the new linear result is mathematically correct.

The migration preserves the established appearance by changing an older `OBS_BLEND_METHOD_DEFAULT` item to the source's requested nonlinear initial method when all of the following are true:

- The source opts in through `OBS_SOURCE_INITIAL_BLEND_METHOD_SRGB_OFF`.
- The scene collection was last saved by an OBS version older than the version that first ships the migration.
- The item still uses `OBS_BLEND_METHOD_DEFAULT`.

Items already using `OBS_BLEND_METHOD_SRGB_OFF`, items belonging to other source types, and other blending settings are not changed. New opted-in sources start with nonlinear blending directly.

This provides a seamless upgrade for existing users while making both the linear and nonlinear paths correct and explicitly selectable.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

Manually tested on a MacBook Pro with an Apple M5 Pro running macOS 26.5.2, together with the companion obs-browser changes.

The test page contains four browser-background regions—transparent, black, white, and transparent—and renders:

- Opaque white.
- White at 75% and 25% opacity.
- Red, green, and blue at 50% opacity.

[index.html](https://github.com/user-attachments/files/31128805/index.html)

OBS 32.2.1 was compared with the combined obs-studio and obs-browser branches using both blending methods and different scene backgrounds.

Verified that:

- The linear method correctly converts the premultiplied browser texture before compositing.
- Semi-transparent colors composite correctly over non-black backgrounds.
- The nonlinear method preserves the appearance expected from Chromium compositing.
- The nonlinear result is no longer approximated only for black backgrounds.
- Switching between the two methods selects the corresponding browser rendering path.

#### OBS 32.2.1

<img width="1920" height="1080" alt="Screenshot 2026-08-15 04-02-03" src="https://github.com/user-attachments/assets/1b2c79de-4e0e-4333-bae9-162869dfc9d5" />

#### This PR with the companion obs-browser changes

<img width="1920" height="1080" alt="Screenshot 2026-08-17 06-52-43" src="https://github.com/user-attachments/assets/adc86c16-b338-4ef4-aee3-dac9fcd5e1e0" />

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!-- Complete the current GitHub AI-disclosure section truthfully. -->
- [x] AI tooling was used for research and autocomplete assistance (copilot). I personally wrote every submitted line of code, deliberately reviewed, understood, and verified it, and personally evaluated all architectural decisions and trade-offs.