### PR TITLE
UI: Fix preview mouse input offset on Wayland fractional scaling

### DIFF
--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -1802,6 +1802,34 @@ void OBSBasic::changeEvent(QEvent *event)
 	}
 }
 
+bool OBSBasic::event(QEvent *event)
+{
+	switch (event->type()) {
+	case QEvent::DevicePixelRatioChange: {
+		/* The device pixel ratio of the window can change at runtime,
+		 * e.g. on Wayland when the initial integer scale is followed
+		 * by the fractional scale, or when the window is moved to a
+		 * monitor with a different scale factor. The cached value is
+		 * used for mouse coordinate mapping of the preview, so make
+		 * sure it stays in sync and the preview geometry is
+		 * recalculated accordingly. */
+		dpi = devicePixelRatioF();
+
+		obs_video_info ovi;
+		if (obs_get_video_info(&ovi)) {
+			ResizePreview(ovi.base_width, ovi.base_height);
+		}
+
+		UpdatePreviewControls();
+		break;
+	}
+	default:
+		break;
+	}
+
+	return OBSMainWindow::event(event);
+}
+
 void OBSBasic::GetFPSCommon(uint32_t &num, uint32_t &den) const
 {
 	const char *val = config_get_string(activeConfiguration, "Video", "FPSCommon");

--- a/frontend/widgets/OBSBasic.hpp
+++ b/frontend/widgets/OBSBasic.hpp
@@ -327,6 +327,7 @@ protected:
 	virtual void closeEvent(QCloseEvent *event) override;
 	virtual bool nativeEvent(const QByteArray &eventType, void *message, qintptr *result) override;
 	virtual void changeEvent(QEvent *event) override;
+	virtual bool event(QEvent *event) override;
 
 signals:
 	void mainWindowClosed();


### PR DESCRIPTION
## Description

Fixes incorrect mouse interaction in the preview when using fractional scaling on Wayland.

OBS caches the device pixel ratio used for preview mouse-coordinate conversion. On Wayland, Qt can initially report an integer scale factor and then update it to the actual fractional scale shortly after startup. When this happened, the cached value could become stale, causing mouse hit-testing to no longer match the rendered preview.

This change handles `QEvent::DevicePixelRatioChange` by refreshing the cached device pixel ratio and recalculating the preview geometry.

As a result, scene items can be selected, moved, and resized correctly when fractional scaling is enabled.

## Motivation and Context

Fixes the input-coordinate issue described in #13552, where preview controls and mouse hit areas could become offset from the visible scene when using Wayland fractional scaling.

The offset increased further away from the top-left of the preview, making scene items difficult or impossible to select, move, or resize.

## How Has This Been Tested?

Tested on:

* Linux / NixOS 26.11
* KDE Plasma on Wayland
* AMD GPU
* 2560x1440 display
* 150% display scaling
* OBS 32.2.1 built with this change

Verified that:

In the photo the resize mouse shape is visible and functional at the corner of the element
<img width="973" height="1050" alt="image" src="https://github.com/user-attachments/assets/75d7ab94-87df-44aa-a4d6-a03d688a985a" />


* Scene items can be selected correctly.
* Scene items can be moved and resized with the mouse.
* Resize handles and mouse hit areas remain aligned with the rendered preview.
* Input remains correct after the device pixel ratio changes at runtime.
* The issue is reproducible without the patch on the same setup.
* `clang-format` passes on the modified files.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Performance enhancement (non-breaking change which improves efficiency)
* [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Documentation (a change to documentation)

## Checklist

* [x] I have read the contributing document.
* [x] My code has been run through clang-format.
* [x] My code follows the project's style guidelines.
* [x] My code is not on the master branch.
* [x] My code has been tested.
* [x] All commit messages are properly formatted and commits squashed where appropriate.
* [ ] I have included updates to all appropriate documentation.
