### PR TITLE
libobs-opengl, frontend: Defer X11 EGL swapchain

### DIFF
--- a/frontend/widgets/OBSQTDisplay.cpp
+++ b/frontend/widgets/OBSQTDisplay.cpp
@@ -143,6 +143,9 @@ void OBSQTDisplay::CreateDisplay()
 	}
 
 	QSize size = GetPixelSize(this);
+	if (size.width() < 1 || size.height() < 1) {
+		return;
+	}
 
 	gs_init_data info = {};
 	info.cx = size.width();
@@ -155,6 +158,9 @@ void OBSQTDisplay::CreateDisplay()
 	}
 
 	display = obs_display_create(&info, backgroundColor);
+	if (!display) {
+		return;
+	}
 
 	emit DisplayCreated(this);
 }

--- a/libobs-opengl/gl-x11-egl.c
+++ b/libobs-opengl/gl-x11-egl.c
@@ -377,20 +377,42 @@ static void gl_x11_egl_platform_destroy(struct gl_platform *plat)
 	bfree(plat);
 }
 
+static bool x11_window_is_viewable(xcb_connection_t *xcb_conn, xcb_window_t window)
+{
+	xcb_generic_error_t *error = NULL;
+	xcb_get_window_attributes_cookie_t cookie;
+	xcb_get_window_attributes_reply_t *attr;
+	bool viewable;
+
+	cookie = xcb_get_window_attributes(xcb_conn, window);
+	attr = xcb_get_window_attributes_reply(xcb_conn, cookie, &error);
+	viewable = !error && attr && attr->map_state == XCB_MAP_STATE_VIEWABLE;
+	free(error);
+	free(attr);
+	return viewable;
+}
+
 static bool gl_x11_egl_platform_init_swapchain(struct gs_swap_chain *swap)
 {
 	const struct gl_platform *plat = swap->device->plat;
 	Display *display = plat->xdisplay;
 	xcb_connection_t *xcb_conn = XGetXCBConnection(display);
-	xcb_window_t wid = xcb_generate_id(xcb_conn);
 	xcb_window_t parent = swap->info.window.id;
-	xcb_get_geometry_reply_t *geometry = get_window_geometry(xcb_conn, parent);
+	xcb_get_geometry_reply_t *geometry = NULL;
+	xcb_window_t wid = 0;
 	bool status = false;
-
 	int visual;
 
-	if (!geometry)
+	if (!parent || !x11_window_is_viewable(xcb_conn, parent)) {
+		return false;
+	}
+
+	geometry = get_window_geometry(xcb_conn, parent);
+	if (!geometry || geometry->width == 0 || geometry->height == 0) {
 		goto fail_geometry_request;
+	}
+
+	wid = xcb_generate_id(xcb_conn);
 
 	{
 		if (!eglGetConfigAttrib(plat->edisplay, plat->config, EGL_NATIVE_VISUAL_ID, (EGLint *)&visual)) {


### PR DESCRIPTION
### Description

Do not create an X11 EGL preview swapchain until the parent native window is a mapped drawable with width/height > 0. Failed create leaves `display == nullptr` so the next paint, resize, or expose can retry.

`CreateDisplay()` also requires a non-zero Qt size and does not emit `DisplayCreated` if `obs_display_create` returns null.

No sleeps. No GLX fallback. Wayland / Windows / macOS swapchain code is unchanged.

### Motivation and Context

On NVIDIA Xorg + KWin, `PreviewEnabled=true` during `OBSInit` can black/glitch the local canvas while streaming still works. Enabling preview later usually works.

Typical log:

```
error: Failed to fetch parent window geometry!
error: gl_platform_init_swapchain failed
error: obs_display_init: Failed to create swap chain
error: X Error: BadWindow ...
error: Cannot get window EGL surface: EGL_BAD_NATIVE_WINDOW
```

`isExposed()` is not "mapped + non-zero geometry + valid EGL native window". `gl_x11_egl_platform_init_swapchain` currently calls `xcb_get_geometry(parent)` then `xcb_create_window` / `eglCreateWindowSurface` too early.

### How Has This Been Tested?

- Change compiles in a 32.1.2 Ubuntu 24.04 ARM Docker build (`libobs-opengl` / `gl-x11-egl.c`).
- Cannot prove the NVIDIA DDX + KWin maximize race on this hardware. That needs Ubuntu 24.04, NVIDIA Xorg, and preview enabled at boot.