### PR TITLE
libobs: Add sub property group

### DIFF
--- a/docs/sphinx/reference-properties.rst
+++ b/docs/sphinx/reference-properties.rst
@@ -610,9 +610,10 @@ Property Enumeration Functions
 
   :return: One of the following values:
 
-            - OBS_COMBO_INVALID
+            - OBS_GROUP_INVALID
             - OBS_GROUP_NORMAL
             - OBS_GROUP_CHECKABLE
+            - OBS_GROUP_SUB
 
 ---------------------
 

--- a/libobs/obs-properties.c
+++ b/libobs/obs-properties.c
@@ -309,7 +309,7 @@ obs_property_t *obs_properties_get(obs_properties_t *props, const char *name)
 
 	/* Recursively check groups as well, if any */
 	HASH_ITER (hh, props->properties, property, tmp) {
-		if (property->type != OBS_PROPERTY_GROUP)
+		if (property->type != OBS_PROPERTY_GROUP || obs_property_group_type(property) == OBS_GROUP_SUB)
 			continue;
 
 		obs_properties_t *group = obs_property_group_content(property);
@@ -349,25 +349,45 @@ void obs_properties_remove_by_name(obs_properties_t *props, const char *name)
 		return;
 
 	HASH_ITER (hh, props->properties, cur, tmp) {
-		if (cur->type != OBS_PROPERTY_GROUP)
+		if (cur->type != OBS_PROPERTY_GROUP || obs_property_group_type(cur) == OBS_GROUP_SUB)
 			continue;
 
 		obs_properties_remove_by_name(obs_property_group_content(cur), name);
 	}
 }
 
-typedef DARRAY(struct obs_property *) obs_property_da_t;
+struct obs_propert_setting {
+	struct obs_property *property;
+	obs_data_t *settings;
+};
 
