### PR TITLE
updater: Add Win32 hot-rename fallback for locked hook DLLs and in-use binaries

### DIFF
--- a/frontend/updater/init-hook-files.c
+++ b/frontend/updater/init-hook-files.c
@@ -34,7 +34,7 @@ static bool add_aap_perms(const wchar_t *dir)
 		goto fail;
 	}
 
-	ea.grfAccessPermissions = GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE;
+	ea.grfAccessPermissions = GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | DELETE;
 
 	/* BUILTIN_USERS */
 	ConvertStringSidToSidW(L"S-1-5-32-545", &bu_sid);
@@ -108,6 +108,35 @@ static LSTATUS get_reg(HKEY hkey, LPCWSTR sub_key, LPCWSTR value_name, bool b64)
 #define IMPLICIT_LAYERS L"SOFTWARE\\Khronos\\Vulkan\\ImplicitLayers"
 #define HOOK_LOCATION L"\\data\\obs-plugins\\win-capture\\"
 
+static bool copy_hook_file(const wchar_t *src, const wchar_t *dst)
+{
+	if (CopyFileW(src, dst, false)) {
+		return true;
+	}
+
+	DWORD err = GetLastError();
+	if (err == ERROR_ACCESS_DENIED || err == ERROR_SHARING_VIOLATION || err == ERROR_USER_MAPPED_FILE ||
+	    err == ERROR_LOCK_VIOLATION) {
+		wchar_t dst_old[MAX_PATH];
+		StringCbCopyW(dst_old, sizeof(dst_old), dst);
+		StringCbCatW(dst_old, sizeof(dst_old), L".old");
+
+		/* ponytail: hot-rename locked DLL to .old and schedule deletion on reboot */
+		bool renamed = MoveFileExW(dst, dst_old, MOVEFILE_REPLACE_EXISTING);
+		for (int i = 0; !renamed && i < 100; i++) {
+			StringCbPrintfW(dst_old, sizeof(dst_old), L"%s.%lu.%d.old", dst, GetTickCount(), i);
+			renamed = MoveFileExW(dst, dst_old, MOVEFILE_REPLACE_EXISTING);
+		}
+
+		if (renamed) {
+			MoveFileExW(dst_old, NULL, MOVEFILE_DELAY_UNTIL_REBOOT);
+			return CopyFileW(src, dst, false);
+		}
+	}
+
+	return false;
+}
+
 static bool update_hook_file(bool b64)
 {
 	wchar_t temp[MAX_PATH];
@@ -117,11 +146,11 @@ static bool update_hook_file(bool b64)
 	wchar_t dst_json[MAX_PATH];
 
 	GetCurrentDirectoryW(_countof(src_json), src_json);
-	StringCbCat(src_json, sizeof(src_json), HOOK_LOCATION);
+	StringCbCatW(src_json, sizeof(src_json), HOOK_LOCATION);
 	make_filename(src_json, L"obs-vulkan", L".json");
 
 	GetCurrentDirectoryW(_countof(src), src);
-	StringCbCat(src, sizeof(src), HOOK_LOCATION);
+	StringCbCatW(src, sizeof(src), HOOK_LOCATION);
 	make_filename(src, L"graphics-hook", L".dll");
 
 	get_programdata_path(temp, L"obs-studio-hook\\");
@@ -136,8 +165,8 @@ static bool update_hook_file(bool b64)
 
 	CreateDirectoryW(temp, NULL);
 	add_aap_perms(temp);
-	CopyFileW(src, dst, false);
-	CopyFileW(src_json, dst_json, false);
+	copy_hook_file(src, dst);
+	copy_hook_file(src_json, dst_json);
 	return true;
 }
 

