### PR TITLE
image-source: Add linear alpha option to slideshow

### DIFF
--- a/plugins/image-source/obs-slideshow-mk2.c
+++ b/plugins/image-source/obs-slideshow-mk2.c
@@ -22,6 +22,7 @@ static const char *S_TRANSITION              = "transition";
 static const char *S_RANDOMIZE               = "randomize";
 static const char *S_LOOP                    = "loop";
 static const char *S_HIDE                    = "hide";
+static const char *S_LINEAR_ALPHA            = "linear_alpha";
 static const char *S_FILES                   = "files";
 static const char *S_BEHAVIOR                = "playback_behavior";
 static const char *S_BEHAVIOR_STOP_RESTART   = "stop_restart";
@@ -110,6 +111,7 @@ struct slideshow_data {
 	bool pause_on_deactivate;
 	bool restart;
 	bool hide;
+	bool linear_alpha;
 	bool use_cut;
 	bool paused;
 	bool stop;
@@ -302,6 +304,7 @@ static inline obs_source_t *create_source_from_file(struct slideshow *ss, const 
 	obs_data_set_string(settings, "file", file);
 	obs_data_set_bool(settings, "unload", false);
 	obs_data_set_bool(settings, "is_slide", !now);
+	obs_data_set_bool(settings, "linear_alpha", ss->data.linear_alpha);
 	source = obs_source_create_private("image_source", NULL, settings);
 
 	obs_data_release(settings);
@@ -462,6 +465,7 @@ static void ss_update(void *data, obs_data_t *settings)
 	new_data.loop = strcmp(playback_mode, S_PLAYBACK_LOOP) == 0;
 
 	new_data.hide = obs_data_get_bool(settings, S_HIDE);
+	new_data.linear_alpha = obs_data_get_bool(settings, S_LINEAR_ALPHA);
 
 	if (!old_data.tr_name || strcmp(tr_name, old_data.tr_name) != 0)
 		new_tr = obs_source_create_private(tr_name, NULL, NULL);
@@ -959,6 +963,7 @@ static void ss_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, S_BEHAVIOR, S_BEHAVIOR_ALWAYS_PLAY);
 	obs_data_set_default_string(settings, S_MODE, S_MODE_AUTO);
 	obs_data_set_default_string(settings, S_PLAYBACK_MODE, S_PLAYBACK_LOOP);
+	obs_data_set_default_bool(settings, S_LINEAR_ALPHA, false);
 }
 
 static const char *file_filter = "Image files (*.bmp *.tga *.png *.jpeg *.jpg"
@@ -1013,6 +1018,7 @@ static obs_properties_t *ss_properties(void *data)
 	obs_property_list_add_string(p, T_PLAYBACK_RANDOM, S_PLAYBACK_RANDOM);
 
 	obs_properties_add_bool(ppts, S_HIDE, T_HIDE);
+	obs_properties_add_bool(ppts, S_LINEAR_ALPHA, obs_module_text("LinearAlpha"));
 
 	p = obs_properties_add_list(ppts, S_CUSTOM_SIZE, T_CUSTOM_SIZE, OBS_COMBO_TYPE_EDITABLE,
 				    OBS_COMBO_FORMAT_STRING);

--- a/plugins/image-source/obs-slideshow.c
+++ b/plugins/image-source/obs-slideshow.c
@@ -18,6 +18,7 @@
 #define S_RANDOMIZE                    "randomize"
 #define S_LOOP                         "loop"
 #define S_HIDE                         "hide"
+#define S_LINEAR_ALPHA                 "linear_alpha"
 #define S_FILES                        "files"
 #define S_BEHAVIOR                     "playback_behavior"
 #define S_BEHAVIOR_STOP_RESTART        "stop_restart"
@@ -88,6 +89,7 @@ struct slideshow {
 	bool restart;
 	bool manual;
 	bool hide;
+	bool linear_alpha;
 	bool use_cut;
 	bool paused;
 	bool stop;
@@ -157,13 +159,14 @@ static obs_source_t *get_source(image_file_array_t *files, const char *path)
 	return source;
 }
 
-static obs_source_t *create_source_from_file(const char *file)
+static obs_source_t *create_source_from_file(const char *file, bool linear_alpha)
 {
 	obs_data_t *settings = obs_data_create();
 	obs_source_t *source;
 
 	obs_data_set_string(settings, "file", file);
 	obs_data_set_bool(settings, "unload", false);
+	obs_data_set_bool(settings, "linear_alpha", linear_alpha);
 	source = obs_source_create_private("image_source", NULL, settings);
 
 	obs_data_release(settings);
@@ -200,19 +203,23 @@ static const char *ss_getname(void *unused)
 	return obs_module_text("SlideShow");
 }
 
