### PR TITLE
frontend: show track label on hover in advanced audio settings

### DIFF
--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -6,7 +6,10 @@
 #include <qt-wrappers.hpp>
 
 #include <QCheckBox>
+#include <QFontMetrics>
 #include <QStackedWidget>
+
+#include <array>
 
 #include "moc_OBSAdvAudioCtrl.cpp"
 
@@ -19,6 +22,8 @@
 
 static inline void setMixer(obs_source_t *source, const int mixerIdx, const bool checked);
 
+constexpr int kMaxTrackLabelWidth = 90;
+static void applyMixerTrackLabel(QCheckBox *box, int trackIndex, config_t *config);
 OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(source_)
 {
 	QHBoxLayout *hlayout;
@@ -50,6 +55,9 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(
 	mixer4 = new QCheckBox();
 	mixer5 = new QCheckBox();
 	mixer6 = new QCheckBox();
+
+	static_assert(MAX_AUDIO_MIXES == 6, "Number of mixer checkboxes must match MAX_AUDIO_MIXES");
+	const std::array<QCheckBox *, MAX_AUDIO_MIXES> mixerBoxes = {mixer1, mixer2, mixer3, mixer4, mixer5, mixer6};
 
 	sigs.emplace_back(handler, "activate", OBSSourceActivated, this);
 	sigs.emplace_back(handler, "deactivate", OBSSourceDeactivated, this);
@@ -164,25 +172,11 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(
 		monitoringType->setAccessibleName(QTStr("Basic.AdvAudio.MonitoringSource").arg(sourceName));
 		monitoringType->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
 	}
-
-	mixer1->setText("1");
-	mixer1->setChecked(mixers & (1 << 0));
-	mixer1->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track1"));
-	mixer2->setText("2");
-	mixer2->setChecked(mixers & (1 << 1));
-	mixer2->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track2"));
-	mixer3->setText("3");
-	mixer3->setChecked(mixers & (1 << 2));
-	mixer3->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track3"));
-	mixer4->setText("4");
-	mixer4->setChecked(mixers & (1 << 3));
-	mixer4->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track4"));
-	mixer5->setText("5");
-	mixer5->setChecked(mixers & (1 << 4));
-	mixer5->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track5"));
-	mixer6->setText("6");
-	mixer6->setChecked(mixers & (1 << 5));
-	mixer6->setAccessibleName(QTStr("Basic.Settings.Output.Adv.Audio.Track6"));
+	config_t *config = main->Config();
+	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
+		applyMixerTrackLabel(mixerBoxes[i], i, config);
+		mixerBoxes[i]->setChecked(mixers & (1 << i));
+	}
 
 	balanceContainer->layout()->addWidget(labelL);
 	balanceContainer->layout()->addWidget(balance);
@@ -194,12 +188,9 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(
 		balanceContainer->setEnabled(false);
 	}
 
-	mixerContainer->layout()->addWidget(mixer1);
-	mixerContainer->layout()->addWidget(mixer2);
-	mixerContainer->layout()->addWidget(mixer3);
-	mixerContainer->layout()->addWidget(mixer4);
-	mixerContainer->layout()->addWidget(mixer5);
-	mixerContainer->layout()->addWidget(mixer6);
+	for (auto &mixerBox : mixerBoxes) {
+		mixerContainer->layout()->addWidget(mixerBox);
+	}
 	mixerContainer->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
 
 	connect(volume, &QDoubleSpinBox::valueChanged, this, &OBSAdvAudioCtrl::volumeChanged);
@@ -216,12 +207,9 @@ OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(
 		connect(mixer, &QCheckBox::clicked, this,
 			[this, num](bool checked) { setMixer(source, num, checked); });
 	};
-	connectMixer(mixer1, 0);
-	connectMixer(mixer2, 1);
-	connectMixer(mixer3, 2);
-	connectMixer(mixer4, 3);
-	connectMixer(mixer5, 4);
-	connectMixer(mixer6, 5);
+	for (int i = 0; i < MAX_AUDIO_MIXES; i++) {
+		connectMixer(mixerBoxes[i], i);
+	}
 
 	setObjectName(sourceName);
 }
@@ -563,6 +551,38 @@ void OBSAdvAudioCtrl::monitoringTypeChanged(int index)
 	OBSBasic::Get()->undo_s.add_action(QTStr("Undo.MonitoringType.Change").arg(name),
 					   std::bind(undo_redo, std::placeholders::_1, prev),
 					   std::bind(undo_redo, std::placeholders::_1, mt), uuid, uuid);
+}
+
+static QString getLocalizedMixerNameByIndex(const int trackIndex)
+{
+	const QByteArray localeKey =
+		QStringLiteral("Basic.Settings.Output.Adv.Audio.Track%1").arg(trackIndex + 1).toUtf8();
+
+	return QTStr(localeKey.constData());
+}
+
+static QString getCustomTrackLabelByIndex(const int trackIndex, config_t *config)
+{
+	const QByteArray configKey = QStringLiteral("Track%1Name").arg(trackIndex + 1).toUtf8();
+
+	//lookup the user's advanced settings for a label for the track
+	const char *labelOverride = config_get_string(config, "AdvOut", configKey.constData());
+	if (labelOverride && *labelOverride) {
+		return QString::fromUtf8(labelOverride);
+	}
+
+	//default to locale-specific track name, eg: Track 1
+	return getLocalizedMixerNameByIndex(trackIndex);
+}
+
+static void applyMixerTrackLabel(QCheckBox *box, const int trackIndex, config_t *config)
+{
+	const QString customLabel = getCustomTrackLabelByIndex(trackIndex, config);
+	const QFontMetrics metrics(box->font());
+
+	box->setText(metrics.elidedText(customLabel, Qt::ElideRight, kMaxTrackLabelWidth));
+	box->setToolTip(customLabel);
+	box->setAccessibleName(getLocalizedMixerNameByIndex(trackIndex));
 }
 
 static inline void setMixer(obs_source_t *source, const int mixerIdx, const bool checked)