--- a/frontend/updater/patch.cpp
+++ b/frontend/updater/patch.cpp
@@ -65,7 +65,7 @@ try {
 	/* --------------------------------- *
 	 * open patch and file to patch      */
 
-	hTarget = CreateFile(targetFile, GENERIC_READ, 0, nullptr, OPEN_EXISTING, 0, nullptr);
+	hTarget = CreateFile(targetFile, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, 0, nullptr);
 	if (!hTarget.Valid()) {
 		throw int(GetLastError());
 	}
@@ -123,7 +123,7 @@ try {
 	size_t result = ZSTD_decompress_usingDict(zstdCtx, newData.data(), newData.size(), patch_data + kHeaderSize,
 						  patch_size - kHeaderSize, oldData.data(), oldData.size());
 
-	if (result != newsize || ZSTD_isError(result)) {
+	if (result != (size_t)newsize || ZSTD_isError(result)) {
 		throw int(-9);
 	}
 
@@ -133,7 +133,30 @@ try {
 	hTarget = nullptr;
 	hTarget = CreateFile(targetFile, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
 	if (!hTarget.Valid()) {
-		throw int(GetLastError());
+		DWORD err = GetLastError();
+		if (err == ERROR_ACCESS_DENIED || err == ERROR_SHARING_VIOLATION ||
+		    err == ERROR_USER_MAPPED_FILE || err == ERROR_LOCK_VIOLATION) {
+			wchar_t targetFileOld[MAX_PATH];
+			StringCbCopy(targetFileOld, sizeof(targetFileOld), targetFile);
+			StringCbCat(targetFileOld, sizeof(targetFileOld), L".old");
+
+			/* ponytail: hot-rename locked binary to .old and schedule deletion on reboot */
+			bool renamed = MoveFileEx(targetFile, targetFileOld, MOVEFILE_REPLACE_EXISTING);
+			for (int i = 0; !renamed && i < 100; i++) {
+				StringCbPrintf(targetFileOld, sizeof(targetFileOld), L"%s.%lu.%d.old",
+					       targetFile, GetTickCount(), i);
+				renamed = MoveFileEx(targetFile, targetFileOld, MOVEFILE_REPLACE_EXISTING);
+			}
+
+			if (renamed) {
+				MoveFileEx(targetFileOld, nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+				hTarget = CreateFile(targetFile, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+			}
+		}
+
+		if (!hTarget.Valid()) {
+			throw int(GetLastError());
+		}
 	}
 
 	DWORD written;

--- a/frontend/updater/updater.cpp
+++ b/frontend/updater/updater.cpp
@@ -24,6 +24,7 @@
 #include <util/windows/CoTaskMemPtr.hpp>
 
 #include <exception>
+#include <filesystem>
 #include <future>
 #include <mutex>
 #include <queue>
@@ -170,7 +171,30 @@ try {
 
 	hDest = CreateFile(dest, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
 	if (!hDest.Valid()) {
-		throw LastError();
+		DWORD err = GetLastError();
+		if (err == ERROR_ACCESS_DENIED || err == ERROR_SHARING_VIOLATION ||
+		    err == ERROR_USER_MAPPED_FILE || err == ERROR_LOCK_VIOLATION) {
+			wchar_t destOld[MAX_PATH];
+			StringCbCopy(destOld, sizeof(destOld), dest);
+			StringCbCat(destOld, sizeof(destOld), L".old");
+
+			/* ponytail: hot-rename locked binary to .old and schedule deletion on reboot */
+			bool renamed = MoveFileEx(dest, destOld, MOVEFILE_REPLACE_EXISTING);
+			for (int i = 0; !renamed && i < 100; i++) {
+				StringCbPrintf(destOld, sizeof(destOld), L"%s.%lu.%d.old", dest,
+					       GetTickCount(), i);
+				renamed = MoveFileEx(dest, destOld, MOVEFILE_REPLACE_EXISTING);
+			}
+
+			if (renamed) {
+				MoveFileEx(destOld, nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+				hDest = CreateFile(dest, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+			}
+		}
+
+		if (!hDest.Valid()) {
+			throw LastError();
+		}
 	}
 
 	BYTE buf[65536];
@@ -274,9 +298,31 @@ static string QuickReadFile(const wchar_t *path)
 static bool QuickWriteFile(const wchar_t *file, const void *data, size_t size)
 try {
 	WinHandle handle = CreateFile(file, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+	if (!handle.Valid()) {
+		DWORD err = GetLastError();
+		if (err == ERROR_ACCESS_DENIED || err == ERROR_SHARING_VIOLATION ||
+		    err == ERROR_USER_MAPPED_FILE || err == ERROR_LOCK_VIOLATION) {
+			wchar_t fileOld[MAX_PATH];
+			StringCbCopy(fileOld, sizeof(fileOld), file);
+			StringCbCat(fileOld, sizeof(fileOld), L".old");
 
-	if (handle == INVALID_HANDLE_VALUE) {
-		throw LastError();
+			/* ponytail: hot-rename locked binary to .old and schedule deletion on reboot */
+			bool renamed = MoveFileEx(file, fileOld, MOVEFILE_REPLACE_EXISTING);
+			for (int i = 0; !renamed && i < 100; i++) {
+				StringCbPrintf(fileOld, sizeof(fileOld), L"%s.%lu.%d.old", file,
+					       GetTickCount(), i);
+				renamed = MoveFileEx(file, fileOld, MOVEFILE_REPLACE_EXISTING);
+			}
+
+			if (renamed) {
+				MoveFileEx(fileOld, nullptr, MOVEFILE_DELAY_UNTIL_REBOOT);
+				handle = CreateFile(file, GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, nullptr);
+			}
+		}
+
+		if (!handle.Valid()) {
+			throw LastError();
+		}
 	}
 
 	DWORD written;
@@ -797,7 +843,7 @@ static bool AddPackageUpdateFiles(const Package &package, const wchar_t *branch)
 
 		/* We don't really care if this fails, it's just to avoid
 		 * wasting bandwidth by downloading unmodified files */
-		B2Hash localFileHash;
+		B2Hash localFileHash = {};
 		bool has_hash = false;
 
 		if (hashes.count(file.name)) {
@@ -1019,7 +1065,8 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 
 		if (!MyCopyFile(file.outputPath.c_str(), oldFileRenamedPath)) {
 			DWORD err = GetLastError();
-			int is_sharing_violation = (err == ERROR_SHARING_VIOLATION || err == ERROR_USER_MAPPED_FILE);
+			int is_sharing_violation = (err == ERROR_ACCESS_DENIED || err == ERROR_SHARING_VIOLATION ||
+						    err == ERROR_USER_MAPPED_FILE || err == ERROR_LOCK_VIOLATION);
 
 			if (is_sharing_violation) {
 				Status(L"Update failed: %s is still in use.  "
@@ -1076,8 +1123,10 @@ static bool UpdateFile(ZSTD_DCtx *ctx, update_t &file)
 		}
 
 		if (!installed_ok) {
-			int is_sharing_violation =
-				(error_code == ERROR_SHARING_VIOLATION || error_code == ERROR_USER_MAPPED_FILE);
+			int is_sharing_violation = (error_code == ERROR_ACCESS_DENIED ||
+						    error_code == ERROR_SHARING_VIOLATION ||
+						    error_code == ERROR_USER_MAPPED_FILE ||
+						    error_code == ERROR_LOCK_VIOLATION);
 
 			if (is_sharing_violation) {
 				if (!already_tried_to_move) {
@@ -1389,13 +1438,13 @@ static bool Update(wchar_t *cmdLine)
 	/* ------------------------------------- *
 	 * Init crypt stuff                      */
 
-	CryptProvider hProvider;
-	if (!CryptAcquireContext(&hProvider, nullptr, MS_ENH_RSA_AES_PROV, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)) {
+	CryptProvider provider;
+	if (!CryptAcquireContext(&provider, nullptr, MS_ENH_RSA_AES_PROV, PROV_RSA_AES, CRYPT_VERIFYCONTEXT)) {
 		SetDlgItemTextW(hwndMain, IDC_STATUS, L"Update failed: CryptAcquireContext failure");
 		return false;
 	}
 
-	::hProvider = hProvider;
+	hProvider = provider;
 
 	/* ------------------------------------- */
 


### PR DESCRIPTION
### Description
When updating OBS Studio or initializing hook files while GPU-accelerated applications (hardware-accelerated terminals, browsers, Discord, GPU control panels, games) hold memory-mapped handles on `graphics-hook64.dll` / `graphics-hook32.dll`, file copy and write operations fail with `ERROR_SHARING_VIOLATION` (error 32) or `ERROR_ACCESS_DENIED` (error 5).

Under Windows Win32 / NTFS semantics, a memory-mapped file cannot be overwritten or deleted directly, but can be renamed within the same volume.

This PR implements:
1. **`frontend/updater/init-hook-files.c`**: Added `copy_hook_file` helper with `MoveFileExW` hot-rename fallback (`.old` suffix with unique bounded retry loop if prior `.old` files exist) and scheduled deletion on next boot via `MOVEFILE_DELAY_UNTIL_REBOOT`. Also granted `DELETE` permission to `BUILTIN_USERS` in `add_aap_perms` so non-elevated user runs can hot-rename in `%PROGRAMDATA%\obs-studio-hook\`.
2. **`frontend/updater/updater.cpp` & `frontend/updater/patch.cpp`**: Added the same hot-rename and reboot cleanup fallback to `MyCopyFile`, `QuickWriteFile`, and `ApplyPatch` to prevent sharing violation aborts during updater file extraction and delta patching.

### Motivation and Context
Resolves in-use file lock errors (e.g. Exit Code 6 / `INST_ERR_FILE_IN_USE`) during silent or automated updates (like `winget upgrade OBSProject.OBSStudio`) without requiring users to terminate running background GPU processes.

Related issue: #12338

### How Has This Been Tested?
- **MSVC Build**: Compiled cleanly on Windows x64.
- **Lock Simulation**: Tested with an active memory-mapped read lock (`FILE_SHARE_READ | FILE_SHARE_DELETE`) on target DLLs: verified that standard `CopyFileW` fails with error 32, whereas `copy_hook_file` successfully renames the locked DLL to `.old`, writes the new version, and registers deferred deletion in `PendingFileRenameOperations`.