-static void add_file(struct slideshow *ss, image_file_array_t *new_files, const char *path, uint32_t *cx, uint32_t *cy)
+static void add_file(struct slideshow *ss, image_file_array_t *new_files, const char *path, uint32_t *cx, uint32_t *cy,
+		     bool reuse_old)
 {
 	struct image_file_data data;
-	obs_source_t *new_source;
+	obs_source_t *new_source = NULL;
 
-	pthread_mutex_lock(&ss->mutex);
-	new_source = get_source(&ss->files, path);
-	pthread_mutex_unlock(&ss->mutex);
+	/* Don't reuse old sources when linear_alpha changed. */
+	if (reuse_old) {
+		pthread_mutex_lock(&ss->mutex);
+		new_source = get_source(&ss->files, path);
+		pthread_mutex_unlock(&ss->mutex);
+	}
 
 	if (!new_source)
 		new_source = get_source(new_files, path);
 	if (!new_source)
-		new_source = create_source_from_file(path);
+		new_source = create_source_from_file(path, ss->linear_alpha);
 
 	if (new_source) {
 		uint32_t new_cx = obs_source_get_width(new_source);
@@ -324,6 +331,9 @@ static void ss_update(void *data, obs_data_t *settings)
 	ss->randomize = obs_data_get_bool(settings, S_RANDOMIZE);
 	ss->loop = obs_data_get_bool(settings, S_LOOP);
 	ss->hide = obs_data_get_bool(settings, S_HIDE);
+	bool new_linear_alpha = obs_data_get_bool(settings, S_LINEAR_ALPHA);
+	bool reuse_old = (ss->linear_alpha == new_linear_alpha);
+	ss->linear_alpha = new_linear_alpha;
 
 	if (!ss->tr_name || strcmp(tr_name, ss->tr_name) != 0)
 		new_tr = obs_source_create_private(tr_name, NULL, NULL);
@@ -369,7 +379,7 @@ static void ss_update(void *data, obs_data_t *settings)
 				dstr_copy(&dir_path, path);
 				dstr_cat_ch(&dir_path, '/');
 				dstr_cat(&dir_path, ent->d_name);
-				add_file(ss, &new_files, dir_path.array, &cx, &cy);
+				add_file(ss, &new_files, dir_path.array, &cx, &cy, reuse_old);
 
 				if (ss->mem_usage >= MAX_MEM_USAGE)
 					break;
@@ -378,7 +388,7 @@ static void ss_update(void *data, obs_data_t *settings)
 			dstr_free(&dir_path);
 			os_closedir(dir);
 		} else {
-			add_file(ss, &new_files, path, &cx, &cy);
+			add_file(ss, &new_files, path, &cx, &cy, reuse_old);
 		}
 
 		obs_data_release(item);
@@ -848,6 +858,7 @@ static void ss_defaults(obs_data_t *settings)
 	obs_data_set_default_string(settings, S_BEHAVIOR, S_BEHAVIOR_ALWAYS_PLAY);
 	obs_data_set_default_string(settings, S_MODE, S_MODE_AUTO);
 	obs_data_set_default_bool(settings, S_LOOP, true);
+	obs_data_set_default_bool(settings, S_LINEAR_ALPHA, false);
 }
 
 static const char *file_filter = "Image files (*.bmp *.tga *.png *.jpeg *.jpg"
@@ -902,6 +913,7 @@ static obs_properties_t *ss_properties(void *data)
 	obs_properties_add_bool(ppts, S_LOOP, T_LOOP);
 	obs_properties_add_bool(ppts, S_HIDE, T_HIDE);
 	obs_properties_add_bool(ppts, S_RANDOMIZE, T_RANDOMIZE);
+	obs_properties_add_bool(ppts, S_LINEAR_ALPHA, obs_module_text("LinearAlpha"));
 
 	p = obs_properties_add_list(ppts, S_CUSTOM_SIZE, T_CUSTOM_SIZE, OBS_COMBO_TYPE_EDITABLE,
 				    OBS_COMBO_FORMAT_STRING);


### PR DESCRIPTION
**TL;DR**

Surfaces the existing "Apply alpha in linear space" (`linear_alpha`) option on the slideshow source, matching the Image and Color sources, and forwards it to the private `image_source` child that renders each slide. Reuses the existing setting key and locale string (no new strings); default `false`, so existing scene collections are unchanged.

### Description

The slideshow already renders every slide through a private `image_source`, which has long offered an "Apply alpha in linear space" toggle (`linear_alpha`), but the slideshow itself did not expose it. This surfaces the same toggle on the slideshow and forwards it to those children, so a slideshow of PNGs with semi-transparent or anti-aliased edges composites identically to the same file shown through an Image source. It reuses the image source's existing `linear_alpha` setting key and its `LinearAlpha` locale string (same module), so no new strings are added.

Notes for reviewers:

- Current-generation slideshow (`obs-slideshow-mk2.c`): rebuilds all child sources on every `update`, so it picks up the new value with no extra handling.
- Obsolete slideshow (`obs-slideshow.c`): caches child sources across updates, so it additionally skips reusing a cached child when the toggle changes, ensuring the new premultiply mode actually takes effect.
- **Independence w.r.t. #13380 (legacy slideshow removal):** the two sources are separate, self-contained hunks. The current-slideshow change does not depend on the obsolete source in any way. If `obs-slideshow.c` is removed by #13380, only its hunk goes away — the option on the current slideshow is unaffected, and this PR rebases over that removal with no functional change. The obsolete-source hunk is included only so users still on that source get the same behavior until it is retired.

### Motivation and Context

The Image and Color sources expose "Apply alpha in linear space", but the slideshow did not, so there was no way to get consistent alpha handling between a slideshow and an Image source showing the same file. Users worked around it by replacing a slideshow with a stack of Image sources. The default is `false`, matching the image source, so existing scene collections are visually unchanged.

### How Has This Been Tested?

Built on Windows (MSVC). Toggling the option on a slideshow of PNGs with an alpha channel changes the composited semi-transparent edges to match an Image source showing the same file with the same option enabled. Default-off leaves existing slideshows unchanged.

### Types of changes

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have read the [contributing document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's style guidelines.
- [x] My code is not on the master branch.
- [x] My code has been tested.