-void obs_properties_apply_settings_internal(obs_properties_t *props, obs_property_da_t *properties_with_callback)
+typedef DARRAY(struct obs_propert_setting) obs_property_setting_da_t;
+
+void obs_properties_apply_settings_internal(obs_properties_t *props, obs_data_t *settings,
+					    obs_property_setting_da_t *properties_with_callback)
 {
 	struct obs_property *p = props->properties;
 
 	while (p) {
 		if (p->type == OBS_PROPERTY_GROUP) {
-			obs_properties_apply_settings_internal(obs_property_group_content(p), properties_with_callback);
+			if (obs_property_group_type(p) == OBS_GROUP_SUB) {
+				obs_data_t *sub_settings = obs_data_get_obj(settings, p->name);
+				if (!sub_settings) {
+					sub_settings = obs_data_create();
+					obs_data_set_obj(settings, p->name, sub_settings);
+				}
+				obs_properties_apply_settings_internal(obs_property_group_content(p), sub_settings,
+								       properties_with_callback);
+				obs_data_release(sub_settings);
+			} else {
+				obs_properties_apply_settings_internal(obs_property_group_content(p), settings,
+								       properties_with_callback);
+			}
 		}
-		if (p->modified || p->modified2)
-			da_push_back((*properties_with_callback), &p);
+		if (p->modified || p->modified2) {
+			struct obs_propert_setting ps = {.property = p, .settings = settings};
+			da_push_back((*properties_with_callback), &ps);
+		}
 
 		p = p->hh.next;
 	}
@@ -378,17 +398,18 @@ void obs_properties_apply_settings(obs_properties_t *props, obs_data_t *settings
 	if (!props)
 		return;
 
-	obs_property_da_t properties_with_callback;
+	obs_property_setting_da_t properties_with_callback;
 	da_init(properties_with_callback);
 
-	obs_properties_apply_settings_internal(props, &properties_with_callback);
+	obs_properties_apply_settings_internal(props, settings, &properties_with_callback);
 
 	while (properties_with_callback.num > 0) {
-		struct obs_property *p = *(struct obs_property **)da_end(properties_with_callback);
+		struct obs_propert_setting setting = *(struct obs_propert_setting *)da_end(properties_with_callback);
+		struct obs_property *p = setting.property;
 		if (p->modified)
-			p->modified(props, p, settings);
+			p->modified(props, p, setting.settings);
 		else if (p->modified2)
-			p->modified2(p->priv, props, p, settings);
+			p->modified2(p->priv, props, p, setting.settings);
 		da_pop_back(properties_with_callback);
 	}
 
@@ -477,7 +498,7 @@ static inline bool contains_prop(struct obs_properties *props, const char *name)
 		return false;
 
 	HASH_ITER (hh, props->properties, p, tmp) {
-		if (p->type != OBS_PROPERTY_GROUP)
+		if (p->type != OBS_PROPERTY_GROUP || obs_property_group_type(p) == OBS_GROUP_SUB)
 			continue;
 		if (contains_prop(obs_property_group_content(p), name))
 			return true;
@@ -744,7 +765,7 @@ obs_property_t *obs_properties_add_group(obs_properties_t *props, const char *na
 		return NULL;
 
 	/* Prevent duplicate properties */
-	if (check_property_group_duplicates(props, group))
+	if (type != OBS_GROUP_SUB && check_property_group_duplicates(props, group))
 		return NULL;
 
 	obs_property_t *p = new_prop(props, name, desc, OBS_PROPERTY_GROUP);
@@ -1393,7 +1414,7 @@ struct media_frames_per_second obs_property_frame_rate_fps_range_max(obs_propert
 enum obs_group_type obs_property_group_type(obs_property_t *p)
 {
 	struct group_data *data = get_type_data(p, OBS_PROPERTY_GROUP);
-	return data ? data->type : OBS_COMBO_INVALID;
+	return data ? data->type : OBS_GROUP_INVALID;
 }
 
 obs_properties_t *obs_property_group_content(obs_property_t *p)

--- a/libobs/obs-properties.h
+++ b/libobs/obs-properties.h
@@ -105,9 +105,10 @@ enum obs_number_type {
 };
 
 enum obs_group_type {
-	OBS_COMBO_INVALID,
+	OBS_GROUP_INVALID,
 	OBS_GROUP_NORMAL,
 	OBS_GROUP_CHECKABLE,
+	OBS_GROUP_SUB,
 };
 
 enum obs_button_type {

--- a/shared/properties-view/properties-view.cpp
+++ b/shared/properties-view/properties-view.cpp
@@ -137,7 +137,7 @@ void OBSPropertiesView::RefreshProperties()
 	bool hasNoProperties = !property;
 
 	while (property) {
-		AddProperty(property, layout);
+		AddProperty(property, layout, settings);
 		obs_property_next(&property);
 	}
 
@@ -253,11 +253,12 @@ void OBSPropertiesView::resizeEvent(QResizeEvent *event)
 }
 
 template<typename Sender, typename SenderParent, typename... Args>
-QWidget *OBSPropertiesView::NewWidget(obs_property_t *prop, Sender *widget, void (SenderParent::*signal)(Args...))
+QWidget *OBSPropertiesView::NewWidget(obs_property_t *prop, Sender *widget, void (SenderParent::*signal)(Args...),
+				      obs_data_t *settings)
 {
 	const char *long_desc = obs_property_long_description(prop);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, widget);
+	WidgetInfo *info = new WidgetInfo(this, prop, widget, settings);
 	QObject::connect(widget, signal, info, &WidgetInfo::ControlChanged);
 	children.emplace_back(info);
 
@@ -265,7 +266,7 @@ QWidget *OBSPropertiesView::NewWidget(obs_property_t *prop, Sender *widget, void
 	return widget;
 }
 
-QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
+QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *desc = obs_property_description(prop);
@@ -276,9 +277,9 @@ QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
 	checkbox->setCheckState(val ? Qt::Checked : Qt::Unchecked);
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
-	QWidget *widget = NewWidget(prop, checkbox, &QCheckBox::checkStateChanged);
+	QWidget *widget = NewWidget(prop, checkbox, &QCheckBox::checkStateChanged, settings);
 #else
-	QWidget *widget = NewWidget(prop, checkbox, &QCheckBox::stateChanged);
+	QWidget *widget = NewWidget(prop, checkbox, &QCheckBox::stateChanged, settings);
 #endif
 
 	if (!long_desc) {
@@ -308,7 +309,7 @@ QWidget *OBSPropertiesView::AddCheckbox(obs_property_t *prop)
 	return widget;
 }
 
-QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, QLabel *&label)
+QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
@@ -319,7 +320,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, Q
 		OBSPlainTextEdit *edit = new OBSPlainTextEdit(this, monospace);
 		edit->setPlainText(QT_UTF8(val));
 		edit->setTabStopDistance(40);
-		return NewWidget(prop, edit, &OBSPlainTextEdit::textChanged);
+		return NewWidget(prop, edit, &OBSPlainTextEdit::textChanged, settings);
 
 	} else if (type == OBS_TEXT_PASSWORD) {
 		QLayout *subLayout = new QHBoxLayout();
@@ -334,7 +335,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, Q
 		subLayout->addWidget(edit);
 		subLayout->addWidget(show);
 
-		WidgetInfo *info = new WidgetInfo(this, prop, edit);
+		WidgetInfo *info = new WidgetInfo(this, prop, edit, settings);
 		connect(show, &QAbstractButton::toggled, info, &WidgetInfo::TogglePasswordText);
 		connect(show, &QAbstractButton::toggled, show,
 			[=](bool hide) { show->setText(hide ? tr("Hide") : tr("Show")); });
@@ -386,7 +387,7 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, Q
 			label->setObjectName(info_label->objectName());
 		}
 
-		WidgetInfo *info = new WidgetInfo(this, prop, info_label);
+		WidgetInfo *info = new WidgetInfo(this, prop, info_label, settings);
 		children.emplace_back(info);
 
 		layout->addRow(label, info_label);
@@ -399,10 +400,10 @@ QWidget *OBSPropertiesView::AddText(obs_property_t *prop, QFormLayout *layout, Q
 	edit->setText(QT_UTF8(val));
 	edit->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
-	return NewWidget(prop, edit, &QLineEdit::textEdited);
+	return NewWidget(prop, edit, &QLineEdit::textEdited, settings);
 }
 
-void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label)
+void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	const char *val = obs_data_get_string(settings, name);
@@ -422,7 +423,7 @@ void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout, QLabe
 	subLayout->addWidget(edit);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, edit);
+	WidgetInfo *info = new WidgetInfo(this, prop, edit, settings);
 	connect(button, &QPushButton::clicked, info, &WidgetInfo::ControlChanged);
 	children.emplace_back(info);
 
@@ -430,7 +431,7 @@ void OBSPropertiesView::AddPath(obs_property_t *prop, QFormLayout *layout, QLabe
 	layout->addRow(*label, subLayout);
 }
 
-void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label)
+void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings)
 {
 	obs_number_type type = obs_property_int_type(prop);
 	QLayout *subLayout = new QHBoxLayout();
@@ -453,7 +454,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout, QLabel
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
 
-	WidgetInfo *info = new WidgetInfo(this, prop, spin);
+	WidgetInfo *info = new WidgetInfo(this, prop, spin, settings);
 	children.emplace_back(info);
 
 	if (type == OBS_NUMBER_SLIDER) {
@@ -478,7 +479,7 @@ void OBSPropertiesView::AddInt(obs_property_t *prop, QFormLayout *layout, QLabel
 	layout->addRow(*label, subLayout);
 }
 
-void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout, QLabel **label)
+void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings)
 {
 	obs_number_type type = obs_property_float_type(prop);
 	QLayout *subLayout = new QHBoxLayout();
@@ -511,7 +512,7 @@ void OBSPropertiesView::AddFloat(obs_property_t *prop, QFormLayout *layout, QLab
 	spin->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 	spin->setSuffix(QT_UTF8(suffix));
 
-	WidgetInfo *info = new WidgetInfo(this, prop, spin);
+	WidgetInfo *info = new WidgetInfo(this, prop, spin, settings);
 	children.emplace_back(info);
 
 	if (type == OBS_NUMBER_SLIDER) {
@@ -626,7 +627,7 @@ static QVariant from_obs_data_autoselect(obs_data_t *data, const char *name, obs
 	PRAGMA_WARN_POP
 }
 
-QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
+QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	obs_combo_type type = obs_property_list_type(prop);
@@ -646,7 +647,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 
 		if (count > 0) {
 			buttonGroup->setExclusive(true);
-			WidgetInfo *info = new WidgetInfo(this, prop, buttonGroup->buttons()[0]);
+			WidgetInfo *info = new WidgetInfo(this, prop, buttonGroup->buttons()[0], settings);
 			children.emplace_back(info);
 			connect(buttonGroup, &QButtonGroup::buttonClicked, info, &WidgetInfo::ControlChanged);
 		}
@@ -677,7 +678,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	}
 
 	if (type == OBS_COMBO_TYPE_EDITABLE) {
-		return NewWidget(prop, combo, &QComboBox::editTextChanged);
+		return NewWidget(prop, combo, &QComboBox::editTextChanged, settings);
 	}
 
 	if (idx != -1) {
@@ -702,7 +703,7 @@ QWidget *OBSPropertiesView::AddList(obs_property_t *prop, bool &warning)
 	QAbstractItemModel *model = combo->model();
 	warning = idx != -1 && model->flags(model->index(idx, 0)) == Qt::NoItemFlags;
 
-	WidgetInfo *info = new WidgetInfo(this, prop, combo);
+	WidgetInfo *info = new WidgetInfo(this, prop, combo, settings);
 	connect(combo, &QComboBox::currentIndexChanged, info, &WidgetInfo::ControlChanged);
 	children.emplace_back(info);
 
@@ -725,7 +726,7 @@ static void NewButton(QLayout *layout, WidgetInfo *info, const char *themeIcon, 
 	layout->addWidget(button);
 }
 
-void OBSPropertiesView::AddEditableList(obs_property_t *prop, QFormLayout *layout, QLabel *&label)
+void OBSPropertiesView::AddEditableList(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	OBSDataArrayAutoRelease array = obs_data_get_array(settings, name);
@@ -756,7 +757,7 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop, QFormLayout *layou
 		list_item->setData(Qt::UserRole, uuid);
 	}
 
-	WidgetInfo *info = new WidgetInfo(this, prop, list);
+	WidgetInfo *info = new WidgetInfo(this, prop, list, settings);
 
 	list->setDragDropMode(QAbstractItemView::InternalMove);
 	connect(list->model(), &QAbstractItemModel::rowsMoved, info, [info]() { info->EditableListChanged(); });
@@ -779,16 +780,17 @@ void OBSPropertiesView::AddEditableList(obs_property_t *prop, QFormLayout *layou
 	layout->addRow(label, subLayout);
 }
 
-QWidget *OBSPropertiesView::AddButton(obs_property_t *prop)
+QWidget *OBSPropertiesView::AddButton(obs_property_t *prop, obs_data_t *settings)
 {
 	const char *desc = obs_property_description(prop);
 
 	QPushButton *button = new QPushButton(QT_UTF8(desc));
 	button->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
-	return NewWidget(prop, button, &QPushButton::clicked);
+	return NewWidget(prop, button, &QPushButton::clicked, settings);
 }
 
-void OBSPropertiesView::AddColorInternal(obs_property_t *prop, QFormLayout *layout, QLabel *&label, bool supportAlpha)
+void OBSPropertiesView::AddColorInternal(obs_property_t *prop, QFormLayout *layout, QLabel *&label, bool supportAlpha,
+					 obs_data_t *settings)
 {
 	QPushButton *button = new QPushButton;
 	QLabel *colorLabel = new QLabel;
@@ -829,7 +831,7 @@ void OBSPropertiesView::AddColorInternal(obs_property_t *prop, QFormLayout *layo
 	subLayout->addWidget(colorLabel);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, colorLabel);
+	WidgetInfo *info = new WidgetInfo(this, prop, colorLabel, settings);
 	connect(button, &QPushButton::clicked, info, &WidgetInfo::ControlChanged);
 	children.emplace_back(info);
 
@@ -837,14 +839,14 @@ void OBSPropertiesView::AddColorInternal(obs_property_t *prop, QFormLayout *layo
 	layout->addRow(label, subLayout);
 }
 
-void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout, QLabel *&label)
+void OBSPropertiesView::AddColor(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings)
 {
-	AddColorInternal(prop, layout, label, false);
+	AddColorInternal(prop, layout, label, false, settings);
 }
 
-void OBSPropertiesView::AddColorAlpha(obs_property_t *prop, QFormLayout *layout, QLabel *&label)
+void OBSPropertiesView::AddColorAlpha(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings)
 {
-	AddColorInternal(prop, layout, label, true);
+	AddColorInternal(prop, layout, label, true, settings);
 }
 
 void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
@@ -886,7 +888,7 @@ void MakeQFont(obs_data_t *font_obj, QFont &font, bool limit = false)
 	}
 }
 
-void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label)
+void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	OBSDataAutoRelease font_obj = obs_data_get_obj(settings, name);
@@ -919,7 +921,7 @@ void OBSPropertiesView::AddFont(obs_property_t *prop, QFormLayout *layout, QLabe
 	subLayout->addWidget(fontLabel);
 	subLayout->addWidget(button);
 
-	WidgetInfo *info = new WidgetInfo(this, prop, fontLabel);
+	WidgetInfo *info = new WidgetInfo(this, prop, fontLabel, settings);
 	connect(button, &QPushButton::clicked, info, &WidgetInfo::ControlChanged);
 	children.emplace_back(info);
 
@@ -1388,7 +1390,8 @@ static void UpdateFPSLabels(OBSFrameRatePropertyWidget *w)
 	w->timePerFrame->setText(QString("Frame Interval: %1 ms").arg(convert_to_frame_interval(*valid_fps) * 1000));
 }
 
