### PR TITLE
win-api: Switch Windows -A apis to -W variants

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -38,6 +38,7 @@
 
 #include <QCheckBox>
 #include <QDesktopServices>
+#include <QDateTime>
 #if defined(_WIN32) || defined(ENABLE_SPARKLE_UPDATER)
 #include <QFile>
 #endif
@@ -331,18 +332,16 @@ bool OBSApp::InitGlobalConfigDefaults()
 
 bool OBSApp::InitGlobalLocationDefaults()
 {
-	char path[512];
-
-	int len = GetAppConfigPath(path, sizeof(path), nullptr);
-	if (len <= 0) {
+	BPtr<char> path = GetAppConfigPathPtr(nullptr);
+	if (!path || !*path.Get()) {
 		OBSErrorBox(NULL, "Unable to get global configuration path.");
 		return false;
 	}
 
-	config_set_default_string(appConfig, "Locations", "Configuration", path);
-	config_set_default_string(appConfig, "Locations", "SceneCollections", path);
-	config_set_default_string(appConfig, "Locations", "Profiles", path);
-	config_set_default_string(appConfig, "Locations", "PluginManagerSettings", path);
+	config_set_default_string(appConfig, "Locations", "Configuration", path.Get());
+	config_set_default_string(appConfig, "Locations", "SceneCollections", path.Get());
+	config_set_default_string(appConfig, "Locations", "Profiles", path.Get());
+	config_set_default_string(appConfig, "Locations", "PluginManagerSettings", path.Get());
 
 	return true;
 }
@@ -407,49 +406,37 @@ static bool do_mkdir(const char *path)
 
 static bool MakeUserDirs()
 {
-	char path[512];
+	BPtr<char> path;
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/basic") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/basic");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/logs") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/logs");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/profiler_data") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/profiler_data");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 
 #ifdef _WIN32
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/crashes") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/crashes");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 #endif
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/updates") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/updates");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/plugin_config") <= 0) {
-		return false;
-	}
-	if (!do_mkdir(path)) {
+	path = GetAppConfigPathPtr("obs-studio/plugin_config");
+	if (!path || !*path.Get() || !do_mkdir(path)) {
 		return false;
 	}
 
@@ -537,10 +524,8 @@ bool OBSApp::UpdatePre22MultiviewLayout(const char *layout)
 
 bool OBSApp::InitGlobalConfig()
 {
-	char path[512];
-
-	int len = GetAppConfigPath(path, sizeof(path), "obs-studio/global.ini");
-	if (len <= 0) {
+	BPtr<char> path = GetAppConfigPathPtr("obs-studio/global.ini");
+	if (!path || !*path.Get()) {
 		return false;
 	}
 
@@ -676,23 +661,21 @@ static constexpr string_view OBSUserIniPath = "/obs-studio/user.ini";
 
 bool OBSApp::MigrateGlobalSettings()
 {
-	char path[512];
-
-	int len = GetAppConfigPath(path, sizeof(path), nullptr);
-	if (len <= 0) {
+	BPtr<char> path = GetAppConfigPathPtr(nullptr);
+	if (!path || !*path.Get()) {
 		OBSErrorBox(nullptr, "Unable to get global configuration path.");
 		return false;
 	}
 
 	std::string legacyConfigFileString;
-	legacyConfigFileString.reserve(strlen(path) + OBSGlobalIniPath.size());
-	legacyConfigFileString.append(path).append(OBSGlobalIniPath);
+	legacyConfigFileString.reserve(strlen(path.Get()) + OBSGlobalIniPath.size());
+	legacyConfigFileString.append(path.Get()).append(OBSGlobalIniPath);
 
 	const std::filesystem::path legacyGlobalConfigFile = std::filesystem::u8path(legacyConfigFileString);
 
 	std::string configFileString;
-	configFileString.reserve(strlen(path) + OBSUserIniPath.size());
-	configFileString.append(path).append(OBSUserIniPath);
+	configFileString.reserve(strlen(path.Get()) + OBSUserIniPath.size());
+	configFileString.append(path.Get()).append(OBSUserIniPath);
 
 	const std::filesystem::path userConfigFile = std::filesystem::u8path(configFileString);
 
@@ -970,13 +953,13 @@ OBSApp::~OBSApp()
 
 static void move_basic_to_profiles(void)
 {
-	char path[512];
+	BPtr<char> path = GetAppConfigPathPtr("obs-studio/basic");
 
-	if (GetAppConfigPath(path, 512, "obs-studio/basic") <= 0) {
+	if (!path || !*path.Get()) {
 		return;
 	}
 
-	const std::filesystem::path basicPath = std::filesystem::u8path(path);
+	const std::filesystem::path basicPath = std::filesystem::u8path(path.Get());
 
 	if (!std::filesystem::exists(basicPath)) {
 		return;
@@ -1034,13 +1017,13 @@ static void move_basic_to_profiles(void)
 
 static void move_basic_to_scene_collections(void)
 {
-	char path[512];
+	BPtr<char> path = GetAppConfigPathPtr("obs-studio/basic");
 
-	if (GetAppConfigPath(path, 512, "obs-studio/basic") <= 0) {
+	if (!path || !*path.Get()) {
 		return;
 	}
 
-	const std::filesystem::path basicPath = std::filesystem::u8path(path);
+	const std::filesystem::path basicPath = std::filesystem::u8path(path.Get());
 
 	if (!std::filesystem::exists(basicPath)) {
 		return;
@@ -1169,9 +1152,9 @@ const char *OBSApp::GetRenderModule() const
 
 static bool StartupOBS(const char *locale, profiler_name_store_t *store)
 {
-	char path[512];
+	BPtr<char> path = GetAppConfigPathPtr("obs-studio/plugin_config");
 
-	if (GetAppConfigPath(path, sizeof(path), "obs-studio/plugin_config") <= 0) {
+	if (!path || !*path.Get()) {
 		return false;
 	}
 
@@ -1515,16 +1498,10 @@ skip:
 
 string GenerateTimeDateFilename(const char *extension, bool noSpace)
 {
-	time_t now = time(0);
-	char file[256] = {};
-	struct tm *cur_time;
+	QString format = noSpace ? "yyyy-MM-dd_hh-mm-ss" : "yyyy-MM-dd hh-mm-ss";
+	QString filename = QDateTime::currentDateTime().toString(format) + "." + extension;
 
-	cur_time = localtime(&now);
-	snprintf(file, sizeof(file), "%d-%02d-%02d%c%02d-%02d-%02d.%s", cur_time->tm_year + 1900, cur_time->tm_mon + 1,
-		 cur_time->tm_mday, noSpace ? '_' : ' ', cur_time->tm_hour, cur_time->tm_min, cur_time->tm_sec,
-		 extension);
-
-	return string(file);
+	return filename.toStdString();
 }
 
 string GenerateSpecifiedFilename(const char *extension, bool noSpace, const char *format)

--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -1743,10 +1743,18 @@ char *GetAppConfigPathPtr(const char *name)
 {
 #if ALLOW_PORTABLE_MODE
 	if (portable_mode) {
-		char path[512];
+		if (!name || !*name) {
+			return bstrdup(CONFIG_PATH);
+		}
 
-		if (snprintf(path, sizeof(path), CONFIG_PATH "/%s", name) > 0) {
-			return bstrdup(path);
+		int len = snprintf(NULL, 0, CONFIG_PATH "/%s", name);
+		if (len <= 0) {
+			return NULL;
+		}
+		char *path = (char *)bmalloc((size_t)len + 1);
+
+		if (snprintf(path, len + 1, CONFIG_PATH "/%s", name) > 0) {
+			return path;
 		} else {
 			return NULL;
 		}

--- a/frontend/OBSApp_Themes.cpp
+++ b/frontend/OBSApp_Themes.cpp
@@ -1000,9 +1000,9 @@ bool OBSApp::SetTheme(const QString &name)
 	filename += ".out";
 
 	filesystem::path debugOut;
-	char configPath[512];
-	if (GetAppConfigPath(configPath, sizeof(configPath), filename.c_str())) {
-		debugOut = absolute(filesystem::u8path(configPath));
+	BPtr<char> configPath = GetAppConfigPathPtr(filename.c_str());
+	if (configPath && *configPath.Get()) {
+		debugOut = absolute(filesystem::u8path(configPath.Get()));
 		filesystem::create_directories(debugOut.parent_path());
 	}
 
@@ -1063,9 +1063,9 @@ bool OBSApp::InitTheme()
 		QDir::addSearchPath("theme", absolute(installSearchDir));
 	}
 
-	char userDir[512];
-	if (GetAppConfigPath(userDir, sizeof(userDir), "obs-studio/themes")) {
-		auto configSearchDir = filesystem::u8path(userDir);
+	BPtr<char> userDir = GetAppConfigPathPtr("obs-studio/themes");
+	if (userDir && *userDir.Get()) {
+		auto configSearchDir = filesystem::u8path(userDir.Get());
 		QDir::addSearchPath("theme", absolute(configSearchDir));
 	}
 

--- a/frontend/dialogs/OBSLogViewer.cpp
+++ b/frontend/dialogs/OBSLogViewer.cpp
@@ -45,11 +45,11 @@ void OBSLogViewer::on_showStartup_clicked(bool checked)
 
 void OBSLogViewer::InitLog()
 {
-	char logDir[512];
+	BPtr<char> logDir = GetAppConfigPathPtr("obs-studio/logs");
 	std::string path;
 
-	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs")) {
-		path += logDir;
+	if (logDir.Get()) {
+		path += logDir.Get();
 		path += "/";
 		path += App()->GetCurrentLog();
 	}
@@ -114,14 +114,14 @@ void OBSLogViewer::AddLine(int type, const QString &str)
 
 void OBSLogViewer::on_openButton_clicked()
 {
-	char logDir[512];
-	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0) {
+	BPtr<char> logDir = GetAppConfigPathPtr("obs-studio/logs");
+	if (!logDir || !*logDir.Get()) {
 		return;
 	}
 
 	const char *log = App()->GetCurrentLog();
 
-	std::string path = logDir;
+	std::string path = logDir.Get();
 	path += "/";
 	path += log;
 

--- a/frontend/importers/classic.cpp
+++ b/frontend/importers/classic.cpp
@@ -548,9 +548,8 @@ OBSImporterFiles ClassicImporter::FindFiles()
 	OBSImporterFiles res;
 
 #ifdef _WIN32
-	char dst[512];
-	int found = os_get_config_path(dst, 512, "OBS\\sceneCollection\\");
-	if (found == -1) {
+	BPtr<char> dst = os_get_config_path_ptr("OBS\\sceneCollection\\");
+	if (!dst) {
 		return res;
 	}
 
@@ -564,7 +563,7 @@ OBSImporterFiles ClassicImporter::FindFiles()
 		string name = ent->d_name;
 		size_t pos = name.find(".xconfig");
 		if (pos != -1 && pos == name.length() - 8) {
-			string path = dst + name;
+			string path = dst.Get() + name;
 			res.push_back(path);
 		}
 	}

--- a/frontend/importers/sl.cpp
+++ b/frontend/importers/sl.cpp
@@ -495,11 +495,9 @@ OBSImporterFiles SLImporter::FindFiles()
 {
 	OBSImporterFiles res;
 #if defined(_WIN32) || defined(__APPLE__)
-	char dst[512];
+	BPtr<char> dst = os_get_config_path_ptr("slobs-client/SceneCollections/");
 
-	int found = os_get_config_path(dst, 512, "slobs-client/SceneCollections/");
-
-	if (found == -1) {
+	if (!dst) {
 		return res;
 	}
 
@@ -515,7 +513,7 @@ OBSImporterFiles SLImporter::FindFiles()
 		size_t pos = name.find_last_of(".json");
 		size_t end_pos = name.size() - 1;
 		if (pos != string::npos && pos == end_pos) {
-			string str = dst + name;
+			string str = dst.Get() + name;
 			res.push_back(str);
 		}
 	}

--- a/frontend/importers/studio.cpp
+++ b/frontend/importers/studio.cpp
@@ -143,27 +143,23 @@ void TranslateOSStudio(Json &res)
 
 static string CheckPath(const string &path, const string &rootDir)
 {
-	char root[512];
-	*root = 0;
-	size_t rootLen = os_get_abs_path(rootDir.c_str(), root, sizeof(root));
+	BPtr<char> root = os_get_abs_path_ptr(rootDir.c_str());
 
-	char absPath[512];
-	*absPath = 0;
-	size_t len = os_get_abs_path((rootDir + path).c_str(), absPath, sizeof(absPath));
+	BPtr<char> absPath = os_get_abs_path_ptr((rootDir + path).c_str());
 
-	if (len == 0) {
+	if (!absPath || !*absPath.Get()) {
 		return path;
 	}
 
-	if (strstr(absPath, root) != absPath) {
+	if (strstr(absPath.Get(), root) != absPath.Get()) {
 		return path;
 	}
 
-	if (*(absPath + rootLen) != QDir::separator().toLatin1()) {
+	if (*(absPath.Get() + strlen(root)) != QDir::separator().toLatin1()) {
 		return path;
 	}
 
-	return absPath;
+	return string(absPath.Get());
 }
 
 void TranslatePaths(Json &res, const string &rootDir)

--- a/frontend/importers/xsplit.cpp
+++ b/frontend/importers/xsplit.cpp
@@ -503,10 +503,8 @@ OBSImporterFiles XSplitImporter::FindFiles()
 {
 	OBSImporterFiles res;
 #ifdef _WIN32
-	char dst[512];
-	int found = os_get_program_data_path(dst, 512, "SplitMediaLabs\\XSplit\\Presentation2.0\\");
-
-	if (found == -1) {
+	BPtr<char> dst = os_get_program_data_path_ptr("SplitMediaLabs\\XSplit\\Presentation2.0\\");
+	if (!dst) {
 		return res;
 	}
 
@@ -521,7 +519,7 @@ OBSImporterFiles XSplitImporter::FindFiles()
 		}
 
 		if (name == "Placements.bpres") {
-			string str = dst + name;
+			string str = dst.Get() + name;
 			res.push_back(str);
 
 			break;

--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -759,9 +759,10 @@ static void main_crash_handler(const char *format, va_list args, void * /* param
 
 	snprintf(message_buffer.get(), size + 1, CRASH_MESSAGE, absolutePath.c_str());
 
-	string finalMessage = string(message_buffer.get(), message_buffer.get() + size);
+	BPtr<wchar_t> finalMessage;
+	os_utf8_to_wcs_ptr(message_buffer.get(), size, &finalMessage);
 
-	int ret = MessageBoxA(NULL, finalMessage.c_str(), "OBS has crashed!", MB_YESNO | MB_ICONERROR | MB_TASKMODAL);
+	int ret = MessageBoxW(NULL, finalMessage, L"OBS has crashed!", MB_YESNO | MB_ICONERROR | MB_TASKMODAL);
 
 	if (ret == IDYES) {
 		size_t len = strlen(text);
@@ -835,10 +836,17 @@ static bool vc_runtime_outdated()
 		return false;
 	}
 
-	int choice = MessageBoxA(NULL, vcRunErrorMsg, vcRunErrorTitle, MB_OKCANCEL | MB_ICONERROR | MB_TASKMODAL);
+	BPtr<wchar_t> title;
+	BPtr<wchar_t> msg;
+	BPtr<wchar_t> url;
+	os_utf8_to_wcs_ptr(vcRunErrorTitle, 0, &title);
+	os_utf8_to_wcs_ptr(vcRunErrorMsg, 0, &msg);
+	os_utf8_to_wcs_ptr(vcRunInstallerUrl, 0, &url);
+
+	int choice = MessageBoxW(NULL, msg, title, MB_OKCANCEL | MB_ICONERROR | MB_TASKMODAL);
 	if (choice == IDOK) {
 		/* Open the URL in the default browser. */
-		ShellExecuteA(NULL, "open", vcRunInstallerUrl, NULL, NULL, SW_SHOWNORMAL);
+		ShellExecuteW(NULL, L"open", url, NULL, NULL, SW_SHOWNORMAL);
 	}
 
 	return true;
@@ -1055,7 +1063,9 @@ int main(int argc, char *argv[])
 				"--disable-missing-files-check: Disable the missing files dialog which can appear on startup.\n\n";
 
 #ifdef _WIN32
-			MessageBoxA(NULL, help.c_str(), "Help", MB_OK | MB_ICONASTERISK);
+			BPtr<wchar_t> wHelp;
+			os_utf8_to_wcs_ptr(help.c_str(), 0, &wHelp);
+			MessageBoxW(NULL, wHelp, L"Help", MB_OK | MB_ICONASTERISK);
 #else
 			std::cout << help << "--version, -V: Get current version.\n";
 #endif

--- a/frontend/updater/updater.cpp
+++ b/frontend/updater/updater.cpp
@@ -1568,7 +1568,8 @@ static bool Update(wchar_t *cmdLine)
 			continue;
 		}
 
-		char outputPath[MAX_PATH];
+		// UTF-16 code unit converted to UTF-8 is 3 bytes at most
+		char outputPath[MAX_PATH * 3];
 		if (!WideToUTF8Buf(outputPath, update.outputPath.c_str())) {
 			continue;
 		}

--- a/frontend/updater/updater.cpp
+++ b/frontend/updater/updater.cpp
@@ -82,6 +82,39 @@ void FreeWinHttpHandle(HINTERNET handle)
 
 /* ----------------------------------------------------------------------- */
 
+static inline bool UTF8ToWide(wchar_t *wide, int wideSize, const char *utf8)
+{
+	return !!MultiByteToWideChar(CP_UTF8, 0, utf8, -1, wide, wideSize);
+}
+
+static inline bool WideToUTF8(char *utf8, int utf8Size, const wchar_t *wide)
+{
+	return !!WideCharToMultiByte(CP_UTF8, 0, wide, -1, utf8, utf8Size, nullptr, nullptr);
+}
+
+static inline bool UTF8ToWidePtr(wchar_t *wide, const char *utf8)
+{
+	wide = nullptr;
+	int utf8_length = (int)strlen(utf8);
+	int size = MultiByteToWideChar(CP_UTF8, 0, utf8, utf8_length + 1, nullptr, 0);
+	if (size <= 0) {
+		return false;
+	}
+
+	wide = (wchar_t *)malloc((size_t)size);
+	if (MultiByteToWideChar(CP_UTF8, 0, utf8, utf8_length + 1, wide, size) <= 0) {
+		free(wide);
+		wide = nullptr;
+		return false;
+	}
+	return true;
+}
+
+#define UTF8ToWideBuf(wide, utf8) UTF8ToWide(wide, _countof(wide), utf8)
+#define WideToUTF8Buf(utf8, wide) WideToUTF8(utf8, _countof(utf8), wide)
+
+/* ----------------------------------------------------------------------- */
+
 static bool IsVSRedistOutdated()
 {
 	VS_FIXEDFILEINFO *info = nullptr;
@@ -559,7 +592,10 @@ try {
 	return true;
 
 } catch (const exception &e) {
-	Status(L"Exception: %S", e.what());
+	wchar_t *what = nullptr;
+	UTF8ToWidePtr(what, e.what());
+	Status(L"Exception: %s", what ? what : L"<encoding error>");
+	free(what);
 	return false;
 } catch (...) {
 	Status(L"Unknown exception occurred in RunDownloadWorkers");
@@ -647,21 +683,6 @@ static bool WaitForOBS()
 
 /* ----------------------------------------------------------------------- */
 
-static inline bool UTF8ToWide(wchar_t *wide, int wideSize, const char *utf8)
-{
-	return !!MultiByteToWideChar(CP_UTF8, 0, utf8, -1, wide, wideSize);
-}
-
-static inline bool WideToUTF8(char *utf8, int utf8Size, const wchar_t *wide)
-{
-	return !!WideCharToMultiByte(CP_UTF8, 0, wide, -1, utf8, utf8Size, nullptr, nullptr);
-}
-
-#define UTF8ToWideBuf(wide, utf8) UTF8ToWide(wide, _countof(wide), utf8)
-#define WideToUTF8Buf(utf8, wide) WideToUTF8(utf8, _countof(utf8), wide)
-
-/* ----------------------------------------------------------------------- */
-
 queue<string> hashQueue;
 
 void HasherThread()
@@ -718,7 +739,10 @@ try {
 	}
 
 } catch (const exception &e) {
-	Status(L"Exception: %S", e.what());
+	wchar_t *what = nullptr;
+	UTF8ToWidePtr(what, e.what());
+	Status(L"Exception: %s", what ? what : L"<encoding error>");
+	free(what);
 } catch (...) {
 	Status(L"Unknown exception occurred in RunHasherWorkers");
 }
@@ -1197,7 +1221,10 @@ try {
 	return true;
 
 } catch (const exception &e) {
-	Status(L"Exception: %S", e.what());
+	wchar_t *what = nullptr;
+	UTF8ToWidePtr(what, e.what());
+	Status(L"Exception: %s", what ? what : L"<encoding error>");
+	free(what);
 	return false;
 } catch (...) {
 	Status(L"Unknown exception occurred in RunUpdateWorkers");
@@ -1226,7 +1253,7 @@ static bool UpdateVSRedists()
 
 	HttpHandle hConnect = WinHttpConnect(hSession, kMSHostname, INTERNET_DEFAULT_HTTPS_PORT, 0);
 	if (!hConnect) {
-		Status(L"Update failed: Couldn't connect to %S", kMSHostname);
+		Status(L"Update failed: Couldn't connect to %s", kMSHostname);
 		return false;
 	}
 
@@ -1330,7 +1357,7 @@ static void UpdateRegistryVersion(const Manifest &manifest)
 					  manifest.beta ? L"beta" : L"rc", manifest.beta ? manifest.beta : manifest.rc);
 	} else {
 		formattedLen = swprintf_s(version, _countof(version), L"%d.%d.%d", manifest.version_major,
-					 manifest.version_minor, manifest.version_patch);
+					  manifest.version_minor, manifest.version_patch);
 	}
 
 	if (formattedLen <= 0) {
@@ -1513,9 +1540,13 @@ static bool Update(wchar_t *cmdLine)
 			json manifestContents = json::parse(manifestFile);
 			manifest = manifestContents.get<Manifest>();
 		} catch (json::exception &e) {
+
+			wchar_t *what = nullptr;
+			UTF8ToWidePtr(what, e.what());
 			Status(L"Update failed: Couldn't parse update "
-			       L"manifest: %S",
-			       e.what());
+			       L"manifest: %s",
+			       what ? what : L"<encoding error>");
+			free(what);
 			return false;
 		}
 	}
@@ -1640,7 +1671,10 @@ static bool Update(wchar_t *cmdLine)
 		json patchManifest = json::parse(newManifest);
 		patches = patchManifest.get<PatchesResponse>();
 	} catch (json::exception &e) {
-		Status(L"Update failed: Couldn't parse patch manifest: %S", e.what());
+		wchar_t *what = NULL;
+		UTF8ToWidePtr(what, e.what());
+		Status(L"Update failed: Couldn't parse patch manifest: %s", what ? what : L"<encoding error>");
+		free(what);
 		return false;
 	}
 

--- a/frontend/updater/updater.cpp
+++ b/frontend/updater/updater.cpp
@@ -1317,19 +1317,19 @@ static bool UpdateVSRedists()
 
 static void UpdateRegistryVersion(const Manifest &manifest)
 {
-	const char *regKey = R"(Software\Microsoft\Windows\CurrentVersion\Uninstall\OBS Studio)";
+	const wchar_t *regKey = LR"(Software\Microsoft\Windows\CurrentVersion\Uninstall\OBS Studio)";
 	LSTATUS res;
 	HKEY key;
-	char version[32];
+	wchar_t version[32];
 	int formattedLen;
 
 	/* The manifest does not store a version string, so we gotta make one ourselves. */
 	if (manifest.beta || manifest.rc) {
-		formattedLen = sprintf_s(version, sizeof(version), "%d.%d.%d-%s%d", manifest.version_major,
-					 manifest.version_minor, manifest.version_patch, manifest.beta ? "beta" : "rc",
-					 manifest.beta ? manifest.beta : manifest.rc);
+		formattedLen = swprintf_s(version, _countof(version), L"%d.%d.%d-%s%d", manifest.version_major,
+					  manifest.version_minor, manifest.version_patch,
+					  manifest.beta ? L"beta" : L"rc", manifest.beta ? manifest.beta : manifest.rc);
 	} else {
-		formattedLen = sprintf_s(version, sizeof(version), "%d.%d.%d", manifest.version_major,
+		formattedLen = swprintf_s(version, _countof(version), L"%d.%d.%d", manifest.version_major,
 					 manifest.version_minor, manifest.version_patch);
 	}
 
@@ -1337,12 +1337,12 @@ static void UpdateRegistryVersion(const Manifest &manifest)
 		return;
 	}
 
-	res = RegOpenKeyExA(HKEY_LOCAL_MACHINE, regKey, 0, KEY_WRITE | KEY_WOW64_32KEY, &key);
+	res = RegOpenKeyExW(HKEY_LOCAL_MACHINE, regKey, 0, KEY_WRITE | KEY_WOW64_32KEY, &key);
 	if (res != ERROR_SUCCESS) {
 		return;
 	}
 
-	RegSetValueExA(key, "DisplayVersion", 0, REG_SZ, (const BYTE *)version, formattedLen + 1);
+	RegSetValueExW(key, L"DisplayVersion", 0, REG_SZ, (const BYTE *)version, (formattedLen + 1) * sizeof(wchar_t));
 	RegCloseKey(key);
 }
 

--- a/frontend/utility/platform-windows.cpp
+++ b/frontend/utility/platform-windows.cpp
@@ -60,11 +60,11 @@ bool GetDataFilePath(const char *data, string &output)
 string GetDefaultVideoSavePath()
 {
 	wchar_t path_utf16[MAX_PATH];
-	char path_utf8[MAX_PATH] = {};
+	BPtr<char> path_utf8;
 
 	SHGetFolderPathW(NULL, CSIDL_MYVIDEO, NULL, SHGFP_TYPE_CURRENT, path_utf16);
 
-	os_wcs_to_utf8(path_utf16, wcslen(path_utf16), path_utf8, MAX_PATH);
+	os_wcs_to_utf8_ptr(path_utf16, wcslen(path_utf16), &path_utf8);
 	return string(path_utf8);
 }
 
@@ -91,10 +91,10 @@ static vector<string> GetUserPreferredLocales()
 			break;
 		}
 
-		char conv[MAX_PATH] = {};
-		os_wcs_to_utf8(&*start, separator - start, conv, MAX_PATH);
+		BPtr<char> conv;
+		os_wcs_to_utf8_ptr(&*start, separator - start, &conv);
 
-		result.emplace_back(conv);
+		result.emplace_back(string(conv.Get()));
 
 		start = separator + 1;
 	}
@@ -307,14 +307,11 @@ RunOnceMutex CheckIfAlreadyRunning(bool &already_running)
 	if (!portable_mode) {
 		name = "OBSStudioCore";
 	} else {
-		char path[500];
-		char absPath[512];
-		*path = 0;
-		*absPath = 0;
-		GetAppConfigPath(path, sizeof(path), "");
-		os_get_abs_path(path, absPath, sizeof(absPath));
+		BPtr<char> path = GetAppConfigPathPtr("");
+		BPtr<char> absPath = os_get_abs_path_ptr(path.Get());
+
 		name = "OBSStudioPortable";
-		name += absPath;
+		name += absPath.Get();
 	}
 
 	BPtr<wchar_t> wname;

--- a/frontend/utility/win-dll-blocklist.c
+++ b/frontend/utility/win-dll-blocklist.c
@@ -357,11 +357,17 @@ void install_dll_blocklist_hook(void)
 
 void log_blocked_dlls(void)
 {
+	// Wide (UTF-16) converted to UTF-8 char is at max 3 bytes
+	char name_utf8[MAX_PATH * 3];
 	for (int i = 0; i < _countof(blocked_modules); i++) {
 		blocked_module_t *b = &blocked_modules[i];
 		if (b->blocked_count) {
-			blog(LOG_WARNING, "Blocked loading of '%S' %" PRIu64 " time%S.", b->name, b->blocked_count,
-			     b->blocked_count == 1 ? L"" : L"s");
+
+			WideCharToMultiByte(CP_UTF8, 0, b->name, (int)b->name_len + 1, name_utf8, sizeof(name_utf8),
+					    NULL, NULL);
+
+			blog(LOG_WARNING, "Blocked loading of '%s' %" PRIu64 " time%s.", name_utf8, b->blocked_count,
+			     b->blocked_count == 1 ? "" : "s");
 		}
 	}
 }

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -144,20 +144,20 @@ static void AddExtraModulePaths()
 		return;
 	}
 
-	char base_module_dir[512];
+	BPtr<char> base_module_dir;
 #if defined(_WIN32)
-	int ret = GetProgramDataPath(base_module_dir, sizeof(base_module_dir), "obs-studio/plugins/%module%");
+	base_module_dir = GetProgramDataPathPtr("obs-studio/plugins/%module%");
 #elif defined(__APPLE__)
-	int ret = GetAppConfigPath(base_module_dir, sizeof(base_module_dir), "obs-studio/plugins/%module%.plugin");
+	base_module_dir = GetAppConfigPathPtr("obs-studio/plugins/%module%.plugin");
 #else
-	int ret = GetAppConfigPath(base_module_dir, sizeof(base_module_dir), "obs-studio/plugins/%module%");
+	base_module_dir = GetAppConfigPathPtr("obs-studio/plugins/%module%");
 #endif
 
-	if (ret <= 0) {
+	if (!base_module_dir || !*base_module_dir.Get()) {
 		return;
 	}
 
-	string path = base_module_dir;
+	string path(base_module_dir.Get());
 #if defined(__APPLE__)
 	/* User Application Support Search Path */
 	obs_add_module_path((path + "/Contents/MacOS").c_str(), (path + "/Contents/Resources").c_str());

--- a/frontend/widgets/OBSBasic_MainControls.cpp
+++ b/frontend/widgets/OBSBasic_MainControls.cpp
@@ -260,12 +260,12 @@ void OBSBasic::on_actionAdvAudioProperties_triggered()
 
 static BPtr<char> ReadLogFile(const char *subdir, const char *log)
 {
-	char logDir[512];
-	if (GetAppConfigPath(logDir, sizeof(logDir), subdir) <= 0) {
+	BPtr<char> logDir = GetAppConfigPathPtr(subdir);
+	if (!logDir || !*logDir.Get()) {
 		return nullptr;
 	}
 
-	string path = logDir;
+	string path(logDir.Get());
 	path += "/";
 	path += log;
 
@@ -312,8 +312,8 @@ void OBSBasic::UploadLog(const char *subdir, const char *file, const LogUploadTy
 
 void OBSBasic::on_actionShowLogs_triggered()
 {
-	char logDir[512];
-	if (GetAppConfigPath(logDir, sizeof(logDir), "obs-studio/logs") <= 0) {
+	BPtr<char> logDir = GetAppConfigPathPtr("obs-studio/logs");
+	if (!logDir || !*logDir.Get()) {
 		return;
 	}
 

--- a/libobs-d3d11/d3d11-subsystem.cpp
+++ b/libobs-d3d11/d3d11-subsystem.cpp
@@ -1221,16 +1221,16 @@ gs_monitor_color_info gs_device::GetMonitorColorInfo(HMONITOR hMonitor)
 	return gs_monitor_color_info(false, 8, 80);
 }
 
-static void PopulateMonitorIds(HMONITOR handle, char *id, char *alt_id, size_t capacity)
+static void PopulateMonitorIds(HMONITOR handle, wchar_t *id, wchar_t *alt_id, size_t capacity)
 {
-	MONITORINFOEXA mi;
+	MONITORINFOEXW mi;
 	mi.cbSize = sizeof(mi);
-	if (GetMonitorInfoA(handle, (LPMONITORINFO)&mi)) {
-		strcpy_s(alt_id, capacity, mi.szDevice);
-		DISPLAY_DEVICEA device;
+	if (GetMonitorInfoW(handle, (LPMONITORINFO)&mi)) {
+		wcscpy_s(alt_id, capacity, mi.szDevice);
+		DISPLAY_DEVICEW device;
 		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
-			strcpy_s(id, capacity, device.DeviceID);
+		if (EnumDisplayDevicesW(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+			wcscpy_s(id, capacity, device.DeviceID);
 		}
 	}
 }
@@ -1257,8 +1257,8 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		DISPLAYCONFIG_TARGET_DEVICE_NAME target;
 
 		constexpr size_t id_capacity = 128;
-		char id[id_capacity]{};
-		char alt_id[id_capacity]{};
+		wchar_t id[id_capacity]{};
+		wchar_t alt_id[id_capacity]{};
 		PopulateMonitorIds(desc.Monitor, id, alt_id, id_capacity);
 
 		MONITORINFOEX info;
@@ -1330,7 +1330,11 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		const ULONG sdr_white_nits = GetSdrMaxNits(desc.Monitor);
 
 		char *friendly_name;
+		char *id_utf8;
+		char *alt_id_utf8;
 		os_wcs_to_utf8_ptr(target.monitorFriendlyDeviceName, 0, &friendly_name);
+		os_wcs_to_utf8_ptr(id, 0, &id_utf8);
+		os_wcs_to_utf8_ptr(alt_id, 0, &alt_id_utf8);
 
 		blog(LOG_INFO,
 		     "\t  output %u:\n"
@@ -1354,8 +1358,10 @@ static inline void LogAdapterMonitors(IDXGIAdapter1 *adapter)
 		     primaries[3][0], primaries[3][1], gamut_size / DoubleTriangleArea(.64, .33, .3, .6, .15, .06),
 		     gamut_size / DoubleTriangleArea(.68, .32, .265, .69, .15, .060),
 		     gamut_size / DoubleTriangleArea(.708, .292, .17, .797, .131, .046), sdr_white_nits, min_luminance,
-		     max_luminance, max_full_frame_luminance, dpiX, scaling, id, alt_id);
+		     max_luminance, max_full_frame_luminance, dpiX, scaling, id_utf8, alt_id_utf8);
 		bfree(friendly_name);
+		bfree(id_utf8);
+		bfree(alt_id_utf8);
 	}
 }
 

--- a/libobs-opengl/gl-windows.c
+++ b/libobs-opengl/gl-windows.c
@@ -84,7 +84,7 @@ static inline void init_dummy_pixel_format(PIXELFORMATDESCRIPTOR *pfd)
 	pfd->dwFlags = PFD_DRAW_TO_WINDOW | PFD_SUPPORT_OPENGL | PFD_DOUBLEBUFFER;
 }
 
-static const char *dummy_window_class = "GLDummyWindow";
+static const wchar_t *dummy_window_class = L"GLDummyWindow";
 static bool registered_dummy_window_class = false;
 
 struct dummy_context {
@@ -96,7 +96,7 @@ struct dummy_context {
 /* Need a dummy window for the dummy context */
 static bool gl_register_dummy_window_class(void)
 {
-	WNDCLASSA wc;
+	WNDCLASSW wc;
 	if (registered_dummy_window_class)
 		return true;
 
@@ -106,7 +106,7 @@ static bool gl_register_dummy_window_class(void)
 	wc.lpfnWndProc = DefWindowProc;
 	wc.lpszClassName = dummy_window_class;
 
-	if (!RegisterClassA(&wc)) {
+	if (!RegisterClassW(&wc)) {
 		blog(LOG_ERROR, "Could not create dummy window class");
 		return false;
 	}
@@ -117,7 +117,7 @@ static bool gl_register_dummy_window_class(void)
 
 static inline HWND gl_create_dummy_window(void)
 {
-	HWND hwnd = CreateWindowExA(0, dummy_window_class, "Dummy GL Window", WS_POPUP, 0, 0, 2, 2, NULL, NULL,
+	HWND hwnd = CreateWindowExW(0, dummy_window_class, L"Dummy GL Window", WS_POPUP, 0, 0, 2, 2, NULL, NULL,
 				    GetModuleHandle(NULL), NULL);
 	if (!hwnd)
 		blog(LOG_ERROR, "Could not create dummy context window");
@@ -344,22 +344,22 @@ static struct gl_windowinfo *gl_windowinfo_bare(const struct gs_init_data *info)
 	return wi;
 }
 
-#define DUMMY_WNDCLASS "Dummy GL Window Class"
+#define DUMMY_WNDCLASS L"Dummy GL Window Class"
 
 static bool register_dummy_class(void)
 {
 	static bool created = false;
 
-	WNDCLASSA wc = {0};
+	WNDCLASSW wc = {0};
 	wc.style = CS_OWNDC;
 	wc.hInstance = GetModuleHandleW(NULL);
-	wc.lpfnWndProc = (WNDPROC)DefWindowProcA;
+	wc.lpfnWndProc = (WNDPROC)DefWindowProcW;
 	wc.lpszClassName = DUMMY_WNDCLASS;
 
 	if (created)
 		return true;
 
-	if (!RegisterClassA(&wc)) {
+	if (!RegisterClassW(&wc)) {
 		blog(LOG_ERROR, "Failed to register dummy GL window class, %lu", GetLastError());
 		return false;
 	}
@@ -370,7 +370,7 @@ static bool register_dummy_class(void)
 
 static bool create_dummy_window(struct gl_platform *plat)
 {
-	plat->window.hwnd = CreateWindowExA(0, DUMMY_WNDCLASS, "OpenGL Dummy Window", WS_POPUP, 0, 0, 1, 1, NULL, NULL,
+	plat->window.hwnd = CreateWindowExW(0, DUMMY_WNDCLASS, L"OpenGL Dummy Window", WS_POPUP, 0, 0, 1, 1, NULL, NULL,
 					    GetModuleHandleW(NULL), NULL);
 	if (!plat->window.hwnd) {
 		blog(LOG_ERROR, "Failed to create dummy GL window, %lu", GetLastError());

--- a/libobs/obs-win-crash-handler.c
+++ b/libobs/obs-win-crash-handler.c
@@ -212,8 +212,8 @@ static inline void init_cpu_info(struct exception_handler_data *data)
 static BOOL CALLBACK enum_all_modules(PCTSTR module_name, DWORD64 module_base, ULONG module_size,
 				      struct exception_handler_data *data)
 {
-	char name_utf8[MAX_PATH];
-	os_wcs_to_utf8(module_name, 0, name_utf8, MAX_PATH);
+	char *name_utf8;
+	os_wcs_to_utf8_ptr(module_name, 0, &name_utf8);
 
 	if (data->main_trace.instruction_ptr >= module_base &&
 	    data->main_trace.instruction_ptr < module_base + module_size) {
@@ -229,6 +229,7 @@ static BOOL CALLBACK enum_all_modules(PCTSTR module_name, DWORD64 module_base, U
 	dstr_catf(&data->module_list, "%08" PRIX64 "-%08" PRIX64 " %s\r\n", module_base, module_base + module_size,
 		  name_utf8);
 #endif
+	bfree(name_utf8);
 	return true;
 }
 
@@ -271,14 +272,14 @@ static inline void write_header(struct exception_handler_data *data)
 
 struct module_info {
 	DWORD64 addr;
-	char name_utf8[MAX_PATH];
+	char name_utf8[FILENAME_MAX_LENGTH_UTF8];
 };
 
 static BOOL CALLBACK enum_module(PCTSTR module_name, DWORD64 module_base, ULONG module_size, struct module_info *info)
 {
 	if (info->addr >= module_base && info->addr < module_base + module_size) {
 
-		os_wcs_to_utf8(module_name, 0, info->name_utf8, MAX_PATH);
+		os_wcs_to_utf8(module_name, 0, info->name_utf8, FILENAME_MAX_LENGTH_UTF8);
 		strlwr(info->name_utf8);
 		return false;
 	}

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -404,11 +404,12 @@ size_t os_get_abs_path(const char *path, char *abspath, size_t size)
 	char newpath[PATH_MAX];
 	int ret;
 
-	if (!abspath)
-		return 0;
-
 	if (!realpath(path, newpath))
 		return 0;
+
+	if (!abspath) {
+		return strlen(newpath);
+	}
 
 	ret = snprintf(abspath, min_size, "%s", newpath);
 	return ret >= 0 ? ret : 0;
@@ -416,9 +417,13 @@ size_t os_get_abs_path(const char *path, char *abspath, size_t size)
 
 char *os_get_abs_path_ptr(const char *path)
 {
-	char *ptr = bmalloc(512);
+	size_t len = os_get_abs_path(path, NULL, 0);
+	if (!len)
+		return NULL;
 
-	if (!os_get_abs_path(path, ptr, 512)) {
+	char *ptr = bmalloc(len + 1);
+
+	if (!os_get_abs_path(path, ptr, len + 1)) {
 		bfree(ptr);
 		ptr = NULL;
 	}

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -474,10 +474,7 @@ struct os_dirent *os_readdir(os_dir_t *dir)
 	if (!dir->cur_dirent)
 		return NULL;
 
-	const size_t length = strlen(dir->cur_dirent->d_name);
-	if (sizeof(dir->out.d_name) <= length)
-		return NULL;
-	memcpy(dir->out.d_name, dir->cur_dirent->d_name, length + 1);
+	dir->out.d_name = dir->cur_dirent->d_name;
 
 	dstr_copy(&file_path, dir->path);
 	dstr_cat(&file_path, "/");

--- a/libobs/util/platform-nix.c
+++ b/libobs/util/platform-nix.c
@@ -263,10 +263,11 @@ char *os_get_config_path_ptr(const char *name)
 			bcrash("Could not get $HOME\n");
 
 		dstr_init_copy(&path, home_ptr);
-		dstr_cat(&path, "/.config/");
-		dstr_cat(&path, name);
+		dstr_cat(&path, "/.config");
 	} else {
 		dstr_init_copy(&path, xdg_ptr);
+	}
+	if (name && *name) {
 		dstr_cat(&path, "/");
 		dstr_cat(&path, name);
 	}

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -503,9 +503,6 @@ size_t os_get_abs_path(const char *path, char *abspath, size_t size)
 	size_t out_len = 0;
 	size_t len;
 
-	if (!abspath)
-		return 0;
-
 	len = os_utf8_to_wcs(path, 0, wpath, MAX_PATH);
 	if (!len)
 		return 0;
@@ -517,9 +514,13 @@ size_t os_get_abs_path(const char *path, char *abspath, size_t size)
 
 char *os_get_abs_path_ptr(const char *path)
 {
-	char *ptr = bmalloc(MAX_PATH);
+	size_t len = os_get_abs_path(path, NULL, 0);
+	if (!len)
+		return NULL;
 
-	if (!os_get_abs_path(path, ptr, MAX_PATH)) {
+	char *ptr = bmalloc(len + 1);
+
+	if (!os_get_abs_path(path, ptr, len + 1)) {
 		bfree(ptr);
 		ptr = NULL;
 	}
@@ -597,18 +598,22 @@ void os_closedir(os_dir_t *dir)
 int64_t os_get_free_space(const char *path)
 {
 	ULARGE_INTEGER remainingSpace;
-	char abs_path[512];
-	wchar_t w_abs_path[512];
+	char *abs_path;
+	wchar_t *w_abs_path;
+	int64_t ret = -1;
 
-	if (os_get_abs_path(path, abs_path, 512) > 0) {
-		if (os_utf8_to_wcs(abs_path, 0, w_abs_path, 512) > 0) {
+	abs_path = os_get_abs_path_ptr(path);
+	if (abs_path) {
+		if (os_utf8_to_wcs_ptr(abs_path, 0, &w_abs_path) > 0) {
 			BOOL success = GetDiskFreeSpaceExW(w_abs_path, (PULARGE_INTEGER)&remainingSpace, NULL, NULL);
 			if (success)
-				return (int64_t)remainingSpace.QuadPart;
+				ret = (int64_t)remainingSpace.QuadPart;
 		}
+		bfree(w_abs_path);
+		bfree(abs_path);
 	}
 
-	return -1;
+	return ret;
 }
 
 static void make_globent(struct os_globent *ent, WIN32_FIND_DATA *wfd, const char *pattern)
@@ -926,24 +931,26 @@ bool get_dll_ver(const wchar_t *lib, struct win_version_info *ver_info)
 	BOOL success;
 	LPVOID data;
 	DWORD size;
-	char utf8_lib[512];
+	char *utf8_lib;
 
 	if (!ver_initialized && !initialize_version_functions())
 		return false;
 	if (!ver_initialize_success)
 		return false;
 
-	os_wcs_to_utf8(lib, 0, utf8_lib, sizeof(utf8_lib));
+	os_wcs_to_utf8_ptr(lib, 0, &utf8_lib);
 
 	size = get_file_version_info_size(lib, NULL);
 	if (!size) {
 		blog(LOG_ERROR, "Failed to get %s version info size", utf8_lib);
+		bfree(utf8_lib);
 		return false;
 	}
 
 	data = bmalloc(size);
 	if (!get_file_version_info(lib, 0, size, data)) {
 		blog(LOG_ERROR, "Failed to get %s version info", utf8_lib);
+		bfree(utf8_lib);
 		bfree(data);
 		return false;
 	}
@@ -951,6 +958,7 @@ bool get_dll_ver(const wchar_t *lib, struct win_version_info *ver_info)
 	success = ver_query_value(data, L"\\", (LPVOID *)&info, &len);
 	if (!success || !info || !len) {
 		blog(LOG_ERROR, "Failed to get %s version info value", utf8_lib);
+		bfree(utf8_lib);
 		bfree(data);
 		return false;
 	}
@@ -960,6 +968,7 @@ bool get_dll_ver(const wchar_t *lib, struct win_version_info *ver_info)
 	ver_info->build = (int)HIWORD(info->dwFileVersionLS);
 	ver_info->revis = (int)LOWORD(info->dwFileVersionLS);
 
+	bfree(utf8_lib);
 	bfree(data);
 	return true;
 }

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -427,8 +427,10 @@ static char *os_get_path_ptr_internal(const char *name, int folder)
 
 	os_wcs_to_utf8_ptr(path_utf16, 0, &ptr);
 	dstr_init_move_array(&path, ptr);
+	if (name && *name) {
 	dstr_cat(&path, "\\");
 	dstr_cat(&path, name);
+	}
 	return path.array;
 }
 

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -106,13 +106,18 @@ void *os_dlopen(const char *path)
 		if (error == ERROR_PROC_NOT_FOUND)
 			return NULL;
 
-		char *message = NULL;
+		wchar_t *message = NULL;
+		char *message_utf8 = NULL;
 
-		FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
+		FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS |
 				       FORMAT_MESSAGE_ALLOCATE_BUFFER,
-			       NULL, error, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), (LPSTR)&message, 0, NULL);
+			       NULL, error, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), (LPWSTR)&message, 0, NULL);
 
-		blog(LOG_INFO, "LoadLibrary failed for '%s': %s (%lu)", path, message, error);
+		if (message)
+			os_wcs_to_utf8_ptr(message, 0, &message_utf8);
+
+		blog(LOG_INFO, "LoadLibrary failed for '%s': %s (%lu)", path, message_utf8 ? message_utf8 : "", error);
+		bfree(message_utf8);
 
 		if (message)
 			LocalFree(message);

--- a/libobs/util/platform-windows.c
+++ b/libobs/util/platform-windows.c
@@ -428,8 +428,8 @@ static char *os_get_path_ptr_internal(const char *name, int folder)
 	os_wcs_to_utf8_ptr(path_utf16, 0, &ptr);
 	dstr_init_move_array(&path, ptr);
 	if (name && *name) {
-	dstr_cat(&path, "\\");
-	dstr_cat(&path, name);
+		dstr_cat(&path, "\\");
+		dstr_cat(&path, name);
 	}
 	return path.array;
 }
@@ -533,6 +533,7 @@ struct os_dir {
 	WIN32_FIND_DATA wfd;
 	bool first;
 	struct os_dirent out;
+	char filename_utf8[FILENAME_MAX_LENGTH_UTF8];
 };
 
 os_dir_t *os_opendir(const char *path)
@@ -580,8 +581,9 @@ struct os_dirent *os_readdir(os_dir_t *dir)
 			return NULL;
 	}
 
-	os_wcs_to_utf8(dir->wfd.cFileName, 0, dir->out.d_name, sizeof(dir->out.d_name));
+	os_wcs_to_utf8(dir->wfd.cFileName, 0, dir->filename_utf8, sizeof(dir->filename_utf8));
 
+	dir->out.d_name = dir->filename_utf8;
 	dir->out.directory = is_dir(&dir->wfd);
 
 	return &dir->out;

--- a/libobs/util/platform.c
+++ b/libobs/util/platform.c
@@ -92,31 +92,32 @@ int64_t os_fgetsize(FILE *file)
 #ifdef _WIN32
 int os_stat(const char *file, struct stat *st)
 {
+	int ret = -1;
 	if (file) {
-		wchar_t w_file[512];
-		size_t size = os_utf8_to_wcs(file, 0, w_file, sizeof(w_file));
-		if (size > 0) {
-			struct _stat st_w32;
-			int ret = _wstat(w_file, &st_w32);
-			if (ret == 0) {
-				st->st_dev = st_w32.st_dev;
-				st->st_ino = st_w32.st_ino;
-				st->st_mode = st_w32.st_mode;
-				st->st_nlink = st_w32.st_nlink;
-				st->st_uid = st_w32.st_uid;
-				st->st_gid = st_w32.st_gid;
-				st->st_rdev = st_w32.st_rdev;
-				st->st_size = st_w32.st_size;
-				st->st_atime = st_w32.st_atime;
-				st->st_mtime = st_w32.st_mtime;
-				st->st_ctime = st_w32.st_ctime;
-			}
-
+		wchar_t *w_file;
+		os_utf8_to_wcs_ptr(file, 0, &w_file);
+		if (!w_file) {
 			return ret;
 		}
-	}
 
-	return -1;
+		struct _stat st_w32;
+		ret = _wstat(w_file, &st_w32);
+		if (ret == 0) {
+			st->st_dev = st_w32.st_dev;
+			st->st_ino = st_w32.st_ino;
+			st->st_mode = st_w32.st_mode;
+			st->st_nlink = st_w32.st_nlink;
+			st->st_uid = st_w32.st_uid;
+			st->st_gid = st_w32.st_gid;
+			st->st_rdev = st_w32.st_rdev;
+			st->st_size = st_w32.st_size;
+			st->st_atime = st_w32.st_atime;
+			st->st_mtime = st_w32.st_mtime;
+			st->st_ctime = st_w32.st_ctime;
+		}
+		bfree(w_file);
+	}
+	return ret;
 }
 #endif
 

--- a/libobs/util/platform.h
+++ b/libobs/util/platform.h
@@ -30,6 +30,15 @@
 extern "C" {
 #endif
 
+#ifdef _WIN32
+/*
+ * Maximum length of a UTF-8 encoded filename (not path) converted from a UTF-16 filename on Windows.
+ * A UTF-16 code unit (wchar_t) can be up to 3 bytes/chars in UTF-8.
+ * Other OSs use UTF-8 apis directly, so the there's no expansion between api and internal storage.
+ */
+#define FILENAME_MAX_LENGTH_UTF8 (_MAX_PATH * 3)
+#endif
+
 EXPORT FILE *os_wfopen(const wchar_t *path, const char *mode);
 EXPORT FILE *os_fopen(const char *path, const char *mode);
 EXPORT int64_t os_fgetsize(FILE *file);
@@ -121,7 +130,7 @@ struct os_dir;
 typedef struct os_dir os_dir_t;
 
 struct os_dirent {
-	char d_name[256];
+	char *d_name;
 	bool directory;
 };
 

--- a/libobs/util/util.hpp
+++ b/libobs/util/util.hpp
@@ -37,7 +37,7 @@ template<typename T> class BPtr {
 
 public:
 	inline BPtr(T *p = nullptr) : ptr(p) {}
-	inline BPtr(BPtr &&other) { *this = std::move(other); }
+	inline BPtr(BPtr &&other) : ptr(nullptr) { *this = std::move(other); }
 	inline ~BPtr() { bfree(ptr); }
 
 	inline T *operator=(T *p)
@@ -49,6 +49,7 @@ public:
 
 	inline BPtr &operator=(BPtr &&other)
 	{
+		bfree(ptr);
 		ptr = other.ptr;
 		other.ptr = nullptr;
 		return *this;

--- a/libobs/util/windows/window-helpers.c
+++ b/libobs/util/windows/window-helpers.c
@@ -98,7 +98,7 @@ static HMODULE kernel32(void)
 {
 	static HMODULE kernel32_handle = NULL;
 	if (!kernel32_handle)
-		kernel32_handle = GetModuleHandleA("kernel32");
+		kernel32_handle = GetModuleHandleW(L"kernel32");
 	return kernel32_handle;
 }
 

--- a/plugins/nv-filters/nvafx-load.h
+++ b/plugins/nv-filters/nvafx-load.h
@@ -219,22 +219,23 @@ void release_lib(void)
 	}
 }
 
-static inline bool nvafx_get_sdk_path(char *buffer, const size_t len)
+static inline bool nvafx_get_sdk_path(wchar_t *buffer, const size_t len)
 {
-	DWORD ret = GetEnvironmentVariableA("NVAFX_SDK_DIR", buffer, (DWORD)len);
+	DWORD ret = GetEnvironmentVariableW(L"NVAFX_SDK_DIR", buffer, (DWORD)len);
 
-	if (!ret || ret >= len - 1) {
-		char path[MAX_PATH];
-		if (!GetEnvironmentVariableA("ProgramFiles", path, MAX_PATH)) {
+	if (!ret || ret >= len) {
+		wchar_t path[MAX_PATH];
+		if (!GetEnvironmentVariableW(L"ProgramFiles", path, MAX_PATH)) {
 			buffer[0] = 0;
 			return false;
 		}
 
-		if (_snprintf_s(buffer, len, _TRUNCATE, "%s\\NVIDIA Corporation\\NVIDIA Audio Effects SDK", path) > 0) {
-			return true;
+		int r = _snwprintf_s(buffer, len, _TRUNCATE, L"%s\\NVIDIA Corporation\\NVIDIA Audio Effects SDK",
+				     path);
+		if (r <= 0 || r >= len) {
+			buffer[0] = 0;
+			return false;
 		}
-
-		return false;
 	}
 
 	return true;
@@ -242,19 +243,19 @@ static inline bool nvafx_get_sdk_path(char *buffer, const size_t len)
 
 static inline bool load_lib()
 {
-	char sdkPath[MAX_PATH];
-	char effectsPath[MAX_PATH];
+	wchar_t sdkPath[MAX_PATH];
+	wchar_t effectsPath[MAX_PATH];
 
 	if (!nvafx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return false;
 	}
 
-	if (_snprintf_s(effectsPath, _countof(effectsPath), _TRUNCATE, "%s\\NVAudioEffects.dll", sdkPath) == -1) {
+	if (_snwprintf_s(effectsPath, _countof(effectsPath), _TRUNCATE, L"%s\\NVAudioEffects.dll", sdkPath) == -1) {
 		return false;
 	}
 
 	nv_audiofx =
-		LoadLibraryExA(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		LoadLibraryExW(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 	return !!nv_audiofx;
 }
@@ -269,14 +270,14 @@ static unsigned int get_lib_version(void)
 
 	version_checked = true;
 
-	char sdkPath[MAX_PATH];
+	wchar_t sdkPath[MAX_PATH];
 	wchar_t dllPath[MAX_PATH];
 
 	if (!nvafx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return version;
 	}
 
-	if (_snwprintf_s(dllPath, _countof(dllPath), _TRUNCATE, L"%S\\NVAudioEffects.dll", sdkPath) == -1) {
+	if (_snwprintf_s(dllPath, _countof(dllPath), _TRUNCATE, L"%s\\NVAudioEffects.dll", sdkPath) == -1) {
 		return version;
 	}
 

--- a/plugins/nv-filters/nvidia-audiofx-filter.c
+++ b/plugins/nv-filters/nvidia-audiofx-filter.c
@@ -583,18 +583,17 @@ static void *nvidia_audio_create(obs_data_t *settings, obs_source_t *filter)
 
 	ng->context = filter;
 
-	char sdk_path[MAX_PATH];
+	wchar_t sdk_path[MAX_PATH];
 
 	/* find SDK */
-	if (!nvafx_get_sdk_path(sdk_path, sizeof(sdk_path))) {
+	if (!nvafx_get_sdk_path(sdk_path, _countof(sdk_path))) {
 		ng->nvidia_sdk_dir_found = false;
 		do_log(LOG_ERROR, "NVAFX redist is not installed.");
 		nvidia_audio_destroy(ng);
 		return NULL;
 	} else {
-		size_t size = sizeof(sdk_path) + 1;
-		ng->sdk_path = bmalloc(size);
-		strcpy(ng->sdk_path, sdk_path);
+
+		os_wcs_to_utf8_ptr(sdk_path, 0, &ng->sdk_path);
 		ng->nvidia_sdk_dir_found = true;
 		ng->nvafx_initialized = false;
 		ng->nvafx_loading = false;
@@ -602,7 +601,7 @@ static void *nvidia_audio_create(obs_data_t *settings, obs_source_t *filter)
 
 		pthread_mutex_init(&ng->nvafx_mutex, NULL);
 
-		info("NVAFX SDK redist path was found here %s", sdk_path);
+		info("NVAFX SDK redist path was found here %s", ng->sdk_path);
 		// set FX
 		const char *method = obs_data_get_string(settings, S_METHOD);
 		set_nv_model(ng, method);

--- a/plugins/nv-filters/nvidia-videofx-filter.c
+++ b/plugins/nv-filters/nvidia-videofx-filter.c
@@ -261,13 +261,20 @@ static bool nvvfx_filter_create_internal(struct nvvfx_data *filter)
 		log_nverror_destroy(filter, vfxErr);
 
 	if (id == S_FX_AIGS || id == S_FX_BG_BLUR) {
-		char buffer[MAX_PATH];
-		char modelDir[MAX_PATH];
+		wchar_t buffer[MAX_PATH];
+		wchar_t modelDir[MAX_PATH];
 		nvvfx_get_sdk_path(buffer, MAX_PATH);
-		size_t max_len = sizeof(buffer) / sizeof(char);
-		snprintf(modelDir, max_len, "%s\\models", buffer);
-		vfxErr = NvVFX_SetString(filter->handle, NVVFX_MODEL_DIRECTORY, modelDir);
+		int ret = _snwprintf(modelDir, _countof(buffer), L"%s\\models", buffer);
+		if (ret < 0 || ret >= MAX_PATH) {
+			return false;
+		}
+
+		char *modelDirUtf8;
+		os_wcs_to_utf8_ptr(modelDir, wcslen(modelDir), &modelDirUtf8);
+
+		vfxErr = NvVFX_SetString(filter->handle, NVVFX_MODEL_DIRECTORY, modelDirUtf8);
 		vfxErr = NvVFX_SetCudaStream(filter->handle, NVVFX_CUDA_STREAM, filter->stream);
+		bfree(modelDirUtf8);
 		if (NVCV_SUCCESS != vfxErr)
 			log_nverror_destroy(filter, vfxErr);
 	}

--- a/plugins/nv-filters/nvvfx-load.h
+++ b/plugins/nv-filters/nvvfx-load.h
@@ -667,22 +667,22 @@ static inline void release_nv_vfx()
 	}
 }
 
-static inline bool nvvfx_get_sdk_path(char *buffer, const size_t len)
+static inline bool nvvfx_get_sdk_path(wchar_t *buffer, const size_t len)
 {
-	DWORD ret = GetEnvironmentVariableA("NV_VIDEO_EFFECTS_PATH", buffer, (DWORD)len);
+	DWORD ret = GetEnvironmentVariableW(L"NV_VIDEO_EFFECTS_PATH", buffer, (DWORD)len);
 
-	if (!ret || ret >= len - 1) {
-		char path[MAX_PATH];
-		if (!GetEnvironmentVariableA("ProgramFiles", path, MAX_PATH)) {
+	if (!ret || ret >= len) {
+		wchar_t path[MAX_PATH];
+		if (!GetEnvironmentVariableW(L"ProgramFiles", path, MAX_PATH)) {
 			buffer[0] = 0;
 			return false;
 		}
 
-		if (_snprintf_s(buffer, len, _TRUNCATE, "%s\\NVIDIA Corporation\\NVIDIA Video Effects", path) > 0) {
-			return true;
+		int r = _snwprintf_s(buffer, len, _TRUNCATE, L"%s\\NVIDIA Corporation\\NVIDIA Video Effects", path);
+		if (r < 0 || r >= len) {
+			buffer[0] = 0;
+			return false;
 		}
-
-		return false;
 	}
 
 	return true;
@@ -690,27 +690,30 @@ static inline bool nvvfx_get_sdk_path(char *buffer, const size_t len)
 
 static inline bool load_nv_vfx_libs()
 {
-	char sdkPath[MAX_PATH];
-	char effectsPath[MAX_PATH];
-	char imagePath[MAX_PATH];
+	wchar_t sdkPath[MAX_PATH];
+	wchar_t effectsPath[MAX_PATH];
+	wchar_t imagePath[MAX_PATH];
+	int ret;
 
 	if (!nvvfx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return false;
 	}
 
-	if (_snprintf_s(effectsPath, _countof(effectsPath), _TRUNCATE, "%s\\NVVideoEffects.dll", sdkPath) == -1) {
+	ret = _snwprintf_s(effectsPath, _countof(effectsPath), _TRUNCATE, L"%s\\NVVideoEffects.dll", sdkPath);
+	if (ret < 0 || ret >= MAX_PATH) {
 		return false;
 	}
 
-	if (_snprintf_s(imagePath, _countof(imagePath), _TRUNCATE, "%s\\NVCVImage.dll", sdkPath) == -1) {
+	ret = _snwprintf_s(imagePath, _countof(imagePath), _TRUNCATE, L"%s\\NVCVImage.dll", sdkPath);
+	if (ret < 0 || ret >= MAX_PATH) {
 		return false;
 	}
 
 	nv_videofx =
-		LoadLibraryExA(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		LoadLibraryExW(effectsPath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 	nv_cvimage =
-		LoadLibraryExA(imagePath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+		LoadLibraryExW(imagePath, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 
 	return !!nv_videofx && !!nv_cvimage;
 }
@@ -725,14 +728,14 @@ static unsigned int get_lib_version(void)
 
 	version_checked = true;
 
-	char sdkPath[MAX_PATH];
+	wchar_t sdkPath[MAX_PATH];
 	wchar_t dllPath[MAX_PATH];
 
 	if (!nvvfx_get_sdk_path(sdkPath, MAX_PATH)) {
 		return version;
 	}
 
-	if (_snwprintf_s(dllPath, _countof(dllPath), _TRUNCATE, L"%S\\NVVideoEffects.dll", sdkPath) == -1) {
+	if (_snwprintf_s(dllPath, _countof(dllPath), _TRUNCATE, L"%s\\NVVideoEffects.dll", sdkPath) == -1) {
 		return version;
 	}
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-srt.h
@@ -481,13 +481,16 @@ static int libsrt_setup(URLContext *h, const char *uri)
 		hints.ai_flags |= AI_PASSIVE;
 	ret = getaddrinfo(hostname[0] ? hostname : NULL, portstr, &hints, &ai);
 	if (ret) {
-		blog(LOG_ERROR, "[obs-ffmpeg mpegts muxer / libsrt]: Failed to resolve hostname %s: %s", hostname,
 #ifdef _WIN32
-		     gai_strerrorA(ret)
+		char *strerror = NULL;
+		os_wcs_to_utf8_ptr(gai_strerrorW(ret), 0, &strerror);
+		blog(LOG_ERROR, "[obs-ffmpeg mpegts muxer / libsrt]: Failed to resolve hostname %s: %s", hostname,
+		     strerror);
+		bfree(strerror);
 #else
-		     gai_strerror(ret)
+		blog(LOG_ERROR, "[obs-ffmpeg mpegts muxer / libsrt]: Failed to resolve hostname %s: %s", hostname,
+		     gai_strerror(ret));
 #endif
-		);
 		s->last_error.obs_output_error_number = OBS_OUTPUT_BAD_PATH;
 		return AVERROR(EIO);
 	}

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -311,14 +311,14 @@ template<typename T> static void set_amf_property(amf_base *enc, const wchar_t *
 /* ------------------------------------------------------------------------- */
 /* Implementation                                                            */
 
-static HMODULE get_lib(const char *lib)
+static HMODULE get_lib(const wchar_t *lib)
 {
-	HMODULE mod = GetModuleHandleA(lib);
+	HMODULE mod = GetModuleHandleW(lib);
 	if (mod) {
 		return mod;
 	}
 
-	return LoadLibraryA(lib);
+	return LoadLibraryW(lib);
 }
 
 #define AMD_VENDOR_ID 0x1002
@@ -327,8 +327,8 @@ typedef HRESULT(WINAPI *CREATEDXGIFACTORY1PROC)(REFIID, void **);
 
 static bool amf_init_d3d11(amf_texencode *enc)
 try {
-	HMODULE dxgi = get_lib("DXGI.dll");
-	HMODULE d3d11 = get_lib("D3D11.dll");
+	HMODULE dxgi = get_lib(L"DXGI.dll");
+	HMODULE d3d11 = get_lib(L"D3D11.dll");
 	CREATEDXGIFACTORY1PROC create_dxgi;
 	PFN_D3D11_CREATE_DEVICE create_device;
 	ComPtr<IDXGIFactory> factory;

--- a/plugins/obs-ffmpeg/texture-amf.cpp
+++ b/plugins/obs-ffmpeg/texture-amf.cpp
@@ -63,6 +63,13 @@ struct adapter_caps {
 	bool supports_av1 = false;
 };
 
+char* WideToUTF8(const wchar_t* wide)
+{
+	char* resultText = NULL;
+	os_wcs_to_utf8_ptr(wide, 0, &resultText);
+	return resultText;
+}
+
 /* ------------------------------------------------------------------------- */
 
 static std::map<uint32_t, adapter_caps> caps;
@@ -282,7 +289,11 @@ template<typename T> static void set_amf_property(amf_base *enc, const wchar_t *
 {
 	AMF_RESULT res = enc->amf_encoder->SetProperty(name, value);
 	if (res != AMF_OK) {
-		error("Failed to set property '%ls': %ls", name, amf_trace->GetResultText(res));
+		char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(res));
+		char *nameUtf8 = WideToUTF8(amf_trace->GetResultText(res));
+		error("Failed to set property '%s': %s", nameUtf8, resultUtf8);
+		bfree(resultUtf8);
+		bfree(nameUtf8);
 	}
 }
 
@@ -886,7 +897,9 @@ try {
 
 } catch (const amf_error &err) {
 	amf_texencode *enc = (amf_texencode *)data;
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	*received_packet = false;
 	return false;
 
@@ -986,7 +999,9 @@ try {
 
 } catch (const amf_error &err) {
 	amf_fallback *enc = (amf_fallback *)data;
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	*received_packet = false;
 	return false;
 } catch (const char *err) {
@@ -1166,7 +1181,9 @@ try {
 	return true;
 
 } catch (const amf_error &err) {
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return false;
 }
 
@@ -1454,7 +1471,9 @@ try {
 
 } catch (const amf_error &err) {
 	amf_base *enc = (amf_base *)data;
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return false;
 }
 
@@ -1744,7 +1763,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[texture-amf-h264] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[texture-amf-h264] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return obs_encoder_create_rerouted(encoder, "h264_fallback_amf");
 
 } catch (const char *err) {
@@ -1788,7 +1809,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[fallback-amf-h264] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[fallback-amf-h264] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return nullptr;
 
 } catch (const char *err) {
@@ -1936,7 +1959,9 @@ try {
 
 } catch (const amf_error &err) {
 	amf_base *enc = (amf_base *)data;
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return false;
 }
 
@@ -2148,7 +2173,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[texture-amf-h265] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[texture-amf-h265] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return obs_encoder_create_rerouted(encoder, "h265_fallback_amf");
 
 } catch (const char *err) {
@@ -2189,7 +2216,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[fallback-amf-h265] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[fallback-amf-h265] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return nullptr;
 
 } catch (const char *err) {
@@ -2364,7 +2393,9 @@ try {
 
 } catch (const amf_error &err) {
 	amf_base *enc = (amf_base *)data;
-	error("%s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	error("%s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return false;
 }
 
@@ -2573,7 +2604,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[texture-amf-av1] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[texture-amf-av1] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return obs_encoder_create_rerouted(encoder, "av1_fallback_amf");
 
 } catch (const char *err) {
@@ -2615,7 +2648,9 @@ try {
 	return enc.release();
 
 } catch (const amf_error &err) {
-	blog(LOG_ERROR, "[fallback-amf-av1] %s: %s: %ls", __FUNCTION__, err.str, amf_trace->GetResultText(err.res));
+	char *resultUtf8 = WideToUTF8(amf_trace->GetResultText(err.res));
+	blog(LOG_ERROR, "[fallback-amf-av1] %s: %s: %s", __FUNCTION__, err.str, resultUtf8);
+	bfree(resultUtf8);
 	return nullptr;
 
 } catch (const char *err) {

--- a/plugins/obs-nvenc/nvenc-d3d11.c
+++ b/plugins/obs-nvenc/nvenc-d3d11.c
@@ -8,13 +8,13 @@
 /* ------------------------------------------------------------------------- */
 /* D3D11 Context/Device management                                           */
 
-static HANDLE get_lib(struct nvenc_data *enc, const char *lib)
+static HANDLE get_lib(struct nvenc_data *enc, const wchar_t *lib)
 {
-	HMODULE mod = GetModuleHandleA(lib);
+	HMODULE mod = GetModuleHandleW(lib);
 	if (mod)
 		return mod;
 
-	mod = LoadLibraryA(lib);
+	mod = LoadLibraryW(lib);
 	if (!mod)
 		error("Failed to load %s", lib);
 	return mod;
@@ -24,8 +24,8 @@ typedef HRESULT(WINAPI *CREATEDXGIFACTORY1PROC)(REFIID, void **);
 
 bool d3d11_init(struct nvenc_data *enc, obs_data_t *settings)
 {
-	HMODULE dxgi = get_lib(enc, "DXGI.dll");
-	HMODULE d3d11 = get_lib(enc, "D3D11.dll");
+	HMODULE dxgi = get_lib(enc, L"DXGI.dll");
+	HMODULE d3d11 = get_lib(enc, L"D3D11.dll");
 	CREATEDXGIFACTORY1PROC create_dxgi;
 	PFN_D3D11_CREATE_DEVICE create_device;
 	IDXGIFactory1 *factory;

--- a/plugins/obs-nvenc/obs-nvenc-test/obs-nvenc-test.cpp
+++ b/plugins/obs-nvenc/obs-nvenc-test/obs-nvenc-test.cpp
@@ -186,7 +186,7 @@ private:
 	bool load_nvml_lib()
 	{
 #ifdef _WIN32
-		nvml_lib = LoadLibraryA("nvml.dll");
+		nvml_lib = LoadLibraryW(L"nvml.dll");
 #else
 		nvml_lib = dlopen("libnvidia-ml.so.1", RTLD_LAZY);
 #endif

--- a/plugins/obs-outputs/net-if.c
+++ b/plugins/obs-outputs/net-if.c
@@ -55,10 +55,12 @@ static void netif_convert_to_string(char *dest, struct sockaddr_storage *byte_ad
 	else if (family == AF_INET6)
 		inet_ntop(family, &(((struct sockaddr_in6 *)byte_address)->sin6_addr), temp_char, INET6_ADDRSTRLEN);
 #else
+	wchar_t temp_wchar[INET6_ADDRSTRLEN] = {0};
 	if (family == AF_INET)
-		InetNtopA(family, &(((SOCKADDR_IN *)byte_address)->sin_addr), temp_char, INET6_ADDRSTRLEN);
+		InetNtopW(family, &(((SOCKADDR_IN *)byte_address)->sin_addr), temp_wchar, INET6_ADDRSTRLEN);
 	else if (family == AF_INET6)
-		InetNtopA(family, &(((SOCKADDR_IN6 *)byte_address)->sin6_addr), temp_char, INET6_ADDRSTRLEN);
+		InetNtopW(family, &(((SOCKADDR_IN6 *)byte_address)->sin6_addr), temp_wchar, INET6_ADDRSTRLEN);
+	WideCharToMultiByte(CP_UTF8, 0, temp_wchar, -1, temp_char, INET6_ADDRSTRLEN, NULL, NULL);
 #endif
 	strncpy(dest, temp_char, INET6_ADDRSTRLEN);
 }
@@ -113,7 +115,10 @@ bool netif_str_to_addr(struct sockaddr_storage *out, int *addr_len, const char *
 	*addr_len = sizeof(*out);
 
 #ifdef _WIN32
-	int ret = WSAStringToAddressA((LPSTR)addr, out->ss_family, NULL, (LPSOCKADDR)out, addr_len);
+	wchar_t *waddr = NULL;
+	os_utf8_to_wcs_ptr(addr, 0, &waddr);
+	int ret = WSAStringToAddressW((LPWSTR)waddr, out->ss_family, NULL, (LPSOCKADDR)out, addr_len);
+	bfree(waddr);
 	if (ret == SOCKET_ERROR)
 		warn("Could not parse address, error code: %d", GetLastError());
 	return ret != SOCKET_ERROR;

--- a/plugins/obs-outputs/net-if.c
+++ b/plugins/obs-outputs/net-if.c
@@ -205,16 +205,20 @@ static inline PIP_ADAPTER_ADDRESSES get_adapters(void)
 	} while ((ret == ERROR_BUFFER_OVERFLOW) && (i < max_tries));
 
 	if (ret != NO_ERROR && ret != ERROR_NO_DATA) {
-		LPSTR msg_buf = NULL;
+		LPWSTR msg_buf = NULL;
 
 		bfree(adapter);
 		adapter = NULL;
 
-		FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+		FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
 				       FORMAT_MESSAGE_IGNORE_INSERTS,
-			       NULL, ret, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&msg_buf, 0, NULL);
+			       NULL, ret, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPWSTR)&msg_buf, 0, NULL);
 		if (msg_buf) {
-			warn("Call to GetAdaptersAddresses failed: %s (%d)", msg_buf, ret);
+			char *msg_utf8 = NULL;
+			os_wcs_to_utf8_ptr(msg_buf, 0, &msg_utf8);
+			warn("Call to GetAdaptersAddresses failed: %s (%d)", msg_utf8 ? msg_utf8 : "<unknown error>",
+			     ret);
+			bfree(msg_utf8);
 			LocalFree(msg_buf);
 		}
 	}

--- a/plugins/text-freetype2/find-font-windows.c
+++ b/plugins/text-freetype2/find-font-windows.c
@@ -170,74 +170,79 @@ char *sfnt_name_to_utf8(FT_SfntName *sfnt_name)
 uint32_t get_font_checksum(void)
 {
 	uint32_t checksum = 0;
-	struct dstr path = {0};
+	wchar_t path[MAX_PATH];
+	wchar_t search[MAX_PATH];
 	HANDLE handle;
-	WIN32_FIND_DATAA wfd;
+	WIN32_FIND_DATAW wfd;
 
-	dstr_reserve(&path, MAX_PATH);
-
-	HRESULT res = SHGetFolderPathA(NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, path.array);
+	HRESULT res = SHGetFolderPathW(NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, path);
 	if (res != S_OK) {
 		blog(LOG_WARNING, "Error finding windows font folder");
 		return 0;
 	}
 
-	path.len = strlen(path.array);
-	dstr_cat(&path, "\\*.*");
+	int ret = _snwprintf(search, MAX_PATH, L"%s\\*.*", path);
+	if (ret < 0 || ret >= MAX_PATH) {
+		return checksum;
+	}
 
-	handle = FindFirstFileA(path.array, &wfd);
-	if (handle == INVALID_HANDLE_VALUE)
-		goto free_string;
-
-	dstr_resize(&path, path.len - 4);
+	handle = FindFirstFileW(search, &wfd);
+	if (handle == INVALID_HANDLE_VALUE) {
+		return checksum;
+	}
 
 	do {
 		checksum = calc_crc32(checksum, &wfd.ftLastWriteTime, sizeof(FILETIME));
-		checksum = calc_crc32(checksum, wfd.cFileName, strlen(wfd.cFileName));
-	} while (FindNextFileA(handle, &wfd));
+		checksum = calc_crc32(checksum, wfd.cFileName, wcslen(wfd.cFileName) * sizeof(wchar_t));
+	} while (FindNextFileW(handle, &wfd));
 
 	FindClose(handle);
-
-free_string:
-	dstr_free(&path);
 	return checksum;
 }
 
 void load_os_font_list(void)
 {
-	struct dstr path = {0};
+	wchar_t path[MAX_PATH];
+	wchar_t search[MAX_PATH];
 	HANDLE handle;
-	WIN32_FIND_DATAA wfd;
+	WIN32_FIND_DATAW wfd;
+	char *path_utf8;
 
-	dstr_reserve(&path, MAX_PATH);
-
-	HRESULT res = SHGetFolderPathA(NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, path.array);
+	HRESULT res = SHGetFolderPathW(NULL, CSIDL_FONTS, NULL, SHGFP_TYPE_CURRENT, path);
 	if (res != S_OK) {
 		blog(LOG_WARNING, "Error finding windows font folder");
 		return;
 	}
 
-	path.len = strlen(path.array);
-	dstr_cat(&path, "\\*.*");
+	int ret = _snwprintf(search, MAX_PATH, L"%s\\*.*", path);
+	if (ret < 0 || ret >= MAX_PATH) {
+		return;
+	}
 
-	handle = FindFirstFileA(path.array, &wfd);
+	handle = FindFirstFileW(search, &wfd);
 	if (handle == INVALID_HANDLE_VALUE)
-		goto free_string;
+		return;
 
-	dstr_resize(&path, path.len - 4);
+	path_utf8 = wide_to_utf8(path, MAX_PATH);
 
 	do {
-		struct dstr full_path = {0};
 		FT_Face face;
 		FT_Long idx = 0;
 		FT_Long max_faces = 1;
+		char *filename;
 
 		if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 			continue;
 
-		dstr_copy_dstr(&full_path, &path);
+		filename = wide_to_utf8(wfd.cFileName, MAX_PATH);
+		if (!filename)
+			continue;
+
+		struct dstr full_path = {0};
+		dstr_copy(&full_path, path_utf8);
 		dstr_cat(&full_path, "\\");
-		dstr_cat(&full_path, wfd.cFileName);
+		dstr_cat(&full_path, filename);
+		bfree(filename);
 
 		while (idx < max_faces) {
 			FT_Error ret = FT_New_Face(ft2_lib, full_path.array, idx, &face);
@@ -250,12 +255,10 @@ void load_os_font_list(void)
 		}
 
 		dstr_free(&full_path);
-	} while (FindNextFileA(handle, &wfd));
+	} while (FindNextFileW(handle, &wfd));
 
+	bfree(path_utf8);
 	FindClose(handle);
 
 	save_font_list();
-
-free_string:
-	dstr_free(&path);
 }

--- a/plugins/win-capture/duplicator-monitor-capture.c
+++ b/plugins/win-capture/duplicator-monitor-capture.c
@@ -190,20 +190,28 @@ static BOOL CALLBACK enum_monitor(HMONITOR handle, HDC hdc, LPRECT rect, LPARAM 
 
 	bool match = false;
 
-	MONITORINFOEXA mi;
+	MONITORINFOEXW mi;
 	mi.cbSize = sizeof(mi);
-	if (GetMonitorInfoA(handle, (LPMONITORINFO)&mi)) {
-		DISPLAY_DEVICEA device;
+	if (GetMonitorInfoW(handle, (LPMONITORINFO)&mi)) {
+		DISPLAY_DEVICEW device;
 		device.cb = sizeof(device);
-		if (EnumDisplayDevicesA(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
-			match = strcmp(monitor->device_id, device.DeviceID) == 0;
+		if (EnumDisplayDevicesW(mi.szDevice, 0, &device, EDD_GET_DEVICE_INTERFACE_NAME)) {
+
+			char *device_id;
+			char *alt_id;
+			os_wcs_to_utf8_ptr(device.DeviceID, 0, &device_id);
+			os_wcs_to_utf8_ptr(mi.szDevice, 0, &alt_id);
+
+			match = strcmp(monitor->device_id, device_id) == 0;
 			if (match) {
-				strcpy_s(monitor->id, _countof(monitor->id), device.DeviceID);
-				strcpy_s(monitor->alt_id, _countof(monitor->alt_id), mi.szDevice);
+				strcpy_s(monitor->id, _countof(monitor->id), device_id);
+				strcpy_s(monitor->alt_id, _countof(monitor->alt_id), alt_id);
 				GetMonitorName(handle, monitor->name, _countof(monitor->name));
 				monitor->rect = *rect;
 				monitor->handle = handle;
 			}
+			bfree(device_id);
+			bfree(alt_id);
 		}
 	}
 

--- a/plugins/win-capture/game-capture-file-init.c
+++ b/plugins/win-capture/game-capture-file-init.c
@@ -179,13 +179,16 @@ static bool update_hook_file(bool b64)
 	wchar_t src_json[MAX_PATH];
 	wchar_t dst_json[MAX_PATH];
 
+	char utf8_str[FILENAME_MAX_LENGTH_UTF8] = "";
+
 	StringCbCopyW(temp, sizeof(temp),
 		      L"..\\..\\data\\obs-plugins\\"
 		      L"win-capture\\");
 	make_filename(temp, L"obs-vulkan", L".json");
 
 	if (_wfullpath(src_json, temp, MAX_PATH) == NULL) {
-		warn("failed to get full path for %ls", temp);
+		os_wcs_to_utf8(temp, 0, utf8_str, sizeof(utf8_str));
+		warn("failed to get full path for %s", utf8_str);
 		return false;
 	}
 
@@ -195,7 +198,8 @@ static bool update_hook_file(bool b64)
 	make_filename(temp, L"graphics-hook", L".dll");
 
 	if (_wfullpath(src, temp, MAX_PATH) == NULL) {
-		warn("failed to get full path for %ls", temp);
+		os_wcs_to_utf8(temp, 0, utf8_str, sizeof(utf8_str));
+		warn("failed to get full path for %s", utf8_str);
 		return false;
 	}
 
@@ -217,18 +221,21 @@ static bool update_hook_file(bool b64)
 		if (!CreateDirectoryW(temp, NULL)) {
 			DWORD err = GetLastError();
 			if (err != ERROR_ALREADY_EXISTS) {
-				warn("failed to create directory %ls (%lu)", temp, err);
+				os_wcs_to_utf8(temp, 0, utf8_str, sizeof(utf8_str));
+				warn("failed to create directory %s (%lu)", utf8_str, err);
 				return false;
 			}
 		}
 		if (has_elevation())
 			add_aap_perms(temp);
 		if (!CopyFileW(src_json, dst_json, false)) {
-			warn("failed to install %ls (%lu)", dst_json, GetLastError());
+			os_wcs_to_utf8(dst_json, 0, utf8_str, sizeof(utf8_str));
+			warn("failed to install %s (%lu)", utf8_str, GetLastError());
 			return false;
 		}
 		if (!CopyFileW(src, dst, false)) {
-			warn("failed to install %ls (%lu)", dst, GetLastError());
+			os_wcs_to_utf8(dst, 0, utf8_str, sizeof(utf8_str));
+			warn("failed to install %s (%lu)", utf8_str, GetLastError());
 			return false;
 		}
 		return true;
@@ -245,7 +252,8 @@ static bool update_hook_file(bool b64)
 	}
 #ifndef _DEBUG
 	if (!get_dll_ver(dst, &ver_dst)) {
-		warn("failed to get version of %ls", dst);
+		os_wcs_to_utf8(dst, 0, utf8_str, sizeof(utf8_str));
+		warn("failed to get version of %s", utf8_str);
 		return false;
 	}
 #endif
@@ -253,16 +261,19 @@ static bool update_hook_file(bool b64)
 	/* if source is greater than dst, overwrite new file  */
 	while (win_version_compare(&ver_dst, &ver_src) < 0) {
 		if (!CopyFileW(src_json, dst_json, false)) {
-			warn("failed to update %ls (%lu)", dst_json, GetLastError());
+			os_wcs_to_utf8(dst_json, 0, utf8_str, sizeof(utf8_str));
+			warn("failed to update %s (%lu)", utf8_str, GetLastError());
 			return false;
 		}
 		if (!CopyFileW(src, dst, false)) {
-			warn("failed to update %ls (%lu)", dst, GetLastError());
+			os_wcs_to_utf8(dst, 0, utf8_str, sizeof(utf8_str));
+			warn("failed to update %s (%lu)", utf8_str, GetLastError());
 			return false;
 		}
 
 		if (!get_dll_ver(dst, &ver_dst)) {
-			warn("failed to get version of %ls", dst);
+			os_wcs_to_utf8(dst, 0, utf8_str, sizeof(utf8_str));
+			warn("failed to get version of %s", utf8_str);
 			return false;
 		}
 	}
@@ -270,7 +281,9 @@ static bool update_hook_file(bool b64)
 	/* do not use if major version incremented in target compared to
 	 * ours */
 	if (ver_dst.major > ver_src.major) {
-		warn("target %ls has major version %d, source has major version %d", dst, ver_dst.major, ver_src.major);
+		os_wcs_to_utf8(dst, 0, utf8_str, sizeof(utf8_str));
+		warn("target %s has major version %d, source has major version %d", utf8_str, ver_dst.major,
+		     ver_src.major);
 		return false;
 	}
 

--- a/plugins/win-capture/get-graphics-offsets/d3d8-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/d3d8-offsets.cpp
@@ -21,13 +21,13 @@ static inline bool d3d8_init(d3d8_info &info)
 	d3d8create_t create;
 	HRESULT hr;
 
-	info.hwnd = CreateWindowExA(0, DUMMY_WNDCLASS, "d3d8 get-addr window", WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
-				    GetModuleHandleA(nullptr), nullptr);
+	info.hwnd = CreateWindowExW(0, DUMMY_WNDCLASS, L"d3d8 get-addr window", WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
+				    GetModuleHandleW(nullptr), nullptr);
 	if (!info.hwnd) {
 		return false;
 	}
 
-	info.module = LoadLibraryA("d3d8.dll");
+	info.module = LoadLibraryW(L"d3d8.dll");
 	if (!info.module) {
 		return false;
 	}

--- a/plugins/win-capture/get-graphics-offsets/d3d9-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/d3d9-offsets.cpp
@@ -18,13 +18,13 @@ static inline bool d3d9_init(d3d9_info &info)
 	d3d9createex_t create;
 	HRESULT hr;
 
-	info.hwnd = CreateWindowExA(0, DUMMY_WNDCLASS, "d3d9 get-offset window", WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
-				    GetModuleHandleA(nullptr), nullptr);
+	info.hwnd = CreateWindowExW(0, DUMMY_WNDCLASS, L"d3d9 get-offset window", WS_POPUP, 0, 0, 1, 1, nullptr, nullptr,
+				    GetModuleHandleW(nullptr), nullptr);
 	if (!info.hwnd) {
 		return false;
 	}
 
-	info.module = LoadLibraryA("d3d9.dll");
+	info.module = LoadLibraryW(L"d3d9.dll");
 	if (!info.module) {
 		return false;
 	}

--- a/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
+++ b/plugins/win-capture/get-graphics-offsets/dxgi-offsets.cpp
@@ -26,20 +26,20 @@ static inline bool dxgi_init(dxgi_info &info)
 	IUnknown *device;
 	HRESULT hr;
 
-	info.hwnd = CreateWindowExA(0, DUMMY_WNDCLASS, "d3d10 get-offset window", WS_POPUP, 0, 0, 2, 2, nullptr,
-				    nullptr, GetModuleHandleA(nullptr), nullptr);
+	info.hwnd = CreateWindowExW(0, DUMMY_WNDCLASS, L"d3d10 get-offset window", WS_POPUP, 0, 0, 2, 2, nullptr,
+				    nullptr, GetModuleHandleW(nullptr), nullptr);
 	if (!info.hwnd) {
 		return false;
 	}
 
-	info.module = LoadLibraryA("dxgi.dll");
+	info.module = LoadLibraryW(L"dxgi.dll");
 	if (!info.module) {
 		return false;
 	}
 
 	create_factory = (create_fac_t)GetProcAddress(info.module, "CreateDXGIFactory1");
 
-	d3d10_module = LoadLibraryA("d3d10.dll");
+	d3d10_module = LoadLibraryW(L"d3d10.dll");
 	if (!d3d10_module) {
 		return false;
 	}

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.c
@@ -10,10 +10,10 @@ int main(int argc, char *argv[])
 	struct dxgi_offsets dxgi = {0};
 	struct dxgi_offsets2 dxgi2 = {0};
 
-	WNDCLASSA wc = {0};
+	WNDCLASSW wc = {0};
 	wc.style = CS_OWNDC;
-	wc.hInstance = GetModuleHandleA(NULL);
-	wc.lpfnWndProc = (WNDPROC)DefWindowProcA;
+	wc.hInstance = GetModuleHandleW(NULL);
+	wc.lpfnWndProc = (WNDPROC)DefWindowProcW;
 	wc.lpszClassName = DUMMY_WNDCLASS;
 
 	SetErrorMode(SEM_FAILCRITICALERRORS);
@@ -25,8 +25,8 @@ int main(int argc, char *argv[])
 	policy.PreferSystem32Images = 1;
 	SetProcessMitigationPolicy(ProcessImageLoadPolicy, &policy, sizeof(policy));
 
-	if (!RegisterClassA(&wc)) {
-		printf("failed to register '%s'\n", DUMMY_WNDCLASS);
+	if (!RegisterClassW(&wc)) {
+		printf("failed to register '%S'\n", DUMMY_WNDCLASS);
 		return -1;
 	}
 

--- a/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.h
+++ b/plugins/win-capture/get-graphics-offsets/get-graphics-offsets.h
@@ -8,7 +8,7 @@
 #include <graphics-hook-info.h>
 #endif
 
-#define DUMMY_WNDCLASS "get_addrs_wndclass"
+#define DUMMY_WNDCLASS L"get_addrs_wndclass"
 
 #ifdef __cplusplus
 extern "C" {

--- a/plugins/win-capture/graphics-hook/d3d12-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d12-capture.cpp
@@ -123,7 +123,7 @@ static bool d3d12_init_11on12(ID3D12Device *device)
 	static bool initialized_func = false;
 
 	if (!initialized_11 && !d3d11) {
-		d3d11 = load_system_library("d3d11.dll");
+		d3d11 = load_system_library(L"d3d11.dll");
 		if (!d3d11) {
 			hlog("d3d12_init_11on12: failed to load d3d11");
 		}
@@ -403,7 +403,7 @@ static bool manually_get_d3d12_addrs(HMODULE d3d12_module, PFN_ExecuteCommandLis
 
 bool hook_d3d12(void)
 {
-	HMODULE d3d12_module = get_system_module("d3d12.dll");
+	HMODULE d3d12_module = get_system_module(L"d3d12.dll");
 	if (!d3d12_module) {
 		hlog_verbose("Failed to find d3d12.dll. Skipping hook attempt.");
 		return false;

--- a/plugins/win-capture/graphics-hook/d3d8-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d8-capture.cpp
@@ -174,7 +174,7 @@ static void d3d8_free()
 
 static void d3d8_init(IDirect3DDevice8 *device)
 {
-	data.d3d8 = get_system_module("d3d8.dll");
+	data.d3d8 = get_system_module(L"d3d8.dll");
 
 	if (!d3d8_init_format_backbuffer(device)) {
 		return;
@@ -349,7 +349,7 @@ static bool manually_get_d3d8_present_addr(HMODULE d3d8_module, void **present_a
 
 bool hook_d3d8(void)
 {
-	HMODULE d3d8_module = get_system_module("d3d8.dll");
+	HMODULE d3d8_module = get_system_module(L"d3d8.dll");
 	uint32_t d3d8_size;
 	void *present_addr = nullptr;
 

--- a/plugins/win-capture/graphics-hook/d3d9-capture.cpp
+++ b/plugins/win-capture/graphics-hook/d3d9-capture.cpp
@@ -121,13 +121,13 @@ static inline bool shex_init_d3d11()
 	HMODULE dxgi;
 	HRESULT hr;
 
-	d3d11 = load_system_library("d3d11.dll");
+	d3d11 = load_system_library(L"d3d11.dll");
 	if (!d3d11) {
 		hlog("d3d9_init: Failed to load D3D11");
 		return false;
 	}
 
-	dxgi = load_system_library("dxgi.dll");
+	dxgi = load_system_library(L"dxgi.dll");
 	if (!dxgi) {
 		hlog("d3d9_init: Failed to load DXGI");
 		return false;
@@ -429,7 +429,7 @@ static void d3d9_init(IDirect3DDevice9 *device)
 	HWND window = nullptr;
 	HRESULT hr;
 
-	data.d3d9 = get_system_module("d3d9.dll");
+	data.d3d9 = get_system_module(L"d3d9.dll");
 	data.device = device;
 
 	hr = device->QueryInterface(__uuidof(IDirect3DDevice9Ex), (void **)&d3d9ex);
@@ -465,7 +465,7 @@ static inline HRESULT get_backbuffer(IDirect3DDevice9 *device, IDirect3DSurface9
 	static bool checked_exceptions = false;
 
 	if (!checked_exceptions) {
-		if (_strcmpi(get_process_name(), "hotd_ng.exe") == 0) {
+		if (_wcsicmp(get_process_name(), L"hotd_ng.exe") == 0) {
 			use_backbuffer = true;
 		}
 		checked_exceptions = true;
@@ -792,7 +792,7 @@ static bool manually_get_d3d9_addrs(HMODULE d3d9_module, void **present_addr, vo
 
 bool hook_d3d9(void)
 {
-	HMODULE d3d9_module = get_system_module("d3d9.dll");
+	HMODULE d3d9_module = get_system_module(L"d3d9.dll");
 	uint32_t d3d9_size;
 	void *present_addr = nullptr;
 	void *present_ex_addr = nullptr;

--- a/plugins/win-capture/graphics-hook/dxgi-capture.cpp
+++ b/plugins/win-capture/graphics-hook/dxgi-capture.cpp
@@ -305,7 +305,7 @@ static HRESULT STDMETHODCALLTYPE hook_present1(IDXGISwapChain1 *swap, UINT sync_
 
 bool hook_dxgi(void)
 {
-	HMODULE dxgi_module = get_system_module("dxgi.dll");
+	HMODULE dxgi_module = get_system_module(L"dxgi.dll");
 	if (!dxgi_module) {
 		hlog_verbose("Failed to find dxgi.dll. Skipping hook attempt.");
 		return false;

--- a/plugins/win-capture/graphics-hook/gl-capture.c
+++ b/plugins/win-capture/graphics-hook/gl-capture.c
@@ -266,13 +266,13 @@ static inline bool gl_shtex_init_d3d11(void)
 	IDXGIAdapter *adapter;
 	HRESULT hr;
 
-	HMODULE d3d11 = load_system_library("d3d11.dll");
+	HMODULE d3d11 = load_system_library(L"d3d11.dll");
 	if (!d3d11) {
 		hlog("gl_shtex_init_d3d11: failed to load D3D11.dll: %d", GetLastError());
 		return false;
 	}
 
-	HMODULE dxgi = load_system_library("dxgi.dll");
+	HMODULE dxgi = load_system_library(L"dxgi.dll");
 	if (!dxgi) {
 		hlog("gl_shtex_init_d3d11: failed to load DXGI.dll: %d", GetLastError());
 		return false;
@@ -563,7 +563,7 @@ static void gl_copy_backbuffer(GLuint dst)
 	glReadBuffer(GL_BACK);
 
 	/* darkest dungeon fix */
-	darkest_dungeon_fix = glGetError() == GL_INVALID_OPERATION && _strcmpi(process_name, "Darkest.exe") == 0;
+	darkest_dungeon_fix = glGetError() == GL_INVALID_OPERATION && _wcsicmp(process_name, L"Darkest.exe") == 0;
 
 	glDrawBuffer(GL_COLOR_ATTACHMENT0);
 	if (gl_error("gl_copy_backbuffer", "failed to set draw buffer")) {
@@ -820,16 +820,18 @@ bool hook_gl(void)
 	void *wgl_slb_proc;
 	void *wgl_sb_proc;
 
-	gl = get_system_module("opengl32.dll");
+	gl = get_system_module(L"opengl32.dll");
 	if (!gl) {
 		return false;
 	}
 
 	/* "life is feudal: your own" somehow uses both opengl and directx at
 	 * the same time, so blacklist it from capturing opengl */
-	const char *process_name = get_process_name();
-	if (_strcmpi(process_name, "yo_cm_client.exe") == 0 || _strcmpi(process_name, "cm_client.exe") == 0) {
-		hlog("Ignoring opengl for game: %s", process_name);
+	const wchar_t *process_name = get_process_name();
+	if (_wcsicmp(process_name, L"yo_cm_client.exe") == 0 || _wcsicmp(process_name, L"cm_client.exe") == 0) {
+		char *process_name_utf8 = wide_to_utf8_ptr(process_name);
+		hlog("Ignoring opengl for game: %s", process_name_utf8 ? process_name_utf8 : "<unknown>");
+		free(process_name_utf8);
 		return true;
 	}
 

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -456,13 +456,15 @@ void hlog(const char *format, ...)
 
 void hlog_hr(const char *text, HRESULT hr)
 {
-	LPSTR buffer = NULL;
+	LPWSTR buffer = NULL;
 
-	FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
-		       NULL, hr, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), (LPSTR)&buffer, 0, NULL);
+	FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+		       NULL, hr, MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), (LPWSTR)&buffer, 0, NULL);
 
 	if (buffer) {
-		hlog("%s (0x%08lX): %s", text, hr, buffer);
+		char* buffer_utf8 = wide_to_utf8_ptr(buffer);
+		hlog("%s (0x%08lX): %s", text, hr, buffer_utf8);
+		free(buffer_utf8);
 		LocalFree(buffer);
 	} else {
 		hlog("%s (0x%08lX)", text, hr);

--- a/plugins/win-capture/graphics-hook/graphics-hook.c
+++ b/plugins/win-capture/graphics-hook/graphics-hook.c
@@ -45,8 +45,8 @@ static HINSTANCE dll_inst = NULL;
 static volatile bool stop_loop = false;
 static HANDLE dup_hook_mutex = NULL;
 static HANDLE capture_thread = NULL;
-char system_path[MAX_PATH] = {0};
-char process_name[MAX_PATH] = {0};
+wchar_t system_path[MAX_PATH] = {0};
+wchar_t process_name[MAX_PATH] = {0};
 wchar_t keepalive_name[64] = {0};
 HWND dummy_window = NULL;
 
@@ -147,7 +147,7 @@ static inline bool init_mutexes(void)
 
 static inline bool init_system_path(void)
 {
-	UINT ret = GetSystemDirectoryA(system_path, MAX_PATH);
+	UINT ret = GetSystemDirectoryW(system_path, MAX_PATH);
 	if (!ret) {
 		hlog("Failed to get windows system path: %lu", GetLastError());
 		return false;
@@ -158,10 +158,13 @@ static inline bool init_system_path(void)
 
 static inline void log_current_process(void)
 {
-	DWORD len = GetModuleBaseNameA(GetCurrentProcess(), NULL, process_name, MAX_PATH);
+	DWORD len = GetModuleBaseNameW(GetCurrentProcess(), NULL, process_name, MAX_PATH);
 	if (len > 0) {
 		process_name[len] = 0;
-		hlog("graphics-hook.dll loaded against process: %s", process_name);
+		char *process_name_utf8 = wide_to_utf8_ptr(process_name);
+		hlog("graphics-hook.dll loaded against process: %s",
+		     process_name_utf8 ? process_name_utf8 : "<unknown>");
+		free(process_name_utf8);
 	} else {
 		hlog("graphics-hook.dll loaded");
 	}

--- a/plugins/win-capture/graphics-hook/graphics-hook.h
+++ b/plugins/win-capture/graphics-hook/graphics-hook.h
@@ -32,9 +32,9 @@ extern "C" {
 
 extern void hlog(const char *format, ...);
 extern void hlog_hr(const char *text, HRESULT hr);
-static inline const char *get_process_name(void);
-static inline HMODULE get_system_module(const char *module);
-static inline HMODULE load_system_library(const char *module);
+static inline const wchar_t *get_process_name(void);
+static inline HMODULE get_system_module(const wchar_t *module);
+static inline HMODULE load_system_library(const wchar_t *module);
 extern uint64_t os_gettime_ns(void);
 
 #define flog(format, ...) hlog("%s: " format, __FUNCTION__, ##__VA_ARGS__)
@@ -106,25 +106,43 @@ extern HANDLE signal_stop;
 extern HANDLE signal_ready;
 extern HANDLE signal_exit;
 extern HANDLE tex_mutexes[2];
-extern char system_path[MAX_PATH];
-extern char process_name[MAX_PATH];
+extern wchar_t system_path[MAX_PATH];
+extern wchar_t process_name[MAX_PATH];
 extern wchar_t keepalive_name[64];
 extern HWND dummy_window;
 extern volatile bool active;
 
-static inline const char *get_process_name(void)
+static inline char *wide_to_utf8_ptr(const wchar_t *wstr)
+{
+	if (!wstr)
+		return NULL;
+
+	int wlen = (int)wcslen(wstr);
+	int size = WideCharToMultiByte(CP_UTF8, 0, wstr, wlen + 1, NULL, 0, NULL, NULL);
+	if (size <= 0)
+		return NULL;
+
+	char *str = (char *)malloc((size_t)size);
+	if (!str)
+		return NULL;
+
+	WideCharToMultiByte(CP_UTF8, 0, wstr, wlen + 1, str, size, NULL, NULL);
+	return str;
+}
+
+static inline const wchar_t *get_process_name(void)
 {
 	return process_name;
 }
 
-static inline HMODULE get_system_module(const char *module)
+static inline HMODULE get_system_module(const wchar_t *module)
 {
-	char base_path[MAX_PATH];
+	wchar_t base_path[MAX_PATH];
 
-	strcpy(base_path, system_path);
-	strcat(base_path, "\\");
-	strcat(base_path, module);
-	return GetModuleHandleA(base_path);
+	wcscpy(base_path, system_path);
+	wcscat(base_path, L"\\");
+	wcscat(base_path, module);
+	return GetModuleHandleW(base_path);
 }
 
 static inline uint32_t module_size(HMODULE module)
@@ -134,20 +152,20 @@ static inline uint32_t module_size(HMODULE module)
 	return success ? info.SizeOfImage : 0;
 }
 
-static inline HMODULE load_system_library(const char *name)
+static inline HMODULE load_system_library(const wchar_t *name)
 {
-	char base_path[MAX_PATH];
+	wchar_t base_path[MAX_PATH];
 	HMODULE module;
 
-	strcpy(base_path, system_path);
-	strcat(base_path, "\\");
-	strcat(base_path, name);
+	wcscpy(base_path, system_path);
+	wcscat(base_path, L"\\");
+	wcscat(base_path, name);
 
-	module = GetModuleHandleA(base_path);
+	module = GetModuleHandleW(base_path);
 	if (module)
 		return module;
 
-	return LoadLibraryA(base_path);
+	return LoadLibraryW(base_path);
 }
 
 static inline bool capture_alive(void)

--- a/plugins/win-capture/graphics-hook/vulkan-capture.c
+++ b/plugins/win-capture/graphics-hook/vulkan-capture.c
@@ -575,13 +575,13 @@ static inline bool vk_shtex_init_d3d11(struct vk_data *data)
 	IDXGIAdapter1 *adapter;
 	HRESULT hr;
 
-	HMODULE d3d11 = load_system_library("d3d11.dll");
+	HMODULE d3d11 = load_system_library(L"d3d11.dll");
 	if (!d3d11) {
 		flog("failed to load d3d11: %d", GetLastError());
 		return false;
 	}
 
-	HMODULE dxgi = load_system_library("dxgi.dll");
+	HMODULE dxgi = load_system_library(L"dxgi.dll");
 	if (!dxgi) {
 		flog("failed to load dxgi: %d", GetLastError());
 		return false;

--- a/shared/ipc-util/ipc-util/pipe-windows.c
+++ b/shared/ipc-util/ipc-util/pipe-windows.c
@@ -63,13 +63,16 @@ error:
 static inline bool ipc_pipe_internal_create_pipe(ipc_pipe_server_t *pipe, const char *name)
 {
 	SECURITY_ATTRIBUTES sa;
-	char new_name[512];
+	wchar_t new_name[512];
+	wchar_t name_utf16[512];
 	void *sd;
 	const DWORD access = PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED;
 	const DWORD flags = PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT;
 
-	strcpy_s(new_name, sizeof(new_name), "\\\\.\\pipe\\");
-	strcat_s(new_name, sizeof(new_name), name);
+	MultiByteToWideChar(CP_UTF8, 0, name, -1, name_utf16, _countof(name_utf16));
+
+	wcscpy_s(new_name, _countof(new_name), L"\\\\.\\pipe\\");
+	wcscat_s(new_name, _countof(new_name), name_utf16);
 
 	sd = create_full_access_security_descriptor();
 	if (!sd) {
@@ -80,7 +83,7 @@ static inline bool ipc_pipe_internal_create_pipe(ipc_pipe_server_t *pipe, const 
 	sa.lpSecurityDescriptor = sd;
 	sa.bInheritHandle = false;
 
-	pipe->handle = CreateNamedPipeA(new_name, access, flags, 1, IPC_PIPE_BUF_SIZE, IPC_PIPE_BUF_SIZE, 0, &sa);
+	pipe->handle = CreateNamedPipeW(new_name, access, flags, 1, IPC_PIPE_BUF_SIZE, IPC_PIPE_BUF_SIZE, 0, &sa);
 	free(sd);
 
 	return pipe->handle != INVALID_HANDLE_VALUE;
@@ -171,12 +174,15 @@ static inline bool ipc_pipe_internal_wait_for_connection(ipc_pipe_server_t *pipe
 static inline bool ipc_pipe_internal_open_pipe(ipc_pipe_client_t *pipe, const char *name)
 {
 	DWORD mode = PIPE_READMODE_MESSAGE;
-	char new_name[512];
+	wchar_t new_name[512];
+	wchar_t name_utf16[512];
 
-	strcpy_s(new_name, sizeof(new_name), "\\\\.\\pipe\\");
-	strcat_s(new_name, sizeof(new_name), name);
+	MultiByteToWideChar(CP_UTF8, 0, name, -1, name_utf16, _countof(name_utf16));
 
-	pipe->handle = CreateFileA(new_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
+	wcscpy_s(new_name, _countof(new_name), L"\\\\.\\pipe\\");
+	wcscat_s(new_name, _countof(new_name), name_utf16);
+
+	pipe->handle = CreateFileW(new_name, GENERIC_READ | GENERIC_WRITE, 0, NULL, OPEN_EXISTING, 0, NULL);
 	if (pipe->handle == INVALID_HANDLE_VALUE) {
 		return false;
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

Based on changes in #13749 (included in this pr) and further supports #13097 
EDIT: The last 2 commits + the merge commit are new.

Change all remaining instances of Windows Ansi api usage to Wide variants. 

Pre-encode format specifiers `%ls` and `%S` (capital S) of printf family using `WideCharToMultiByte` / `MultiByteToWideChar` and then `%s` (small s) instead
  - This is necessary because OBS doesn't set C runtime locale/encoding, so printf function family cannot know the target/source encoding for `%ls` and `%S` specifiers and thus will fail on anything non-ascii. 
  - Addresses non-UTF8 / truncated content being saved in the logs.
  - Printing to console using these is still a problem, since OBS doesn't set encoding for console either. As result non-ascii may appear garbled, but this wasn't working earlier either, it's just may be garbled differently.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Based on discussions on #13097 to move away from A apis, so OBS doesn't need to deal with the ansi encodings.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tried opening and restarting with a scene with all source types active.
Could still check outputs to console.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [ ] My code has been tested.
- [ ] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [x] I have used AI tooling in the creation of this PR -->
<!-- - [x] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
