### PR TITLE
frontend: Fix YouTube Auto-stop setting not being saved

### DIFF
--- a/frontend/dialogs/OBSYoutubeActions.cpp
+++ b/frontend/dialogs/OBSYoutubeActions.cpp
@@ -642,7 +642,7 @@ void OBSYoutubeActions::SaveSettings(BroadcastDescription &broadcast)
 	config_set_string(main->activeConfiguration, "YouTube", "Latency", QT_TO_UTF8(broadcast.latency));
 	config_set_bool(main->activeConfiguration, "YouTube", "MadeForKids", broadcast.made_for_kids);
 	config_set_bool(main->activeConfiguration, "YouTube", "AutoStart", broadcast.auto_start);
-	config_set_bool(main->activeConfiguration, "YouTube", "AutoStop", broadcast.auto_start);
+	config_set_bool(main->activeConfiguration, "YouTube", "AutoStop", broadcast.auto_stop);
 	config_set_bool(main->activeConfiguration, "YouTube", "DVR", broadcast.dvr);
 	config_set_bool(main->activeConfiguration, "YouTube", "ScheduleForLater", broadcast.schedul_for_later);
 	config_set_string(main->activeConfiguration, "YouTube", "Projection", QT_TO_UTF8(broadcast.projection));


### PR DESCRIPTION
### Description
`OBSYoutubeActions::SaveSettings()` persists the `YouTube` → `AutoStop` config value from `broadcast.auto_start` instead of `broadcast.auto_stop`:

```cpp
config_set_bool(main->activeConfiguration, "YouTube", "AutoStart", broadcast.auto_start);
config_set_bool(main->activeConfiguration, "YouTube", "AutoStop",  broadcast.auto_start); // should be auto_stop
```

`broadcast.auto_stop` is populated correctly from `ui->checkAutoStop` in `UiToBroadcast()`, and `LoadSettings()` reads the `AutoStop` key back into `ui->checkAutoStop`, so the only defect is this one write. This PR changes that argument to `broadcast.auto_stop`.

Spotted while working on #13185, which edits the same function; kept separate so that PR stays scoped to the language feature.

### Motivation and Context
With "Remember settings" enabled, the Auto-stop checkbox in the YouTube broadcast dialog never round-trips its own state. On the next open it silently takes the last saved Auto-start value, so a user who wants Auto-start on but Auto-stop off cannot keep that combination.

### How Has This Been Tested?
- Built the frontend target locally (Windows, RelWithDebInfo, MSVC).
- Confirmed by inspection: `UiToBroadcast()` sets `broadcast.auto_stop`, `LoadSettings()` consumes the `AutoStop` key; only the `SaveSettings()` write was wrong.
- OS: Windows 11

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.