### PR TITLE
libobs: Fix audio transitions with output scaling

### DIFF
--- a/libobs/obs-audio.c
+++ b/libobs/obs-audio.c
@@ -582,8 +582,17 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 
 	pthread_mutex_lock(&obs->video.mixes_mutex);
 	for (size_t j = 0; j < obs->video.mixes.num; j++) {
-		struct obs_view *view = obs->video.mixes.array[j]->view;
-		if (!view)
+		struct obs_core_video_mix *mix = obs->video.mixes.array[j];
+		struct obs_view *view = mix->view;
+		bool duplicate_view = false;
+
+		for (size_t k = 0; k < j; k++) {
+			if (obs->video.mixes.array[k]->view == view) {
+				duplicate_view = true;
+				break;
+			}
+		}
+		if (!view || duplicate_view)
 			continue;
 
 		pthread_mutex_lock(&view->channels_mutex);
@@ -599,7 +608,7 @@ bool audio_callback(void *param, uint64_t start_ts_in, uint64_t end_ts_in, uint6
 				continue;
 
 			/* first, add top - level sources as root_nodes */
-			if (obs->video.mixes.array[j]->mix_audio)
+			if (mix->mix_audio)
 				da_push_back(audio->root_nodes, &source);
 
 			/* Build audio tree, tag duplicate individual sources */


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Encoder output scaling creates an encoder-only video mix which causes the same audio tree to be scanned twice. Previously this wasn't an issue but after commit [50cdabbb5](https://github.com/obsproject/obs-studio/commit/50cdabbb5f1578796a459801b44d131f6509da97) added duplicate audio source detection this caused these sources to be marked as duplicates and mixed outside the transition audio path. This change ensures we only process each video view once when building the audio render tree.  Definitely needs a review, probably from @pkviet who would be the most familiar with this and I have no doubt there could be something I am missing despite how much research I tried to do beforehand. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #12912 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Created two scenes with separate audio sources both playing audio, set a fade transition with 5000ms and tested with both rescaling enabled and disabled. Without these changes, the audio would hard cut instead of smoothly fade when rescaling was enabled. After these changes, the results are identical whether rescaling is enabled or disabled and the audio fades smoothly. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [] I have used AI tooling in the creation of this PR -->
<!-- - [] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
