### PR TITLE
frontend: Use styling for source items visual appearance

### DIFF
--- a/frontend/components/SourceTreeItem.cpp
+++ b/frontend/components/SourceTreeItem.cpp
@@ -4,6 +4,7 @@
 #include <widgets/OBSBasic.hpp>
 
 #include <qt-wrappers.hpp>
+#include <Idian/Utils.hpp>
 
 #include <QCheckBox>
 #include <QLineEdit>
@@ -68,20 +69,23 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 		iconLabel = new QLabel();
 		iconLabel->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 		iconLabel->setPixmap(pixmap);
-		iconLabel->setEnabled(sourceVisible);
 		iconLabel->setStyleSheet("background: none");
-		iconLabel->setProperty("class", "source-icon");
+		idian::Utils::addClass(iconLabel, "source-icon");
+		idian::Utils::toggleClass(iconLabel, "text-muted", !sourceVisible);
+		idian::Utils::applyColorToIcon(iconLabel);
 	}
 
 	vis = new QCheckBox();
-	vis->setProperty("class", "checkbox-icon indicator-visibility");
+	idian::Utils::addClass(vis, "checkbox-icon");
+	idian::Utils::addClass(vis, "indicator-visibility");
 	vis->setChecked(sourceVisible);
 	vis->setAccessibleName(QTStr("Basic.Main.Sources.Visibility"));
 	vis->setAccessibleDescription(QTStr("Basic.Main.Sources.VisibilityDescription").arg(name));
 	vis->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Preferred);
 
 	lock = new QCheckBox();
-	lock->setProperty("class", "checkbox-icon indicator-lock");
+	idian::Utils::addClass(lock, "checkbox-icon");
+	idian::Utils::addClass(lock, "indicator-lock");
 	lock->setChecked(obs_sceneitem_locked(sceneitem));
 	lock->setAccessibleName(QTStr("Basic.Main.Sources.Lock"));
 	lock->setAccessibleDescription(QTStr("Basic.Main.Sources.LockDescription").arg(name));
@@ -90,13 +94,13 @@ SourceTreeItem::SourceTreeItem(SourceTree *tree_, OBSSceneItem sceneitem_) : tre
 	label = new OBSSourceLabel(source);
 	label->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
 	label->setAttribute(Qt::WA_TranslucentBackground);
