### PR TITLE
win-capture: Initialize window capture immediately

### DIFF
--- a/plugins/win-capture/window-capture.c
+++ b/plugins/win-capture/window-capture.c
@@ -299,6 +299,7 @@ static bool load_winrt_imports(struct winrt_exports *exports, void *module, cons
 }
 
 extern bool graphics_uses_d3d11;
+static void force_reset(struct window_capture *wc);
 
 static void *wc_create(obs_data_t *settings, obs_source_t *source)
 {
@@ -345,6 +346,7 @@ static void *wc_create(obs_data_t *settings, obs_source_t *source)
 
 	update_settings(wc, settings);
 	log_settings(wc, settings);
+	force_reset(wc);
 	return wc;
 }
 


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->
Initialize new window capture instances through the existing update path so the first lookup is not delayed by 1 second and instead happens on the next video tick.

NOTE: I did consider that using the OBS_SOURCE_DO_NOT_DUPLICATE flag for window capture sources would also fix but I am not sure if there is a specific reason we allow duplication for window capture sources but not display capture.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->
Fixes #4878 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->
Created two scenes with the same window capture source, enabled studio mode and the duplicate sources option, and then pressed the transition button to switch between the scenes. On the current release the program scene goes black for 1 second after pressing transition, with these changes it does not.

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [] I have used AI tooling in the creation of this PR -->
<!-- - [] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
