### PR TITLE
rtmp-services: Update Twitch/IVS Ingests

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,11 +1,11 @@
 {
     "$schema": "schema/package-schema.json",
     "url": "https://obsproject.com/obs2_update/rtmp-services/v5",
-    "version": 287,
+    "version": 288,
     "files": [
         {
             "name": "services.json",
-            "version": 287
+            "version": 288
         }
     ]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -11,188 +11,56 @@
             "multitrack_video_learn_more_link": "https://help.twitch.tv/s/article/multiple-encodes",
             "servers": [
                 {
-                    "name": "Asia: Hong Kong",
-                    "url": "rtmp://live-hkg.twitch.tv/app"
+                    "name": "Asia Pacific (Mumbai)",
+                    "url": "rtmp://aps30.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Seoul, South Korea",
-                    "url": "rtmp://live-sel.twitch.tv/app"
+                    "name": "Asia Pacific (Seoul)",
+                    "url": "rtmp://apn20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Singapore",
-                    "url": "rtmp://live-sin.twitch.tv/app"
+                    "name": "Asia Pacific (Singapore)",
+                    "url": "rtmp://aps10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Taipei, Taiwan",
-                    "url": "rtmp://live-tpe.twitch.tv/app"
+                    "name": "Asia Pacific (Sydney)",
+                    "url": "rtmp://aps20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Tokyo, Japan",
-                    "url": "rtmp://live-tyo.twitch.tv/app"
+                    "name": "Asia Pacific (Tokyo)",
+                    "url": "rtmp://apn10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Australia: Sydney",
-                    "url": "rtmp://live-syd.twitch.tv/app"
+                    "name": "Europe (Frankfurt)",
+                    "url": "rtmp://euc10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: Amsterdam, NL",
-                    "url": "rtmp://live-ams.twitch.tv/app"
+                    "name": "Europe (Ireland)",
+                    "url": "rtmp://euw10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: Berlin, DE",
-                    "url": "rtmp://live-ber.twitch.tv/app"
+                    "name": "Europe (Paris)",
+                    "url": "rtmp://euw30.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: Copenhagen, DK",
-                    "url": "rtmp://live-cph.twitch.tv/app"
+                    "name": "Europe (Stockholm)",
+                    "url": "rtmp://eun10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: Frankfurt, DE",
-                    "url": "rtmp://live-fra.twitch.tv/app"
+                    "name": "South America (S\u00e3o Paulo)",
+                    "url": "rtmp://sae10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: Helsinki, FI",
-                    "url": "rtmp://live-hel.twitch.tv/app"
+                    "name": "US East (N. Virginia)",
+                    "url": "rtmp://use10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: Lisbon, Portugal",
-                    "url": "rtmp://live-lis.twitch.tv/app"
+                    "name": "US East (Ohio)",
+                    "url": "rtmp://use20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "EU: London, UK",
-                    "url": "rtmp://live-lhr.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Madrid, Spain",
-                    "url": "rtmp://live-mad.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Marseille, FR",
-                    "url": "rtmp://live-mrs.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Milan, Italy",
-                    "url": "rtmp://live-mil.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Norway, Oslo",
-                    "url": "rtmp://live-osl.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Paris, FR",
-                    "url": "rtmp://live-cdg.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Prague, CZ",
-                    "url": "rtmp://live-prg.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Stockholm, SE",
-                    "url": "rtmp://live-arn.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Vienna, Austria",
-                    "url": "rtmp://live-vie.twitch.tv/app"
-                },
-                {
-                    "name": "EU: Warsaw, Poland",
-                    "url": "rtmp://live-waw.twitch.tv/app"
-                },
-                {
-                    "name": "NA: Mexico City",
-                    "url": "rtmp://live-qro.twitch.tv/app"
-                },
-                {
-                    "name": "NA: Quebec, Canada",
-                    "url": "rtmp://live-ymq.twitch.tv/app"
-                },
-                {
-                    "name": "NA: Toronto, Canada",
-                    "url": "rtmp://live-yto.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Argentina",
-                    "url": "rtmp://live-eze.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Chile",
-                    "url": "rtmp://live-scl.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Lima, Peru",
-                    "url": "rtmp://live-lim.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Medellin, Colombia",
-                    "url": "rtmp://live-mde.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Rio de Janeiro, Brazil",
-                    "url": "rtmp://live-rio.twitch.tv/app"
-                },
-                {
-                    "name": "South America: Sao Paulo, Brazil",
-                    "url": "rtmp://live-sao.twitch.tv/app"
-                },
-                {
-                    "name": "US Central: Dallas, TX",
-                    "url": "rtmp://live-dfw.twitch.tv/app"
-                },
-                {
-                    "name": "US Central: Denver, CO",
-                    "url": "rtmp://live-den.twitch.tv/app"
-                },
-                {
-                    "name": "US Central: Houston, TX",
-                    "url": "rtmp://live-hou.twitch.tv/app"
-                },
-                {
-                    "name": "US Central: Salt Lake City, UT",
-                    "url": "rtmp://live-slc.twitch.tv/app"
-                },
-                {
-                    "name": "US East: Ashburn, VA",
-                    "url": "rtmp://live-iad.twitch.tv/app"
-                },
-                {
-                    "name": "US East: Atlanta, GA",
-                    "url": "rtmp://live-atl.twitch.tv/app"
-                },
-                {
-                    "name": "US East: Chicago",
-                    "url": "rtmp://live-ord.twitch.tv/app"
-                },
-                {
-                    "name": "US East: Miami, FL",
-                    "url": "rtmp://live-mia.twitch.tv/app"
-                },
-                {
-                    "name": "US East: New York, NY",
-                    "url": "rtmp://live-jfk.twitch.tv/app"
-                },
-                {
-                    "name": "US West: Los Angeles, CA",
-                    "url": "rtmp://live-lax.twitch.tv/app"
-                },
-                {
-                    "name": "US West: Phoenix, AZ",
-                    "url": "rtmp://live-phx.twitch.tv/app"
-                },
-                {
-                    "name": "US West: Portland, Oregon",
-                    "url": "rtmp://live-pdx.twitch.tv/app"
-                },
-                {
-                    "name": "US West: San Francisco, CA",
-                    "url": "rtmp://live-sfo.twitch.tv/app"
-                },
-                {
-                    "name": "US West: San Jose, CA",
-                    "url": "rtmp://live-sjc.twitch.tv/app"
-                },
-                {
-                    "name": "US West: Seattle, WA",
-                    "url": "rtmp://live-sea.twitch.tv/app"
+                    "name": "US West (Oregon)",
+                    "url": "rtmp://usw20.contribute.live-video.net/app/"
                 }
             ],
             "recommended": {
@@ -2727,620 +2595,108 @@
             ],
             "servers": [
                 {
-                    "name": "Asia: China, Hong Kong (6) (RTMPS)",
-                    "url": "rtmps://hkg06.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Mumbai) (RTMPS)",
+                    "url": "rtmps://aps30.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: India, Bangalore (1) (RTMPS)",
-                    "url": "rtmps://blr01.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Seoul) (RTMPS)",
+                    "url": "rtmps://apn20.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: India, Chennai (RTMPS)",
-                    "url": "rtmps://maa01.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Singapore) (RTMPS)",
+                    "url": "rtmps://aps10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: India, Hyderabad (1) (RTMPS)",
-                    "url": "rtmps://hyd01.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Sydney) (RTMPS)",
+                    "url": "rtmps://aps20.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: India, Mumbai (RTMPS)",
-                    "url": "rtmps://bom01.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Tokyo) (RTMPS)",
+                    "url": "rtmps://apn10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: India, New Delhi (RTMPS)",
-                    "url": "rtmps://del01.contribute.live-video.net/app"
+                    "name": "Europe (Frankfurt) (RTMPS)",
+                    "url": "rtmps://euc10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Indonesia, Cikarang Barat (1) (RTMPS)",
-                    "url": "rtmps://jkt01.contribute.live-video.net/app"
+                    "name": "Europe (Ireland) (RTMPS)",
+                    "url": "rtmps://euw10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Indonesia, Jakarta (2) (RTMPS)",
-                    "url": "rtmps://jkt02.contribute.live-video.net/app"
+                    "name": "Europe (Paris) (RTMPS)",
+                    "url": "rtmps://euw30.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Japan, Osaka (1) (RTMPS)",
-                    "url": "rtmps://osa01.contribute.live-video.net/app"
+                    "name": "Europe (Stockholm) (RTMPS)",
+                    "url": "rtmps://eun10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Japan, Tokyo (3) (RTMPS)",
-                    "url": "rtmps://tyo03.contribute.live-video.net/app"
+                    "name": "South America (S\u00e3o Paulo) (RTMPS)",
+                    "url": "rtmps://sae10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Japan, Tokyo (5) (RTMPS)",
-                    "url": "rtmps://tyo05.contribute.live-video.net/app"
+                    "name": "US East (N. Virginia) (RTMPS)",
+                    "url": "rtmps://use10.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Manila, Philippines (1) (RTMPS)",
-                    "url": "rtmps://mnl01.contribute.live-video.net/app"
+                    "name": "US East (Ohio) (RTMPS)",
+                    "url": "rtmps://use20.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Singapore (1) (RTMPS)",
-                    "url": "rtmps://sin01.contribute.live-video.net/app"
+                    "name": "US West (Oregon) (RTMPS)",
+                    "url": "rtmps://usw20.contribute.live-video.net:443/app/"
                 },
                 {
-                    "name": "Asia: Singapore (4) (RTMPS)",
-                    "url": "rtmps://sin04.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Mumbai) (RTMP)",
+                    "url": "rtmp://aps30.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: South Korea, Seoul (3) (RTMPS)",
-                    "url": "rtmps://sel03.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Seoul) (RTMP)",
+                    "url": "rtmp://apn20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: South Korea, Seoul (4) (RTMPS)",
-                    "url": "rtmps://sel04.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Singapore) (RTMP)",
+                    "url": "rtmp://aps10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Taiwan, Taipei (1) (RTMPS)",
-                    "url": "rtmps://tpe01.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Sydney) (RTMP)",
+                    "url": "rtmp://aps20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Taiwan, Taipei (3) (RTMPS)",
-                    "url": "rtmps://tpe03.contribute.live-video.net/app"
+                    "name": "Asia Pacific (Tokyo) (RTMP)",
+                    "url": "rtmp://apn10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Asia: Thailand, Bangkok (2) (RTMPS)",
-                    "url": "rtmps://bkk02.contribute.live-video.net/app"
+                    "name": "Europe (Frankfurt) (RTMP)",
+                    "url": "rtmp://euc10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: Austria, Vienna (2) (RTMPS)",
-                    "url": "rtmps://vie02.contribute.live-video.net/app"
+                    "name": "Europe (Ireland) (RTMP)",
+                    "url": "rtmp://euw10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: Czech Republic, Prague (RTMPS)",
-                    "url": "rtmps://prg03.contribute.live-video.net/app"
+                    "name": "Europe (Paris) (RTMP)",
+                    "url": "rtmp://euw30.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: Denmark, Copenhagen (RTMPS)",
-                    "url": "rtmps://cph.contribute.live-video.net/app"
+                    "name": "Europe (Stockholm) (RTMP)",
+                    "url": "rtmp://eun10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: Finland, Helsinki (3) (RTMPS)",
-                    "url": "rtmps://hel03.contribute.live-video.net/app"
+                    "name": "South America (S\u00e3o Paulo) (RTMP)",
+                    "url": "rtmp://sae10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: France, Marseille (RTMPS)",
-                    "url": "rtmps://mrs.contribute.live-video.net/app"
+                    "name": "US East (N. Virginia) (RTMP)",
+                    "url": "rtmp://use10.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: France, Marseille (2) (RTMPS)",
-                    "url": "rtmps://mrs02.contribute.live-video.net/app"
+                    "name": "US East (Ohio) (RTMP)",
+                    "url": "rtmp://use20.contribute.live-video.net/app/"
                 },
                 {
-                    "name": "Europe: France, Paris (10) (RTMPS)",
-                    "url": "rtmps://cdg10.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: France, Paris (2) (RTMPS)",
-                    "url": "rtmps://cdg02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Berlin (RTMPS)",
-                    "url": "rtmps://ber.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Dusseldorf (1) (RTMPS)",
-                    "url": "rtmps://dus01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (2) (RTMPS)",
-                    "url": "rtmps://fra02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (5) (RTMPS)",
-                    "url": "rtmps://fra05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (6) (RTMPS)",
-                    "url": "rtmps://fra06.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Munich (1) (RTMPS)",
-                    "url": "rtmps://muc01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Italy, Milan (2) (RTMPS)",
-                    "url": "rtmps://mil02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Netherlands, Amsterdam (2) (RTMPS)",
-                    "url": "rtmps://ams02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Netherlands, Amsterdam (3) (RTMPS)",
-                    "url": "rtmps://ams03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Norway, Oslo (RTMPS)",
-                    "url": "rtmps://osl.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Poland, Warsaw (2) (RTMPS)",
-                    "url": "rtmps://waw02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Spain, Madrid (1) (RTMPS)",
-                    "url": "rtmps://mad01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Spain, Madrid (2) (RTMPS)",
-                    "url": "rtmps://mad02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Sweden, Stockholm (3) (RTMPS)",
-                    "url": "rtmps://arn03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Sweden, Stockholm (4) (RTMPS)",
-                    "url": "rtmps://arn04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (3) (RTMPS)",
-                    "url": "rtmps://lhr03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (4) (RTMPS)",
-                    "url": "rtmps://lhr04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (8) (RTMPS)",
-                    "url": "rtmps://lhr08.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Canada, Quebec (RTMPS)",
-                    "url": "rtmps://ymq03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Canada, Toronto (RTMPS)",
-                    "url": "rtmps://yto.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Mexico, Queretaro (3) (RTMPS)",
-                    "url": "rtmps://qro03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Mexico, Queretaro (4) (RTMPS)",
-                    "url": "rtmps://qro04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Oceania: Australia, Sydney (2) (RTMPS)",
-                    "url": "rtmps://syd02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Oceania: Australia, Sydney (3) (RTMPS)",
-                    "url": "rtmps://syd03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Fortaleza (1) (RTMPS)",
-                    "url": "rtmps://for01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Rio de Janeiro (3) (RTMPS)",
-                    "url": "rtmps://rio03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Rio de Janeiro (4) (RTMPS)",
-                    "url": "rtmps://rio04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Sao Paulo (RTMPS)",
-                    "url": "rtmps://sao03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Sao Paulo (5) (RTMPS)",
-                    "url": "rtmps://sao05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Buenos Aires, Argentina (1) (RTMPS)",
-                    "url": "rtmps://bue01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Colombia, Bogota (1) (RTMPS)",
-                    "url": "rtmps://bog01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Dallas, TX (RTMPS)",
-                    "url": "rtmps://dfw.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Dallas, TX (2) (RTMPS)",
-                    "url": "rtmps://dfw02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Denver, CO (52) (RTMPS)",
-                    "url": "rtmps://den52.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Garland, TX (56) (RTMPS)",
-                    "url": "rtmps://dfw56.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Houston, TX (50) (RTMPS)",
-                    "url": "rtmps://iah50.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Ashburn, VA (5) (RTMPS)",
-                    "url": "rtmps://iad05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Atlanta, GA (RTMPS)",
-                    "url": "rtmps://atl.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Chicago, IL (3) (RTMPS)",
-                    "url": "rtmps://ord03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Chicago, IL (56) (RTMPS)",
-                    "url": "rtmps://ord56.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: McAllen, TX (1) (RTMPS)",
-                    "url": "rtmps://mfe01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Miami, FL (5) (RTMPS)",
-                    "url": "rtmps://mia05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: New York, NY (RTMPS)",
-                    "url": "rtmps://jfk.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: New York, NY (50) (RTMPS)",
-                    "url": "rtmps://jfk50.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Los Angeles, CA (RTMPS)",
-                    "url": "rtmps://lax.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Salt Lake City, UT (RTMPS)",
-                    "url": "rtmps://slc.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: San Francisco, CA (RTMPS)",
-                    "url": "rtmps://sfo.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: San Jose, California (6) (RTMPS)",
-                    "url": "rtmps://sjc06.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Seattle, WA (RTMPS)",
-                    "url": "rtmps://sea.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Seattle, WA (2) (RTMPS)",
-                    "url": "rtmps://sea02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: China, Hong Kong (6) (RTMP)",
-                    "url": "rtmp://hkg06.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: India, Bangalore (1) (RTMP)",
-                    "url": "rtmp://blr01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: India, Chennai (RTMP)",
-                    "url": "rtmp://maa01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: India, Hyderabad (1) (RTMP)",
-                    "url": "rtmp://hyd01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: India, Mumbai (RTMP)",
-                    "url": "rtmp://bom01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: India, New Delhi (RTMP)",
-                    "url": "rtmp://del01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Indonesia, Cikarang Barat (1) (RTMP)",
-                    "url": "rtmp://jkt01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Indonesia, Jakarta (2) (RTMP)",
-                    "url": "rtmp://jkt02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Japan, Osaka (1) (RTMP)",
-                    "url": "rtmp://osa01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Japan, Tokyo (3) (RTMP)",
-                    "url": "rtmp://tyo03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Japan, Tokyo (5) (RTMP)",
-                    "url": "rtmp://tyo05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Manila, Philippines (1) (RTMP)",
-                    "url": "rtmp://mnl01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Singapore (1) (RTMP)",
-                    "url": "rtmp://sin01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Singapore (4) (RTMP)",
-                    "url": "rtmp://sin04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: South Korea, Seoul (3) (RTMP)",
-                    "url": "rtmp://sel03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: South Korea, Seoul (4) (RTMP)",
-                    "url": "rtmp://sel04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Taiwan, Taipei (1) (RTMP)",
-                    "url": "rtmp://tpe01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Taiwan, Taipei (3) (RTMP)",
-                    "url": "rtmp://tpe03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Asia: Thailand, Bangkok (2) (RTMP)",
-                    "url": "rtmp://bkk02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Austria, Vienna (2) (RTMP)",
-                    "url": "rtmp://vie02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Czech Republic, Prague (RTMP)",
-                    "url": "rtmp://prg03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Denmark, Copenhagen (RTMP)",
-                    "url": "rtmp://cph.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Finland, Helsinki (3) (RTMP)",
-                    "url": "rtmp://hel03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: France, Marseille (RTMP)",
-                    "url": "rtmp://mrs.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: France, Marseille (2) (RTMP)",
-                    "url": "rtmp://mrs02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: France, Paris (10) (RTMP)",
-                    "url": "rtmp://cdg10.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: France, Paris (2) (RTMP)",
-                    "url": "rtmp://cdg02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Berlin (RTMP)",
-                    "url": "rtmp://ber.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Dusseldorf (1) (RTMP)",
-                    "url": "rtmp://dus01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (2) (RTMP)",
-                    "url": "rtmp://fra02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (5) (RTMP)",
-                    "url": "rtmp://fra05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Frankfurt (6) (RTMP)",
-                    "url": "rtmp://fra06.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Germany, Munich (1) (RTMP)",
-                    "url": "rtmp://muc01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Italy, Milan (2) (RTMP)",
-                    "url": "rtmp://mil02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Netherlands, Amsterdam (2) (RTMP)",
-                    "url": "rtmp://ams02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Netherlands, Amsterdam (3) (RTMP)",
-                    "url": "rtmp://ams03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Norway, Oslo (RTMP)",
-                    "url": "rtmp://osl.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Poland, Warsaw (2) (RTMP)",
-                    "url": "rtmp://waw02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Spain, Madrid (1) (RTMP)",
-                    "url": "rtmp://mad01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Spain, Madrid (2) (RTMP)",
-                    "url": "rtmp://mad02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Sweden, Stockholm (3) (RTMP)",
-                    "url": "rtmp://arn03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: Sweden, Stockholm (4) (RTMP)",
-                    "url": "rtmp://arn04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (3) (RTMP)",
-                    "url": "rtmp://lhr03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (4) (RTMP)",
-                    "url": "rtmp://lhr04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Europe: UK, London (8) (RTMP)",
-                    "url": "rtmp://lhr08.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Canada, Quebec (RTMP)",
-                    "url": "rtmp://ymq03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Canada, Toronto (RTMP)",
-                    "url": "rtmp://yto.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Mexico, Queretaro (3) (RTMP)",
-                    "url": "rtmp://qro03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "NA: Mexico, Queretaro (4) (RTMP)",
-                    "url": "rtmp://qro04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Oceania: Australia, Sydney (2) (RTMP)",
-                    "url": "rtmp://syd02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "Oceania: Australia, Sydney (3) (RTMP)",
-                    "url": "rtmp://syd03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Fortaleza (1) (RTMP)",
-                    "url": "rtmp://for01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Rio de Janeiro (3) (RTMP)",
-                    "url": "rtmp://rio03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Rio de Janeiro (4) (RTMP)",
-                    "url": "rtmp://rio04.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Sao Paulo (RTMP)",
-                    "url": "rtmp://sao03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Brazil, Sao Paulo (5) (RTMP)",
-                    "url": "rtmp://sao05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Buenos Aires, Argentina (1) (RTMP)",
-                    "url": "rtmp://bue01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "South America: Colombia, Bogota (1) (RTMP)",
-                    "url": "rtmp://bog01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Dallas, TX (RTMP)",
-                    "url": "rtmp://dfw.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Dallas, TX (2) (RTMP)",
-                    "url": "rtmp://dfw02.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Denver, CO (52) (RTMP)",
-                    "url": "rtmp://den52.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Garland, TX (56) (RTMP)",
-                    "url": "rtmp://dfw56.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US Central: Houston, TX (50) (RTMP)",
-                    "url": "rtmp://iah50.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Ashburn, VA (5) (RTMP)",
-                    "url": "rtmp://iad05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Atlanta, GA (RTMP)",
-                    "url": "rtmp://atl.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Chicago, IL (3) (RTMP)",
-                    "url": "rtmp://ord03.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Chicago, IL (56) (RTMP)",
-                    "url": "rtmp://ord56.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: McAllen, TX (1) (RTMP)",
-                    "url": "rtmp://mfe01.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: Miami, FL (5) (RTMP)",
-                    "url": "rtmp://mia05.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: New York, NY (RTMP)",
-                    "url": "rtmp://jfk.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US East: New York, NY (50) (RTMP)",
-                    "url": "rtmp://jfk50.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Los Angeles, CA (RTMP)",
-                    "url": "rtmp://lax.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Salt Lake City, UT (RTMP)",
-                    "url": "rtmp://slc.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: San Francisco, CA (RTMP)",
-                    "url": "rtmp://sfo.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: San Jose, California (6) (RTMP)",
-                    "url": "rtmp://sjc06.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Seattle, WA (RTMP)",
-                    "url": "rtmp://sea.contribute.live-video.net/app"
-                },
-                {
-                    "name": "US West: Seattle, WA (2) (RTMP)",
-                    "url": "rtmp://sea02.contribute.live-video.net/app"
+                    "name": "US West (Oregon) (RTMP)",
+                    "url": "rtmp://usw20.contribute.live-video.net/app/"
                 }
             ],
             "multitrack_video_configuration_url": "https://ingest.contribute.live-video.net/api/v3/GetClientConfiguration",

--- a/plugins/rtmp-services/service-specific/twitch.c
+++ b/plugins/rtmp-services/service-specific/twitch.c
@@ -42,7 +42,8 @@ void twitch_ingests_refresh(int seconds)
 
 void load_twitch_data(void)
 {
-	struct ingest def = {.name = bstrdup("Default"), .url = bstrdup("rtmp://live.twitch.tv/app")};
+	struct ingest def = {.name = bstrdup("Default"),
+			     .url = bstrdup("rtmp://ingest.global-contribute.live-video.net/app")};
 	load_service_data(&twitch, "twitch_ingests.json", &def);
 }
 


### PR DESCRIPTION
### Description

Updates the list of Twitch and IVS ingests as currently found on https://ingest.contribute.live-video.net/ingests

### Motivation and Context

The old URLs are for PoPs that no longer exist, and are redirected to new ones, but will stop working eventually.

### How Has This Been Tested?

Launched OBS, observed new server list.

### Types of changes

- Tweak (non-breaking change to improve existing functionality)

### Checklist:

- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
