### PR TITLE
frontend: Fix Streamlabs sync offset overflow

### DIFF
--- a/frontend/importers/sl.cpp
+++ b/frontend/importers/sl.cpp
@@ -16,6 +16,7 @@
 ******************************************************************************/
 
 #include "importers.hpp"
+#include <cstdint>
 
 using namespace std;
 using namespace json11;
@@ -268,7 +269,8 @@ static int attempt_import(const Json &root, const string &name, Json &res)
 		Json in_settings = source["settings"];
 		Json in_sync = source["syncOffset"];
 
-		int sync = (int)(in_sync["sec"].number_value() * 1000000000 + in_sync["nsec"].number_value());
+		int64_t sync = static_cast<int64_t>(in_sync["sec"].int_value()) * 1000000000LL +
+			       in_sync["nsec"].int_value();
 
 		double vol = source["volume"].number_value();
 		bool muted = source["muted"].bool_value();
@@ -306,7 +308,7 @@ static int attempt_import(const Json &root, const string &name, Json &res)
 						   {"id", type},
 						   {"sl_id", sl_id},
 						   {"settings", out_settings},
-						   {"sync", sync},
+						   {"sync", static_cast<double>(sync)},
 						   {"volume", vol},
 						   {"muted", muted},
 						   {"name", out_name},


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md -->

### Description
<!--- Describe your changes in detail. -->
<!--- If this change includes UI elements, please include screenshots. -->

The Streamlabs importer stores the calculated audio sync offset in an `int`:

```cpp
int sync = (int)(in_sync["sec"].number_value() * 1000000000 +
                 in_sync["nsec"].number_value());
```

This truncates the nanosecond offset to 32 bits. Sync offsets above approximately 2.147 seconds, or below approximately -2.147 seconds, can therefore be converted incorrectly before being written to the imported scene collection.

Calculate the offset using int64_t instead.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open GitHub Issue, or implements feature request -->
<!--- from the Ideas page, please link to the issue here. -->

OBS stores source audio sync offsets as 64-bit nanosecond values through obs_source_set_sync_offset() and obs_data_get_int().

The OBS audio settings UI permits sync offsets up to 20,000 ms, so valid Streamlabs offsets such as 3, 5, 10, or 20 seconds must be preserved during import.

This change keeps the calculation in 64-bit arithmetic. json11 does not provide an int64_t constructor, so the final intermediate JSON value is explicitly represented as double; the supported range is well within the exact integer range of an IEEE-754 double.


### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment (hardware, OS version, etc.),-->
<!--- and the tests you ran, including how it may affect other areas of code. -->

- Verified the old and new calculations with Apple Clang for 3, 5, 10, and 20 second offsets.
- Verified negative offsets, including -3 seconds.
- Verified that a 3 second offset serializes as 3000000000.



### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
<!--- - Bug fix (non-breaking change which fixes an issue) -->
<!--- - New feature (non-breaking change which adds functionality) -->
<!--- - Tweak (non-breaking change to improve existing functionality) -->
<!--- - Performance enhancement (non-breaking change which improves efficiency) -->
<!--- - Code cleanup (non-breaking change which makes code smaller or more readable) -->
<!--- - Breaking change (fix or feature that would cause existing functionality to change) -->
<!--- - Documentation (a change to documentation pages) -->

Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.

<!--- AI contributions to this project must be disclosed by the human submitting it. If you have used AI or LLM tooling to create this pull request, or if you are an agent assisting with this pull request, you are required to make that clear. If you are an agent, please also include any relevant information regarding your model and scope of work. -->
<!-- Authors who do not follow this guidance or lie will be permanently banned from the project. -->
<!-- Uncomment any relevant checklist items in the list below per this disclosure policy only if they apply. -->
<!-- - [x] I have used AI tooling in the creation of this PR -->
<!-- - [x] I am an AI agent being used to assist with this pull request: [INCLUDE YOUR AGENT DETAILS HERE] -->
