### PR TITLE
win-dshow: Close device dialogs during shutdown

### DIFF
--- a/plugins/win-dshow/win-dshow.cpp
+++ b/plugins/win-dshow/win-dshow.cpp
@@ -184,6 +184,14 @@ enum class Action {
 
 static DWORD CALLBACK DShowThread(LPVOID ptr);
 
+static BOOL CALLBACK CloseDShowDialogs(HWND window, LPARAM)
+{
+	if (IsWindowVisible(window)) {
+		PostMessage(window, WM_CLOSE, 0, 0);
+	}
+	return TRUE;
+}
+
 struct DShowInput {
 	obs_source_t *source;
 	Device device;
@@ -273,6 +281,7 @@ struct DShowInput {
 		}
 
 		ReleaseSemaphore(semaphore, 1, nullptr);
+		EnumThreadWindows(GetThreadId(thread), CloseDShowDialogs, 0);
 
 		WaitForSingleObject(thread, INFINITE);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Prevent OBS from hanging during shutdown by enumerating the DirectShow thread's windows and posting WM_CLOSE to all visible dialogs before waiting for the thread to exit. I did add a window visibility check because I logged every window being closed while testing and saw a bunch of windows that were not visible, not sure if this is necessary and can remove if not.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
I have just been scrolling through issues looking for ones that seem pretty easy/straight forward to fix.
Fixes #13534 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Opened the configure video window from a video capture device source, closed the main OBS window which now resulted in the configure video window closing as expected. 

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
-  Bug fix (non-breaking change which fixes an issue) 
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [] I have used AI tooling in the creation of this PR -->
<!-- - [] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
