### PR TITLE
libobs-winrt: Capture secondary windows

### DIFF
--- a/libobs-winrt/winrt-capture.cpp
+++ b/libobs-winrt/winrt-capture.cpp
@@ -27,6 +27,25 @@ try {
 	return false;
 }
 
+static void
+winrt_capture_enable_secondary_windows(const winrt::Windows::Graphics::Capture::GraphicsCaptureSession &session,
+				       HWND window)
+{
+#if defined(NTDDI_WIN11_GE)
+	try {
+		if (window && winrt::Windows::Foundation::Metadata::ApiInformation::IsPropertyPresent(
+				      L"Windows.Graphics.Capture.GraphicsCaptureSession", L"IncludeSecondaryWindows")) {
+			session.IncludeSecondaryWindows(true);
+		}
+	} catch (const winrt::hresult_error &err) {
+		blog(LOG_ERROR, "winrt_capture_enable_secondary_windows (0x%08X): %s", err.code().value,
+		     winrt::to_string(err.message()).c_str());
+	} catch (...) {
+		blog(LOG_ERROR, "winrt_capture_enable_secondary_windows (0x%08X)", winrt::to_hresult().value);
+	}
+#endif
+}
+
 template<typename T>
 static winrt::com_ptr<T> GetDXGIInterfaceFromObject(winrt::Windows::Foundation::IInspectable const &object)
 {
@@ -313,6 +332,8 @@ static void winrt_capture_device_loss_rebuild(void *device_void, void *data)
 			capture->last_size);
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session = frame_pool.CreateCaptureSession(item);
 
+	winrt_capture_enable_secondary_windows(session, capture->window);
+
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::RequestAccessAsync(
 			winrt::Windows::Graphics::Capture::GraphicsCaptureAccessKind::Borderless)
@@ -378,6 +399,8 @@ try {
 		winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::Create(
 			device, static_cast<winrt::Windows::Graphics::DirectX::DirectXPixelFormat>(format), 2, size);
 	const winrt::Windows::Graphics::Capture::GraphicsCaptureSession session = frame_pool.CreateCaptureSession(item);
+
+	winrt_capture_enable_secondary_windows(session, window);
 
 	if (winrt_capture_border_toggle_supported()) {
 		winrt::Windows::Graphics::Capture::GraphicsCaptureAccess::RequestAccessAsync(


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Enable IncludeSecondaryWindows when available so child windows are captured on Windows 11 24H2 and later. Microsoft [docs](https://learn.microsoft.com/en-us/uwp/api/windows.graphics.capture.graphicscapturesession.includesecondarywindows?view=winrt-26100) were my friend on this one but I really just copied what was being done in the same file for IsCursorCaptureEnabled. 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Saw someone complaining in support that menus in Pro Tools weren't being captured with a window capture source.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Tested v32.2.2 capturing Blender with WGC capture selected, the preferences menu was not visible in the capture. After these changes the preferences window was now captured. I don't have an older build of Windows to test on but behavior should be unchanged there since we are checking for IncludeSecondaryWindows at runtime before this is enabled. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
- Tweak (non-breaking change to improve existing functionality)
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [] I have used AI tooling in the creation of this PR -->
<!-- - [] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
