### PR TITLE
mac-videotoolbox: Enable RealTime for hardware H.264/HEVC

### DIFF
--- a/plugins/mac-videotoolbox/encoder.c
+++ b/plugins/mac-videotoolbox/encoder.c
@@ -492,11 +492,12 @@ static OSStatus create_encoder(struct vt_encoder *enc)
 	VTCompressionSessionRef s;
 
 	const char *codec_name = obs_encoder_get_codec(enc->encoder);
+	struct vt_encoder_type_data *type_data = (struct vt_encoder_type_data *)obs_encoder_get_type_data(enc->encoder);
+	bool hardware_h26x = type_data->hardware_accelerated &&
+			     (enc->codec_type == kCMVideoCodecType_H264 || enc->codec_type == kCMVideoCodecType_HEVC);
 
 	CFDictionaryRef encoder_spec;
 	if (strcmp(codec_name, "prores") == 0) {
-		struct vt_encoder_type_data *type_data =
-			(struct vt_encoder_type_data *)obs_encoder_get_type_data(enc->encoder);
 		encoder_spec = create_prores_encoder_spec(enc->codec_type, type_data->hardware_accelerated);
 	} else {
 		encoder_spec = create_encoder_spec(enc->vt_encoder_id);
@@ -593,7 +594,8 @@ static OSStatus create_encoder(struct vt_encoder *enc)
 	}
 
 	// This can fail depending on hardware configuration
-	code = session_set_prop(s, kVTCompressionPropertyKey_RealTime, kCFBooleanFalse);
+	code = session_set_prop(s, kVTCompressionPropertyKey_RealTime,
+				hardware_h26x ? kCFBooleanTrue : kCFBooleanFalse);
 	if (code != noErr)
 		log_osstatus(LOG_WARNING, enc,
 			     "setting kVTCompressionPropertyKey_RealTime failed, "


### PR DESCRIPTION
## Description

Set `kVTCompressionPropertyKey_RealTime` to `true` for hardware H.264
and HEVC VideoToolbox encoders.

Software H.264/HEVC and ProRes remain at `false`. EncoderID selection
and all other encoder behavior remain unchanged.

## Motivation and Context

5bbb36acf changed RealTime from `true` to `false` in 2022 after
preliminary testing suggested that `true` could prevent the encoder
from maintaining its target frame rate.

On an M4 Max, I can reproduce severe encoding stalls with multiple
simultaneous hardware VideoToolbox sessions when RealTime is `false`.

I tested the relevant variables independently:

- Upstream EncoderID + RealTime=false: stalls reproduced.
- No EncoderID + RequireHardware=true + RealTime=false: stalls reproduced.
- No EncoderID + RealTime=true: no stalls observed.
- Upstream EncoderID + RealTime=true: no stalls observed across repeated tests.

This suggests that changing EncoderID selection is unnecessary for this
case. Setting RealTime=true was sufficient to avoid the stalls in the
tested workload.

Related: #13578

## How Has This Been Tested?

Tested on a Mac Studio M4 Max (40-core GPU, 48 GB), macOS 26.6.2.

The main workload used Twitch Enhanced Broadcasting with five
simultaneous hardware H.264/HEVC sessions, plus 2560x1440 60 fps
hardware HEVC recording at CRF/Quality 0.81 with Spatial AQ. Tests also
included an additional hardware HEVC recording, for up to seven
simultaneous VideoToolbox hardware sessions.

I tested repeated stream start/stop cycles, clean OBS restarts, and
runs ranging from several minutes to roughly 30 minutes. The severe
encoding lag seen with RealTime=false did not recur with RealTime=true
in these tests.

B-frames were also checked with ffprobe. They remained present with
RealTime=true, with distinct PTS/DTS, monotonic DTS, and offsets
consistent with frame reordering. No changes to AllowFrameReordering,
parse\_sample(), or timestamp handling were needed.

Validation:

- clang-format 22.1.3: pass
- git diff --check: pass
- mac-videotoolbox Debug arm64: pass
- ALL\_BUILD Debug arm64: pass

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance enhancement (non-breaking change which improves efficiency)

## AI Disclosure

- [x] I have used AI tooling in the creation of this PR

OpenAI ChatGPT/Codex (GPT-5.6 Sol) was used for log and diff analysis,
A/B test planning, repository work, formatting/build checks, and PR
preparation.

Anthropic Claude Code (Claude Opus 5) was used for static review,
repository/history analysis, and regression analysis.

I performed and evaluated all hardware tests myself. AI suggestions
were not accepted without validation: the EncoderID alternative was
tested and rejected, and the B-frame concern was verified separately
with ffprobe. I reviewed and accepted the final change.

## Limitations

These tests do not establish how VideoToolbox assigns sessions to
physical Media Engines, that EncoderID identifies a physical engine,
or that this behavior generalizes to every Mac or workload.

## Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