-	label->setEnabled(sourceVisible);
+	idian::Utils::toggleClass(label, "text-muted", !sourceVisible);
 
 	const char *sourceId = obs_source_get_unversioned_id(source);
 	switch (obs_source_load_state(sourceId)) {
 	case OBS_MODULE_DISABLED:
 	case OBS_MODULE_MISSING:
-		label->setStyleSheet("QLabel {color: #CC0000;}");
+		idian::Utils::addClass(label, "text-danger");
 		break;
 	default:
 		break;
@@ -470,9 +474,10 @@ bool SourceTreeItem::eventFilter(QObject *object, QEvent *event)
 void SourceTreeItem::VisibilityChanged(bool visible)
 {
 	if (iconLabel) {
-		iconLabel->setEnabled(visible);
+		idian::Utils::toggleClass(iconLabel, "text-muted", !visible);
+		idian::Utils::applyColorToIcon(iconLabel);
 	}
-	label->setEnabled(visible);
+	idian::Utils::toggleClass(label, "text-muted", !visible);
 	vis->setChecked(visible);
 }
 
@@ -538,7 +543,7 @@ void SourceTreeItem::Update(bool force)
 
 	} else if (type == Type::Group) {
 		expand = new QCheckBox();
-		expand->setProperty("class", "checkbox-icon indicator-expand");
+		idian::Utils::addClass(expand, "checkbox-icon indicator-expand");
 		expand->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
 #ifdef __APPLE__
 		expand->setAttribute(Qt::WA_LayoutUsesWidgetRect);

--- a/shared/qt/idian/include/Idian/StateEventFilter.cpp
+++ b/shared/qt/idian/include/Idian/StateEventFilter.cpp
@@ -17,10 +17,10 @@
 
 #include <Idian/StateEventFilter.hpp>
 #include <Idian/Utils.hpp>
+
 #include <QAbstractButton>
 #include <QFocusEvent>
-#include <QStyleOptionButton>
-#include <QTimer>
+#include <QLabel>
 
 namespace idian {
 StateEventFilter::StateEventFilter(idian::Utils *utils, QWidget *target) : QObject(target), target(target), utils(utils)
@@ -102,7 +102,13 @@ bool StateEventFilter::eventFilter(QObject *obj, QEvent *event)
 
 	if (updateIconColors) {
 		// Delay icon update
-		QTimer::singleShot(0, this, [this, widget]() { utils->applyColorToIcon(widget); });
+		if (QLabel *label = qobject_cast<QLabel *>(widget)) {
+			QMetaObject::invokeMethod(
+				this, [this, label]() { utils->applyColorToIcon(label); }, Qt::QueuedConnection);
+		} else if (QAbstractButton *button = qobject_cast<QAbstractButton *>(widget)) {
+			QMetaObject::invokeMethod(
+				this, [this, button]() { utils->applyColorToIcon(button); }, Qt::QueuedConnection);
+		}
 	}
 
 	return QObject::eventFilter(obj, event);

--- a/shared/qt/idian/include/Idian/Utils.cpp
+++ b/shared/qt/idian/include/Idian/Utils.cpp
@@ -20,13 +20,14 @@
 #include <Idian/StateEventFilter.hpp>
 
 #include <QAbstractButton>
+#include <QLabel>
 #include <QPainter>
 #include <QStyleOptionButton>
+#include <QStyleOptionFrame>
 
 namespace idian {
-void Utils::applyColorToIcon(QWidget *widget)
+void Utils::applyColorToIcon(QAbstractButton *button)
 {
-	QAbstractButton *button = qobject_cast<QAbstractButton *>(widget);
 	if (button && !button->icon().isNull()) {
 		// Filter is on a widget with an icon set, update its colors
 		QStyleOptionButton opt;
@@ -39,6 +40,19 @@ void Utils::applyColorToIcon(QWidget *widget)
 		tintedIcon.addPixmap(tinted, QIcon::Disabled);
 
 		button->setIcon(tintedIcon);
+	}
+}
+
+void Utils::applyColorToIcon(QLabel *label)
+{
+	if (label && !label->pixmap().isNull()) {
+		QStyleOptionFrame opt;
+		opt.initFrom(label);
+
+		QColor color = opt.palette.color(QPalette::Text);
+		QPixmap tinted = recolorPixmap(label->pixmap(), color);
+
+		label->setPixmap(tinted);
 	}
 }
 

--- a/shared/qt/idian/include/Idian/Utils.hpp
+++ b/shared/qt/idian/include/Idian/Utils.hpp
@@ -21,6 +21,9 @@
 #include <QStyle>
 #include <QWidget>
 
+class QAbstractButton;
+class QLabel;
+
 namespace idian {
 
 // Helpers for OBS Idian widgets
@@ -114,7 +117,8 @@ public:
 		}
 	}
 
-	static void applyColorToIcon(QWidget *widget);
+	static void applyColorToIcon(QAbstractButton *button);
+	static void applyColorToIcon(QLabel *label);
 
 	static QPixmap recolorPixmap(const QPixmap &src, const QColor &color);
 


### PR DESCRIPTION
### Description
The icon and text label for items in the sources list was previously enabled/disabled based on the scene item visibility state. As of Qt 6.11 Qt no longer triggers context menus when right clicking a disabled QLabel. This means right-clicking a hidden scene item on the source icon or name would not show a context menu.

Updates SourceTreeItem to use styling classes via idian helpers instead of changing the enabled state of these labels.

### Motivation and Context
Fixes context menus not appearing for hidden scene items when clicking certain regions of the source list.

### How Has This Been Tested?
Toggled scene item visibility and right-clicked on sources in the sources list.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
- Code cleanup (non-breaking change which makes code smaller or more readable)
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [x] I have used AI tooling in the creation of this PR -->
<!-- - [x] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
