### PR TITLE
frontend: Add --disable-preview launch flag

### DIFF
--- a/frontend/obs-main.cpp
+++ b/frontend/obs-main.cpp
@@ -74,6 +74,7 @@ bool opt_allow_opengl = false;
 bool opt_always_on_top = false;
 bool opt_disable_updater = false;
 bool opt_disable_missing_files_check = false;
+bool opt_disable_preview = false;
 string opt_starting_collection;
 string opt_starting_profile;
 string opt_starting_scene;
@@ -1011,6 +1012,9 @@ int main(int argc, char *argv[])
 		} else if (arg_is(argv[i], "--studio-mode", nullptr)) {
 			opt_studio_mode = true;
 
+		} else if (arg_is(argv[i], "--disable-preview", nullptr)) {
+			opt_disable_preview = true;
+
 		} else if (arg_is(argv[i], "--allow-opengl", nullptr)) {
 			opt_allow_opengl = true;
 
@@ -1035,6 +1039,7 @@ int main(int argc, char *argv[])
 				"--profile <string>: Use specific profile.\n"
 				"--scene <string>: Start with specific scene.\n\n"
 				"--studio-mode: Enable studio mode.\n"
+				"--disable-preview: Disable the main preview for this launch (session only).\n"
 				"--minimize-to-tray: Minimize to system tray.\n"
 #if ALLOW_PORTABLE_MODE
 				"--portable, -p: Use portable mode.\n"

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -81,6 +81,7 @@ extern bool disable_3p_plugins;
 extern bool opt_studio_mode;
 extern bool opt_always_on_top;
 extern bool opt_minimize_tray;
+extern bool opt_disable_preview;
 extern std::string opt_starting_profile;
 extern std::string opt_starting_collection;
 
@@ -1148,10 +1149,20 @@ void OBSBasic::OBSInit()
 
 	previewEnabled = config_get_bool(App()->GetUserConfig(), "BasicWindow", "PreviewEnabled");
 
+	if (opt_disable_preview) {
+		if (IsPreviewProgramMode()) {
+			blog(LOG_INFO, "[Preview] --disable-preview ignored because studio mode is active");
+		} else {
+			previewEnabled = false;
+			blog(LOG_INFO,
+			     "[Preview] Disabled by --disable-preview (session override, not written to user.ini)");
+		}
+	}
+
 	if (!previewEnabled && !IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, previewEnabled);
+		EnablePreviewDisplay(false);
 	} else if (!previewEnabled && IsPreviewProgramMode()) {
-		QMetaObject::invokeMethod(this, &OBSBasic::EnablePreviewDisplay, Qt::QueuedConnection, true);
+		EnablePreviewDisplay(true);
 	}
 
 	disableSaving--;

--- a/frontend/widgets/OBSBasic_Preview.cpp
+++ b/frontend/widgets/OBSBasic_Preview.cpp
@@ -265,6 +265,10 @@ void OBSBasic::EnablePreviewDisplay(bool enable)
 	obs_display_set_enabled(ui->preview->GetDisplay(), enable);
 	ui->previewContainer->setVisible(enable);
 	ui->previewDisabledWidget->setVisible(!enable);
+
+	if (enable) {
+		ui->preview->CreateDisplay();
+	}
 }
 
 void OBSBasic::TogglePreview()

--- a/frontend/widgets/OBSQTDisplay.cpp
+++ b/frontend/widgets/OBSQTDisplay.cpp
@@ -138,6 +138,10 @@ void OBSQTDisplay::CreateDisplay()
 		return;
 	}
 
+	if (!isVisible()) {
+		return;
+	}
+
 	if (!windowHandle()->isExposed()) {
 		return;
 	}


### PR DESCRIPTION
### Description

Adds `--disable-preview`, a session-only launch flag that starts OBS with the main preview off.

It uses the same UI path as disabling preview from the menu (`EnablePreviewDisplay(false)`). The disabled-preview placeholder is shown, and preview can still be turned back on from the UI later.

The main preview widget is hidden before first expose, so the preview swapchain is not created until preview is enabled, or studio mode needs those displays.

```
obs --disable-preview
```

### Motivation and Context

The main preview is on by default, and that is unchanged. Some launches simply do not need the local canvas: the extra GPU/compositor work is wasted, and `PreviewEnabled` in `user.ini` is the wrong lever for a one-shot override.

Writing `PreviewEnabled=false` changes a saved setting. The next start without that write comes up with preview off. A launch flag matches `--studio-mode` and `--disable-missing-files-check`: it applies to this process only.

### Persist rules

- The flag does not write `user.ini` at startup.
- `InitUserConfigDefaults` is unchanged. Unflagged OBS still defaults preview on.
- On clean exit, persist whatever was last chosen in the UI (`previewEnabled`), same as today.
- Next process with `--disable-preview`: preview off again. Without the flag: `user.ini` wins.

### Studio mode

`--studio-mode` and an existing Preview/Program session win. Those canvases stay visible. If both flags are passed:

```
[Preview] --disable-preview ignored because studio mode is active
```

Projectors, filters, source properties, interact windows, encoder, stream, record, virtual cam, and obs-websocket are unchanged.

### How Has This Been Tested?

- `obs --help` lists `--disable-preview`.
- `obs --disable-preview` with `PreviewEnabled=true` (or the key missing) starts with the disabled-preview placeholder and logs the session override. `user.ini` is not set to false at startup.
- Enabling preview from the UI after that still creates the canvas.
- `--studio-mode --disable-preview` stays in studio mode and logs the ignore line.
- Restart without the flag follows the saved `PreviewEnabled` value.