### PR TITLE
frontend: Add --disable-preview launch flag

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -74,6 +74,7 @@ bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
 bool opt_disable_updater = false;
 bool opt_disable_missing_files_check = false;
+bool opt_disable_preview = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
@@ -1011,6 +1012,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--studio-mode", nullptr)) {
 			opt_studio_mode = true;
 
+		} else if (arg_is(argv[i], "--disable-preview", nullptr)) {
+			opt_disable_preview = true;
+
 		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
 			opt_allow_opengl = true;
 
@@ -1035,6 +1039,7 @@ int main(int argc, char *argv[])
 				"--profile <string>: Use specific profile.\n"
 				"--scene <string>: Start with specific scene.\n\n"
 				"--studio-mode: Enable studio mode.\n"
+				"--disable-preview: Disable the main preview for this launch (session only).\n"
 				"--minimize-to-tray: Minimize to system tray.\n"
 #if ALLOW_PORTABLE_MODE
 				"--portable, -p: Use portable mode.\n"

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -81,6 +81,7 @@ extern bool disable_3p_plugins;
 extern bool opt_studio_mode;
 extern bool opt_always_on_top;
 extern bool opt_minimize_tray;
+extern bool opt_disable_preview;
 extern std::string opt_starting_profile;
 extern std::string opt_starting_collection;
 
@@ -1148,10 +1149,20 @@ void OBSBasic::OBSInit()
 
 	previewEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow", "PreviewEnabled");
 
+	if (opt_disable_preview) {
+		if (IsPreviewProgramMode()) {
+			blog(LOG_INFO, "[Preview] --disable-preview ignored because studio mode is active");
+		} else {
+			previewEnabled = false;
+			blog(LOG_INFO,
+			     "[Preview] Disabled by --disable-preview (session override, not written to user.ini)");
+		}
+	}
+
 	if (!previewEnabled && !IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, previewEnabled);
+		EnablePreviewDisplay(false);
 	} else if (!previewEnabled && IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, true);
+		EnablePreviewDisplay(true);
 	}
 
 	disableSaving--;

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -265,6 +265,10 @@ void OBSBasic::EnablePreviewDisplay(bool enable)
 	obs_display_set_enabled(ui->preview->GetDisplay(), enable);
 	ui->previewContainer->setVisible(enable);
 	ui->previewDisabledWidget->setVisible(!enable);
+
+	if (enable) {
+		ui->preview->CreateDisplay();
+	}
 }
 
 void OBSBasic::TogglePreview()

--- a/frontend/widgets/OBSQTDisplay.cpp
+++ b/frontend/widgets/OBSQTDisplay.cpp
@@ -138,6 +138,10 @@ void OBSQTDisplay::CreateDisplay()
 		return;
 	}
 
+	if (!isVisible()) {
+		return;
+	}
+
 	if (!windowHandle()->isExposed()) {
 		return;
 	}


### PR DESCRIPTION
### Description

Adds `obs --disable-preview` as a first-class launch flag.

On this launch only, the main preview is treated as disabled even if `user.ini` has `BasicWindow/PreviewEnabled=true` or the key is missing (OBS default is true). The same UI path as a normal disable is used (`EnablePreviewDisplay(false)`), so operators can click Enable Preview later.

The preview widget is hidden before the first expose so the main `OBSQTDisplay` swapchain is not created until the operator enables preview, or studio mode needs those displays.

### Motivation and Context

Headless / remote operators currently write `user.ini` `[BasicWindow] PreviewEnabled=false` before `exec obs`. That mutates a persistent user setting, races with a clean exit that writes `previewEnabled` back, and is the wrong place for a session override.

Argv is the native OBS contract, same as `--studio-mode` and `--disable-missing-files-check`.

Launch line:

```
obs --disable-preview
```

### Persist rules

- The flag does not write `user.ini` at startup.
- `InitUserConfigDefaults` is unchanged: unflagged OBS still defaults preview on.
- On clean exit, persist whatever the operator last chose (`previewEnabled`), same as today.
- Next process with `--disable-preview`: preview off again. Without the flag: `user.ini` wins.

### Studio mode

`--studio-mode` / an existing `PreviewProgramMode` session wins. Dual view stays visible. If both flags are passed, one info line is logged:

```
[Preview] --disable-preview ignored because studio mode is active
```

Projectors, filters, source properties, interact windows, encoder/stream/record/virtual cam/obs-websocket are unchanged.

### How Has This Been Tested?

- Built OBS 32.1.2 on Ubuntu 24.04 (Docker, Mesa llvmpipe + Xvfb).
- `obs --help` lists `--disable-preview`.
- `obs --disable-preview` with `user.ini` `PreviewEnabled=true` logs the session override and does not write `PreviewEnabled=false` at startup.
- `--studio-mode --disable-preview` logs the ignore line and stays in studio mode.
- Unflagged OBS does not log the override.

Not tested: Windows/macOS GUI click-to-enable after the flag (argv parse is shared). NVIDIA Xorg preview-on-at-boot race is a separate PR.