### PR TITLE
frontend: Add runtime status files

### DIFF
--- a/frontend/OBSApp.cpp
+++ b/frontend/OBSApp.cpp
@@ -23,6 +23,7 @@
 #include <utility/CrashHandler.hpp>
 #include <utility/OBSEventFilter.hpp>
 #include <utility/OBSProxyStyle.hpp>
+#include <utility/RuntimeStatus.hpp>
 #if defined(_WIN32) || defined(ENABLE_SPARKLE_UPDATER)
 #include <utility/models/branches.hpp>
 #endif
@@ -959,6 +960,7 @@ OBSApp::OBSApp(int &argc, char **argv, profiler_name_store_t *store)
 	setDesktopFileName("com.obsproject.Studio");
 
 	pluginManager_ = std::make_unique<OBS::PluginManager>();
+	runtimeStatus_ = std::make_unique<OBS::RuntimeStatus>();
 }
 
 OBSApp::~OBSApp()
@@ -1994,6 +1996,10 @@ void OBSApp::commitData(QSessionManager &manager)
 
 void OBSApp::applicationShutdown() noexcept
 {
+	if (runtimeStatus_) {
+		runtimeStatus_->shutdown();
+	}
+
 #ifdef _WIN32
 	bool disableAudioDucking = config_get_bool(appConfig, "Audio", "DisableAudioDucking");
 	if (disableAudioDucking) {

--- a/frontend/OBSApp.hpp
+++ b/frontend/OBSApp.hpp
@@ -53,6 +53,7 @@ class CrashHandler;
 enum class LogFileType { NoType, CurrentAppLog, LastAppLog, CrashLog };
 enum class LogFileState { NoState, New, Uploaded };
 class PluginManager;
+class RuntimeStatus;
 } // namespace OBS
 
 struct UpdateBranch {
@@ -95,6 +96,7 @@ private:
 	ThumbnailManager *thumbnailManager = nullptr;
 
 	std::unique_ptr<OBS::PluginManager> pluginManager_;
+	std::unique_ptr<OBS::RuntimeStatus> runtimeStatus_;
 
 	bool UpdatePre22MultiviewLayout(const char *layout);
 
@@ -154,6 +156,7 @@ public:
 	inline bool HotkeysEnabledInFocus() const { return enableHotkeysInFocus; }
 
 	inline QMainWindow *GetMainWindow() const { return mainWindow.data(); }
+	inline OBS::RuntimeStatus *GetRuntimeStatus() const { return runtimeStatus_.get(); }
 
 	inline config_t *GetAppConfig() const { return appConfig; }
 	inline config_t *GetUserConfig() const { return userConfig; }

--- a/frontend/cmake/ui-utility.cmake
+++ b/frontend/cmake/ui-utility.cmake
@@ -50,6 +50,8 @@ target_sources(
     utility/RemuxWorker.cpp
     utility/RemuxWorker.hpp
     utility/ResizeSignaler.hpp
+    utility/RuntimeStatus.cpp
+    utility/RuntimeStatus.hpp
     utility/SceneRenameDelegate.cpp
     utility/SceneRenameDelegate.hpp
     utility/ScreenshotObj.cpp

--- a/frontend/utility/RuntimeStatus.cpp
+++ b/frontend/utility/RuntimeStatus.cpp
@@ -1,0 +1,288 @@
+/******************************************************************************
+    Copyright (C) 2026 by nicolaeser <nico@laeser.software>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#include "RuntimeStatus.hpp"
+
+#include <util/base.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <cerrno>
+#include <csignal>
+#include <unistd.h>
+#endif
+
+namespace {
+
+constexpr const char *kPidFileName = "obs.pid";
+constexpr const char *kStreamingFileName = "streaming";
+constexpr const char *kRecordingFileName = "recording";
+
+int currentProcessId()
+{
+#ifdef _WIN32
+	return static_cast<int>(GetCurrentProcessId());
+#else
+	return static_cast<int>(getpid());
+#endif
+}
+
+bool processIsAlive(int pid)
+{
+	if (pid <= 0) {
+		return false;
+	}
+
+#ifdef _WIN32
+	HANDLE handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, static_cast<DWORD>(pid));
+	if (!handle) {
+		return false;
+	}
+
+	DWORD exitCode = 0;
+	const bool isAlive = GetExitCodeProcess(handle, &exitCode) && exitCode == STILL_ACTIVE;
+	CloseHandle(handle);
+	return isAlive;
+#else
+	if (kill(static_cast<pid_t>(pid), 0) == 0) {
+		return true;
+	}
+
+	return errno != ESRCH;
+#endif
+}
+
+int readPidFile(const std::filesystem::path &path)
+{
+	std::ifstream file(path);
+	if (!file) {
+		return 0;
+	}
+
+	int pid = 0;
+	file >> pid;
+	if (!file) {
+		return 0;
+	}
+
+	return pid;
+}
+
+bool writeFile(const std::filesystem::path &path, const std::string &contents)
+{
+	std::ofstream file(path, std::ios::out | std::ios::trunc | std::ios::binary);
+	if (!file) {
+		return false;
+	}
+
+	file.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+	return static_cast<bool>(file);
+}
+
+std::vector<std::filesystem::path> statusDirectoryCandidates()
+{
+	std::vector<std::filesystem::path> candidates;
+
+	const char *overrideDirectory = std::getenv("OBS_STATUS_DIR");
+	if (overrideDirectory && *overrideDirectory) {
+		candidates.emplace_back(std::filesystem::u8path(overrideDirectory));
+		return candidates;
+	}
+
+#ifndef _WIN32
+	const char *xdgRuntimeDirectory = std::getenv("XDG_RUNTIME_DIR");
+	if (xdgRuntimeDirectory && *xdgRuntimeDirectory) {
+		candidates.emplace_back(std::filesystem::u8path(xdgRuntimeDirectory) / "obs-studio");
+	}
+#endif
+
+	std::error_code error;
+	const std::filesystem::path tempDirectory = std::filesystem::temp_directory_path(error);
+	if (!error) {
+#ifdef _WIN32
+		candidates.emplace_back(tempDirectory / "obs-studio");
+#else
+		candidates.emplace_back(tempDirectory / ("obs-studio-" + std::to_string(getuid())));
+#endif
+	}
+
+	return candidates;
+}
+
+} // namespace
+
+namespace OBS {
+
+RuntimeStatus::RuntimeStatus() : processId_{currentProcessId()}, pidText_{std::to_string(processId_) + '\n'}
+{
+	initialize();
+}
+
+RuntimeStatus::~RuntimeStatus()
+{
+	shutdown();
+}
+
+void RuntimeStatus::initialize()
+{
+	const std::vector<std::filesystem::path> candidates = statusDirectoryCandidates();
+
+	for (const std::filesystem::path &directory : candidates) {
+		if (tryInitializeDirectory(directory)) {
+			blog(LOG_INFO, "Status directory: %s", statusDirectory_.u8string().c_str());
+			return;
+		}
+	}
+
+	blog(LOG_WARNING, "Failed to create status directory");
+}
+
+bool RuntimeStatus::tryInitializeDirectory(const std::filesystem::path &directory)
+{
+	if (directory.empty()) {
+		return false;
+	}
+
+	std::error_code error;
+	std::filesystem::create_directories(directory, error);
+	if (error) {
+		blog(LOG_DEBUG, "Failed to create status directory '%s': %s", directory.u8string().c_str(),
+		     error.message().c_str());
+		return false;
+	}
+
+	statusDirectory_ = directory;
+
+	const int existingPid = readPidFile(markerPath(kPidFileName));
+	if (existingPid > 0 && existingPid != processId_ && processIsAlive(existingPid)) {
+		blog(LOG_WARNING, "Status directory already in use by PID %d", existingPid);
+		statusDirectory_.clear();
+		return false;
+	}
+
+	removeStaleFiles();
+	writeMarker(kPidFileName);
+
+	if (!std::filesystem::exists(markerPath(kPidFileName), error) || error) {
+		blog(LOG_DEBUG, "Failed to write PID file in '%s'", directory.u8string().c_str());
+		statusDirectory_.clear();
+		return false;
+	}
+
+	isActive_ = true;
+	return true;
+}
+
+void RuntimeStatus::removeStaleFiles()
+{
+	removeMarker(kStreamingFileName);
+	removeMarker(kRecordingFileName);
+}
+
+void RuntimeStatus::writeMarker(const char *name)
+{
+	if (statusDirectory_.empty() || !name || !*name) {
+		return;
+	}
+
+	const std::filesystem::path path = markerPath(name);
+	if (!writeFile(path, pidText_)) {
+		blog(LOG_WARNING, "Failed to write status file '%s'", path.u8string().c_str());
+	}
+}
+
+void RuntimeStatus::removeMarker(const char *name)
+{
+	if (statusDirectory_.empty() || !name || !*name) {
+		return;
+	}
+
+	std::error_code error;
+	std::filesystem::remove(markerPath(name), error);
+}
+
+void RuntimeStatus::setMarker(const char *name, bool isActive)
+{
+	if (isActive) {
+		writeMarker(name);
+	} else {
+		removeMarker(name);
+	}
+}
+
+std::filesystem::path RuntimeStatus::markerPath(const char *name) const
+{
+	return statusDirectory_ / name;
+}
+
+void RuntimeStatus::handleFrontendEvent(enum obs_frontend_event event)
+{
+	if (!isActive_) {
+		return;
+	}
+
+	switch (event) {
+	case OBS_FRONTEND_EVENT_STREAMING_STARTED:
+		setMarker(kStreamingFileName, true);
+		break;
+
+	case OBS_FRONTEND_EVENT_STREAMING_STOPPED:
+		setMarker(kStreamingFileName, false);
+		break;
+
+	case OBS_FRONTEND_EVENT_RECORDING_STARTED:
+		setMarker(kRecordingFileName, true);
+		break;
+
+	case OBS_FRONTEND_EVENT_RECORDING_STOPPED:
+		setMarker(kRecordingFileName, false);
+		break;
+
+	case OBS_FRONTEND_EVENT_EXIT:
+		shutdown();
+		break;
+
+	default:
+		break;
+	}
+}
+
+void RuntimeStatus::shutdown() noexcept
+{
+	if (!isActive_) {
+		return;
+	}
+
+	removeMarker(kStreamingFileName);
+	removeMarker(kRecordingFileName);
+	removeMarker(kPidFileName);
+
+	isActive_ = false;
+}
+
+} // namespace OBS

--- a/frontend/utility/RuntimeStatus.hpp
+++ b/frontend/utility/RuntimeStatus.hpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+    Copyright (C) 2026 by nicolaeser <nico@laeser.software>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+******************************************************************************/
+
+#pragma once
+
+#include <obs-frontend-api.h>
+
+#include <filesystem>
+#include <string>
+
+namespace OBS {
+
+class RuntimeStatus {
+public:
+	RuntimeStatus();
+	~RuntimeStatus();
+
+	RuntimeStatus(const RuntimeStatus &) = delete;
+	RuntimeStatus &operator=(const RuntimeStatus &) = delete;
+	RuntimeStatus(RuntimeStatus &&) = delete;
+	RuntimeStatus &operator=(RuntimeStatus &&) = delete;
+
+	void handleFrontendEvent(enum obs_frontend_event event);
+	void shutdown() noexcept;
+
+private:
+	void initialize();
+	bool tryInitializeDirectory(const std::filesystem::path &directory);
+	void removeStaleFiles();
+	void writeMarker(const char *name);
+	void removeMarker(const char *name);
+	void setMarker(const char *name, bool isActive);
+	std::filesystem::path markerPath(const char *name) const;
+
+	int processId_ = 0;
+	std::string pidText_;
+	std::filesystem::path statusDirectory_;
+	bool isActive_ = false;
+};
+
+} // namespace OBS

--- a/frontend/widgets/OBSBasic.cpp
+++ b/frontend/widgets/OBSBasic.cpp
@@ -40,6 +40,7 @@
 #include <models/SceneCollection.hpp>
 #include <settings/OBSBasicSettings.hpp>
 #include <utility/QuickTransition.hpp>
+#include <utility/RuntimeStatus.hpp>
 #include <utility/SceneRenameDelegate.hpp>
 #if defined(_WIN32) || defined(WHATSNEW_ENABLED)
 #include <utility/WhatsNewInfoThread.hpp>
@@ -2193,6 +2194,10 @@ void OBSBasic::SetDisplayAffinity(QWindow *window)
 
 void OBSBasic::OnEvent(enum obs_frontend_event event)
 {
+	if (OBS::RuntimeStatus *runtimeStatus = App()->GetRuntimeStatus()) {
+		runtimeStatus->handleFrontendEvent(event);
+	}
+
 	if (api) {
 		api->on_event(event);
 	}


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
Adds runtime status files for the OBS process and for active streaming and recording outputs.

While OBS is running it writes `obs.pid`. A `streaming` file is created while streaming is active, and a `recording` file is created while recording is active. Those marker files are removed when the corresponding output stops. All files are removed on a clean shutdown.

The status directory can be overridden with `OBS_STATUS_DIR`. Otherwise OBS uses `$XDG_RUNTIME_DIR/obs-studio`, falling back to a per-user path under the system temporary directory. If a PID file for a different live process is already present, OBS does not take over that directory.

### Motivation and Context
Other programs currently have no way to observe from the filesystem whether OBS is streaming or recording. They have to attach to the UI or use obs-websocket.

A PID file and output marker files allow those programs to detect whether OBS is in use without a live API connection.

### How Has This Been Tested?
The helper is invoked from OBSApp construction and shutdown, and from `OBSBasic::OnEvent` for `STREAMING_STARTED` / `STREAMING_STOPPED`, `RECORDING_STARTED` / `RECORDING_STOPPED`, and `EXIT`.

Please verify on Linux:

- `obs.pid` is created at startup and removed on exit
- `streaming` exists only while streaming
- `recording` exists only while recording
- `OBS_STATUS_DIR` overrides the default directory

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- New feature (non-breaking change which adds functionality)

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
