### PR TITLE
frontend: Fix profile import with trailing path slash

### DIFF
--- a/frontend/widgets/OBSBasic_Profiles.cpp
+++ b/frontend/widgets/OBSBasic_Profiles.cpp
@@ -558,7 +558,8 @@ void OBSBasic::on_actionImportProfile_triggered()
 	const QString sourceDirectory = SelectDirectory(this, QTStr("Basic.MainMenu.Profile.Import"), home);
 
 	if (!sourceDirectory.isEmpty() && !sourceDirectory.isNull()) {
-		const std::filesystem::path sourcePath = std::filesystem::u8path(sourceDirectory.toStdString());
+		const std::filesystem::path sourcePath =
+			std::filesystem::u8path(QDir::cleanPath(sourceDirectory).toStdString());
 		const std::string directoryName = sourcePath.filename().u8string();
 
 		if (auto profile = GetProfileByDirectoryName(directoryName)) {


### PR DESCRIPTION
### Description

Normalizes the directory selected in the profile import dialog with `QDir::cleanPath()` before deriving the profile directory name from it.

### Motivation and Context

When the directory chooser returns a path with a trailing separator, `std::filesystem::path::filename()` yields an empty string. The import then uses an empty directory name, copies the profile files into the profiles root and no new profile shows up in the list.

Fixes #13862

### How Has This Been Tested?

macOS 26, Xcode build. Imported a profile from a directory path with and without a trailing slash; both now create a correctly named profile that appears in the profile menu. Importing a profile whose directory name already exists still shows the "profile exists" warning.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] My code has been run through clang-format.
- [x] I have read the [contributing](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst) document.
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed.
- [x] I have included updates to all appropriate documentation.