-void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormLayout *layout, QLabel *&label)
+void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormLayout *layout, QLabel *&label,
+				     obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
 	bool enabled = obs_property_enabled(prop);
@@ -1414,7 +1417,7 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 	int selector_mode = obs_data_get_int(settings, "fps_selector_mode");
 
 	auto widget = CreateFrameRateWidget(prop, warning, option, selector_mode, valid_fps, fps_ranges);
-	auto info = new WidgetInfo(this, prop, widget);
+	auto info = new WidgetInfo(this, prop, widget, settings);
 
 	widget->setToolTip(QT_UTF8(obs_property_long_description(prop)));
 
@@ -1487,17 +1490,20 @@ void OBSPropertiesView::AddFrameRate(obs_property_t *prop, bool &warning, QFormL
 	});
 }
 
-void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
+void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout, obs_data_t *settings)
 {
 	const char *name = obs_property_name(prop);
-	bool val = obs_data_get_bool(settings, name);
 	const char *desc = obs_property_description(prop);
 	enum obs_group_type type = obs_property_group_type(prop);
 
 	// Create GroupBox
 	QGroupBox *groupBox = new QGroupBox(QT_UTF8(desc));
-	groupBox->setCheckable(type == OBS_GROUP_CHECKABLE);
-	groupBox->setChecked(groupBox->isCheckable() ? val : true);
+	if (type == OBS_GROUP_CHECKABLE) {
+		groupBox->setCheckable(true);
+		groupBox->setChecked(obs_data_get_bool(settings, name));
+	} else {
+		groupBox->setCheckable(false);
+	}
 	groupBox->setAccessibleName("group");
 	groupBox->setEnabled(obs_property_enabled(prop));
 
@@ -1506,10 +1512,20 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 	subLayout->setFieldGrowthPolicy(QFormLayout::AllNonFixedFieldsGrow);
 	groupBox->setLayout(subLayout);
 
+	obs_data_t *subSettings = settings;
+	if (type == OBS_GROUP_SUB) {
+		subSettings = obs_data_get_obj(settings, name);
+		if (!subSettings) {
+			subSettings = obs_data_create();
+			obs_data_set_obj(settings, name, subSettings);
+		}
+		obs_data_release(subSettings);
+	}
+
 	obs_properties_t *content = obs_property_group_content(prop);
 	obs_property_t *el = obs_properties_first(content);
 	while (el != nullptr) {
-		AddProperty(el, subLayout);
+		AddProperty(el, subLayout, subSettings);
 		obs_property_next(&el);
 	}
 
@@ -1517,14 +1533,14 @@ void OBSPropertiesView::AddGroup(obs_property_t *prop, QFormLayout *layout)
 	layout->setWidget(layout->rowCount(), QFormLayout::ItemRole::SpanningRole, groupBox);
 
 	// Register Group Widget
-	WidgetInfo *info = new WidgetInfo(this, prop, groupBox);
+	WidgetInfo *info = new WidgetInfo(this, prop, groupBox, settings);
 	children.emplace_back(info);
 
 	// Signals
 	connect(groupBox, &QGroupBox::toggled, info, &WidgetInfo::ControlChanged);
 }
 