--- a/frontend/components/OBSAdvAudioCtrl.cpp
+++ b/frontend/components/OBSAdvAudioCtrl.cpp
@@ -6,7 +6,6 @@
 #include <qt-wrappers.hpp>
 
 #include <QCheckBox>
-#include <QFontMetrics>
 #include <QStackedWidget>
 
 #include <array>
@@ -22,7 +21,6 @@
 
 static inline void setMixer(obs_source_t *source, const int mixerIdx, const bool checked);
 
-constexpr int kMaxTrackLabelWidth = 90;
 static void applyMixerTrackLabel(QCheckBox *box, int trackIndex, config_t *config);
 OBSAdvAudioCtrl::OBSAdvAudioCtrl(QGridLayout *, obs_source_t *source_) : source(source_)
 {
@@ -578,9 +576,7 @@ static QString getCustomTrackLabelByIndex(const int trackIndex, config_t *config
 static void applyMixerTrackLabel(QCheckBox *box, const int trackIndex, config_t *config)
 {
 	const QString customLabel = getCustomTrackLabelByIndex(trackIndex, config);
-	const QFontMetrics metrics(box->font());
-
-	box->setText(metrics.elidedText(customLabel, Qt::ElideRight, kMaxTrackLabelWidth));
+	box->setText(QString::fromUtf8(std::to_string(trackIndex+1)));
 	box->setToolTip(customLabel);
 	box->setAccessibleName(getLocalizedMixerNameByIndex(trackIndex));
 }


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->
### Description
Modifies the advanced audio settings menu to show the track name as configured in Settings > Output > Audio > Advanced Mode, eg:
<img width="991" height="739" alt="2026-08-23-000309_hyprshot" src="https://github.com/user-attachments/assets/a76320f2-748a-4cd9-9233-d644d6b3ad25" />


### Motivation and Context
Ideas: https://ideas.obsproject.com/posts/2247/show-track-names-on-advanced-audio-properties-pane

Say you set a custom name for Track 3 as "Game Audio" and Track 2 as "Browser Audio" and Track 4 as "Discord" or something, when I'm in the advanced audio settings screen, it's impossible for me to remember which are which, and configure which audio streams go to which tracks at a glance

Example of the problematic UI:
<img width="1420" height="349" alt="2026-08-22-222438_hyprshot" src="https://github.com/user-attachments/assets/27838d6a-db37-4ec3-a2d5-5409617c088a" />



Screenshot of the proposed fix:
<img width="1638" height="479" alt="2026-08-23-000038_hyprshot" src="https://github.com/user-attachments/assets/d824dc5e-c762-4b12-88ba-b0ca8eca9de0" />


I figured using the a11y based label as the fallback instead of the number works better, IMO "Games" and "Track 4" reads better than "Games" and "4", but feel free to let me know if breaking that is a problem and I'm happy to change it

There are a few places in the codebase with this pattern that could probably be improved, not sure if this is a good candidate for a wider refactor in the future or not, but the guidelines say to keep changes small

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested manually on x86_64 Arch Linux 7.1.6

I built the code and ran obs, and tried things like long strings and short strings, and no strings at all, I don't expect this to be something that would possibly break any functionality, I wasn't sure about a maximum length on these strings, i don't see an enforced max, so I didn't want to set a rule, however I didn't want one really long source name to push all the others to the end, and even showing "This is a re.." gives you a lot more context than "6", if you hover over it, I set the tooltip to the full version on hover, so people can see the full name if they're confused, but doing so required QFontMetrics, if that's an overstep let me know and I'm happy to revert it to just showing full length strings, I also considered maybe extracting it to a separate matrix beneath the main mixer list, but that seemed a lot more heavy-handed

### Types of changes
- Tweak: Change the label of the check boxes in the advanced audio UI
- Code Cleanup: use a loop that references the MAX_AUDIO_MIXES parameter instead of re-writing the same code n times

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [X] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [X] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [X] My code is not on the master branch.
- [X] My code has been tested.
- [X] All commit messages are properly formatted and commits squashed where appropriate.
- [ ] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
### AI Disclaimer
- [X] I have used AI tooling in the creation of this PR 

the above is strictly in the sense that I asked AI questions about project structure and CPP conventions, I wrote the code, I did not tell claude "pls make this do this" and then submit a PR


## Open Questions:
- Should we change the accessibility label to use this instead? I would think for the same reason, showing the track name (eg: "Games" instead of "Track 4") is additional context and helps screen reader users more, but I'm hesitant to change that without further discussion since it's probably something that requires broader discussion