-void OBSPropertiesView::AddProperty(obs_property_t *property, QFormLayout *layout)
+void OBSPropertiesView::AddProperty(obs_property_t *property, QFormLayout *layout, obs_data_t *settings)
 {
 	const char *name = obs_property_name(property);
 	obs_property_type type = obs_property_get_type(property);
@@ -1541,43 +1557,43 @@ void OBSPropertiesView::AddProperty(obs_property_t *property, QFormLayout *layou
 	case OBS_PROPERTY_INVALID:
 		return;
 	case OBS_PROPERTY_BOOL:
-		widget = AddCheckbox(property);
+		widget = AddCheckbox(property, settings);
 		break;
 	case OBS_PROPERTY_INT:
-		AddInt(property, layout, &label);
+		AddInt(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_FLOAT:
-		AddFloat(property, layout, &label);
+		AddFloat(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_TEXT:
-		widget = AddText(property, layout, label);
+		widget = AddText(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_PATH:
-		AddPath(property, layout, &label);
+		AddPath(property, layout, &label, settings);
 		break;
 	case OBS_PROPERTY_LIST:
-		widget = AddList(property, warning);
+		widget = AddList(property, warning, settings);
 		break;
 	case OBS_PROPERTY_COLOR:
-		AddColor(property, layout, label);
+		AddColor(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_FONT:
-		AddFont(property, layout, label);
+		AddFont(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_BUTTON:
-		widget = AddButton(property);
+		widget = AddButton(property, settings);
 		break;
 	case OBS_PROPERTY_EDITABLE_LIST:
-		AddEditableList(property, layout, label);
+		AddEditableList(property, layout, label, settings);
 		break;
 	case OBS_PROPERTY_FRAME_RATE:
-		AddFrameRate(property, warning, layout, label);
+		AddFrameRate(property, warning, layout, label, settings);
 		break;
 	case OBS_PROPERTY_GROUP:
-		AddGroup(property, layout);
+		AddGroup(property, layout, settings);
 		break;
 	case OBS_PROPERTY_COLOR_ALPHA:
-		AddColorAlpha(property, layout, label);
+		AddColorAlpha(property, layout, label, settings);
 	}
 
 	if (!widget && !label) {
@@ -1690,7 +1706,7 @@ static bool FrameRateChangedRational(OBSFrameRatePropertyWidget *w, obs_data_ite
 	return true;
 }
 
-static bool FrameRateChanged(QWidget *widget, const char *name, OBSData &settings)
+static bool FrameRateChanged(QWidget *widget, const char *name, obs_data_t *settings)
 {
 	auto w = qobject_cast<OBSFrameRatePropertyWidget *>(widget);
 	if (!w) {
@@ -1762,19 +1778,19 @@ static bool FrameRateChanged(QWidget *widget, const char *name, OBSData &setting
 void WidgetInfo::BoolChanged(const char *setting)
 {
 	QCheckBox *checkbox = static_cast<QCheckBox *>(widget);
-	obs_data_set_bool(view->settings, setting, checkbox->checkState() == Qt::Checked);
+	obs_data_set_bool(settings, setting, checkbox->checkState() == Qt::Checked);
 }
 
 void WidgetInfo::IntChanged(const char *setting)
 {
 	QSpinBox *spin = static_cast<QSpinBox *>(widget);
-	obs_data_set_int(view->settings, setting, spin->value());
+	obs_data_set_int(settings, setting, spin->value());
 }
 
 void WidgetInfo::FloatChanged(const char *setting)
 {
 	QDoubleSpinBox *spin = static_cast<QDoubleSpinBox *>(widget);
-	obs_data_set_double(view->settings, setting, spin->value());
+	obs_data_set_double(settings, setting, spin->value());
 }
 
 void WidgetInfo::TextChanged(const char *setting)
@@ -1783,12 +1799,12 @@ void WidgetInfo::TextChanged(const char *setting)
 
 	if (type == OBS_TEXT_MULTILINE) {
 		OBSPlainTextEdit *edit = static_cast<OBSPlainTextEdit *>(widget);
-		obs_data_set_string(view->settings, setting, QT_TO_UTF8(edit->toPlainText()));
+		obs_data_set_string(settings, setting, QT_TO_UTF8(edit->toPlainText()));
 		return;
 	}
 
 	QLineEdit *edit = static_cast<QLineEdit *>(widget);
-	obs_data_set_string(view->settings, setting, QT_TO_UTF8(edit->text()));
+	obs_data_set_string(settings, setting, QT_TO_UTF8(edit->text()));
 }
 
 bool WidgetInfo::PathChanged(const char *setting)
@@ -1825,7 +1841,7 @@ bool WidgetInfo::PathChanged(const char *setting)
 	}
 
 	edit->setText(path);
-	obs_data_set_string(view->settings, setting, QT_TO_UTF8(path));
+	obs_data_set_string(settings, setting, QT_TO_UTF8(path));
 	return true;
 }
 
@@ -1855,16 +1871,16 @@ void WidgetInfo::ListChanged(const char *setting)
 	case OBS_COMBO_FORMAT_INVALID:
 		return;
 	case OBS_COMBO_FORMAT_INT:
-		obs_data_set_int(view->settings, setting, data.value<long long>());
+		obs_data_set_int(settings, setting, data.value<long long>());
 		break;
 	case OBS_COMBO_FORMAT_FLOAT:
-		obs_data_set_double(view->settings, setting, data.value<double>());
+		obs_data_set_double(settings, setting, data.value<double>());
 		break;
 	case OBS_COMBO_FORMAT_STRING:
-		obs_data_set_string(view->settings, setting, data.toByteArray().constData());
+		obs_data_set_string(settings, setting, data.toByteArray().constData());
 		break;
 	case OBS_COMBO_FORMAT_BOOL:
-		obs_data_set_bool(view->settings, setting, data.value<double>());
+		obs_data_set_bool(settings, setting, data.value<double>());
 		break;
 	}
 }
@@ -1872,7 +1888,7 @@ void WidgetInfo::ListChanged(const char *setting)
 bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 {
 	const char *desc = obs_property_description(property);
-	long long val = obs_data_get_int(view->settings, setting);
+	long long val = obs_data_get_int(settings, setting);
 	QColor color = color_from_int(val);
 	QColor::NameFormat format;
 
@@ -1913,7 +1929,7 @@ bool WidgetInfo::ColorChangedInternal(const char *setting, bool supportAlpha)
 				     .arg(palette.color(QPalette::Window).name(format))
 				     .arg(palette.color(QPalette::WindowText).name(format)));
 
-	obs_data_set_int(view->settings, setting, color_to_int(color));
+	obs_data_set_int(settings, setting, color_to_int(color));
 
 	return true;
 }
@@ -1930,7 +1946,7 @@ bool WidgetInfo::ColorAlphaChanged(const char *setting)
 
 bool WidgetInfo::FontChanged(const char *setting)
 {
-	OBSDataAutoRelease font_obj = obs_data_get_obj(view->settings, setting);
+	OBSDataAutoRelease font_obj = obs_data_get_obj(settings, setting);
 	bool success;
 	uint32_t flags;
 	QFont font;
@@ -1972,14 +1988,14 @@ bool WidgetInfo::FontChanged(const char *setting)
 	label->setFont(labelFont);
 	label->setText(QString("%1 %2").arg(font.family(), font.styleName()));
 
-	obs_data_set_obj(view->settings, setting, font_obj);
+	obs_data_set_obj(settings, setting, font_obj);
 	return true;
 }
 
 void WidgetInfo::GroupChanged(const char *setting)
 {
 	QGroupBox *groupbox = static_cast<QGroupBox *>(widget);
-	obs_data_set_bool(view->settings, setting, groupbox->isCheckable() ? groupbox->isChecked() : true);
+	obs_data_set_bool(settings, setting, groupbox->isCheckable() ? groupbox->isChecked() : true);
 }
 
 void WidgetInfo::EditableListChanged()
@@ -1998,7 +2014,7 @@ void WidgetInfo::EditableListChanged()
 		obs_data_array_push_back(array, arrayItem);
 	}
 
-	obs_data_set_array(view->settings, setting, array);
+	obs_data_set_array(settings, setting, array);
 
 	ControlChanged();
 }
@@ -2088,7 +2104,7 @@ void WidgetInfo::ControlChanged()
 	case OBS_PROPERTY_EDITABLE_LIST:
 		break;
 	case OBS_PROPERTY_FRAME_RATE:
-		if (!FrameRateChanged(widget, setting, view->settings)) {
+		if (!FrameRateChanged(widget, setting, settings)) {
 			return;
 		}
 		break;

--- a/shared/properties-view/properties-view.hpp
+++ b/shared/properties-view/properties-view.hpp
@@ -30,6 +30,7 @@ private:
 	QPointer<QTimer> update_timer;
 	bool recently_updated = false;
 	OBSData old_settings_cache;
+	obs_data_t *settings;
 
 	void BoolChanged(const char *setting);
 	void IntChanged(const char *setting);
@@ -48,10 +49,11 @@ private:
 	void TogglePasswordText(bool checked);
 
 public:
-	inline WidgetInfo(OBSPropertiesView *view_, obs_property_t *prop, QWidget *widget_)
+	inline WidgetInfo(OBSPropertiesView *view_, obs_property_t *prop, QWidget *widget_, obs_data_t *settings_)
 		: view(view_),
 		  property(prop),
-		  widget(widget_)
+		  widget(widget_),
+		  settings(settings_)
 	{
 	}
 
@@ -105,25 +107,28 @@ private:
 	bool disableScrolling = false;
 
 	template<typename Sender, typename SenderParent, typename... Args>
-	QWidget *NewWidget(obs_property_t *prop, Sender *widget, void (SenderParent::*signal)(Args...));
+	QWidget *NewWidget(obs_property_t *prop, Sender *widget, void (SenderParent::*signal)(Args...),
+			   obs_data_t *settings);
 
-	QWidget *AddCheckbox(obs_property_t *prop);
-	QWidget *AddText(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	void AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	void AddFloat(obs_property_t *prop, QFormLayout *layout, QLabel **label);
-	QWidget *AddList(obs_property_t *prop, bool &warning);
-	void AddEditableList(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	QWidget *AddButton(obs_property_t *prop);
-	void AddColorInternal(obs_property_t *prop, QFormLayout *layout, QLabel *&label, bool supportAlpha);
-	void AddColor(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	void AddColorAlpha(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label);
-	void AddFrameRate(obs_property_t *prop, bool &warning, QFormLayout *layout, QLabel *&label);
+	QWidget *AddCheckbox(obs_property_t *prop, obs_data_t *settings);
+	QWidget *AddText(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings);
+	void AddPath(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings);
+	void AddInt(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings);
+	void AddFloat(obs_property_t *prop, QFormLayout *layout, QLabel **label, obs_data_t *settings);
+	QWidget *AddList(obs_property_t *prop, bool &warning, obs_data_t *settings);
+	void AddEditableList(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings);
+	QWidget *AddButton(obs_property_t *prop, obs_data_t *settings);
+	void AddColorInternal(obs_property_t *prop, QFormLayout *layout, QLabel *&label, bool supportAlpha,
+			      obs_data_t *settings);
+	void AddColor(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings);
+	void AddColorAlpha(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings);
+	void AddFont(obs_property_t *prop, QFormLayout *layout, QLabel *&label, obs_data_t *settings);
+	void AddFrameRate(obs_property_t *prop, bool &warning, QFormLayout *layout, QLabel *&label,
+			  obs_data_t *settings);
 
-	void AddGroup(obs_property_t *prop, QFormLayout *layout);
+	void AddGroup(obs_property_t *prop, QFormLayout *layout, obs_data_t *settings);
 
-	void AddProperty(obs_property_t *property, QFormLayout *layout);
+	void AddProperty(obs_property_t *property, QFormLayout *layout, obs_data_t *settings);
 
 	void resizeEvent(QResizeEvent *event) override;
 


### PR DESCRIPTION
### Description
Add sub property group, this will make the properties in the group be in a setting object with the name of the group instead of all properties in the root settings object.

### Motivation and Context
I want to have multiple groups with settings that do not have unique setting names, only unique per group.
Previous version #7612 was closed without warning

### How Has This Been Tested?
On windows 64 bit with a lua script

### Types of changes
- New feature (non-breaking change which adds functionality) 

### Checklist:
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.md).
- [x] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format).
- [x] My code follows the project's [**style guidelines**](https://github.com/obsproject/obs-studio/blob/master/CODESTYLE.md)
- [x] My code is not on the master branch.
- [x] My code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation.
